### PR TITLE
Fix mono-repo "failed to create object" error

### DIFF
--- a/pkg/syncer/reconcile/apply.go
+++ b/pkg/syncer/reconcile/apply.go
@@ -168,7 +168,7 @@ func (c *clientApplier) Update(ctx context.Context, intendedState, currentState 
 // RemoveNomosMeta implements Applier.
 func (c *clientApplier) RemoveNomosMeta(ctx context.Context, u *unstructured.Unstructured) (bool, status.Error) {
 	var changed bool
-	_, err := c.client.Update(ctx, u, func(obj client.Object) (client.Object, error) {
+	_, err := c.client.Apply(ctx, u, func(obj client.Object) (client.Object, error) {
 		changed = metadata.RemoveConfigSyncMetadata(obj)
 		if !changed {
 			return obj, syncerclient.NoUpdateNeeded()

--- a/pkg/syncer/reconcile/namespaceconfig.go
+++ b/pkg/syncer/reconcile/namespaceconfig.go
@@ -341,8 +341,7 @@ func (r *namespaceConfigReconciler) setNamespaceConfigStatus(ctx context.Context
 		klog.V(3).Infof("Skipping status update for NamespaceConfig %q; status is already up-to-date.", config.Name)
 		return nil
 	}
-
-	updateFn := func(obj client.Object) (client.Object, error) {
+	_, err := r.client.ApplyStatus(ctx, config, func(obj client.Object) (client.Object, error) {
 		newPN := obj.(*v1.NamespaceConfig)
 		newPN.Status.Token = config.Spec.Token
 		newPN.Status.SyncTime = r.now()
@@ -353,11 +352,9 @@ func (r *namespaceConfigReconciler) setNamespaceConfigStatus(ctx context.Context
 		} else {
 			newPN.Status.SyncState = v1.StateSynced
 		}
-
 		newPN.SetGroupVersionKind(kinds.NamespaceConfig())
 		return newPN, nil
-	}
-	_, err := r.client.UpdateStatus(ctx, config, updateFn)
+	})
 	// TODO: Missing error monitoring like util.go/SetClusterConfigStatus.
 	return err
 }

--- a/pkg/syncer/reconcile/util.go
+++ b/pkg/syncer/reconcile/util.go
@@ -100,8 +100,7 @@ func SetClusterConfigStatus(ctx context.Context, c *syncerclient.Client, config 
 		klog.V(3).Infof("Status for ClusterConfig %q is already up-to-date.", config.Name)
 		return nil
 	}
-
-	updateFn := func(obj client.Object) (client.Object, error) {
+	_, err := c.ApplyStatus(ctx, config, func(obj client.Object) (client.Object, error) {
 		newConfig := obj.(*v1.ClusterConfig)
 		newConfig.Status.Token = config.Spec.Token
 		newConfig.Status.SyncTime = now()
@@ -112,10 +111,8 @@ func SetClusterConfigStatus(ctx context.Context, c *syncerclient.Client, config 
 		} else {
 			newConfig.Status.SyncState = v1.StateSynced
 		}
-
 		return newConfig, nil
-	}
-	_, err := c.UpdateStatus(ctx, config, updateFn)
+	})
 	return err
 }
 


### PR DESCRIPTION
- Rename Update to Apply to reflect existing client-side apply behavior
- Add an Update method to update directly (and send metrics) when the Get has already been performed
- Fix "failed to create object" error in the mono-repo finalizer by switching from Upsert to Apply
- Remove unused Upsert function
- Add additional equivelency checks to avoid updates when using Apply and ApplyStatus