### PR TITLE
Cleanup logs & errors in reconciler-manager

### DIFF
--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
-	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
@@ -40,67 +38,73 @@ import (
 // created in config-management-system namespace instead of reposync namespace.
 //
 // NOTE: Update this method when resources created by namespace controller changes.
-func (r *RepoSyncReconciler) cleanupNSControllerResources(ctx context.Context, ns, rsName string) error {
-	reconcilerName := core.NsReconcilerName(ns, rsName)
-	r.log.Info("Cleaning up namespace controller resources", "reconcilerName", reconcilerName)
+func (r *RepoSyncReconciler) cleanupNSControllerResources(ctx context.Context, rsKey, reconcilerKey types.NamespacedName) error {
+	r.log.Info("Deleting managed objects",
+		logFieldObject, rsKey.String(),
+		logFieldKind, r.syncKind)
 
-	reposyncList := &v1beta1.RepoSyncList{}
-	if err := r.client.List(ctx, reposyncList, client.InNamespace(ns)); err != nil {
-		return errors.Wrapf(err, "failed to list the RepoSync objects in namespace %q", ns)
+	rsList := &v1beta1.RepoSyncList{}
+	if err := r.client.List(ctx, rsList, client.InNamespace(rsKey.Namespace)); err != nil {
+		return errors.Wrapf(err, "failed to list RepoSync managed objects in namespace %q", rsKey.Namespace)
 	}
 
 	// Delete namespace controller resources and return to reconcile loop in case
 	// of errors to try cleaning up resources again.
 
 	// Deployment
-	if err := r.deleteDeployment(ctx, reconcilerName); err != nil {
+	if err := r.deleteDeployment(ctx, reconcilerKey); err != nil {
 		return err
 	}
 	// configmaps
-	if err := r.deleteConfigmap(ctx, reconcilerName); err != nil {
+	if err := r.deleteConfigMaps(ctx, reconcilerKey); err != nil {
 		return err
 	}
 	// serviceaccount
-	if err := r.deleteServiceAccount(ctx, reconcilerName); err != nil {
+	if err := r.deleteServiceAccount(ctx, reconcilerKey); err != nil {
 		return err
 	}
 	// rolebinding
-	if err := r.deleteRoleBinding(ctx, ns, reposyncList); err != nil {
+	if err := r.deleteRoleBinding(ctx, rsList, rsKey.Namespace, reconcilerKey.Namespace); err != nil {
 		return err
 	}
 	// secret
-	if err := r.deleteSecret(ctx, reconcilerName); err != nil {
+	if err := r.deleteSecrets(ctx, reconcilerKey); err != nil {
 		return err
 	}
 
-	delete(r.repoSyncs, types.NamespacedName{Namespace: ns, Name: rsName})
+	delete(r.repoSyncs, rsKey)
 	return nil
 }
 
-func (r *RepoSyncReconciler) cleanup(ctx context.Context, name, namespace string, gvk schema.GroupVersionKind) error {
+func (r *reconcilerBase) cleanup(ctx context.Context, key types.NamespacedName, gvk schema.GroupVersionKind) error {
 	u := &unstructured.Unstructured{}
-	u.SetName(name)
-	u.SetNamespace(namespace)
+	u.SetName(key.Name)
+	u.SetNamespace(key.Namespace)
 	u.SetGroupVersionKind(gvk)
-	err := r.client.Delete(ctx, u)
-	if err != nil {
+	if err := r.client.Delete(ctx, u); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.log.V(4).Info("resource not present", "namespace", namespace, "resource", name)
+			r.log.Info("Object already deleted",
+				logFieldObject, key.String(),
+				logFieldKind, gvk.Kind)
 			return nil
 		}
+		return err
 	}
-	return err
+	r.log.Info("Object successfully deleted",
+		logFieldObject, key.String(),
+		logFieldKind, gvk.Kind)
+	return nil
 }
 
-func (r *RepoSyncReconciler) deleteSecret(ctx context.Context, reconcilerName string) error {
+func (r *RepoSyncReconciler) deleteSecrets(ctx context.Context, reconcilerKey types.NamespacedName) error {
 	secretList := &corev1.SecretList{}
-	if err := r.client.List(ctx, secretList, client.InNamespace(configsync.ControllerNamespace)); err != nil {
+	if err := r.client.List(ctx, secretList, client.InNamespace(reconcilerKey.Namespace)); err != nil {
 		return err
 	}
 
 	for _, s := range secretList.Items {
-		if strings.HasPrefix(s.Name, reconcilerName) {
-			if err := r.cleanup(ctx, s.Name, s.Namespace, kinds.Secret()); err != nil {
+		if strings.HasPrefix(s.Name, reconcilerKey.Name) {
+			if err := r.cleanup(ctx, client.ObjectKeyFromObject(&s), kinds.Secret()); err != nil {
 				return err
 			}
 		}
@@ -108,48 +112,49 @@ func (r *RepoSyncReconciler) deleteSecret(ctx context.Context, reconcilerName st
 	return nil
 }
 
-func (r *RepoSyncReconciler) deleteConfigmap(ctx context.Context, reconcilerName string) error {
+func (r *RepoSyncReconciler) deleteConfigMaps(ctx context.Context, reconcilerKey types.NamespacedName) error {
 	cms := []string{
-		ReconcilerResourceName(reconcilerName, reconcilermanager.Reconciler),
-		ReconcilerResourceName(reconcilerName, reconcilermanager.HydrationController),
-		ReconcilerResourceName(reconcilerName, reconcilermanager.GitSync),
+		ReconcilerResourceName(reconcilerKey.Name, reconcilermanager.Reconciler),
+		ReconcilerResourceName(reconcilerKey.Name, reconcilermanager.HydrationController),
+		ReconcilerResourceName(reconcilerKey.Name, reconcilermanager.GitSync),
 	}
-	for _, c := range cms {
-		if err := r.cleanup(ctx, c, v1.NSConfigManagementSystem, kinds.ConfigMap()); err != nil {
+	for _, name := range cms {
+		key := types.NamespacedName{Namespace: reconcilerKey.Namespace, Name: name}
+		if err := r.cleanup(ctx, key, kinds.ConfigMap()); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *RepoSyncReconciler) deleteServiceAccount(ctx context.Context, reconcilerName string) error {
-	return r.cleanup(ctx, reconcilerName, v1.NSConfigManagementSystem, kinds.ServiceAccount())
+func (r *RepoSyncReconciler) deleteServiceAccount(ctx context.Context, reconcilerKey types.NamespacedName) error {
+	return r.cleanup(ctx, reconcilerKey, kinds.ServiceAccount())
 }
 
-func (r *RepoSyncReconciler) deleteRoleBinding(ctx context.Context, namespace string, reposyncList *v1beta1.RepoSyncList) error {
+func (r *RepoSyncReconciler) deleteRoleBinding(ctx context.Context, rsList *v1beta1.RepoSyncList, rsNamespace, reconcilerNamespace string) error {
 	rbName := RepoSyncPermissionsName()
-	if len(reposyncList.Items) == 0 {
-		return r.cleanup(ctx, rbName, namespace, kinds.RoleBinding())
+	if len(rsList.Items) == 0 {
+		return r.cleanup(ctx, client.ObjectKey{Namespace: rsNamespace, Name: rbName}, kinds.RoleBinding())
 	}
 	rb := &rbacv1.RoleBinding{}
-	if err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: rbName}, rb); err != nil {
-		return errors.Wrapf(err, "failed to get the RoleBinding object %s/%s", namespace, rbName)
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: rsNamespace, Name: rbName}, rb); err != nil {
+		return errors.Wrapf(err, "failed to get the RoleBinding object %s/%s", rsNamespace, rbName)
 	}
-	if err := r.updateRoleBindingSubjects(rb, reposyncList); err != nil {
-		return errors.Wrapf(err, "failed to update subjects of the RoleBinding object %s/%s", namespace, rbName)
+	if err := r.updateRoleBindingSubjects(rb, rsList, reconcilerNamespace); err != nil {
+		return errors.Wrapf(err, "failed to update subjects of the RoleBinding object %s/%s", rsNamespace, rbName)
 	}
 	return r.client.Update(ctx, rb)
 }
 
-func (r *RepoSyncReconciler) deleteDeployment(ctx context.Context, reconcilerName string) error {
-	return r.cleanup(ctx, reconcilerName, v1.NSConfigManagementSystem, kinds.Deployment())
+func (r *RepoSyncReconciler) deleteDeployment(ctx context.Context, reconcilerKey types.NamespacedName) error {
+	return r.cleanup(ctx, reconcilerKey, kinds.Deployment())
 }
 
-func (r *RepoSyncReconciler) updateRoleBindingSubjects(rb *rbacv1.RoleBinding, rsList *v1beta1.RepoSyncList) error {
+func (r *RepoSyncReconciler) updateRoleBindingSubjects(rb *rbacv1.RoleBinding, rsList *v1beta1.RepoSyncList, reconcilerNamespace string) error {
 	var subjects []rbacv1.Subject
 	for _, rs := range rsList.Items {
 		subjects = append(subjects, subject(core.NsReconcilerName(rs.Namespace, rs.Name),
-			configsync.ControllerNamespace,
+			reconcilerNamespace,
 			"ServiceAccount"))
 	}
 	sort.SliceStable(subjects, func(i, j int) bool {
@@ -159,9 +164,9 @@ func (r *RepoSyncReconciler) updateRoleBindingSubjects(rb *rbacv1.RoleBinding, r
 	return nil
 }
 
-func (r *RootSyncReconciler) deleteClusterRoleBinding(ctx context.Context) error {
+func (r *RootSyncReconciler) deleteClusterRoleBinding(ctx context.Context, reconcilerNamespace string) error {
 	rootsyncList := &v1beta1.RootSyncList{}
-	if err := r.client.List(ctx, rootsyncList, client.InNamespace(configsync.ControllerNamespace)); err != nil {
+	if err := r.client.List(ctx, rootsyncList, client.InNamespace(reconcilerNamespace)); err != nil {
 		return errors.Wrapf(err, "failed to list the RootSync objects")
 	}
 	crbName := RootSyncPermissionsName()
@@ -172,7 +177,7 @@ func (r *RootSyncReconciler) deleteClusterRoleBinding(ctx context.Context) error
 	if err := r.client.Get(ctx, client.ObjectKey{Name: crbName}, crb); err != nil {
 		return errors.Wrapf(err, "failed to get the ClusterRoleBinding object %s", crbName)
 	}
-	return r.updateClusterRoleBindingSubjects(crb, rootsyncList)
+	return r.updateClusterRoleBindingSubjects(crb, rootsyncList, reconcilerNamespace)
 }
 
 // cleanup cleans up cluster-scoped resources that are created for RootSync.
@@ -194,11 +199,11 @@ func (r *RootSyncReconciler) cleanup(ctx context.Context, name string, gvk schem
 	return err
 }
 
-func (r *RootSyncReconciler) updateClusterRoleBindingSubjects(crb *rbacv1.ClusterRoleBinding, rsList *v1beta1.RootSyncList) error {
+func (r *RootSyncReconciler) updateClusterRoleBindingSubjects(crb *rbacv1.ClusterRoleBinding, rsList *v1beta1.RootSyncList, reconcilerNamespace string) error {
 	var subjects []rbacv1.Subject
 	for _, rs := range rsList.Items {
 		subjects = append(subjects, subject(core.RootReconcilerName(rs.Name),
-			configsync.ControllerNamespace,
+			reconcilerNamespace,
 			"ServiceAccount"))
 	}
 	sort.SliceStable(subjects, func(i, j int) bool {

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -71,7 +71,6 @@ const (
 	pollingPeriod = "50ms"
 )
 
-// Set in init.
 var filesystemPollingPeriod time.Duration
 var hydrationPollingPeriod time.Duration
 var nsReconcilerName = core.NsReconcilerName(reposyncNs, reposyncName)
@@ -325,7 +324,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -421,7 +420,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -597,7 +596,7 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -626,7 +625,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -665,7 +664,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -716,7 +715,7 @@ func TestRepoSyncCreateWithPrivateCert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 
 	nsSecretName := nsReconcilerName + "-" + secretName
 	nsPrivateCertSecret := nsReconcilerName + "-" + privateCertSecret
@@ -755,7 +754,7 @@ func TestRepoSyncUpdatePrivateCert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	nsSecretName := nsReconcilerName + "-" + secretName
 	repoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -797,7 +796,7 @@ func TestRepoSyncUpdatePrivateCert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	nsPrivateCertSecret := nsReconcilerName + "-" + privateCertSecret
 	updatedRepoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -844,7 +843,7 @@ func TestRepoSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -873,7 +872,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -898,7 +897,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -923,7 +922,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	updatedRepoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -983,7 +982,7 @@ func TestRepoSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1012,7 +1011,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1037,7 +1036,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1117,7 +1116,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		core.Labels(label),
 	)
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1148,7 +1147,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1173,7 +1172,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1202,7 +1201,7 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1304,7 +1303,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	)
 	wantRoleBindings := map[core.ID]*rbacv1.RoleBinding{core.IDOf(roleBinding1): roleBinding1}
 
-	repoContainerEnv1 := testReconciler.populateRepoContainerEnvs(ctx, rs1, nsReconcilerName)
+	repoContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName)
 	repoDeployment1 := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1342,7 +1341,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncNameLabel:      rs2.Name,
 	}
 
-	repoContainerEnv2 := testReconciler.populateRepoContainerEnvs(ctx, rs2, nsReconcilerName2)
+	repoContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
 	repoDeployment2 := repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
@@ -1394,7 +1393,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncNameLabel:      rs3.Name,
 	}
 
-	repoContainerEnv3 := testReconciler.populateRepoContainerEnvs(ctx, rs3, nsReconcilerName3)
+	repoContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
 	repoDeployment3 := repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
@@ -1449,7 +1448,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncNameLabel:      rs4.Name,
 	}
 
-	repoContainerEnv4 := testReconciler.populateRepoContainerEnvs(ctx, rs4, nsReconcilerName4)
+	repoContainerEnv4 := testReconciler.populateContainerEnvs(ctx, rs4, nsReconcilerName4)
 	repoDeployment4 := repoSyncDeployment(
 		nsReconcilerName4,
 		setServiceAccountName(nsReconcilerName4),
@@ -1504,7 +1503,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncNameLabel:      rs5.Name,
 	}
 
-	repoContainerEnv5 := testReconciler.populateRepoContainerEnvs(ctx, rs5, nsReconcilerName5)
+	repoContainerEnv5 := testReconciler.populateContainerEnvs(ctx, rs5, nsReconcilerName5)
 	repoDeployment5 := repoSyncDeployment(
 		nsReconcilerName5,
 		setServiceAccountName(nsReconcilerName5),
@@ -1548,7 +1547,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv1 = testReconciler.populateRepoContainerEnvs(ctx, rs1, nsReconcilerName)
+	repoContainerEnv1 = testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName)
 	repoDeployment1 = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1572,7 +1571,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv2 = testReconciler.populateRepoContainerEnvs(ctx, rs2, nsReconcilerName2)
+	repoContainerEnv2 = testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
 	repoDeployment2 = repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
@@ -1596,7 +1595,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv3 = testReconciler.populateRepoContainerEnvs(ctx, rs3, nsReconcilerName3)
+	repoContainerEnv3 = testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
 	repoDeployment3 = repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
@@ -1994,7 +1993,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
@@ -2050,7 +2049,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
@@ -2076,7 +2075,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2106,7 +2105,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
-	repoContainerEnvs := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 
 	repoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2131,7 +2130,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
@@ -2177,7 +2176,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		core.Labels(label),
 	)
 
-	repoContainerEnv := testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2211,7 +2210,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		t.Errorf("ServiceAccount diff %s", diff)
 	}
 
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2233,7 +2232,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
-	repoContainerEnv = testReconciler.populateRepoContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),

--- a/pkg/reconcilermanager/controllers/secret.go
+++ b/pkg/reconcilermanager/controllers/secret.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -51,78 +51,126 @@ func shouldUpsertPrivateCertSecret(rs *v1beta1.RepoSync) bool {
 }
 
 func shouldUpsertGitSecret(rs *v1beta1.RepoSync) bool {
-	return rs.Spec.SourceType == string(v1beta1.GitSource) && rs.Spec.Git != nil && !SkipForAuth(rs.Spec.Auth)
+	return v1beta1.SourceType(rs.Spec.SourceType) == v1beta1.GitSource && rs.Spec.Git != nil && !SkipForAuth(rs.Spec.Auth)
 }
 
 func shouldUpsertHelmSecret(rs *v1beta1.RepoSync) bool {
-	return rs.Spec.SourceType == string(v1beta1.HelmSource) && rs.Spec.Helm != nil && !SkipForAuth(rs.Spec.Helm.Auth)
+	return v1beta1.SourceType(rs.Spec.SourceType) == v1beta1.HelmSource && rs.Spec.Helm != nil && !SkipForAuth(rs.Spec.Helm.Auth)
 }
 
-// upsertSecrets creates or updates all secrets in config-management-system
-// namespace using existing secrets in the reposync.namespace.
-func upsertSecrets(ctx context.Context, rs *v1beta1.RepoSync, c client.Client, reconcilerName string) error {
+// upsertAuthSecret creates or updates the auth secret in the
+// config-management-system namespace using an existing secret in the RepoSync
+// namespace.
+func upsertAuthSecret(ctx context.Context, rs *v1beta1.RepoSync, c client.Client, reconcilerRef types.NamespacedName) (client.ObjectKey, error) {
+	rsRef := client.ObjectKeyFromObject(rs)
+	switch {
+	case shouldUpsertGitSecret(rs):
+		nsSecretRef, cmsSecretRef := getSecretRefs(rsRef, reconcilerRef, rs.Spec.Git.SecretRef.Name)
+		userSecret, err := getUserSecret(ctx, c, nsSecretRef)
+		if err != nil {
+			return cmsSecretRef, errors.Wrap(err, "user secret required for git client authentication")
+		}
+		err = upsertSecret(ctx, c, cmsSecretRef, rsRef, userSecret)
+		if err != nil {
+			return cmsSecretRef, err
+		}
+		return cmsSecretRef, nil
+	case shouldUpsertHelmSecret(rs):
+		nsSecretRef, cmsSecretRef := getSecretRefs(rsRef, reconcilerRef, rs.Spec.Helm.SecretRef.Name)
+		userSecret, err := getUserSecret(ctx, c, nsSecretRef)
+		if err != nil {
+			return cmsSecretRef, errors.Wrap(err, "user secret required for helm client authentication")
+		}
+		err = upsertSecret(ctx, c, cmsSecretRef, rsRef, userSecret)
+		if err != nil {
+			return cmsSecretRef, err
+		}
+		return cmsSecretRef, nil
+	default:
+		// No secret required
+		return client.ObjectKey{}, nil
+	}
+}
+
+// upsertCACertSecret creates or updates the CA cert secret in the
+// config-management-system namespace using an existing secret in the RepoSync
+// namespace.
+func upsertCACertSecret(ctx context.Context, rs *v1beta1.RepoSync, c client.Client, reconcilerRef types.NamespacedName) (client.ObjectKey, error) {
+	rsRef := client.ObjectKeyFromObject(rs)
 	if shouldUpsertPrivateCertSecret(rs) {
-		err := upsertSecret(ctx, rs, c, reconcilerName, rs.Spec.Git.PrivateCertSecret.Name)
+		nsSecretRef, cmsSecretRef := getSecretRefs(rsRef, reconcilerRef, rs.Spec.Git.PrivateCertSecret.Name)
+		userSecret, err := getUserSecret(ctx, c, nsSecretRef)
 		if err != nil {
-			return err
+			return cmsSecretRef, errors.Wrap(err, "user secret required for git server validation")
 		}
-	}
-	if shouldUpsertGitSecret(rs) {
-		err := upsertSecret(ctx, rs, c, reconcilerName, rs.Spec.Git.SecretRef.Name)
+		err = upsertSecret(ctx, c, cmsSecretRef, rsRef, userSecret)
 		if err != nil {
-			return err
+			return cmsSecretRef, err
 		}
+		return cmsSecretRef, nil
 	}
-	if shouldUpsertHelmSecret(rs) {
-		err := upsertSecret(ctx, rs, c, reconcilerName, rs.Spec.Helm.SecretRef.Name)
-		if err != nil {
-			return err
+	// No secret required
+	return client.ObjectKey{}, nil
+}
+
+func getSecretRefs(rsRef, reconcilerRef client.ObjectKey, secretName string) (nsSecretRef, cmsSecretRef client.ObjectKey) {
+	// User managed secret
+	nsSecretRef = client.ObjectKey{
+		Namespace: rsRef.Namespace,
+		Name:      secretName,
+	}
+	// reconciler-manager managed secret
+	cmsSecretRef = client.ObjectKey{
+		Namespace: reconcilerRef.Namespace,
+		Name:      ReconcilerResourceName(reconcilerRef.Name, secretName),
+	}
+	return nsSecretRef, cmsSecretRef
+}
+
+// getUserSecret gets a user managed secret in the same namespace as the RepoSync.
+func getUserSecret(ctx context.Context, c client.Client, nsSecretRef client.ObjectKey) (*corev1.Secret, error) {
+	nsSecret := &corev1.Secret{}
+	if err := getSecret(ctx, c, nsSecretRef, nsSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nsSecret, errors.Errorf(
+				"secret %s not found", nsSecretRef)
 		}
+		return nsSecret, errors.Wrapf(err,
+			"secret %s get failed", nsSecretRef)
 	}
-	return nil
+	return nsSecret, nil
 }
 
 // upsertSecret creates or updates a secret in config-management-system
-// namespace using an existing secret in the reposync.namespace.
-func upsertSecret(ctx context.Context, rs *v1beta1.RepoSync, c client.Client, reconcilerName, nsSecretName string) error {
-	// namespaceSecret represent secret in reposync.namespace.
-	namespaceSecret := &corev1.Secret{}
-	if err := get(ctx, nsSecretName, rs.Namespace, namespaceSecret, c); err != nil {
-		if apierrors.IsNotFound(err) {
-			return errors.Errorf(
-				"%s not found. Create %s secret in %s namespace", nsSecretName, nsSecretName, rs.Namespace)
-		}
-		return errors.Wrapf(err, "error while retrieving namespace secret")
-	}
-	// existingsecret represent secret in config-management-system namespace.
-	existingsecret := &corev1.Secret{}
-	secretName := ReconcilerResourceName(reconcilerName, nsSecretName)
-	if err := get(ctx, secretName, v1.NSConfigManagementSystem, existingsecret, c); err != nil {
+// namespace using an existing user secret.
+func upsertSecret(ctx context.Context, c client.Client, cmsSecretRef, rsRef types.NamespacedName, userSecret *corev1.Secret) error {
+	cmsSecret := &corev1.Secret{}
+	if err := getSecret(ctx, c, cmsSecretRef, cmsSecret); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err,
-				"failed to get secret %s in namespace %s", secretName, v1.NSConfigManagementSystem)
+				"secret %s get failed", cmsSecretRef)
 		}
-		// Secret not present in config-management-system namespace. Create one using
-		// secret in reposync.namespace.
-		if err := create(ctx, namespaceSecret, reconcilerName, c, rs.Name, rs.Namespace); err != nil {
+		// Secret not present in config-management-system namespace.
+		// Create one using secret in the RepoSync namespace.
+		if err := createSecret(ctx, c, cmsSecretRef, rsRef, userSecret); err != nil {
 			return errors.Wrapf(err,
-				"failed to create %s secret in %s namespace",
-				nsSecretName, v1.NSConfigManagementSystem)
+				"secret %s create failed", cmsSecretRef)
 		}
 		return nil
 	}
 	// Update the existing secret in config-management-system.
-	if err := update(ctx, existingsecret, namespaceSecret, c); err != nil {
-		return errors.Wrapf(err, "failed to update the secret %s", existingsecret.Name)
+	if err := updateSecret(ctx, c, cmsSecret, userSecret); err != nil {
+		return errors.Wrapf(err,
+			"secret %s update failed", cmsSecretRef)
 	}
 	return nil
 }
 
-// GetKeys returns the keys that are contained in the Secret.
-func GetKeys(ctx context.Context, c client.Client, secretName, namespace string) map[string]bool {
+// GetSecretKeys returns the keys that are contained in the Secret.
+func GetSecretKeys(ctx context.Context, c client.Client, sRef types.NamespacedName) map[string]bool {
 	// namespaceSecret represent secret in reposync.namespace.
 	namespaceSecret := &corev1.Secret{}
-	if err := get(ctx, secretName, namespace, namespaceSecret, c); err != nil {
+	if err := getSecret(ctx, c, sRef, namespaceSecret); err != nil {
 		return nil
 	}
 	results := map[string]bool{}
@@ -132,44 +180,37 @@ func GetKeys(ctx context.Context, c client.Client, secretName, namespace string)
 	return results
 }
 
-// get secret using provided namespace and name.
-func get(ctx context.Context, name, namespace string, secret *corev1.Secret, c client.Client) error {
-	// NamespacedName for the secret.
-	nn := client.ObjectKey{
-		Name:      name,
-		Namespace: namespace,
-	}
-	return c.Get(ctx, nn, secret)
+// getSecret secret using provided namespace and name.
+func getSecret(ctx context.Context, c client.Client, sRef types.NamespacedName, secret *corev1.Secret) error {
+	return c.Get(ctx, sRef, secret)
 }
 
-// create secret get the existing secret in reposync.namespace and use secret.data and
-// secret.type to create a new secret in config-management-system namespace.
-func create(ctx context.Context, namespaceSecret *corev1.Secret, reconcilerName string, c client.Client, syncName string, syncNamespace string) error {
+// createSecret secret get the existing secret in reposync.namespace and use secret.data and
+// secret.type to createSecret a new secret in config-management-system namespace.
+func createSecret(ctx context.Context, c client.Client, sRef, rsRef types.NamespacedName, namespaceSecret *corev1.Secret) error {
 	newSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       kinds.Secret().Kind,
 			APIVersion: kinds.Secret().Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: sRef.Namespace,
+			Name:      sRef.Name,
 			Labels: map[string]string{
-				metadata.SyncNamespaceLabel: syncNamespace,
-				metadata.SyncNameLabel:      syncName,
+				metadata.SyncNamespaceLabel: rsRef.Namespace,
+				metadata.SyncNameLabel:      rsRef.Name,
 			},
 		},
+		Type: namespaceSecret.Type,
+		Data: namespaceSecret.Data,
 	}
-
-	// mutate newSecret with values from the secret in reposync.namespace.
-	newSecret.Name = ReconcilerResourceName(reconcilerName, namespaceSecret.Name)
-	newSecret.Namespace = v1.NSConfigManagementSystem
-	newSecret.Data = namespaceSecret.Data
-	newSecret.Type = namespaceSecret.Type
 
 	return c.Create(ctx, newSecret)
 }
 
-// update secret fetch the existing secret from the cluster and use secret.data and
+// updateSecret secret fetch the existing secret from the cluster and use secret.data and
 // secret.type to create a new secret in config-management-system namespace.
-func update(ctx context.Context, existingsecret *corev1.Secret, namespaceSecret *corev1.Secret, c client.Client) error {
+func updateSecret(ctx context.Context, c client.Client, existingsecret *corev1.Secret, namespaceSecret *corev1.Secret) error {
 	// Update data and type for the existing secret with values from the secret in
 	// reposync.namespace
 	existingsecret.Data = namespaceSecret.Data


### PR DESCRIPTION
- Make managed object and sync object log messages more consistent
- Use ObjectKeys/NamespacedNames where possible to avoid making
  assumptions about which namespace to use, and make it easier to
  log the namespace & name together.
- Seperate auth secret and ca cert secret upserts to make the code
  easier to read, and have distinct error messages, that explain
  what the secret is for, since the user needs to supply it.