### PR TITLE
rc tag creation separate from rc build

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -9,11 +9,9 @@ __tag-release-candidate:
 	CS_VERSION="$(CS_VERSION)" ./scripts/tag-release-candidate.sh
 
 .PHONY: __build-release-candidate
-__build-release-candidate: __tag-release-candidate
+__build-release-candidate:
 	@echo "+++ Building release candidate"
 	@$(eval GCR_PREFIX := "config-management-release")
-	@test -n "$(CS_VERSION)" || (echo "CS_VERSION unset" ; exit 1)
-	$(eval RC_TAG != git tag --points-at "HEAD" --list "$(CS_VERSION)-rc.*" | sort -V | tail -n 1)
 	@test -n "$(RC_TAG)" || (echo "RC_TAG unset" ; exit 1)
 
 	$(MAKE) config-sync-manifest \

--- a/scripts/tag-release-candidate.sh
+++ b/scripts/tag-release-candidate.sh
@@ -98,6 +98,13 @@ echo "+++ Most recent RC of version $CS_VERSION: $RC"
 NEXT_RC=$(increment_rc_of_semver "$RC")
 echo "+++ Incremented RC.  NEXT_RC: $NEXT_RC"
 
+read -rp "This will create ${NEXT_RC} - Proceed (yes/no)? " choice
+case "${choice}" in
+  yes) ;;
+  no) exit 1 ;;
+  *) err "Unrecognized choice ${choice}"
+esac
+
 git tag -a "$NEXT_RC" -m "Release candidate $NEXT_RC"
 echo "+++ Successfully tagged commit $(git rev-parse HEAD) as ${NEXT_RC}"
 


### PR DESCRIPTION
This change separates the creation of RC tagging from the building of
the RC artifacts. This makes the targets a bit for flexible and enables
the use of tag-based triggers to run the RC build step.

A prompt is added to the RC tagging target with the intent of making it
an interactive step.