### PR TITLE
[WIP] Add resource attributes

### DIFF
--- a/e2e/nomostest/metrics/parse.go
+++ b/e2e/nomostest/metrics/parse.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.opencensus.io/tag"
 )
 
 // ParseMetrics connects to the local port where metrics are being forwarded to
@@ -71,8 +70,8 @@ func parseMetricName(m string) (string, error) {
 }
 
 // parseTags filters for the metric tag keys and values.
-func parseTags(m string) []tag.Tag {
-	var tags []tag.Tag
+func parseTags(m string) []Tag {
+	var tags []Tag
 	// match all tags: {operation="create",status="success",type="Namespace"}
 	regex := regexp.MustCompile(`{(.*?)}`)
 	ss := regex.FindStringSubmatch(m)
@@ -83,9 +82,8 @@ func parseTags(m string) []tag.Tag {
 			regex = regexp.MustCompile(`(.*?)="(.*?)"`)
 			ss = regex.FindStringSubmatch(t)
 			if ss != nil {
-				key, _ := tag.NewKey(ss[1])
-				tags = append(tags, tag.Tag{
-					Key:   key,
+				tags = append(tags, Tag{
+					Key:   ss[1],
 					Value: ss[2],
 				})
 			}

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -19,18 +19,17 @@ import (
 	"testing"
 	"time"
 
-	"go.opencensus.io/tag"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/metrics"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/metrics"
 	ocmetrics "kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
@@ -261,10 +260,10 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 		if err := nt.ValidateResourceOverrideCount(string(controllers.RootReconcilerType), "git-sync", "cpu", 1); err != nil {
 			return err
 		}
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
-			{Key: metrics.KeyContainer, Value: "reconciler"},
-			{Key: metrics.KeyResourceType, Value: "memory"},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
+			{Key: ocmetrics.KeyContainer.Name(), Value: "reconciler"},
+			{Key: ocmetrics.KeyResourceType.Name(), Value: "memory"},
 		}); err != nil {
 			return err
 		}
@@ -343,8 +342,8 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
 		}); err != nil {
 			return err
 		}
@@ -567,10 +566,10 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 		if err := nt.ValidateResourceOverrideCount(string(controllers.RootReconcilerType), "git-sync", "cpu", 1); err != nil {
 			return err
 		}
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
-			{Key: metrics.KeyContainer, Value: "reconciler"},
-			{Key: metrics.KeyResourceType, Value: "memory"},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
+			{Key: ocmetrics.KeyContainer.Name(), Value: "reconciler"},
+			{Key: ocmetrics.KeyResourceType.Name(), Value: "memory"},
 		}); err != nil {
 			return err
 		}
@@ -649,8 +648,8 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
 		}); err != nil {
 			return err
 		}

--- a/manifests/otel-agent-cm.yaml
+++ b/manifests/otel-agent-cm.yaml
@@ -33,6 +33,24 @@ data:
           insecure: true
     processors:
       batch:
+      # Generate resource attributes from metric tags.
+      # This is done in the sidecar instead of the reconciler, because
+      # attributes are not otherwise mutable after constructing a metrics
+      # emitter.
+      attributes/sync:
+        actions:
+          - key: configsync.sync.kind
+            action: insert
+            from_context: sync_kind
+          - key: configsync.sync.name
+            action: insert
+            from_context: sync_name
+          - key: configsync.sync.namespace
+            action: insert
+            from_context: sync_namespace
+          - key: configsync.reconciler.name
+            action: insert
+            from_context: reconciler_name
     extensions:
       health_check:
     service:
@@ -40,5 +58,5 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch]
+          processors: [batch, attributes/sync]
           exporters: [opencensus]

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -30,6 +30,9 @@ data:
       prometheus:
         endpoint: :8675
         namespace: config_sync
+        resource_to_telemetry_conversion:
+          enabled: true
+        metric_expiration: 5m
     processors:
       batch:
     extensions:

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -41,6 +41,9 @@ exporters:
   prometheus:
     endpoint: :8675
     namespace: config_sync
