### PR TITLE
add watch for privateCertSecret

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -53,6 +53,11 @@ const (
 	// It will be used in both the indexing and watching.
 	gitSecretRefField = ".spec.git.secretRef.name"
 
+	// privateCertSecretField is the path of the field in the RootSync|RepoSync CRDs
+	// that we wish to use as the "object reference".
+	// It will be used in both the indexing and watching.
+	privateCertSecretField = ".spec.git.privateCertSecret.name"
+
 	// helmSecretRefField is the path of the field in the RootSync|RepoSync CRDs
 	// that we wish to use as the "object reference".
 	// It will be used in both the indexing and watching.


### PR DESCRIPTION
This updates the watch function to map changes to the user-managed
secret in the RepoSync namespace to the upserted secret in the
config-management-system namespace. This ensures the secret is kept up
to date if the user updates the secret.

Change is based on https://github.com/GoogleContainerTools/kpt-config-sync/pull/11