### PR TITLE
Fail test during reset if sync still in-progress

### DIFF
--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -36,6 +36,7 @@ import (
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/util/repo"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -698,7 +699,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		})
 	} else {
 		_, err = nomostest.Retry(60*time.Second, func() error {
-			return nt.Validate("repo", "",
+			return nt.Validate(repo.DefaultName, "",
 				&v1.Repo{}, repoHasErrors("KNV"+status.EmptySourceErrorCode))
 		})
 	}

--- a/e2e/testcases/resource_conditions_test.go
+++ b/e2e/testcases/resource_conditions_test.go
@@ -34,6 +34,7 @@ import (
 	"kpt.dev/configsync/pkg/policycontroller/constraint"
 	"kpt.dev/configsync/pkg/policycontroller/constrainttemplate"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/util/repo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -66,7 +67,7 @@ func TestResourceConditionAnnotations(t *testing.T) {
 	// Ensure we don't already have error conditions.
 	// In this test, and so below, it is sufficient to block on the Repo object reporting
 	// the conditions, as all it is doing is aggregating conditions from ClusterConfig/NamespaceConfigs.
-	err1 := nt.Validate("repo", "", &v1.Repo{},
+	err1 := nt.Validate(repo.DefaultName, "", &v1.Repo{},
 		hasConditions())
 	err2 := nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
 		hasConditions())
@@ -101,10 +102,10 @@ func TestResourceConditionAnnotations(t *testing.T) {
 	_, err1 = nomostest.Retry(40*time.Second, func() error {
 		if support {
 			// We expect three errors even though we only supplied two.
-			return nt.Validate("repo", "", &v1.Repo{},
+			return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 				hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError), string(v1.ResourceStateError)))
 		}
-		return nt.Validate("repo", "", &v1.Repo{},
+		return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 			hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError)))
 	})
 	// The ClusterConfig error from the ClusterRole gets duplicated.
@@ -139,7 +140,7 @@ func TestResourceConditionAnnotations(t *testing.T) {
 
 	// Ensure error conditions are removed.
 	_, err1 = nomostest.Retry(20*time.Second, func() error {
-		return nt.Validate("repo", "", &v1.Repo{},
+		return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 			hasConditions())
 	})
 	err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
@@ -171,10 +172,10 @@ func TestResourceConditionAnnotations(t *testing.T) {
 	_, err1 = nomostest.Retry(40*time.Second, func() error {
 		if support {
 			// We expect three reconciling conditions even though we only supplied two.
-			return nt.Validate("repo", "", &v1.Repo{},
+			return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 				hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
 		}
-		return nt.Validate("repo", "", &v1.Repo{},
+		return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 			hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
 	})
 	// The ClusterConfig condition from the ClusterRole gets duplicated.
@@ -209,7 +210,7 @@ func TestResourceConditionAnnotations(t *testing.T) {
 
 	// Ensure reconciling conditions are removed.
 	_, err1 = nomostest.Retry(40*time.Second, func() error {
-		return nt.Validate("repo", "", &v1.Repo{},
+		return nt.Validate(repo.DefaultName, "", &v1.Repo{},
 			hasConditions())
 	})
 	err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},

--- a/pkg/testing/fake/repo.go
+++ b/pkg/testing/fake/repo.go
@@ -34,7 +34,7 @@ func RepoVersion(version string) core.MetaMutator {
 func RepoObject(opts ...core.MetaMutator) *v1.Repo {
 	result := &v1.Repo{TypeMeta: ToTypeMeta(kinds.Repo())}
 	defaultMutate(result)
-	mutate(result, core.Name("repo"))
+	mutate(result, core.Name(repo.DefaultName))
 	RepoVersion(repo.CurrentVersion)(result)
 	for _, opt := range opts {
 		opt(result)

--- a/pkg/util/repo/default.go
+++ b/pkg/util/repo/default.go
@@ -23,11 +23,14 @@ import (
 // CurrentVersion is the version of the format for the ConfigManagement Repo.
 const CurrentVersion = "1.0.0"
 
+// DefaultName is the name of the default cluster-scope Repo in mono-repo mode.
+const DefaultName = "repo"
+
 // Default returns a default Repo in case one is not defined in the source of truth.
 func Default() *v1.Repo {
 	return setTypeMeta(&v1.Repo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "repo",
+			Name: DefaultName,
 		},
 		Spec: v1.RepoSpec{
 			Version: CurrentVersion,


### PR DESCRIPTION
This should prevent mono-repo test suite timeout when a test wedges the syncer, causing all subsequent tests to fail.