### PR TITLE
register the status reader for rollout objects

### DIFF
--- a/e2e/testcases/rollout_test.go
+++ b/e2e/testcases/rollout_test.go
@@ -1,0 +1,137 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ArgoRolloutNS = "argo-rollouts"
+	RolloutNS     = "rollout"
+)
+
+func TestRolloutResourcesOnCSR(t *testing.T) {
+	nt := nomostest.New(
+		t,
+		ntopts.SkipMonoRepo,
+		ntopts.NamespaceRepo(ArgoRolloutNS, configsync.RepoSyncName),
+		ntopts.NamespaceRepo(RolloutNS, configsync.RepoSyncName),
+	)
+
+	// Get the absolute path of the rollout testdata
+	testDataDir, err := filepath.Abs("../testdata/rollout/")
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// install argo rollouts
+	nn := nomostest.RepoSyncNN(ArgoRolloutNS, configsync.RepoSyncName)
+	repo, exist := nt.NonRootRepos[nn]
+	if !exist {
+		nt.T.Fatal("nonexistent repo")
+	}
+	repo.Copy(filepath.Join(testDataDir, "install.yaml"), "acme/namespaces/argo-rollouts")
+	repo.CommitAndPush("install Argo Rollouts in the argo-rollouts namespace")
+	nt.WaitForRepoSyncs()
+
+	// sync with initial config
+	nn = nomostest.RepoSyncNN(RolloutNS, configsync.RepoSyncName)
+	repo, exist = nt.NonRootRepos[nn]
+	if !exist {
+		nt.T.Fatal("nonexistent repo")
+	}
+	repo.Copy(filepath.Join(testDataDir, "rollout-blue.yaml"), "acme/namespaces/rollout/rollout.yaml")
+	repo.Copy(filepath.Join(testDataDir, "service.yaml"), "acme/namespaces/rollout/service.yaml")
+	repo.Copy(filepath.Join(testDataDir, "test-success.yaml"), "acme/namespaces/rollout/test.yaml")
+	repo.CommitAndPush("initial config")
+	nt.WaitForRepoSyncs()
+
+	// Verify that the Rollout object is in the desired state.
+	// We do not need to verify the analysisTemplate object
+	// as it does not have a status specification
+	// it will always in the Current status
+	gvkRollout := schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Rollout",
+	}
+
+	// First update needs to be healthy
+	validateRolloutResourceHealthy(nt, gvkRollout, "rollouts-demo", RolloutNS)
+
+	// Update the image tag in the rollout.yaml
+	repo.Copy(filepath.Join(testDataDir, "rollout-yellow.yaml"), "acme/namespaces/rollout/rollout.yaml")
+	repo.CommitAndPush("update the image tag to yellow")
+	nt.WaitForRepoSyncs()
+
+	// Analysis should succeed, so the rollout object needs to be Healthy
+	validateRolloutResourceHealthy(nt, gvkRollout, "rollouts-demo", RolloutNS)
+
+	// Update the rollout.yaml and test.yaml
+	repo.Copy(filepath.Join(testDataDir, "rollout-blue.yaml"), "acme/namespaces/rollout/rollout.yaml")
+	repo.Copy(filepath.Join(testDataDir, "test-failed.yaml"), "acme/namespaces/rollout/test.yaml")
+	repo.CommitAndPush("update the image tag to blue and force the analysis runs failed")
+	nt.WaitForRepoSyncs()
+
+	// Analysis should fail, so the rollout object needs to be Degraded
+	validateRolloutResourceDegraded(nt, gvkRollout, "rollouts-demo", RolloutNS)
+
+}
+
+func validateRolloutResourceHealthy(nt *nomostest.NT, gvk schema.GroupVersionKind, name, namespace string) {
+	nomostest.Wait(nt.T, fmt.Sprintf("wait for rollout resources %q %v to be healthty", name, gvk),
+		nt.DefaultWaitTimeout, func() error {
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(gvk)
+			return nt.Validate(name, namespace, u, rolloutResourceHealthy)
+		})
+}
+
+func validateRolloutResourceDegraded(nt *nomostest.NT, gvk schema.GroupVersionKind, name, namespace string) {
+	nomostest.Wait(nt.T, fmt.Sprintf("wait for rollout resources %q %v to be degraded", name, gvk),
+		nt.DefaultWaitTimeout, func() error {
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(gvk)
+			return nt.Validate(name, namespace, u, rolloutResourceDegraded)
+		})
+}
+
+func rolloutResourceHealthy(o client.Object) error {
+	u := o.(*unstructured.Unstructured)
+	phase, found, err := unstructured.NestedString(u.Object, "status", "phase")
+	if err != nil || !found || phase != "Healthy" {
+		return fmt.Errorf(".status.phase not found %v", err)
+	}
+	return nil
+}
+
+func rolloutResourceDegraded(o client.Object) error {
+	u := o.(*unstructured.Unstructured)
+	phase, found, err := unstructured.NestedString(u.Object, "status", "phase")
+	if err != nil || !found || phase != "Degraded" {
+		return fmt.Errorf(".status.phase not found %v", err)
+	}
+	return nil
+}

