### PR TITLE
add wait for ready to kind cluster creation

### DIFF
--- a/e2e/nomostest/ntopts/kind.go
+++ b/e2e/nomostest/ntopts/kind.go
@@ -211,6 +211,8 @@ apiServer:
 			}),
 			// Retain nodes for debugging logs.
 			cluster.CreateWithRetain(true),
+			// Wait for cluster to be ready before proceeding
+			cluster.CreateWithWaitForReady(10*time.Minute),
 		)
 		if err == nil {
 			return nil


### PR DESCRIPTION
There is a flaky condition in the kind e2e tests where the nodes are not
yet available when the git server pod is created. This may be a race
condition where the nodes are not ready yet, so this change attempts to
address it by adding a wait for ready step to the cluster creation.