### PR TITLE
Load allow vertical scale flag in reconciler manager

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -37,6 +37,7 @@ import (
 	"kpt.dev/configsync/pkg/profiler"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+	"kpt.dev/configsync/pkg/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
@@ -70,10 +71,12 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var allowVerticalScale bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&allowVerticalScale, "allow-vertical-scale", util.EnvBool(reconcilermanager.AllowVerticalScale, false), "Allowing vertical scale to let VPA manage the resource")
 	flag.Parse()
 
 	profiler.Service()
@@ -91,7 +94,7 @@ func main() {
 
 	repoSync := controllers.NewRepoSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("RepoSync"),
-		mgr.GetScheme())
+		mgr.GetScheme(), allowVerticalScale)
 	if err := repoSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RepoSync")
 		os.Exit(1)
@@ -99,7 +102,7 @@ func main() {
 
 	rootSync := controllers.NewRootSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("RootSync"),
-		mgr.GetScheme())
+		mgr.GetScheme(), allowVerticalScale)
 	if err := rootSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RootSync")
 		os.Exit(1)

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -74,6 +74,9 @@ const (
 	// StatusMode is to control if the kpt applier needs to inject the actuation data
 	// into the ResourceGroup object.
 	StatusMode = "STATUS_MODE"
+
+	// AllowVerticalScale indicates that resources will be managed by VPA
+	AllowVerticalScale = "ALLOW_VERTICAL_SCALE"
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -70,7 +70,7 @@ type RepoSyncReconciler struct {
 }
 
 // NewRepoSyncReconciler returns a new RepoSyncReconciler.
-func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
+func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme, allowVerticalScale bool) *RepoSyncReconciler {
 	return &RepoSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
@@ -80,6 +80,7 @@ func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
 			syncKind:                kindRepoSync,
+			allowVerticalScale:      allowVerticalScale,
 		},
 		repoSyncs: make(map[types.NamespacedName]struct{}),
 	}

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -79,7 +79,7 @@ type RootSyncReconciler struct {
 }
 
 // NewRootSyncReconciler returns a new RootSyncReconciler.
-func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
+func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme, allowVerticalScale bool) *RootSyncReconciler {
 	return &RootSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
@@ -89,6 +89,7 @@ func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
 			syncKind:                kindRootSync,
+			allowVerticalScale:      allowVerticalScale,
 		},
 	}
 }

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -135,6 +135,7 @@ func setupRootReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 		fakeClient,
 		controllerruntime.Log.WithName("controllers").WithName("RootSync"),
 		s,
+		allowVerticalScale,
 	)
 	return fakeClient, testReconciler
 }
@@ -2262,6 +2263,71 @@ func validateRootSyncStatus(want *v1beta1.RootSync, fakeClient *syncerFake.Clien
 		return fmt.Errorf("rootsync diff %s", diff)
 	}
 	return nil
+}
+
+func TestUpdateRootReconcilerWithAllowVerticalScale(t *testing.T) {
+	// Mock out parseDeployment for testing.
+	parseDeployment = parsedDeployment
+
+	rs := rootSync(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
+	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
+	allowVerticalScale = true
+	fakeClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+
+	// Test creating Deployment resources.
+	ctx := context.Background()
+	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
+		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
+	}
+
+	rootDeployment := rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+	)
+
+	updatedCPU := "249m"
+	updatedMemory := "259Mi"
+	deploymentCoreObject := fakeClient.Objects[core.IDOf(rootDeployment)]
+	updatedDeployment := deploymentCoreObject.(*appsv1.Deployment)
+	containerName := updatedDeployment.Spec.Template.Spec.Containers[0].Name
+	var updatedReplica int32 = 20
+	*updatedDeployment.Spec.Replicas = updatedReplica
+	// mock VPA behavior of changing deployment resources
+	updatedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(updatedCPU),
+		corev1.ResourceMemory: resource.MustParse(updatedMemory),
+	}
+
+	if err := fakeClient.Update(ctx, updatedDeployment); err != nil {
+		t.Fatalf("failed to update the deployment request, got error: %v, want error: nil", err)
+	}
+
+	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
+		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
+	}
+
+	// when allow vertical scale is enabled, original deployment resource should not be updated
+	// other updated deployment should be reverted
+	expectedResource := []v1beta1.ContainerResourcesSpec{
+		{
+			ContainerName: containerName,
+			CPURequest:    resource.MustParse(updatedCPU),
+			MemoryRequest: resource.MustParse(updatedMemory),
+		},
+	}
+
+	rootContainerEnvs2 := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment2 := rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerResourcesMutator(expectedResource),
+		containerEnvMutator(rootContainerEnvs2),
+	)
+
+	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment2): rootDeployment2}
+	if err := validateDeployments(wantDeployments, fakeClient); err != nil {
+		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	allowVerticalScale = false
 }
 
 type depMutator func(*appsv1.Deployment)


### PR DESCRIPTION
Load --allow-vertical-scale flag from reconcilerManager deployment, keep current container resources when flag is enabled, and add e2e test.

--allow-vertical-scale flag is declared in the reconcilerManager deployment when allowVerticalScale is set to true in the ConfigManagement API. When the flag is enabled, the reconciler should load the flag, and copy over all containers' resources from the current reconciler Deployment to the declared manifest, so that the discrepancy will not cause any Deployment update. That implies any resource override applied to the declared Deployment will be ignored. Changes to anything other than the resource will not be maintained and will be reverted back

The e2e test will simulate the scenario by adding the --allow-vertical-scale flag to the reconciler-manager deployment, perform an update to the resource of a container in the reconciler deployment and another update to minReadySeconds field. The update to the resource should then be maintained and not reverted, while minReadySeconds update is reverted