+    resource_to_telemetry_conversion:
+      enabled: true
+    metric_expiration: 5m
   googlecloud:
     metric:
       prefix: "custom.googleapis.com/opencensus/config_sync/"

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -61,6 +61,11 @@ var (
 
 	// KeyResourceType groups metris by their resource types. Possible values: cpu, memory.
 	KeyResourceType, _ = tag.NewKey("resource")
+
+	KeySyncKind, _       = tag.NewKey("sync_kind")
+	KeySyncName, _       = tag.NewKey("sync_name")
+	KeySyncNamespace, _  = tag.NewKey("sync_namespace")
+	KeyReconcilerName, _ = tag.NewKey("reconciler_name")
 )
 
 // StatusTagKey returns a string representation of the error, if it exists, otherwise success.

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -21,13 +21,15 @@ import (
 
 var distributionBounds = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
 
+var globalTagKeys = []tag.Key{KeySyncKind, KeySyncName, KeySyncNamespace, KeyReconcilerName}
+
 var (
 	// APICallDurationView aggregates the APICallDuration metric measurements.
 	APICallDurationView = &view.View{
 		Name:        APICallDuration.Name(),
 		Measure:     APICallDuration,
 		Description: "The latency distribution of API server calls",
-		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
+		TagKeys:     append([]tag.Key{KeyOperation, KeyStatus}, globalTagKeys...),
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -36,7 +38,7 @@ var (
 		Name:        ReconcilerErrors.Name(),
 		Measure:     ReconcilerErrors,
 		Description: "The current number of errors in the RootSync and RepoSync reconcilers",
-		TagKeys:     []tag.Key{KeyComponent, KeyErrorClass},
+		TagKeys:     append([]tag.Key{KeyComponent, KeyErrorClass}, globalTagKeys...),
 		Aggregation: view.LastValue(),
 	}
 
@@ -45,7 +47,7 @@ var (
 		Name:        PipelineError.Name(),
 		Measure:     PipelineError,
 		Description: "A boolean indicates if any error happens from different stages when syncing a commit",
-		TagKeys:     []tag.Key{KeyName, KeyReconcilerType, KeyComponent},
+		TagKeys:     append([]tag.Key{KeyName, KeyReconcilerType, KeyComponent}, globalTagKeys...),
 		Aggregation: view.LastValue(),
 	}
 
@@ -54,7 +56,7 @@ var (
 		Name:        ReconcileDuration.Name(),
 		Measure:     ReconcileDuration,
 		Description: "The latency distribution of RootSync and RepoSync reconcile events",
-		TagKeys:     []tag.Key{KeyStatus},
+		TagKeys:     append([]tag.Key{KeyStatus}, globalTagKeys...),
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -63,7 +65,7 @@ var (
 		Name:        ParserDuration.Name(),
 		Measure:     ParserDuration,
 		Description: "The latency distribution of the parse-apply-watch loop",
-		TagKeys:     []tag.Key{KeyStatus, KeyTrigger, KeyParserSource},
+		TagKeys:     append([]tag.Key{KeyStatus, KeyTrigger, KeyParserSource}, globalTagKeys...),
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -72,6 +74,7 @@ var (
 		Name:        LastSync.Name(),
 		Measure:     LastSync,
 		Description: "The timestamp of the most recent sync from Git",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.LastValue(),
 	}
 
@@ -80,6 +83,7 @@ var (
 		Name:        DeclaredResources.Name(),
 		Measure:     DeclaredResources,
 		Description: "The current number of declared resources parsed from Git",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.LastValue(),
 	}
 
@@ -88,7 +92,7 @@ var (
 		Name:        ApplyOperations.Name() + "_total",
 		Measure:     ApplyOperations,
 		Description: "The total number of operations that have been performed to sync resources to source of truth",
-		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
+		TagKeys:     append([]tag.Key{KeyOperation, KeyStatus}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -97,7 +101,7 @@ var (
 		Name:        ApplyDuration.Name(),
 		Measure:     ApplyDuration,
 		Description: "The latency distribution of applier resource sync events",
-		TagKeys:     []tag.Key{KeyStatus},
+		TagKeys:     append([]tag.Key{KeyStatus}, globalTagKeys...),
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -106,7 +110,7 @@ var (
 		Name:        LastApply.Name(),
 		Measure:     LastApply,
 		Description: "The timestamp of the most recent applier resource sync event",
-		TagKeys:     []tag.Key{KeyStatus, KeyCommit},
+		TagKeys:     append([]tag.Key{KeyStatus, KeyCommit}, globalTagKeys...),
 		Aggregation: view.LastValue(),
 	}
 
@@ -115,6 +119,7 @@ var (
 		Name:        ResourceFights.Name() + "_total",
 		Measure:     ResourceFights,
 		Description: "The total number of resources that are being synced too frequently",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -123,7 +128,7 @@ var (
 		Name:        RemediateDuration.Name(),
 		Measure:     RemediateDuration,
 		Description: "The latency distribution of remediator reconciliation events",
-		TagKeys:     []tag.Key{KeyStatus},
+		TagKeys:     append([]tag.Key{KeyStatus}, globalTagKeys...),
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -132,6 +137,7 @@ var (
 		Name:        ResourceConflicts.Name() + "_total",
 		Measure:     ResourceConflicts,
 		Description: "The total number of resource conflicts resulting from a mismatch between the cached resources and cluster resources",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -140,7 +146,7 @@ var (
 		Name:        InternalErrors.Name() + "_total",
 		Measure:     InternalErrors,
 		Description: "The total number of internal errors triggered by Config Sync",
-		TagKeys:     []tag.Key{KeyInternalErrorSource},
+		TagKeys:     append([]tag.Key{KeyInternalErrorSource}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -149,6 +155,7 @@ var (
 		Name:        RenderingCount.Name() + "_total",
 		Measure:     RenderingCount,
 		Description: "The total number of renderings that are performed",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -157,6 +164,7 @@ var (
 		Name:        SkipRenderingCount.Name() + "_total",
 		Measure:     SkipRenderingCount,
 		Description: "The total number of renderings that are skipped",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -165,7 +173,7 @@ var (
 		Name:        ResourceOverrideCount.Name() + "_total",
 		Measure:     ResourceOverrideCount,
 		Description: "The total number of RootSync/RepoSync objects including the `spec.override.resources` field",
-		TagKeys:     []tag.Key{KeyContainer, KeyResourceType},
+		TagKeys:     append([]tag.Key{KeyContainer, KeyResourceType}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -174,6 +182,7 @@ var (
 		Name:        GitSyncDepthOverrideCount.Name() + "_total",
 		Measure:     GitSyncDepthOverrideCount,
 		Description: "The total number of RootSync/RepoSync objects including the `spec.override.gitSyncDepth` field",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 
@@ -182,6 +191,7 @@ var (
 		Name:        NoSSLVerifyCount.Name() + "_total",
 		Measure:     NoSSLVerifyCount,
 		Description: "The number of RootSync/RepoSync objects whose `spec.git.noSSLVerify` field is set to `true`",
+		TagKeys:     append([]tag.Key{}, globalTagKeys...),
 		Aggregation: view.Count(),
 	}
 )

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -82,6 +82,18 @@ type namespace struct {
 
 var _ Parser = &namespace{}
 
+func (p *namespace) SyncKind() string {
+	return "RepoSync"
+}
+
+func (p *namespace) SyncName() string {
+	return p.options().syncName
+}
+
+func (p *namespace) SyncNamespace() string {
+	return string(p.scope)
+}
+
 func (p *namespace) options() *opts {
 	return &(p.opts)
 }

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -87,6 +87,15 @@ type Parser interface {
 	RemediatorConflictErrors() []status.ManagementConflictError
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
+	// SyncKind returns the kind of the sync object that generated this
+	// reconciler: RootSync or RepoSync
+	SyncKind() string
+	// SyncKind returns the name of the sync object that generated this
+	// reconciler.
+	SyncName() string
+	// SyncNamespace returns the namespace of the sync object that generated
+	// this reconciler.
+	SyncNamespace() string
 }
 
 func (o *opts) k8sClient() client.Client {

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -90,6 +90,18 @@ type root struct {
 
 var _ Parser = &root{}
 
+func (p *root) SyncKind() string {
+	return "RootSync"
+}
+
+func (p *root) SyncName() string {
+	return p.options().syncName
+}
+
+func (p *root) SyncNamespace() string {
+	return configsync.ControllerNamespace
+}
+
 func (p *root) options() *opts {
 	return &(p.opts)
 }


### PR DESCRIPTION
This is still WIP, but demonstrates how to add resource attributes at runtime using metric tags that are converted to attributes by the otel agent sidecar before sending to the otel collector. The otel collector can then convert them back into tags for the prometheus exporter, because prometheus doesn't support attributes.

This allows us to use convert high-cardinality tags into attributes for GCP monitoring and Google monarch, while still being able to test them using prometheus.

We will need to decide, however, if we want to keep the tag to attribute conversion on by default or whether we just enable it for tests and provide docs or a flag for customers to turn them on if desired.

I've only made the change to the reconciler, but the more important change would be to do the same to the reconciler-manager and the resource-group-controller, because they are 1-to-Many when it comes to reconcilers and sync objects.

I added a log to the e2e tests to print the metrics as yaml for debugging.