--- a/e2e/testdata/rollout/install.yaml
+++ b/e2e/testdata/rollout/install.yaml
@@ -1,0 +1,14709 @@
+# This is an auto-generated file. DO NOT EDIT
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: analysisruns.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AnalysisRun
+    listKind: AnalysisRunList
+    plural: analysisruns
+    shortNames:
+    - ar
+    singular: analysisrun
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: AnalysisRun status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+              terminate:
+                type: boolean
+            required:
+            - metrics
+            type: object
+          status:
+            properties:
+              dryRunSummary:
+                properties:
+                  count:
+                    format: int32
+                    type: integer
+                  error:
+                    format: int32
+                    type: integer
+                  failed:
+                    format: int32
+                    type: integer
+                  inconclusive:
+                    format: int32
+                    type: integer
+                  successful:
+                    format: int32
+                    type: integer
+                type: object
+              message:
+                type: string
+              metricResults:
+                items:
+                  properties:
+                    consecutiveError:
+                      format: int32
+                      type: integer
+                    count:
+                      format: int32
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    error:
+                      format: int32
+                      type: integer
+                    failed:
+                      format: int32
+                      type: integer
+                    inconclusive:
+                      format: int32
+                      type: integer
+                    measurements:
+                      items:
+                        properties:
+                          finishedAt:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          phase:
+                            type: string
+                          resumeAt:
+                            format: date-time
+                            type: string
+                          startedAt:
+                            format: date-time
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - phase
+                        type: object
+                      type: array
+                    message:
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                    successful:
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+              phase:
+                type: string
+              runSummary:
+                properties:
+                  count:
+                    format: int32
+                    type: integer
+                  error:
+                    format: int32
+                    type: integer
+                  failed:
+                    format: int32
+                    type: integer
+                  inconclusive:
+                    format: int32
+                    type: integer
+                  successful:
+                    format: int32
+                    type: integer
+                type: object
+              startedAt:
+                format: date-time
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: analysistemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AnalysisTemplate
+    listKind: AnalysisTemplateList
+    plural: analysistemplates
+    shortNames:
+    - at
+    singular: analysistemplate
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+            required:
+            - metrics
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: clusteranalysistemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ClusterAnalysisTemplate
+    listKind: ClusterAnalysisTemplateList
+    plural: clusteranalysistemplates
+    shortNames:
+    - cat
+    singular: clusteranalysistemplate
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+            required:
+            - metrics
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: experiments.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Experiment
+    listKind: ExperimentList
+    plural: experiments
+    shortNames:
+    - exp
+    singular: experiment
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Experiment status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analyses:
+                items:
+                  properties:
+                    args:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              fieldRef:
+                                properties:
+                                  fieldPath:
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    clusterScope:
+                      type: boolean
+                    name:
+                      type: string
+                    requiredForCompletion:
+                      type: boolean
+                    templateName:
+                      type: string
+                  required:
+                  - name
+                  - templateName
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              duration:
+                type: string
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              progressDeadlineSeconds:
+                format: int32
+                type: integer
+              scaleDownDelaySeconds:
+                format: int32
+                type: integer
+              templates:
+                items:
+                  properties:
+                    minReadySeconds:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    replicas:
+                      format: int32
+                      type: integer
+                    selector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    service:
+                      type: object
+                    template:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            activeDeadlineSeconds:
+                              format: int64
+                              type: integer
+                            affinity:
+                              properties:
+                                nodeAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          preference:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      properties:
+                                        nodeSelectorTerms:
+                                          items:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              type: boolean
+                            containers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      requests:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            dnsConfig:
+                              properties:
+                                nameservers:
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              type: string
+                            enableServiceLinks:
+                              type: boolean
+                            ephemeralContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      requests:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  targetContainerName:
+                                    type: string
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              items:
+                                properties:
+                                  hostnames:
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              type: boolean
+                            hostNetwork:
+                              type: boolean
+                            hostPID:
+                              type: boolean
+                            hostname:
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      requests:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            nodeName:
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            preemptionPolicy:
+                              type: string
+                            priority:
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              type: string
+                            readinessGates:
+                              items:
+                                properties:
+                                  conditionType:
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              type: string
+                            runtimeClassName:
+                              type: string
+                            schedulerName:
+                              type: string
+                            securityContext:
+                              properties:
+                                fsGroup:
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  type: string
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              type: string
+                            serviceAccountName:
+                              type: string
+                            setHostnameAsFQDN:
+                              type: boolean
+                            shareProcessNamespace:
+                              type: boolean
+                            subdomain:
+                              type: string
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            tolerations:
+                              items:
+                                properties:
+                                  effect:
+                                    type: string
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  tolerationSeconds:
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    type: string
+                                  whenUnsatisfiable:
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - selector
+                  - template
+                  type: object
+                type: array
+              terminate:
+                type: boolean
+            required:
+            - templates
+            type: object
+          status:
+            properties:
+              analysisRuns:
+                items:
+                  properties:
+                    analysisRun:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                  required:
+                  - analysisRun
+                  - name
+                  - phase
+                  type: object
+                type: array
+              availableAt:
+                format: date-time
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              phase:
+                type: string
+              templateStatuses:
+                items:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    collisionCount:
+                      format: int32
+                      type: integer
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    podTemplateHash:
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    serviceName:
+                      type: string
+                    status:
+                      type: string
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  required:
+                  - availableReplicas
+                  - name
+                  - readyReplicas
+                  - replicas
+                  - updatedReplicas
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: rollouts.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Rollout
+    listKind: RolloutList
+    plural: rollouts
+    shortNames:
+    - ro
+    singular: rollout
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of desired pods
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Total number of non-terminated pods targeted by this rollout
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: Total number of non-terminated pods targeted by this rollout that
+        have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Up-to-date
+      type: integer
+    - description: Total number of available pods (ready for at least minReadySeconds)
+        targeted by this rollout
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analysis:
+                properties:
+                  successfulRunHistoryLimit:
+                    format: int32
+                    type: integer
+                  unsuccessfulRunHistoryLimit:
+                    format: int32
+                    type: integer
+                type: object
+              minReadySeconds:
+                format: int32
+                type: integer
+              paused:
+                type: boolean
+              progressDeadlineAbort:
+                type: boolean
+              progressDeadlineSeconds:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              restartAt:
+                format: date-time
+                type: string
+              revisionHistoryLimit:
+                format: int32
+                type: integer
+              selector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              strategy:
+                properties:
+                  blueGreen:
+                    properties:
+                      abortScaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                      activeMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      activeService:
+                        type: string
+                      antiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            type: object
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                        type: object
+                      autoPromotionEnabled:
+                        type: boolean
+                      autoPromotionSeconds:
+                        format: int32
+                        type: integer
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      postPromotionAnalysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          dryRun:
+                            items:
+                              properties:
+                                metricName:
+                                  type: string
+                              required:
+                              - metricName
+                              type: object
+                            type: array
+                          measurementRetention:
+                            items:
+                              properties:
+                                limit:
+                                  format: int32
+                                  type: integer
+                                metricName:
+                                  type: string
+                              required:
+                              - limit
+                              - metricName
+                              type: object
+                            type: array
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      prePromotionAnalysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          dryRun:
+                            items:
+                              properties:
+                                metricName:
+                                  type: string
+                              required:
+                              - metricName
+                              type: object
+                            type: array
+                          measurementRetention:
+                            items:
+                              properties:
+                                limit:
+                                  format: int32
+                                  type: integer
+                                metricName:
+                                  type: string
+                              required:
+                              - limit
+                              - metricName
+                              type: object
+                            type: array
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      previewMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      previewReplicaCount:
+                        format: int32
+                        type: integer
+                      previewService:
+                        type: string
+                      scaleDownDelayRevisionLimit:
+                        format: int32
+                        type: integer
+                      scaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                    required:
+                    - activeService
+                    type: object
+                  canary:
+                    properties:
+                      abortScaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                      analysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          dryRun:
+                            items:
+                              properties:
+                                metricName:
+                                  type: string
+                              required:
+                              - metricName
+                              type: object
+                            type: array
+                          measurementRetention:
+                            items:
+                              properties:
+                                limit:
+                                  format: int32
+                                  type: integer
+                                metricName:
+                                  type: string
+                              required:
+                              - limit
+                              - metricName
+                              type: object
+                            type: array
+                          startingStep:
+                            format: int32
+                            type: integer
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      antiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            type: object
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                        type: object
+                      canaryMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      canaryService:
+                        type: string
+                      dynamicStableScale:
+                        type: boolean
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      pingPong:
+                        properties:
+                          pingService:
+                            type: string
+                          pongService:
+                            type: string
+                        required:
+                        - pingService
+                        - pongService
+                        type: object
+                      scaleDownDelayRevisionLimit:
+                        format: int32
+                        type: integer
+                      scaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                      stableMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      stableService:
+                        type: string
+                      steps:
+                        items:
+                          properties:
+                            analysis:
+                              properties:
+                                args:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          podTemplateHashValue:
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                dryRun:
+                                  items:
+                                    properties:
+                                      metricName:
+                                        type: string
+                                    required:
+                                    - metricName
+                                    type: object
+                                  type: array
+                                measurementRetention:
+                                  items:
+                                    properties:
+                                      limit:
+                                        format: int32
+                                        type: integer
+                                      metricName:
+                                        type: string
+                                    required:
+                                    - limit
+                                    - metricName
+                                    type: object
+                                  type: array
+                                templates:
+                                  items:
+                                    properties:
+                                      clusterScope:
+                                        type: boolean
+                                      templateName:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            experiment:
+                              properties:
+                                analyses:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                podTemplateHashValue:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      clusterScope:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      requiredForCompletion:
+                                        type: boolean
+                                      templateName:
+                                        type: string
+                                    required:
+                                    - name
+                                    - templateName
+                                    type: object
+                                  type: array
+                                duration:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      name:
+                                        type: string
+                                      replicas:
+                                        format: int32
+                                        type: integer
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      specRef:
+                                        type: string
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - name
+                                    - specRef
+                                    type: object
+                                  type: array
+                              required:
+                              - templates
+                              type: object
+                            pause:
+                              properties:
+                                duration:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            setCanaryScale:
+                              properties:
+                                matchTrafficWeight:
+                                  type: boolean
+                                replicas:
+                                  format: int32
+                                  type: integer
+                                weight:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            setWeight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      trafficRouting:
+                        properties:
+                          alb:
+                            properties:
+                              annotationPrefix:
+                                type: string
+                              ingress:
+                                type: string
+                              rootService:
+                                type: string
+                              servicePort:
+                                format: int32
+                                type: integer
+                              stickinessConfig:
+                                properties:
+                                  durationSeconds:
+                                    format: int64
+                                    type: integer
+                                  enabled:
+                                    type: boolean
+                                required:
+                                - durationSeconds
+                                - enabled
+                                type: object
+                            required:
+                            - ingress
+                            - servicePort
+                            type: object
+                          ambassador:
+                            properties:
+                              mappings:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - mappings
+                            type: object
+                          appMesh:
+                            properties:
+                              virtualNodeGroup:
+                                properties:
+                                  canaryVirtualNodeRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  stableVirtualNodeRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                required:
+                                - canaryVirtualNodeRef
+                                - stableVirtualNodeRef
+                                type: object
+                              virtualService:
+                                properties:
+                                  name:
+                                    type: string
+                                  routes:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          istio:
+                            properties:
+                              destinationRule:
+                                properties:
+                                  canarySubsetName:
+                                    type: string
+                                  name:
+                                    type: string
+                                  stableSubsetName:
+                                    type: string
+                                required:
+                                - canarySubsetName
+                                - name
+                                - stableSubsetName
+                                type: object
+                              virtualService:
+                                properties:
+                                  name:
+                                    type: string
+                                  routes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlsRoutes:
+                                    items:
+                                      properties:
+                                        port:
+                                          format: int64
+                                          type: integer
+                                        sniHosts:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - name
+                                type: object
+                              virtualServices:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    routes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tlsRoutes:
+                                      items:
+                                        properties:
+                                          port:
+                                            format: int64
+                                            type: integer
+                                          sniHosts:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          nginx:
+                            properties:
+                              additionalIngressAnnotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              annotationPrefix:
+                                type: string
+                              stableIngress:
+                                type: string
+                            required:
+                            - stableIngress
+                            type: object
+                          smi:
+                            properties:
+                              rootService:
+                                type: string
+                              trafficSplitName:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              template:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        type: boolean
+                      containers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dnsConfig:
+                        properties:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      enableServiceLinks:
+                        type: boolean
+                      ephemeralContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            targetContainerName:
+                              type: string
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      hostAliases:
+                        items:
+                          properties:
+                            hostnames:
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              type: string
+                          type: object
+                        type: array
+                      hostIPC:
+                        type: boolean
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      hostname:
+                        type: string
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      initContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                requests:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      nodeName:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      os:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      preemptionPolicy:
+                        type: string
+                      priority:
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        type: string
+                      readinessGates:
+                        items:
+                          properties:
+                            conditionType:
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        type: string
+                      runtimeClassName:
+                        type: string
+                      schedulerName:
+                        type: string
+                      securityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      setHostnameAsFQDN:
+                        type: boolean
+                      shareProcessNamespace:
+                        type: boolean
+                      subdomain:
+                        type: string
+                      terminationGracePeriodSeconds:
+                        format: int64
+                        type: integer
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        items:
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                    required:
+                    - containers
+                    type: object
+                type: object
+              workloadRef:
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              HPAReplicas:
+                format: int32
+                type: integer
+              abort:
+                type: boolean
+              abortedAt:
+                format: date-time
+                type: string
+              alb:
+                properties:
+                  canaryTargetGroup:
+                    properties:
+                      arn:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - arn
+                    - name
+                    type: object
+                  loadBalancer:
+                    properties:
+                      arn:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - arn
+                    - name
+                    type: object
+                  stableTargetGroup:
+                    properties:
+                      arn:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - arn
+                    - name
+                    type: object
+                type: object
+              availableReplicas:
+                format: int32
+                type: integer
+              blueGreen:
+                properties:
+                  activeSelector:
+                    type: string
+                  postPromotionAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  prePromotionAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  previewSelector:
+                    type: string
+                  scaleUpPreviewCheckPoint:
+                    type: boolean
+                type: object
+              canary:
+                properties:
+                  currentBackgroundAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  currentExperiment:
+                    type: string
+                  currentStepAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  stablePingPong:
+                    type: string
+                  weights:
+                    properties:
+                      additional:
+                        items:
+                          properties:
+                            podTemplateHash:
+                              type: string
+                            serviceName:
+                              type: string
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - weight
+                          type: object
+                        type: array
+                      canary:
+                        properties:
+                          podTemplateHash:
+                            type: string
+                          serviceName:
+                            type: string
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        type: object
+                      stable:
+                        properties:
+                          podTemplateHash:
+                            type: string
+                          serviceName:
+                            type: string
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        type: object
+                      verified:
+                        type: boolean
+                    required:
+                    - canary
+                    - stable
+                    type: object
+                type: object
+              collisionCount:
+                format: int32
+                type: integer
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerPause:
+                type: boolean
+              currentPodHash:
+                type: string
+              currentStepHash:
+                type: string
+              currentStepIndex:
+                format: int32
+                type: integer
+              message:
+                type: string
+              observedGeneration:
+                type: string
+              pauseConditions:
+                items:
+                  properties:
+                    reason:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                  required:
+                  - reason
+                  - startTime
+                  type: object
+                type: array
+              phase:
+                type: string
+              promoteFull:
+                type: boolean
+              readyReplicas:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              restartedAt:
+                format: date-time
+                type: string
+              selector:
+                type: string
+              stableRS:
+                type: string
+              updatedReplicas:
+                format: int32
+                type: integer
+              workloadObservedGeneration:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.HPAReplicas
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/name: argo-rollouts
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/name: argo-rollouts
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/status
+  - rollouts/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
+  - analysisruns/finalizers
+  - experiments
+  - experiments/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysistemplates
+  - clusteranalysistemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  - apps
+  resources:
+  - deployments
+  - podtemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - destinationrules
+  verbs:
+  - watch
+  - get
+  - update
+  - patch
+  - list
+- apiGroups:
+  - split.smi-spec.io
+  resources:
+  - trafficsplits
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - patch
+- apiGroups:
+  - getambassador.io
+  - x.getambassador.io
+  resources:
+  - mappings
+  - ambassadormappings
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - targetgroupbindings
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
+  - virtualservices
+  verbs:
+  - watch
+  - get
+  - list
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
+  - virtualnodes
+  - virtualrouters
+  verbs:
+  - watch
+  - get
+  - list
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-admin
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: argo-rollouts-aggregate-to-admin
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-edit
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-rollouts-aggregate-to-edit
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - rollouts/status
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name: argo-rollouts-aggregate-to-view
+    app.kubernetes.io/part-of: argo-rollouts
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-rollouts-aggregate-to-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - rollouts/scale
+  - experiments
+  - analysistemplates
+  - clusteranalysistemplates
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/name: argo-rollouts
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-rollouts
+subjects:
+- kind: ServiceAccount
+  name: argo-rollouts
+  namespace: argo-rollouts
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-rollouts-notification-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argo-rollouts-metrics
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8090
+    protocol: TCP
+    targetPort: 8090
+  selector:
+    app.kubernetes.io/name: argo-rollouts
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: rollouts-controller
+    app.kubernetes.io/name: argo-rollouts
+    app.kubernetes.io/part-of: argo-rollouts
+  name: argo-rollouts
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-rollouts
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argo-rollouts
+    spec:
+      containers:
+      - image: quay.io/argoproj/argo-rollouts:v1.2.2
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: argo-rollouts
+        ports:
+        - containerPort: 8090
+          name: metrics
+        - containerPort: 8080
+          name: healthz
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 4
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: argo-rollouts

