### PR TITLE
remove exclusion of acm-psp from oss manifest

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -246,7 +246,6 @@ __config-sync-manifest-oss:
 		--exclude='admission-webhook.yaml' \
 		.output/deployment/* .output/oss/cloned/deployment/
 	rsync \
-		--exclude='acm-psp.yaml' \
 		--exclude='policy-controller-psp.yaml' \
 		--exclude='cluster-config-crd.yaml' \
 		--exclude='hierarchyconfig-crd.yaml' \


### PR DESCRIPTION
This ensures CS works on clusters with PSP enabled. Although PSP is
deprecated, there might still be users for it until we stop supporting
GKE versions older than 1.25.