### PR TITLE
fix: Handle empty initContainers in pod resources

### DIFF
--- a/pkg/core/structured.go
+++ b/pkg/core/structured.go
@@ -15,7 +15,7 @@
 package core
 
 import (
-	"encoding/json"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -47,17 +47,12 @@ func init() {
 func RemarshalToStructured(u *unstructured.Unstructured) (runtime.Object, error) {
 	result, err := scheme.Scheme.New(u.GetObjectKind().GroupVersionKind())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get concrete type for object: %w", err)
 	}
 
-	jsn, err := u.MarshalJSON()
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), result)
 	if err != nil {
-		return nil, err
-	}
-
-	err = json.Unmarshal(jsn, result)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to convert resource to its concrete type: %w", err)
 	}
 
 	return result, nil

--- a/pkg/core/structured_test.go
+++ b/pkg/core/structured_test.go
@@ -18,13 +18,51 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/yaml"
 )
+
+var podResourceImplicitNull = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test
+spec:
+  containers:
+  - name: test-container
+    image: fake-image:latest
+  initContainers:
+
+`
+
+var podResourceExplicitNull = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test
+spec:
+  containers:
+  - name: test-container
+    image: fake-image:latest
+  initContainers: null
+`
+
+func fakePodWithNilInitContainers(res string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal([]byte(res), u); err != nil {
+		panic(err)
+	}
+
+	return u
+}
 
 func TestRemarshalToStructured(t *testing.T) {
 	testcases := []struct {
@@ -41,6 +79,16 @@ func TestRemarshalToStructured(t *testing.T) {
 			name: "v1beta1 RepoSync",
 			u:    fake.UnstructuredObject(kinds.RepoSyncV1Beta1(), core.Name(configsync.RepoSyncName), core.Namespace("test"), core.Annotations(nil), core.Labels(nil)),
 			obj:  fake.RepoSyncObjectV1Beta1("test", configsync.RepoSyncName),
+		},
+		{
+			name: "v1 Pod with empty initContainers to test nil marshalling - implicit",
+			u:    fakePodWithNilInitContainers(podResourceImplicitNull),
+			obj:  fake.PodObject("test-pod", []corev1.Container{{Name: "test-container", Image: "fake-image:latest"}}, core.Namespace("test")),
+		},
+		{
+			name: "v1 Pod with empty initContainers to test nil marshalling - explicit",
+			u:    fakePodWithNilInitContainers(podResourceExplicitNull),
+			obj:  fake.PodObject("test-pod", []corev1.Container{{Name: "test-container", Image: "fake-image:latest"}}, core.Namespace("test")),
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
When describing a pod, we can have the initContainers field to be null.
This causes an error when we use unstructured.NestedSlice to access this
field as the unstructured library tries to assert nil to []interface{},
but fails, since we can't assert a nil value to be of []interface{}.
This PR ignores empty initContainers since it can still be a valid
resource yaml. It also ignores an empty port field gracefully.

This PR also uses the official conversion library function to convert an
unstructured object to its concrete type for validation purposes.

Tested by running reconciler-manager on a live cluster.