--- a/e2e/testdata/rollout/rollout-blue.yaml
+++ b/e2e/testdata/rollout/rollout-blue.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  replicas: 1
+  strategy:
+    canary:
+      steps:
+      - setWeight: 20
+      - pause: {duration: 10}
+      - analysis:
+          templates:
+          - templateName: simpletest
+      - setWeight: 40
+      - pause: {duration: 10}
+      - setWeight: 60
+      - pause: {duration: 10}
+      - setWeight: 80
+      - pause: {duration: 10}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: argoproj/rollouts-demo:blue
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 5m

--- a/e2e/testdata/rollout/rollout-yellow.yaml
+++ b/e2e/testdata/rollout/rollout-yellow.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  replicas: 1
+  strategy:
+    canary:
+      steps:
+      - setWeight: 20
+      - pause: {duration: 10}
+      - analysis:
+          templates:
+          - templateName: simpletest
+      - setWeight: 40
+      - pause: {duration: 10}
+      - setWeight: 60
+      - pause: {duration: 10}
+      - setWeight: 80
+      - pause: {duration: 10}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+      - name: rollouts-demo
+        image: argoproj/rollouts-demo:yellow
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 5m

--- a/e2e/testdata/rollout/service.yaml
+++ b/e2e/testdata/rollout/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollouts-demo
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: rollouts-demo

--- a/e2e/testdata/rollout/test-failed.yaml
+++ b/e2e/testdata/rollout/test-failed.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: simpletest
+spec:
+  metrics:
+  - name: simpletest
+    provider:
+      job:
+        spec:
+          backoffLimit: 1
+          template:
+            spec:
+              containers:
+              - name: simpletest
+                image: debian:stable-slim
+                command: ["/bin/sh"]
+                args: ["-c", "exit 1"]
+              restartPolicy: Never

--- a/e2e/testdata/rollout/test-success.yaml
+++ b/e2e/testdata/rollout/test-success.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: simpletest
+spec:
+  metrics:
+  - name: simpletest
+    provider:
+      job:
+        spec:
+          backoffLimit: 1
+          template:
+            spec:
+              containers:
+              - name: simpletest
+                image: debian:stable-slim
+                command: ["/bin/sh"]
+                args: ["-c", "exit 0"]
+              restartPolicy: Never


### PR DESCRIPTION
This change utilizes the new functions in cli-utils and kpt to register the status reader for rollout objects in the applier builder.
Note: since it depends on the new version of cli-utils and kpt, this PR can be tested only after the new dependencies are released and imported.