### PR TITLE
Add unit test for parseAndUpdate

### DIFF
--- a/pkg/syncer/syncertest/fake/discovery_client.go
+++ b/pkg/syncer/syncertest/fake/discovery_client.go
@@ -19,28 +19,54 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"kpt.dev/configsync/pkg/util/discovery"
+	discovery "k8s.io/client-go/discovery"
+	discoveryutil "kpt.dev/configsync/pkg/util/discovery"
 )
 
 // discoveryClient implements the subset of the DiscoveryInterface used by the
 // Syncer.
 type discoveryClient struct {
 	resources []*metav1.APIResourceList
+	errors    error
 }
 
 // ServerResources implements discovery.ServerResourcer.
 func (d discoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return nil, d.resources, nil
+	return nil, d.resources, d.errors
 }
 
-var _ discovery.ServerResourcer = discoveryClient{}
+var _ discoveryutil.ServerResourcer = discoveryClient{}
+
+func discoveryError(err error, gvks ...schema.GroupVersionKind) error {
+	groups := make(map[schema.GroupVersion]error)
+	for _, gvk := range gvks {
+		gv := gvk.GroupVersion()
+		groups[gv] = err
+	}
+	return &discovery.ErrGroupDiscoveryFailed{Groups: groups}
+}
 
 // NewDiscoveryClient returns a discoveryClient that reports types available
-// to the API Server.
+// to the API Server with no errors
 //
 // Does not report the scope of each GVK as no tests requiring a discoveryClient
 // use scope information.
-func NewDiscoveryClient(gvks ...schema.GroupVersionKind) discovery.ServerResourcer {
+func NewDiscoveryClient(gvks ...schema.GroupVersionKind) discoveryutil.ServerResourcer {
+	return NewDiscoveryClientWithError(nil, gvks...)
+}
+
+// NewDiscoveryClientWithError returns a discoveryClient that reports types available
+// to the API Server with no errors, or ErrGroupDiscoveryFailed error with the
+// specified wantedErr
+//
+// Does not report the scope of each GVK as no tests requiring a discoveryClient
+// use scope information.
+func NewDiscoveryClientWithError(wantedErr error, gvks ...schema.GroupVersionKind) discoveryutil.ServerResourcer {
+	if wantedErr != nil {
+		return discoveryClient{
+			errors: discoveryError(wantedErr, gvks...),
+		}
+	}
 	gvs := make(map[string][]string)
 	for _, gvk := range gvks {
 		gv := gvk.GroupVersion().String()
@@ -62,8 +88,8 @@ func NewDiscoveryClient(gvks ...schema.GroupVersionKind) discovery.ServerResourc
 					Kind: k,
 				})
 		}
+		resources = append(resources, resource)
 	}
-
 	return discoveryClient{
 		resources: resources,
 	}


### PR DESCRIPTION
This test is intended to validate the fix in https://github.com/GoogleContainerTools/kpt-config-sync/pull/28.

When discovery call fails due to any possible reason and some objects in the inventory are with scope Unknown, the parser previously would ignore the error and skip sending these objects to the applier, causing the objects to be pruned in later process. 

The above mentioned fix makes the discovery failure a blocking error so no object with scope Unknown will be skipped, as error will be early returned instead of moving on. 