### PR TITLE
reconciler-manager cleanup

### DIFF
--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -1587,10 +1586,7 @@ func TestMapSecretToRootSyncs(t *testing.T) {
 		requests := make([]reconcile.Request, len(rootSyncs[secretName]))
 		for i, rs := range rootSyncs[secretName] {
 			requests[i] = reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      rs.GetName(),
-					Namespace: rs.GetNamespace(),
-				},
+				NamespacedName: client.ObjectKeyFromObject(rs),
 			}
 		}
 		return requests

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -190,7 +191,8 @@ func TestCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sKey, err := upsertAuthSecret(context.Background(), tc.reposync, tc.client, nsReconcilerKey)
+			log := logr.Discard()
+			sKey, err := upsertAuthSecret(context.Background(), log, tc.reposync, tc.client, nsReconcilerKey)
 			assert.Equal(t, tc.wantKey, sKey, "unexpected secret key returned")
 			if tc.wantError {
 				assert.Error(t, err, "expected upsertSecrets to error")


### PR DESCRIPTION
- Make logs a little more consistent
- Add a few missing logs to catch all managed object upserts
- Log namespace/name instead of the raw NamespacedName object
- Use -Ref for ObjectKey and NamespacedName variable names
- Reduce number of pointers to types objects, where possible.