### PR TITLE
Change helm.values field type from unstructured to JSON

### DIFF
--- a/e2e/testcases/csr_auth_test.go
+++ b/e2e/testcases/csr_auth_test.go
@@ -288,7 +288,7 @@ func testWorkloadIdentity(t *testing.T, testSpec workloadIdentityTestSpec) {
 		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"dir": "%s", "image": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s"}, "git": null}}`,
 			v1beta1.OciSource, tenant, testSpec.sourceRepo, testSpec.gsaEmail))
 	case v1beta1.HelmSource:
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"chart": "%s", "repo": "%s", "version": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "releaseName": "my-coredns", "namespace": "coredns"}, "git": null}}`,
+		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"chart": "%s", "repo": "%s", "version": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "releaseName": "my-coredns", "namespace": "coredns", "values": {"image.pullPolicy": "Always"}}, "git": null}}`,
 			v1beta1.HelmSource, testSpec.sourceChart, testSpec.sourceRepo, testSpec.sourceVersion, testSpec.gsaEmail))
 	}
 
@@ -301,7 +301,7 @@ func testWorkloadIdentity(t *testing.T, testSpec workloadIdentityTestSpec) {
 		nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(testSpec.rootCommitFn),
 			nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: testSpec.sourceChart}))
 		if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
-			containerImagePullPolicy("IfNotPresent")); err != nil {
+			containerImagePullPolicy("Always")); err != nil {
 			nt.T.Error(err)
 		}
 	} else {

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -216,7 +216,7 @@ spec:
                   values:
                     description: values to use instead of default values that accompany
                       the chart
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   version:
                     description: version is the chart version. If this is not specified,
                       the latest version is used
@@ -1183,7 +1183,7 @@ spec:
                   values:
                     description: values to use instead of default values that accompany
                       the chart
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   version:
                     description: version is the chart version. If this is not specified,
                       the latest version is used

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -216,7 +216,7 @@ spec:
                   values:
                     description: values to use instead of default values that accompany
                       the chart
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   version:
                     description: version is the chart version. If this is not specified,
                       the latest version is used
@@ -1183,7 +1183,7 @@ spec:
                   values:
                     description: values to use instead of default values that accompany
                       the chart
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   version:
                     description: version is the chart version. If this is not specified,
                       the latest version is used

--- a/pkg/api/configsync/v1alpha1/helmconfig.go
+++ b/pkg/api/configsync/v1alpha1/helmconfig.go
@@ -15,8 +15,8 @@
 package v1alpha1
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/api/configsync"
 )
 
@@ -42,7 +42,7 @@ type Helm struct {
 
 	// values to use instead of default values that accompany the chart
 	// +optional
-	Values *unstructured.Unstructured `json:"values,omitempty"`
+	Values *apiextensionsv1.JSON `json:"values,omitempty"`
 
 	// includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
 	// If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -15,8 +15,8 @@
 package v1beta1
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/api/configsync"
 )
 
@@ -42,7 +42,7 @@ type Helm struct {
 
 	// values to use instead of default values that accompany the chart
 	// +optional
-	Values *unstructured.Unstructured `json:"values,omitempty"`
+	Values *apiextensionsv1.JSON `json:"values,omitempty"`
 
 	// includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
 	// If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.


### PR DESCRIPTION
This change is to resolve the issue that kubebuilder does not work with
map[string]interface{} and consider unstructured type as Object.

apiextentionsv1.JSON represents any valid JSON value, it supports
map[string]interface{}. After change the field type, user will be able to set the values in this format:
values: {key : val}