### PR TITLE
upsert privateCertSecret from RepoSync

### DIFF
--- a/e2e/nomostest/ssh.go
+++ b/e2e/nomostest/ssh.go
@@ -237,7 +237,7 @@ func downloadSSHKey(nt *NT) string {
 	return privateKeyPath(nt)
 }
 
-// CreateNamespaceSecret creates secret in a given namespace using privateKeyPath.
+// CreateNamespaceSecret creates secrets in a given namespace using local paths.
 func CreateNamespaceSecret(nt *NT, ns string) {
 	nt.T.Helper()
 	privateKeypath := nt.gitPrivateKeyPath
@@ -245,4 +245,5 @@ func CreateNamespaceSecret(nt *NT, ns string) {
 		privateKeypath = privateKeyPath(nt)
 	}
 	createSecret(nt, ns, namespaceSecret, fmt.Sprintf("ssh=%s", privateKeypath))
+	createSecret(nt, ns, gitServerPublicCertSecret, fmt.Sprintf("cert=%s", caCertPath(nt)))
 }

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -68,6 +69,7 @@ func TestPrivateCertSecretV1Alpha1(t *testing.T) {
 	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
+	reconcilerName := core.NsReconcilerName(backendNamespace, configsync.RepoSyncName)
 
 	// Set RootSync SyncURL to use HTTPS
 	rootSyncHTTPS := "https://test-git-server.config-management-system-test/git/config-management-system/root-sync"
@@ -96,7 +98,7 @@ func TestPrivateCertSecretV1Alpha1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use HTTPS")
 	// RepoSync should fail without privateCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncHTTPS))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -106,7 +108,7 @@ func TestPrivateCertSecretV1Alpha1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync set privateCertSecret")
 	nt.WaitForRepoSyncs()
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, privateCertPath))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, privateCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -135,7 +137,7 @@ func TestPrivateCertSecretV1Alpha1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync unset privateCertSecret")
 	// RepoSync should fail without privateCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -148,7 +150,7 @@ func TestPrivateCertSecretV1Alpha1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use SSH")
 	nt.WaitForRepoSyncs()
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -177,6 +179,7 @@ func TestPrivateCertSecretV1Beta1(t *testing.T) {
 	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
+	reconcilerName := core.NsReconcilerName(backendNamespace, configsync.RepoSyncName)
 
 	// Set RootSync SyncURL to use HTTPS
 	rootSyncHTTPS := "https://test-git-server.config-management-system-test/git/config-management-system/root-sync"
@@ -205,7 +208,7 @@ func TestPrivateCertSecretV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use HTTPS")
 	// RepoSync should fail without privateCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncHTTPS))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -215,7 +218,13 @@ func TestPrivateCertSecretV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync set privateCertSecret")
 	nt.WaitForRepoSyncs()
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, privateCertPath))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, privateCertPath))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// Check that the namespace secret was upserted to c-m-s namespace
+	err = nt.Validate(controllers.ReconcilerResourceName(reconcilerName, privateCertSecret), v1.NSConfigManagementSystem, &corev1.Secret{})
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -244,7 +253,7 @@ func TestPrivateCertSecretV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync unset privateCertSecret")
 	// RepoSync should fail without privateCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -257,7 +266,7 @@ func TestPrivateCertSecretV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use SSH")
 	nt.WaitForRepoSyncs()
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
+	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -160,7 +160,7 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 
 	// Create secret in config-management-system namespace using the
 	// existing secret in the reposync.namespace.
-	if err := upsertSecret(ctx, rs, r.client, reconcilerName); err != nil {
+	if err := upsertSecrets(ctx, rs, r.client, reconcilerName); err != nil {
 		var authType configsync.AuthType
 		if rs.Spec.SourceType == string(v1beta1.GitSource) {
 			authType = rs.Spec.Auth
@@ -785,6 +785,9 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 		// authenticate with the git or helm repository using the authorization method specified
 		// in the RepoSync CR.
 		secretName := ReconcilerResourceName(reconcilerName, secretRefName)
+		if usePrivateCert(privateCertSecret) {
+			privateCertSecret = ReconcilerResourceName(reconcilerName, privateCertSecret)
+		}
 		templateSpec.Volumes = filterVolumes(templateSpec.Volumes, auth, secretName, privateCertSecret, rs.Spec.SourceType, r.membership)
 		var updatedContainers []corev1.Container
 		// Mutate spec.Containers to update name, configmap references and volumemounts.

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -171,7 +171,7 @@ func TestCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := upsertSecret(context.Background(), tc.reposync, tc.client, nsReconcilerName)
+			err := upsertSecrets(context.Background(), tc.reposync, tc.client, nsReconcilerName)
 			if tc.wantError && err == nil {
 				t.Errorf("Create() got error: %q, want error", err)
 			} else if !tc.wantError && err != nil {


### PR DESCRIPTION
This follows the pattern of the user-provided secrets for git
credentials, where the user is expected to create the RepoSync secret in
the same namespace as the RepoSync. The secrets are then upserted to the
config-management-system namespace by the Reconciler. This is to support
use cases where the RepoSync user does not have access to the c-m-s
namespace.