### PR TITLE
fix lint-license-headers make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,8 @@ license-headers: "$(GOBIN)/addlicense"
 	"$(GOBIN)/addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE -ignore=vendor/** -ignore=third_party/** . 2>&1 | sed '/ skipping: / d'
 
 .PHONY: lint-license-headers
-lint-license-headers:
-	"$(GOBIN)/addlicense" -check -ignore=vendor/** -ignore=third_party/** . 2>&1 | sed '/ skipping: / d'
+lint-license-headers: "$(GOBIN)/addlicense"
+	GOBIN=$(GOBIN) ./scripts/lint-license-headers.sh
 
 lint-yaml:
 	@./scripts/lint-yaml.sh

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/scripts/lint-license-headers.sh
+++ b/scripts/lint-license-headers.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [ "${GOBIN:-"unset"}" == "unset" ]; then
+  echo "GOBIN unset"
+  exit 1
+fi
+
+"${GOBIN}/addlicense" -check -ignore=vendor/** -ignore=third_party/** -ignore=.output/** . 2>&1 | sed '/ skipping: / d'


### PR DESCRIPTION
the exit code was being lost in the previous make target due to the
pipe. This change moves the command to a bash script with pipefail
enabled so that the exit code is not lost.