### PR TITLE
Allow other declared resources in the config-management-system namespace

### DIFF
--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -200,8 +200,6 @@ func Generate() AllExamples {
 
 	// 1034
 	result.add(nonhierarchical.IllegalNamespace(fake.Namespace("namespaces/" + configmanagement.ControllerNamespace)))
-	result.add(nonhierarchical.ObjectInIllegalNamespace(fake.RoleAtPath("namespaces/"+configmanagement.ControllerNamespace+"/role.yaml",
-		core.Namespace("namespaces/"+configmanagement.ControllerNamespace))))
 
 	// 1035 is Deprecated.
 	result.markDeprecated("1035")

--- a/e2e/testdata/object-in-cms-namespace/cmsconfigmap.yaml
+++ b/e2e/testdata/object-in-cms-namespace/cmsconfigmap.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cms-configmap
+  namespace: config-management-system
+  annotations:
+    comments: "Configmap created in CMS namespace"
+data:
+  action: "30"
+  documentary: "5"
+  sci_fi: "1000"

--- a/e2e/testdata/object-in-cms-namespace/cmsrole.yaml
+++ b/e2e/testdata/object-in-cms-namespace/cmsrole.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+   name: cms-roles
+   namespace: config-management-system
+   annotations:
+    comments: "Role created in CMS namespace"
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list"]

--- a/pkg/importer/analyzer/validation/nonhierarchical/illegal_namespace_validator.go
+++ b/pkg/importer/analyzer/validation/nonhierarchical/illegal_namespace_validator.go
@@ -16,7 +16,6 @@ package nonhierarchical
 
 import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
-	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,14 +24,6 @@ import (
 const IllegalNamespaceErrorCode = "1034"
 
 var illegalNamespaceError = status.NewErrorBuilder(IllegalNamespaceErrorCode)
-
-// ObjectInIllegalNamespace reports that an object has been declared in an illegal Namespace.
-func ObjectInIllegalNamespace(resource client.Object) status.Error {
-	return illegalNamespaceError.
-		Sprintf("Only %s configs are allowed in the %q namespace",
-			kinds.RootSyncV1Beta1().Kind, configmanagement.ControllerNamespace).
-		BuildWithResources(resource)
-}
 
 // IllegalNamespace reports that the config-management-system Namespace MUST NOT be declared.
 func IllegalNamespace(resource client.Object) status.Error {

--- a/pkg/validate/raw/validate/namespace_validator.go
+++ b/pkg/validate/raw/validate/namespace_validator.go
@@ -27,7 +27,6 @@ import (
 // to the following rules:
 // - if the object is a Namespace, it must not be `config-management-system`
 // - if the object has a metadata namespace, it must be a valid k8s namespace
-//   and it must not be in `config-management-system`
 func Namespace(obj ast.FileObject) status.Error {
 	if obj.GetObjectKind().GroupVersionKind().GroupKind() == kinds.Namespace().GroupKind() {
 		return validateNamespace(obj)
@@ -52,10 +51,6 @@ func validateObjectNamespace(obj ast.FileObject) status.Error {
 	}
 	if !isValidNamespace(ns) {
 		return nonhierarchical.InvalidNamespaceError(obj)
-	}
-	if configmanagement.IsControllerNamespace(ns) &&
-		obj.GetKind() != kinds.RootSyncV1Beta1().Kind {
-		return nonhierarchical.ObjectInIllegalNamespace(obj)
 	}
 	return nil
 }

--- a/pkg/validate/raw/validate/namespace_validator_test.go
+++ b/pkg/validate/raw/validate/namespace_validator_test.go
@@ -46,18 +46,8 @@ func TestNamespace(t *testing.T) {
 			wantErr: nonhierarchical.InvalidNamespaceError(fake.Role()),
 		},
 		{
-			name:    "Role with illegal namespace",
-			obj:     fake.Role(core.Namespace(configmanagement.ControllerNamespace)),
-			wantErr: nonhierarchical.ObjectInIllegalNamespace(fake.Role()),
-		},
-		{
 			name: "RootSync with config-management-system namespace",
 			obj:  fake.RootSyncV1Beta1("foo"),
-		},
-		{
-			name:    "RepoSync with config-management-system namespace",
-			obj:     fake.RepoSyncV1Beta1(configmanagement.ControllerNamespace, "foo"),
-			wantErr: nonhierarchical.ObjectInIllegalNamespace(fake.RepoSyncV1Beta1(configmanagement.ControllerNamespace, "foo")),
 		},
 		{
 			name: "Valid namespace",


### PR DESCRIPTION
To vertically scale ACM pods, we want to manage autoscaler resource in the root repository. Right now, only RootSync object can be declared in the config-management-namespace, therefore we want to loosen the restriction in Config Sync by removing ObjectInIllegalNamespace error. This will allow user to sync other resource type in config-management-namespace using unstructured repo config