### PR TITLE
[WIP] Use predicate to filter reconciles

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -82,15 +82,6 @@ type reconcilerBase struct {
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string
-
-	// lastReconciledResourceVersions is a cache of the last reconciled
-	// ResourceVersion for each R*Sync objects.
-	//
-	// This is used for an optimization to avoid re-reconciling.
-	// However, since ResourceVersion must be treated as opaque, we can't know
-	// if it's the latest or not. So this is just an optimization, not a guarantee.
-	// https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
-	lastReconciledResourceVersions map[types.NamespacedName]string
 }
 
 func (r *reconcilerBase) upsertServiceAccount(
@@ -443,36 +434,25 @@ func (r *reconcilerBase) addTemplateLabels(deployment *appsv1.Deployment, labelM
 	deployment.Spec.Template.Labels = currentLabels
 }
 
-// setLastReconciled sets the last resourceVersion that was fully reconciled for
-// a specific R*Sync object. This should only be set if the reconciler
-// successfully performed an update of the R*Sync in this reconcile attempt.
-func (r *reconcilerBase) setLastReconciled(nn types.NamespacedName, resourceVersion string) {
-	if r.lastReconciledResourceVersions == nil {
-		r.lastReconciledResourceVersions = make(map[types.NamespacedName]string)
+// addTypeInformationToObject adds TypeMeta information to a runtime.Object based upon the loaded scheme.Scheme
+// inspired by: https://github.com/kubernetes/cli-runtime/blob/v0.19.2/pkg/printers/typesetter.go#L41.
+// Note: The function only works for GVKs registered with the local scheme with exact version matching.
+func (r *reconcilerBase) addTypeInformationToObject(obj runtime.Object) error {
+	gvks, _, err := r.scheme.ObjectKinds(obj)
+	if err != nil {
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
 	}
-	r.lastReconciledResourceVersions[nn] = resourceVersion
-}
 
-// clearLastReconciled clears the last reconciled resourceVersion for a specific
-// R*Sync object. This should be called after a R*Sync is deleted.
-func (r *reconcilerBase) clearLastReconciled(nn types.NamespacedName) {
-	if r.lastReconciledResourceVersions == nil {
-		return
+	for _, gvk := range gvks {
+		if len(gvk.Kind) == 0 {
+			continue
+		}
+		if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
 	}
-	delete(r.lastReconciledResourceVersions, nn)
-}
 
-// isLastReconciled checks if a resourceVersion for a specific R*Sync object is
-// the same as last one that was reconciled. If true, reconciliation can safely
-// be skipped, because that resourceVersion is no longer the latest, and a new
-// reconcile should be queued to handle the latest.
-func (r *reconcilerBase) isLastReconciled(nn types.NamespacedName, resourceVersion string) bool {
-	if r.lastReconciledResourceVersions == nil {
-		return false
-	}
-	lastReconciled := r.lastReconciledResourceVersions[nn]
-	if lastReconciled == "" {
-		return false
-	}
-	return resourceVersion == lastReconciled
+	return nil
 }

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -2455,81 +2454,6 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := validateRepoSyncStatus(wantRs, fakeClient); err != nil {
 		t.Error(err)
 	}
-}
-
-func TestRepoSyncReconcileStaleClientCache(t *testing.T) {
-	rs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, testReconciler := setupNSReconciler(t, rs)
-	ctx := context.Background()
-
-	// Simulate ResourceVersion set by apiserver
-	rs.ResourceVersion = "1"
-	err := fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and update the RepoSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect Stalled condition with True status, because the RepoSync is invalid
-	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition := reposync.GetCondition(rs.Status.Conditions, v1beta1.RepoSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "KNV1061: RepoSyncs must specify spec.sourceType", "unexpected Stalled condition message")
-
-	// Expect next Reconcile to error since the ResourceVersion hasn't been updated.
-	// This means the client cache hasn't been updated and isn't returning the latest version.
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.Error(t, err, "expected Reconcile to error")
-	require.Equal(t, err.Error(), "ResourceVersion already reconciled: 1", "unexpected Reconcile error")
-
-	// Simulate ResourceVersion updated in the client cache by the
-	// reconciler-manager's resource watch from the apiserver
-	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	rs.ResourceVersion = "A" // doesn't need to be increasing or even numeric
-	err = fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and NOT update the RepoSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect the same Stalled condition error message
-	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition = reposync.GetCondition(rs.Status.Conditions, v1beta1.RepoSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "KNV1061: RepoSyncs must specify spec.sourceType", "unexpected Stalled condition message")
-
-	// Simulate a spec update, with ResourceVersion updated by the apiserver
-	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
-	rs.ResourceVersion = "2" // doesn't need to be increasing or even numeric
-	err = fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and update the RepoSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect Stalled condition with True status, because the RepoSync is differently invalid
-	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition = reposync.GetCondition(rs.Status.Conditions, v1beta1.RepoSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "RepoSyncs must specify spec.git when spec.sourceType is \"git\"", "unexpected Stalled condition message")
 }
 
 func validateRepoSyncStatus(want *v1beta1.RepoSync, fakeClient *syncerFake.Client) error {

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -2123,81 +2122,6 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := validateRootSyncStatus(wantRs, fakeClient); err != nil {
 		t.Error(err)
 	}
-}
-
-func TestRootSyncReconcileStaleClientCache(t *testing.T) {
-	rs := fake.RootSyncObjectV1Beta1(rootsyncName)
-	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, testReconciler := setupRootReconciler(t, rs)
-	ctx := context.Background()
-
-	// Simulate ResourceVersion set by apiserver
-	rs.ResourceVersion = "1"
-	err := fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and update the RootSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect Stalled condition with True status, because the RootSync is invalid
-	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition := rootsync.GetCondition(rs.Status.Conditions, v1beta1.RootSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "KNV1061: RootSyncs must specify spec.sourceType", "unexpected Stalled condition message")
-
-	// Expect next Reconcile to error since the ResourceVersion hasn't been updated.
-	// This means the client cache hasn't been updated and isn't returning the latest version.
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.Error(t, err, "expected Reconcile to error")
-	require.Equal(t, err.Error(), "ResourceVersion already reconciled: 1", "unexpected Reconcile error")
-
-	// Simulate ResourceVersion updated in the client cache by the
-	// reconciler-manager's resource watch from the apiserver
-	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	rs.ResourceVersion = "A" // doesn't need to be increasing or even numeric
-	err = fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and NOT update the RootSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect the same Stalled condition error message
-	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition = rootsync.GetCondition(rs.Status.Conditions, v1beta1.RootSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "KNV1061: RootSyncs must specify spec.sourceType", "unexpected Stalled condition message")
-
-	// Simulate a spec update, with ResourceVersion updated by the apiserver
-	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
-	rs.ResourceVersion = "2" // doesn't need to be increasing or even numeric
-	err = fakeClient.Update(ctx, rs)
-	require.NoError(t, err, "unexpected Update error")
-
-	// Reconcile should succeed and update the RootSync
-	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.NoError(t, err, "unexpected Reconcile error")
-
-	// Expect Stalled condition with True status, because the RootSync is differently invalid
-	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
-	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
-	require.NoError(t, err, "unexpected Get error")
-	reconcilingCondition = rootsync.GetCondition(rs.Status.Conditions, v1beta1.RootSyncStalled)
-	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
-	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
-	require.Contains(t, reconcilingCondition.Message, "RootSyncs must specify spec.git when spec.sourceType is \"git\"", "unexpected Stalled condition message")
 }
 
 func validateRootSyncStatus(want *v1beta1.RootSync, fakeClient *syncerFake.Client) error {


### PR DESCRIPTION
- Don't enqueue a reconcile if the ResourceVersion hasn't changed
- Remove lock and resourceVersion cache that was attempting to dedupe
  the hard way
- Reduce watch scope from cluster to namespace for Deployments and
  RootSync Secrets
- Add RootSync watch for managed ClusterRoleBindings (shared), to
  ensure that changes to the crb are reverted without needing to update
  another watched object.
- Add RootSync ownership for managed ServiceAccounts, to ensure that
  changes to the sa are reverted without needing to update another
  watched object.
