### PR TITLE
Use kstatus for reconciler deployment status

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -301,13 +301,8 @@ func keepCurrentContainerResources(declared, current *appsv1.Deployment) bool {
 	return resourceChanged
 }
 
-// deploymentStatus return standardized status for Deployment.
-//
-// For Deployments, we look at .status.conditions as well as the other properties
-// under .status. Status will be Failed if the progress deadline has been exceeded.
-// Code Reference: https://github.com/kubernetes-sigs/cli-utils/blob/v0.22.0/pkg/kstatus/status/core.go
-// TODO  Update to use the library kstatus once available.
-func (r *reconcilerBase) deploymentStatus(ctx context.Context, key client.ObjectKey) (*deploymentStatus, error) {
+// deployment returns the deployment from the server
+func (r *reconcilerBase) deployment(ctx context.Context, key client.ObjectKey) (*appsv1.Deployment, error) {
 	var depObj appsv1.Deployment
 	if err := r.client.Get(ctx, key, &depObj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -316,7 +311,7 @@ func (r *reconcilerBase) deploymentStatus(ctx context.Context, key client.Object
 		}
 		return nil, errors.Wrapf(err, "error while retrieving deployment")
 	}
-	return checkDeploymentConditions(&depObj)
+	return &depObj, nil
 }
 
 func mutateContainerResource(ctx context.Context, c *corev1.Container, override v1beta1.OverrideSpec, reconcilerType string) {

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -46,6 +46,7 @@ import (
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -248,19 +249,29 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	}
 	rs.Status.Reconciler = reconcilerName
 
-	var result *deploymentStatus
+	// Get the latest deployment to check the status.
+	// For other operations, upsertDeployment will have returned the latest already.
 	if op == controllerutil.OperationResultNone {
-		// Get status from server
-		result, err = r.deploymentStatus(ctx, client.ObjectKey{
+		deployObj, err = r.deployment(ctx, types.NamespacedName{
 			Namespace: v1.NSConfigManagementSystem,
 			Name:      reconcilerName,
 		})
-	} else {
-		// Get status from create/update result
-		result, err = checkDeploymentConditions(deployObj)
+		if err != nil {
+			log.Error(err, "Failed to get Deployment")
+			reposync.SetStalled(rs, "Deployment", err)
+			// Get errors should always trigger retry (return error),
+			// even if status update is successful.
+			_, updateErr := r.updateStatus(ctx, currentRS, rs)
+			if updateErr != nil {
+				log.Error(updateErr, "failed to update RepoSync status")
+			}
+			return controllerruntime.Result{}, err
+		}
 	}
+
+	result, err := computeDeploymentStatus(deployObj)
 	if err != nil {
-		log.Error(err, "Failed to check reconciler deployment conditions")
+		log.Error(err, "Failed to compute reconciler deployment status")
 		reposync.SetStalled(rs, "Deployment", err)
 		// Get errors should always trigger retry (return error),
 		// even if status update is successful.
@@ -272,21 +283,21 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	}
 
 	// Update RepoSync status based on reconciler deployment condition result.
-	switch result.status {
-	case statusInProgress:
+	switch result.Status {
+	case kstatus.InProgressStatus:
 		// inProgressStatus indicates that the deployment is not yet
 		// available. Hence update the Reconciling status condition.
-		reposync.SetReconciling(rs, "Deployment", result.message)
+		reposync.SetReconciling(rs, "Deployment", result.Message)
 		// Clear Stalled condition.
 		reposync.ClearCondition(rs, v1beta1.RepoSyncStalled)
-	case statusFailed:
+	case kstatus.FailedStatus:
 		// statusFailed indicates that the deployment failed to reconcile. Update
 		// Reconciling status condition with appropriate message specifying the
 		// reason for failure.
-		reposync.SetReconciling(rs, "Deployment", result.message)
+		reposync.SetReconciling(rs, "Deployment", result.Message)
 		// Set Stalled condition with the deployment statusFailed.
-		reposync.SetStalled(rs, "Deployment", errors.New(string(result.status)))
-	case statusCurrent:
+		reposync.SetStalled(rs, "Deployment", errors.New(string(result.Status)))
+	case kstatus.CurrentStatus:
 		// currentStatus indicates that the deployment is available, which qualifies
 		// to clear the Reconciling status condition in RepoSync.
 		reposync.ClearCondition(rs, v1beta1.RepoSyncReconciling)
@@ -301,7 +312,7 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, err
 	}
 
-	if updated && result.status == statusCurrent {
+	if updated && result.Status == kstatus.CurrentStatus {
 		r.log.Info("Deployment successfully reconciled", operationSubjectName, reconcilerName, executedOperation, op)
 	}
 	return controllerruntime.Result{}, nil

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -173,9 +173,9 @@ func TestCreate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := upsertSecrets(context.Background(), tc.reposync, tc.client, nsReconcilerName)
 			if tc.wantError && err == nil {
-				t.Errorf("Create() got error: %q, want error", err)
+				t.Errorf("upsertSecrets() got error: %q, want error", err)
 			} else if !tc.wantError && err != nil {
-				t.Errorf("Create() got error: %q, want error: nil", err)
+				t.Errorf("upsertSecrets() got error: %q, want error: nil", err)
 			}
 			if !tc.wantError {
 				if diff := cmp.Diff(tc.client.Objects[core.IDOf(tc.wantSecret)], tc.wantSecret); diff != "" {

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/pkg/util/log/error.go
+++ b/pkg/util/log/error.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package log
 
 import (


### PR DESCRIPTION
- This reduces duplicate code in CS and makes the messages more
  consistent.