### PR TITLE
added a design doc template

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-ConfigSync follows the fork and PR model that a lot of OSS projects do.  If you
+ConfigSync follows the [Kubernetes contribution process].  If you
 are looking to contribute to this project please fork it, create a change
 and then submit a PR against the `main` branch which is the HEAD of development.
 
@@ -33,3 +33,4 @@ Guidelines](https://opensource.google/conduct/).
 
 [developer guide]: development.md
 [design document]: design-docs/00-template.md
+[Kubernetes contribution process]: https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,11 @@
 # How to Contribute
 
-Config Sync is currently being mirrored from internal Google systems to Github,
-but we are working on migrating all the infrastructure for the project onto
-github. Our goal is that all development of Config Sync will happen in this
-repository. We expect to complete this effort in a couple of months, so stay tuned.
+ConfigSync follows the fork and PR model that a lot of OSS projects do.  If you
+are looking to contribute to this project please fork it, create a change
+and then submit a PR against the `main` branch which is the HEAD of development.
 
-In the meantime, we will try to upstream any PRs made against this github repo
-on a best-effort basis. If you run into any issues using Config Sync or have
-any suggestions or questions to the Config Sync team, file an issue.
-
-When you are ready, take a look at our [developer guide] to get started.
+For larger changes and for anything that has a change to the CLI and API please
+write a [design document] first.
 
 ## Contributor License Agreement
 
@@ -36,3 +32,4 @@ This project follows [Google's Open Source Community
 Guidelines](https://opensource.google/conduct/).
 
 [developer guide]: development.md
+[design document]: design-docs/00-template.md

--- a/docs/design-docs/00-template.md
+++ b/docs/design-docs/00-template.md
@@ -1,0 +1,90 @@
+# Title
+
+* Author(s): \<your name\>, \<your github alias\>
+* Approver: \<kpt-maintainer\>
+
+>    Every feature will need design sign off an PR approval from a core
+>    maintainer.  If you have not got in touch with anyone yet, you can leave
+>    this blank and we will try to line someone up for you.
+
+## Why
+
+Please provide a reason to have this feature.  For best results a feature should
+be addressing a problem that is described in a github issue.  Link the issues
+in this section.  The more user requests are linked here the more likely this
+design is going to get prioritized on the roadmap.
+
+It's good to include some background about the problem, but do not use that as a
+substitute for real user feedback.
+
+## Design
+
+Please describe your solution. Please list any:
+
+* new config changes
+* interface changes
+* design assumptions
+
+For a new config change, please mention:
+
+* Is it backwards compatible? If not, what is the migration and deprecation 
+  plan?
+
+
+## User Guide
+
+This section should be written in the form of a detailed user guide describing 
+the user journey. It should start from a reasonable initial state, often from 
+scratch (Instead of starting midway through a convoluted scenario) in order 
+to provide enough context for the reader and demonstrate possible workflows. 
+This is a form of DDD (Documentation-Driven-Development), which is an effective 
+technique to empathize with the user early in the process (As opposed to 
+late-stage user-empathy sessions).
+
+This section should be as detailed as possible. For example if proposing a CLI 
+change, provide the exact commands the user needs to run, along with flag 
+descriptions, and success and failure messages (Failure messages are an 
+important part of a good UX). This level of detail serves two functions:
+
+It forces the author and the readers to explicitly think about possible friction
+points, pitfalls, failure scenarios, and corner cases (“A measure of a good 
+engineer is not how clever they are, but whether they think about all the 
+corner cases”). Makes it easier to author the user-facing docs as part of the 
+development process (Ideally as part of the same PR) as opposed to it being an 
+afterthought.
+
+## Open Issues/Questions
+
+Please list any open questions here in the following format:
+
+### \<Question\>
+
+Resolution: Please list the resolution if resolved during the design process or
+specify __Not Yet Resolved__
+
+## Alternatives Considered
+
+If there is an industry precedent or alternative approaches please list them 
+here as well as citing *why* you decided not to pursue those paths.
+
+### \<Approach\>
+
+Links and description of the approach, the pros and cons identified during the 
+design.
+
+# Review Process
+
+Design doc creators should raise the pull request similar to [this](https://github.com/GoogleContainerTools/kpt/pull/2576).
+Please name your documents with the design document number.  Pick n+1 from what's currently merged knowing that a slight
+renaming might need to happen if multiple design docs get accepted simultaneously.
+Please keep the name of the design doc in lower case with dashes in between words.
+
+Reviewers are auto-assigned to review the PR. Optionally, doc owner can mention any
+specific reviewers on the PR description. The turn around time for each review cycle
+on the PR from kpt maintainers is 1-2 days. After maintainers add comments to the PR,
+doc owner should respond to each of those comments and hit `Resolve conversation` button on the 
+comment thread. Once all the comments are resolved, design doc creator should hit `Re-request review`
+icon next to each reviewers' avatar in reviewers section. Reviewers will then be notified and, they will go through the
+resolved comments and might reopen the comment threads, and the cycle continues.
+Once all the reviewers approve the PR, it will be merged by the maintainers.
+Any design doc PRs which are not attended by the doc creators for more than 2 weeks will be closed.

--- a/docs/design-docs/00-template.md
+++ b/docs/design-docs/00-template.md
@@ -2,12 +2,17 @@
 
 * Author(s): \<your name\>, \<your github alias\>
 * Approver: \<kpt-maintainer\>
+* Status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
 
 >    Every feature will need design sign off an PR approval from a core
 >    maintainer.  If you have not got in touch with anyone yet, you can leave
 >    this blank and we will try to line someone up for you.
 
-## Why
+## Summary
+
+Please provide a 1-2 paragraph summary of what this feature is designed to do.
+
+## Motivation
 
 Please provide a reason to have this feature.  For best results a feature should
 be addressing a problem that is described in a github issue.  Link the issues
@@ -17,7 +22,7 @@ design is going to get prioritized on the roadmap.
 It's good to include some background about the problem, but do not use that as a
 substitute for real user feedback.
 
-## Design
+## Design Overview
 
 Please describe your solution. Please list any:
 
@@ -53,6 +58,19 @@ corner cases”). Makes it easier to author the user-facing docs as part of the
 development process (Ideally as part of the same PR) as opposed to it being an 
 afterthought.
 
+## Risks and Mitigations
+
+What are the major risks of implementing this feature?  What is the mitigration
+plan? Example:
+
+| Risk                               | Mitigration                                     |
+| ---------------------------------- | ----------------------------------------------- |
+| The feature might increase load    | The implementation will need to add a load test |
+| Another Risk                       | Another mitigration                             |
+
+## Test Plan
+
+
 ## Open Issues/Questions
 
 Please list any open questions here in the following format:
@@ -66,6 +84,7 @@ specify __Not Yet Resolved__
 
 If there is an industry precedent or alternative approaches please list them 
 here as well as citing *why* you decided not to pursue those paths.
+
 
 ### \<Approach\>
 


### PR DESCRIPTION
Created a design document template similar to the one that is used in kpt.  I suggest that we start using the design document process in the public repo instead of internal Google docs.