### PR TITLE
pass caCertPath to shared test envs

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -186,6 +186,7 @@ func SharedTestEnv(t testing2.NTB, opts *ntopts.New) *NT {
 		RootRepos:               sharedNt.RootRepos,
 		NonRootRepos:            make(map[types.NamespacedName]*Repository),
 		gitPrivateKeyPath:       sharedNt.gitPrivateKeyPath,
+		caCertPath:              sharedNt.caCertPath,
 		gitRepoPort:             sharedNt.gitRepoPort,
 		scheme:                  sharedNt.scheme,
 		otelCollectorPort:       sharedNt.otelCollectorPort,


### PR DESCRIPTION
This fixes a failure we are seeing in shared test environments where the
once created caCertPath was not being properly passed to the shared test
NT.