### PR TITLE
Avoid object updates if semantically equal

### DIFF
--- a/pkg/importer/differ/differ.go
+++ b/pkg/importer/differ/differ.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -230,5 +230,5 @@ func (d *differ) updateSyncs(ctx context.Context, current, desired namespaceconf
 
 // syncsEqual returns true if the syncs are equivalent.
 func syncsEqual(l *v1.Sync, r *v1.Sync) bool {
-	return cmp.Equal(l.Spec, r.Spec) && compare.ObjectMetaEqual(l, r)
+	return equality.Semantic.DeepEqual(l.Spec, r.Spec) && compare.ObjectMetaEqual(l, r)
 }

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -27,7 +27,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/diff"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/reader"
@@ -35,6 +34,7 @@ import (
 	"kpt.dev/configsync/pkg/remediator"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/compare"
 	utildiscovery "kpt.dev/configsync/pkg/util/discovery"
 	"kpt.dev/configsync/pkg/validate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -281,7 +281,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 	}
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, diff.IgnoreTimestampUpdates) {
+	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping status update for RepoSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -43,6 +43,7 @@ import (
 	"kpt.dev/configsync/pkg/remediator"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/compare"
 	utildiscovery "kpt.dev/configsync/pkg/util/discovery"
 	"kpt.dev/configsync/pkg/validate"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -376,7 +377,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, errs status.MultiEr
 	}
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, diff.IgnoreTimestampUpdates) {
+	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping status update for RootSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}

--- a/pkg/reconcilermanager/controllers/otel_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_controller.go
@@ -17,13 +17,13 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	traceapi "cloud.google.com/go/trace/apiv2"
 	"github.com/go-logr/logr"
 	"golang.org/x/oauth2/google"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kpt.dev/configsync/pkg/core"
@@ -167,7 +167,7 @@ func (r *OtelReconciler) updateDeploymentAnnotation(ctx context.Context, hash []
 	// creates/updates.
 	core.SetAnnotation(&dep.Spec.Template, metadata.ConfigMapAnnotationKey, fmt.Sprintf("%x", hash))
 
-	if reflect.DeepEqual(existing, dep) {
+	if equality.Semantic.DeepEqual(existing, dep) {
 		return nil
 	}
 

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -19,13 +19,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -224,7 +224,7 @@ func (r *reconcilerBase) createOrPatchDeployment(ctx context.Context, declared *
 			"mutator", mutator)
 	}
 
-	if reflect.DeepEqual(current.Labels, declared.Labels) && reflect.DeepEqual(current.Spec, declared.Spec) {
+	if equality.Semantic.DeepEqual(current.Labels, declared.Labels) && equality.Semantic.DeepEqual(current.Spec, declared.Spec) {
 		return controllerutil.OperationResultNone, nil
 	}
 
@@ -330,7 +330,7 @@ func keepCurrentContainerResources(declared, current *appsv1.Deployment) bool {
 	for _, existingContainer := range current.Spec.Template.Spec.Containers {
 		for i, desiredContainer := range declared.Spec.Template.Spec.Containers {
 			if existingContainer.Name == desiredContainer.Name &&
-				!reflect.DeepEqual(declared.Spec.Template.Spec.Containers[i].Resources, existingContainer.Resources) {
+				!equality.Semantic.DeepEqual(declared.Spec.Template.Spec.Containers[i].Resources, existingContainer.Resources) {
 				declared.Spec.Template.Spec.Containers[i].Resources = existingContainer.Resources
 				resourceChanged = true
 			}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -39,12 +39,12 @@ import (
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/diff"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/compare"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -791,7 +791,7 @@ func (r *RepoSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 	rs.Status.ObservedGeneration = rs.Generation
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, diff.IgnoreTimestampUpdates) {
+	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(3).Infof("Skipping status update for RepoSync %s (ResourceVersion: %s)",
 			client.ObjectKeyFromObject(rs), rs.ResourceVersion)
 		return false, nil

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -40,12 +40,12 @@ import (
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/diff"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/compare"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -566,7 +566,7 @@ func (r *RootSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 	rs.Status.ObservedGeneration = rs.Generation
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, diff.IgnoreTimestampUpdates) {
+	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(3).Infof("Skipping status update for RootSync %s (ResourceVersion: %s)",
 			client.ObjectKeyFromObject(rs), rs.ResourceVersion)
 		return false, nil

--- a/pkg/syncer/crd/reconcile.go
+++ b/pkg/syncer/crd/reconcile.go
@@ -16,12 +16,12 @@ package crd
 
 import (
 	"context"
-	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -244,7 +244,7 @@ func (r *reconciler) reconcile(ctx context.Context, name string) status.MultiErr
 		mErr = status.Append(mErr, err)
 	} else {
 		allCrds := r.toCrdSet(crdList)
-		if !reflect.DeepEqual(r.allCrds, allCrds) {
+		if !equality.Semantic.DeepEqual(r.allCrds, allCrds) {
 			needRestart = true
 			r.recorder.Eventf(clusterConfig, corev1.EventTypeNormal, v1.EventReasonCRDChange,
 				"crds changed on the cluster restarting syncer controllers")

--- a/pkg/syncer/reconcile/apply.go
+++ b/pkg/syncer/reconcile/apply.go
@@ -17,11 +17,11 @@ package reconcile
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -452,5 +452,5 @@ func equal(dryrunState, currentState *unstructured.Unstructured) bool {
 	obj2 := currentState.DeepCopy()
 	cleanFields(obj1)
 	cleanFields(obj2)
-	return reflect.DeepEqual(obj1.Object, obj2.Object)
+	return equality.Semantic.DeepEqual(obj1.Object, obj2.Object)
 }

--- a/pkg/syncer/reconcile/repostatus.go
+++ b/pkg/syncer/reconcile/repostatus.go
@@ -16,12 +16,12 @@ package reconcile
 
 import (
 	"context"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -228,13 +228,13 @@ func (s syncState) merge(repoStatus *v1.RepoStatus, now func() metav1.Time) {
 	})
 
 	nonEmpty := len(repoStatus.Sync.InProgress) > 0 || len(inProgress) > 0
-	if nonEmpty && !reflect.DeepEqual(repoStatus.Sync.InProgress, inProgress) {
+	if nonEmpty && !equality.Semantic.DeepEqual(repoStatus.Sync.InProgress, inProgress) {
 		repoStatus.Sync.InProgress = inProgress
 		updated = true
 	}
 
 	nonEmpty = len(repoStatus.Sync.ResourceConditions) > 0 || len(s.resourceConditions) > 0
-	if nonEmpty && !reflect.DeepEqual(repoStatus.Sync.ResourceConditions, s.resourceConditions) {
+	if nonEmpty && !equality.Semantic.DeepEqual(repoStatus.Sync.ResourceConditions, s.resourceConditions) {
 		repoStatus.Sync.ResourceConditions = s.resourceConditions
 		updated = true
 	}

--- a/pkg/syncer/reconcile/util.go
+++ b/pkg/syncer/reconcile/util.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -172,11 +171,11 @@ func filterContextCancelled(err error) error {
 		}
 	}
 	c := errors.Cause(err)
-	if reflect.DeepEqual(c, context.Canceled) {
+	if errors.Is(c, context.Canceled) {
 		return nil
 	}
 	// http client errors don't implement causer. The underlying error is in one of the struct's fields.
-	if ue, ok := c.(*url.Error); ok && reflect.DeepEqual(ue.Err, context.Canceled) {
+	if ue, ok := c.(*url.Error); ok && errors.Is(ue.Err, context.Canceled) {
 		return nil
 	}
 	return err

--- a/pkg/syncer/sync/reconciler.go
+++ b/pkg/syncer/sync/reconciler.go
@@ -17,10 +17,10 @@ package sync
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -170,7 +170,7 @@ func (r *metaReconciler) reconcileSyncs(ctx context.Context, request reconcile.R
 		ss.Status = v1.Syncing
 
 		// Check if status changed before updating.
-		if !reflect.DeepEqual(sync.Status, ss) {
+		if !equality.Semantic.DeepEqual(sync.Status, ss) {
 			updateFn := func(obj client.Object) (client.Object, error) {
 				s := obj.(*v1.Sync)
 				s.Status = ss

--- a/pkg/util/compare/compare.go
+++ b/pkg/util/compare/compare.go
@@ -15,9 +15,8 @@
 package compare
 
 import (
-	"reflect"
-
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/equality"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/decode"
@@ -26,7 +25,8 @@ import (
 
 // ObjectMetaEqual returns true if the Meta field of left and right objects are equal.
 func ObjectMetaEqual(left client.Object, right client.Object) bool {
-	return reflect.DeepEqual(left.GetLabels(), right.GetLabels()) && reflect.DeepEqual(left.GetAnnotations(), right.GetAnnotations())
+	return equality.Semantic.DeepEqual(left.GetLabels(), right.GetLabels()) &&
+		equality.Semantic.DeepEqual(left.GetAnnotations(), right.GetAnnotations())
 }
 
 // GenericResourcesEqual returns true if the GenericResources slices are

--- a/pkg/util/compare/comparer.go
+++ b/pkg/util/compare/comparer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package diff
+package compare
 
 import (
 	"github.com/google/go-cmp/cmp"

--- a/pkg/util/compare/comparer_test.go
+++ b/pkg/util/compare/comparer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package diff
+package compare
 
 import (
 	"testing"

--- a/pkg/util/repo/client.go
+++ b/pkg/util/repo/client.go
@@ -21,6 +21,7 @@ import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/status"
 	syncclient "kpt.dev/configsync/pkg/syncer/client"
+	"kpt.dev/configsync/pkg/util/compare"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -100,7 +101,7 @@ func (c *Client) UpdateSourceStatus(ctx context.Context, repo *v1.Repo) (*v1.Rep
 func (c *Client) UpdateSyncStatus(ctx context.Context, repo *v1.Repo) (*v1.Repo, status.Error) {
 	updateFn := func(obj client.Object) (client.Object, error) {
 		newRepo := obj.(*v1.Repo)
-		if cmp.Equal(repo.Status.Sync, newRepo.Status.Sync) {
+		if cmp.Equal(repo.Status.Sync, newRepo.Status.Sync, compare.IgnoreTimestampUpdates) {
 			return newRepo, syncclient.NoUpdateNeeded()
 		}
 		newRepo.Status.Sync = repo.Status.Sync

--- a/pkg/util/watch/manager.go
+++ b/pkg/util/watch/manager.go
@@ -17,9 +17,9 @@ package watch
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -119,7 +119,7 @@ func (m *subManager) context() context.Context {
 }
 
 func (m *subManager) needsRestart(toWatch map[schema.GroupVersionKind]bool) bool {
-	return !reflect.DeepEqual(m.watching, toWatch)
+	return !equality.Semantic.DeepEqual(m.watching, toWatch)
 }
 
 // Restart implements RestartableManager.


### PR DESCRIPTION
- This avoids generation & resourceVersion bloat, which can cause
  unnecessary watch updates and ectd memory leaks.

`equality.Semantic.DeepEqual` is used by `CreateOrUpdate` in controller-runtime:  
https://github.com/kubernetes-sigs/controller-runtime/blob/v0.12.3/pkg/controller/controllerutil/controllerutil.go#L215