### PR TITLE
Fix printing not ready pod logs

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -907,7 +907,7 @@ func (nt *NT) printNotReadyContainerLogs(pod corev1.Pod) {
 		// Only print logs for containers that are not ready.
 		// The reconciler container's logs have been printed in testLogs, so ignore it.
 		if !cs.Ready && cs.Name != reconcilermanager.Reconciler {
-			args := []string{"logs", "pod", pod.GetName(), "-n", pod.GetNamespace(), "-c", cs.Name}
+			args := []string{"logs", pod.GetName(), "-n", pod.GetNamespace(), "-c", cs.Name}
 			cmd := fmt.Sprintf("kubectl %s", strings.Join(args, " "))
 			out, err := nt.Kubectl(args...)
 			if err != nil {


### PR DESCRIPTION
```
Usage:
  kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER] [options]
```
Removed unnecessary "pod" argument that was causing this error:
```
    nt.go:914: error running `kubectl logs pod ns-reconciler-bookinfo-6cfc9bff98-wn5gc -n config-management-system -c otel-agent`: exit status 1
        Error from server (NotFound): pods "pod" not found}
```