### PR TITLE
rename kubevirt operator files in examples

### DIFF
--- a/e2e/testcases/apply_scoped_resource_test.go
+++ b/e2e/testcases/apply_scoped_resource_test.go
@@ -63,7 +63,7 @@ func TestApplyScopedResourcesHierarchicalMode(t *testing.T) {
 		// Avoids KNV2006 since the repo contains a number of cluster scoped resources
 		// https://cloud.google.com/anthos-config-management/docs/reference/errors#knv2006
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/kubevirt-operator-cluster-role.yaml")
-		nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/kubevirt.io:operator-clusterrole.yaml")
+		nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/kubevirt.io-operator-clusterrole.yaml")
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/kubevirt-cluster-critical.yaml")
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove cluster roles and priority class")
 		nt.WaitForRepoSyncs()
@@ -131,7 +131,7 @@ func TestApplyScopedResourcesUnstructuredMode(t *testing.T) {
 		// Avoids KNV2006 since the repo contains a number of cluster scoped resources
 		// https://cloud.google.com/anthos-config-management/docs/reference/errors#knv2006
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt-operator.yaml")
-		nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt.io:operator.yaml")
+		nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt.io-operator.yaml")
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrolebinding_kubevirt-operator.yaml")
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/priorityclass_kubevirt-cluster-critical.yaml")
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove cluster roles and priority class")

--- a/examples/kubevirt-compiled/clusterrole_kubevirt.io-operator.yaml
+++ b/examples/kubevirt-compiled/clusterrole_kubevirt.io-operator.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     operator.kubevirt.io: ""
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: kubevirt.io:operator
+  name: kubevirt.io-operator
 rules:
 - apiGroups:
   - kubevirt.io

--- a/examples/kubevirt/cluster/kubevirt.io-operator-clusterrole.yaml
+++ b/examples/kubevirt/cluster/kubevirt.io-operator-clusterrole.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubevirt.io:operator
+  name: kubevirt.io-operator
   labels:
     operator.kubevirt.io: ""
     rbac.authorization.k8s.io/aggregate-to-admin: "true"


### PR DESCRIPTION
The presence of colons in the file names made it so that the project was
not importable by other go projects.

GoogleContainerTools/kpt-config-sync#4