### PR TITLE
Increase the test resource-group-controller memory request to 200Mi

### DIFF
--- a/e2e/nomostest/webhook.go
+++ b/e2e/nomostest/webhook.go
@@ -80,6 +80,7 @@ func StopWebhook(nt *NT) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
+	*nt.WebhookDisabled = true
 }
 
 func installWebhook(nt *NT, nomos ntopts.Nomos) {
@@ -99,4 +100,5 @@ func installWebhook(nt *NT, nomos ntopts.Nomos) {
 			nt.T.Fatal(err)
 		}
 	}
+	*nt.WebhookDisabled = false
 }

--- a/manifests/test-resources/resourcegroup-manifest.yaml
+++ b/manifests/test-resources/resourcegroup-manifest.yaml
@@ -503,7 +503,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/pkg/api/configmanagement/register.go
+++ b/pkg/api/configmanagement/register.go
@@ -53,6 +53,12 @@ const (
 
 	// HierarchyConfigKind is the string constant for the HierarchyConfig GroupVersionKind
 	HierarchyConfigKind = "HierarchyConfig"
+
+	// RGControllerNamespace is the namespace used for the resource-group controller
+	RGControllerNamespace = "resource-group-system"
+
+	// RGControllerName is the name used for the resource-group controller
+	RGControllerName = "resource-group-controller-manager"
 )
 
 // IsControllerNamespace returns true if the namespace is the ACM Controller Namespace.

--- a/pkg/bugreport/bugreport.go
+++ b/pkg/bugreport/bugreport.go
@@ -439,7 +439,7 @@ func (b *BugReporter) FetchCMSystemPods(ctx context.Context) (rd []Readable) {
 	var namespaces = []string{
 		configmanagement.ControllerNamespace,
 		metav1.NamespaceSystem,
-		RGControllerNamespace,
+		configmanagement.RGControllerNamespace,
 		metrics.MonitoringNamespace,
 		policycontroller.NamespaceSystem,
 	}

--- a/pkg/bugreport/constants.go
+++ b/pkg/bugreport/constants.go
@@ -34,17 +34,11 @@ const (
 	ResourceGroup = Product("Resource Group")
 )
 
-// Resource Group constants
-const (
-	// RGControllerNamespace is the namespace used for the resource-group controller
-	RGControllerNamespace = "resource-group-system"
-)
-
 var (
 	productNamespaces = map[Product]string{
 		PolicyController:     policycontroller.NamespaceSystem,
 		ConfigSync:           configmanagement.ControllerNamespace,
-		ResourceGroup:        RGControllerNamespace,
+		ResourceGroup:        configmanagement.RGControllerNamespace,
 		ConfigSyncMonitoring: metrics.MonitoringNamespace,
 	}
 )

--- a/pkg/reconcilermanager/controllers/deployment_conditions.go
+++ b/pkg/reconcilermanager/controllers/deployment_conditions.go
@@ -22,9 +22,9 @@ import (
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
-// computeDeploymentStatus uses kstatus to compute the deployment status based
+// ComputeDeploymentStatus uses kstatus to compute the deployment status based
 // on its conditions and other status fields.
-func computeDeploymentStatus(depObj *appsv1.Deployment) (*kstatus.Result, error) {
+func ComputeDeploymentStatus(depObj *appsv1.Deployment) (*kstatus.Result, error) {
 	objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(depObj)
 	if err != nil {
 		return nil, err

--- a/pkg/reconcilermanager/controllers/deployment_conditions_test.go
+++ b/pkg/reconcilermanager/controllers/deployment_conditions_test.go
@@ -159,11 +159,11 @@ func TestComputeDeploymentStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotResult, err := computeDeploymentStatus(tc.reconcilerDeployment)
+			gotResult, err := ComputeDeploymentStatus(tc.reconcilerDeployment)
 			if tc.wantError && err == nil {
-				t.Errorf("computeDeploymentStatus() got error: %q, want error", err)
+				t.Errorf("ComputeDeploymentStatus() got error: %q, want error", err)
 			} else if !tc.wantError && err != nil {
-				t.Errorf("computeDeploymentStatus() got error: %q, want error: nil", err)
+				t.Errorf("ComputeDeploymentStatus() got error: %q, want error: nil", err)
 			}
 			if !tc.wantError {
 				testutil.AssertEqual(t, tc.wantStatus, gotResult, "unexpected status")

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -327,7 +327,7 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		}
 	}
 
-	result, err := computeDeploymentStatus(deployObj)
+	result, err := ComputeDeploymentStatus(deployObj)
 	if err != nil {
 		log.Error(err, "Managed object status check failed",
 			logFieldObject, reconcilerRef.String(),

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -278,7 +278,7 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		}
 	}
 
-	result, err := computeDeploymentStatus(deployObj)
+	result, err := ComputeDeploymentStatus(deployObj)
 	if err != nil {
 		log.Error(err, "Managed object status check failed",
 			logFieldObject, reconcilerRef.String(),


### PR DESCRIPTION
The resource-group-controller's default memory request is increased from 50Mi to 200Mi to address the crashlooping issue on the autopilot cluster.
