### PR TITLE
fix caCertPath for shared test envs

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -342,7 +342,7 @@ func FreshTestEnv(t testing2.NTB, opts *ntopts.New) *NT {
 		// create the Namespaces + Secrets before anything else.
 		nt.gitPrivateKeyPath = generateSSHKeys(nt)
 
-		generateSSLKeys(nt)
+		nt.caCertPath = generateSSLKeys(nt)
 
 		waitForGit := installGitServer(nt)
 		if err := waitForGit(); err != nil {

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -119,6 +119,9 @@ type NT struct {
 	// gitPrivateKeyPath is the path to the private key used for communicating with the Git server.
 	gitPrivateKeyPath string
 
+	// caCertPath is the path to the CA cert used for communicating with the Git server.
+	caCertPath string
+
 	// gitRepoPort is the local port that forwards to the git repo deployment.
 	gitRepoPort int
 
@@ -857,8 +860,8 @@ func (nt *NT) testLogs(previousPodLog bool) {
 // testPods prints the output of `kubectl get pods`, which includes a 'RESTARTS' column
 // indicating how many times each pod has restarted. If a pod has restarted, the following
 // two commands can be used to get more information:
-//   1) kubectl get pods -n config-management-system -o yaml
-//   2) kubectl logs deployment/<deploy-name> <container-name> -n config-management-system -p
+//  1. kubectl get pods -n config-management-system -o yaml
+//  2. kubectl logs deployment/<deploy-name> <container-name> -n config-management-system -p
 func (nt *NT) testPods() {
 	out, err := nt.Kubectl("get", "pods", "-n", configmanagement.ControllerNamespace)
 	// Print a standardized header before each printed log to make ctrl+F-ing the

--- a/e2e/nomostest/ssh.go
+++ b/e2e/nomostest/ssh.go
@@ -211,7 +211,7 @@ func generateSSLKeys(nt *NT) string {
 		fmt.Sprintf("server.crt=%s", certPath(nt)),
 		fmt.Sprintf("server.key=%s", certPrivateKeyPath(nt)))
 
-	return certPath(nt)
+	return caCertPath(nt)
 }
 
 // downloadSSHKey downloads the private SSH key from Cloud Secret Manager.
@@ -247,6 +247,10 @@ func CreateNamespaceSecret(nt *NT, ns string) {
 	}
 	createSecret(nt, ns, namespaceSecret, fmt.Sprintf("ssh=%s", privateKeypath))
 	if nt.GitProvider.Type() == e2e.Local {
-		createSecret(nt, ns, gitServerPublicCertSecret, fmt.Sprintf("cert=%s", caCertPath(nt)))
+		caCertPathVal := nt.caCertPath
+		if len(caCertPathVal) == 0 {
+			caCertPathVal = caCertPath(nt)
+		}
+		createSecret(nt, ns, gitServerPublicCertSecret, fmt.Sprintf("cert=%s", caCertPathVal))
 	}
 }


### PR DESCRIPTION
Shared test environments create the secret files once and then store the
path in the nt object to share the path between tests. This change
updates the test scaffolding to properly handle this for the CA cert
secret.