### PR TITLE
Increase the `parallel` flag of e2e presubmit jobs

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -170,10 +170,10 @@ test-e2e-go-ephemeral: __push-local-image
 	@docker run -v /var/run/docker.sock:/var/run/docker.sock --network="host" prow-image make __test-e2e-go-nobuild-prow
 test-e2e-go-ephemeral-mono-repo: __push-local-image
 	kind delete clusters --all
-	./scripts/e2e-go-ephemeral.sh --timeout 60m --parallel 18 --image-tag=$(LATEST_IMAGE_TAG)
+	./scripts/e2e-go-ephemeral.sh --timeout 60m --parallel 23 --image-tag=$(LATEST_IMAGE_TAG) --test.run TestIncreaseParallel*
 test-e2e-go-ephemeral-multi-repo: __push-local-image
 	kind delete clusters --all
-	./scripts/e2e-go-ephemeral.sh --multirepo --timeout 60m --parallel 18 --image-tag=$(LATEST_IMAGE_TAG)
+	./scripts/e2e-go-ephemeral.sh --multirepo --timeout 60m --parallel 23 --image-tag=$(LATEST_IMAGE_TAG) --test.run TestIncreaseParallel*
 
 # Runs the Go e2e tests against multi-repo Config Sync.
 # Rebuilds the nomos image, so use this when you're actively modifying the Nomos

--- a/e2e/nomostest/config-sync.go
+++ b/e2e/nomostest/config-sync.go
@@ -510,6 +510,9 @@ func ValidateMultiRepoDeployments(nt *NT) error {
 		errs = status.Append(errs, err)
 	}
 	if errs != nil {
+		for deployment := range deployments {
+			nt.Kubectl("describe", "deploy", deployment.Name, "-n", deployment.Namespace)
+		}
 		return errs
 	}
 

--- a/e2e/testcases/acme_test.go
+++ b/e2e/testcases/acme_test.go
@@ -51,6 +51,112 @@ func configSyncManagementLabels(namespace, folder string) map[string]string {
 	return labels
 }
 
+func TestIncreaseParallel_1(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_2(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_3(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_4(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_5(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_6(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_7(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_8(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_9(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_10(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_11(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_12(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_13(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_14(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_15(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_16(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_17(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_18(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_19(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_20(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_21(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_22(t *testing.T) {
+	nomostest.New(t)
+}
+func TestIncreaseParallel_23(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_24(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_25(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_26(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_27(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_28(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_29(t *testing.T) {
+	nomostest.New(t)
+}
+
+func TestIncreaseParallel_30(t *testing.T) {
+	nomostest.New(t)
+}
+
 func TestAcmeCorpRepo(t *testing.T) {
 	nt := nomostest.New(t)
 


### PR DESCRIPTION
Increase the `parallel` flag from 18 to 24 to reduce the excution time of the `kpt-config-sync-presubmit-e2e-multi-repo` job, which runs in the `large-job-pool` and each node in the pool has 30 vCPUs.

Each vCPU corresponds to a hardware thread rather than a core, this PR is to figure out whether setting the `parallel` flag to 24 could reduce the execution time.