### PR TITLE
add dockerfile for docker-buildenv image

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -20,6 +20,20 @@ push-buildenv: build-buildenv
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
 	@docker push $(BUILDENV_IMAGE)
 
+GCB_DOCKER_GCLOUD_VERSION := v20220617-174ad91c3a
+GCP_DOCKER_GCLOUD_TAG := gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:$(GCB_DOCKER_GCLOUD_VERSION)
+DOCKER_BUILDENV_TAG ?= gcr.io/$(GCR_PREFIX)/docker-buildenv:$(GCB_DOCKER_GCLOUD_VERSION)
+# Build the docker-buildenv image that can be used for containerized building of Config Sync artifacts
+build-docker-buildenv: build/docker-buildenv/Dockerfile
+	@echo "+++ Creating the docker container for $(DOCKER_BUILDENV_TAG)"
+	@docker build $(DOCKER_BUILD_QUIET) build/docker-buildenv \
+ 		-t $(DOCKER_BUILDENV_TAG) \
+ 		--build-arg BASE_IMAGE=$(GCP_DOCKER_GCLOUD_TAG)
+# Push the docker-buildenv image
+push-docker-buildenv: build-docker-buildenv
+	@gcloud $(GCLOUD_QUIET) auth configure-docker
+	@docker push $(DOCKER_BUILDENV_TAG)
+
 .PHONY: install-kustomize
 # install kustomize binary
 install-kustomize:

--- a/build/docker-buildenv/Dockerfile
+++ b/build/docker-buildenv/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220617-174ad91c3a
+
+# Environment to build the helper binaries from.
+FROM ${BASE_IMAGE} AS docker-buildenv
+
+RUN apk add rsync
+
+RUN gcloud components install gsutil
+


### PR DESCRIPTION
Add a dockerfile that can be used for running the make targets for
building Config Sync artifacts, such as make config-sync-manifest. This
is intended for use in CI to build Config Sync artifacts.