### PR TITLE
Fix metrics validation

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -181,6 +181,7 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		IsGKEAutopilot:          sharedNt.IsGKEAutopilot,
 		DefaultWaitTimeout:      sharedNt.DefaultWaitTimeout,
 		DefaultReconcileTimeout: sharedNt.DefaultReconcileTimeout,
+		DefaultMetricsTimeout:   sharedNt.DefaultMetricsTimeout,
 		kubeconfigPath:          sharedNt.kubeconfigPath,
 		MultiRepo:               sharedNt.MultiRepo,
 		ReconcilerPollingPeriod: sharedNT.ReconcilerPollingPeriod,
@@ -295,6 +296,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		Config:                  opts.RESTConfig,
 		Client:                  c,
 		DefaultReconcileTimeout: 1 * time.Minute,
+		DefaultMetricsTimeout:   1 * time.Minute,
 		kubeconfigPath:          kubeconfigPath,
 		MultiRepo:               opts.Nomos.MultiRepo,
 		ReconcilerPollingPeriod: 50 * time.Millisecond,
@@ -428,12 +430,14 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 
 	nt.PortForwardOtelCollector()
 
+	nt.Control = opts.Control
 	switch opts.Control {
 	case ntopts.DelegatedControl:
 		setupDelegatedControl(nt, opts)
 	case ntopts.CentralControl:
 		setupCentralizedControl(nt, opts)
 	default:
+		nt.Control = ntopts.CentralControl
 		// Most tests don't care about centralized/delegated control, but can
 		// specify the behavior if that distinction is under test.
 		setupCentralizedControl(nt, opts)

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -41,7 +41,7 @@ type MultiRepo struct {
 	RootRepos map[string]RepoOpts
 
 	// Control indicates options for configuring Namespace Repos.
-	Control repoControl
+	Control RepoControl
 
 	// SkipMultiRepo will skip the test if run in multi repo mode.  This stutters because we decided to embed
 	// this struct inside of the "New" struct rather than have it as a member.
@@ -131,8 +131,8 @@ func WithCentralizedControl(opt *New) {
 	opt.Control = CentralControl
 }
 
-// repoControl indicates the type of control for Namespace repos.
-type repoControl string
+// RepoControl indicates the type of control for Namespace repos.
+type RepoControl string
 
 const (
 	// DelegatedControl indicates the central admin only declares the Namespace

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -197,7 +197,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("ClusterRole"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test ClusterRole
+			metrics.ResourceCreated("ClusterRole"))
 		if err != nil {
 			return err
 		}
@@ -228,7 +230,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("ClusterRole", 2))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test ClusterRole
+			metrics.ResourcePatched("ClusterRole", 2))
 		if err != nil {
 			return err
 		}
@@ -250,7 +254,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1, metrics.ResourceDeleted("ClusterRole"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(),
+			metrics.ResourceDeleted("ClusterRole"))
 		if err != nil {
 			return err
 		}

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -228,7 +228,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err := nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err
@@ -258,7 +259,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(),
 			metrics.ResourceDeleted("RoleBinding"))
 		if err != nil {
 			return err
@@ -281,7 +283,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
 			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
@@ -303,7 +306,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
 			metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err
@@ -326,7 +330,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(),
 			metrics.ResourceDeleted("RoleBinding"))
 		if err != nil {
 			return err
@@ -348,7 +353,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -84,7 +84,8 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Anvil
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Anvil"))
 		if err != nil {
 			return err
@@ -174,7 +175,8 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Anvil
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Anvil"))
 		if err != nil {
 			return err

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -43,7 +43,8 @@ func TestIgnoreKptfiles(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
 			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -65,7 +65,8 @@ func TestPreventDeletionNamespace(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Role
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Role"))
 		if err != nil {
 			return err
@@ -96,7 +97,8 @@ func TestPreventDeletionNamespace(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(),
 			metrics.ResourceDeleted("Role"))
 		if err != nil {
 			return err

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -69,7 +69,8 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 5,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+4, // 4 for the test Namespace, CRD & Anvils
 			metrics.ResourceCreated("CustomResourceDefinition"), metrics.ResourceCreated("Namespace"),
 			metrics.GVKMetric{
 				GVK:   "Anvil",
@@ -105,7 +106,8 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 5,
+		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+4, // 4 for the test Namespace, CRD & Anvils
 			metrics.ResourcePatched("Namespace", 2),
 			metrics.GVKMetric{
 				GVK:   "Anvil",

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -64,7 +64,9 @@ func TestDeclareNamespace(t *testing.T) {
 
 	// Validate no error metrics are emitted.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -93,7 +95,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -118,7 +122,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("Namespace", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourcePatched("Namespace", 1))
 		if err != nil {
 			return err
 		}
@@ -143,7 +149,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("Namespace", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourcePatched("Namespace", 1))
 		if err != nil {
 			return err
 		}
@@ -168,7 +176,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("Namespace", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourcePatched("Namespace", 1))
 		if err != nil {
 			return err
 		}
@@ -198,7 +208,9 @@ func TestNamespaceExistsAndDeclared(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -229,7 +241,9 @@ func TestNamespaceEnabledAnnotationNotDeclared(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(), // test Namespace not committed
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -268,7 +282,9 @@ func TestManagementDisabledNamespace(t *testing.T) {
 
 		// Validate multi-repo metrics.
 		err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3, metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("ConfigMap"))
+			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+				nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & ConfigMap
+				metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("ConfigMap"))
 			if err != nil {
 				return err
 			}
@@ -300,7 +316,9 @@ func TestManagementDisabledNamespace(t *testing.T) {
 
 		// Validate multi-repo metrics.
 		err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3, metrics.ResourcePatched("Namespace", 1), metrics.ResourcePatched("ConfigMap", 1))
+			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+				nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & ConfigMap
+				metrics.ResourcePatched("Namespace", 1), metrics.ResourcePatched("ConfigMap", 1))
 			if err != nil {
 				return err
 			}
@@ -329,7 +347,8 @@ func TestManagementDisabledNamespace(t *testing.T) {
 
 		// Validate multi-repo metrics.
 		err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1)
+			err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+				nt.DefaultRootSyncObjectCount())
 			if err != nil {
 				return err
 			}
@@ -395,7 +414,9 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 5, metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("ConfigMap"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+4, // 4 for the test Namespace & ConfigMaps
+			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("ConfigMap"))
 		if err != nil {
 			return err
 		}
@@ -427,7 +448,9 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 4, metrics.ResourcePatched("ConfigMap", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+3, // 3 for the test Namespace & ConfigMaps
+			metrics.ResourcePatched("ConfigMap", 1))
 		if err != nil {
 			return err
 		}
@@ -451,7 +474,8 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3)
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2) // 2 for the test Namespace & ConfigMap
 		if err != nil {
 			return err
 		}
@@ -485,7 +509,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -511,7 +537,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("Namespace", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourcePatched("Namespace", 1))
 		if err != nil {
 			return err
 		}
@@ -535,7 +563,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourcePatched("Namespace", 1))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourcePatched("Namespace", 1))
 		if err != nil {
 			return err
 		}
@@ -568,7 +598,9 @@ func TestDoNotRemoveManagedByLabelExceptForConfigManagement(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(), // test Namespace not committed
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -609,7 +641,8 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Role
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Role"))
 		if err != nil {
 			return err
@@ -636,7 +669,9 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1, metrics.ResourceDeleted("Role"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount(),
+			metrics.ResourceDeleted("Role"))
 		if err != nil {
 			return err
 		}
@@ -666,9 +701,13 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	numDeclaredObjs := nt.DefaultRootSyncObjectCount()
+	numDeclaredObjs += 2 // 2 for the test Namespaces
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			numDeclaredObjs,
 			metrics.GVKMetric{
 				GVK:   "Namespace",
 				APIOp: "update",
@@ -690,7 +729,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	// We expect this to fail.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/ns.yaml")
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/bar/ns.yaml")
-	nt.RootRepos[configsync.RootSyncName].Remove(nt.RootRepos[configsync.RootSyncName].SafetyNSPath)
+	nt.RootRepos[configsync.RootSyncName].RemoveSafetyNamespace()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("undeclare all Namespaces")
 
 	if nt.MultiRepo {
@@ -712,6 +751,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	// Wait 10 seconds before checking the namespaces.
 	// Checking the namespaces immediately may not catch the case where
 	// Config Sync deletes the namespaces even if EmptySourceError is detected.
+	// TODO: Is this a bug? Why are we allowing premature deletion?
 	time.Sleep(10 * time.Second)
 
 	err = nt.Validate("foo", "", &corev1.Namespace{})
@@ -723,8 +763,15 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	// While we don't expect the Namespaces to be deleted,
+	// we do expect them to have been removed from the declared_resources metric.
+	numDeclaredObjs -= 2 // -2 for the removed test Namespaces
+	numDeclaredObjs--    // -1 for the removed safety Namespace
+
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSyncError(nomostest.DefaultRootReconcilerName), func() error {
-		return nt.ReconcilerMetrics.ValidateDeclaredResources(nomostest.DefaultRootReconcilerName, 0)
+		rootReconcilerMetrics := nt.ReconcilerMetrics.FilterByReconciler(nomostest.DefaultRootReconcilerName)
+		err := rootReconcilerMetrics.ValidateDeclaredResources(numDeclaredObjs)
+		return errors.Wrapf(err, "for reconciler %s", nomostest.DefaultRootReconcilerName)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -732,7 +779,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 
 	// Add safety back so we resume syncing.
 	safetyNs := nt.RootRepos[configsync.RootSyncName].SafetyNSName
-	nt.RootRepos[configsync.RootSyncName].Add(nt.RootRepos[configsync.RootSyncName].SafetyNSPath, fake.NamespaceObject(safetyNs))
+	nt.RootRepos[configsync.RootSyncName].AddSafetyNamespace()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("re-declare safety Namespace")
 	nt.WaitForRepoSyncs()
 
@@ -748,9 +795,12 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	numDeclaredObjs++ // 1 for the re-added safety Namespace
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			numDeclaredObjs,
 			metrics.ResourceCreated("Namespace"),
 			metrics.GVKMetric{
 				GVK:      "Namespace",
@@ -791,9 +841,12 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	numDeclaredObjs-- // -1 for the removed safety Namespace
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 0,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			numDeclaredObjs,
 			metrics.GVKMetric{
 				GVK:      "Namespace",
 				APIOp:    "delete",

--- a/e2e/testcases/preserve_fields_test.go
+++ b/e2e/testcases/preserve_fields_test.go
@@ -115,7 +115,8 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Service
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Service"))
 		if err != nil {
 			return err
@@ -140,7 +141,8 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Service
 			metrics.ResourcePatched("Namespace", 2), metrics.ResourcePatched("Service", 2))
 		if err != nil {
 			return err
@@ -390,7 +392,8 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & ConfigMap
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("ConfigMap"))
 		if err != nil {
 			return err
@@ -418,7 +421,8 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & ConfigMap
 			metrics.ResourcePatched("Namespace", 2), metrics.ResourcePatched("ConfigMap", 2))
 		if err != nil {
 			return err
@@ -443,7 +447,8 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 3,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & ConfigMap
 			metrics.ResourcePatched("Namespace", 3), metrics.ResourcePatched("ConfigMap", 3))
 		if err != nil {
 			return err

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -152,7 +152,9 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 2, metrics.ResourceCreated("Namespace"))
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
 		}
@@ -183,7 +185,8 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 1,
+		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
+			1, // 1 for the test Namespace
 			metrics.GVKMetric{
 				GVK:   "Namespace",
 				APIOp: "delete",

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -30,6 +30,8 @@ data:
       prometheus:
         endpoint: :8675
         namespace: config_sync
+        resource_to_telemetry_conversion:
+          enabled: true
     processors:
       batch:
     extensions:

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -41,6 +41,8 @@ exporters:
   prometheus:
     endpoint: :8675
     namespace: config_sync
+    resource_to_telemetry_conversion:
+      enabled: true
   googlecloud:
     metric:
       prefix: "custom.googleapis.com/opencensus/config_sync/"

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -25,6 +25,7 @@ var (
 	KeyName, _ = tag.NewKey("name")
 
 	// KeyReconcilerType groups metrics by the reconciler type. Possible values: root, namespace.
+	// TODO: replace with configsync.sync.kind resource attribute
 	KeyReconcilerType, _ = tag.NewKey("reconciler")
 
 	// KeyOperation groups metrics by their operation. Possible values: create, patch, update, delete.
@@ -58,29 +59,27 @@ var (
 	KeyCommit, _ = tag.NewKey("commit")
 
 	// KeyContainer groups metrics by their container names. Possible values: reconciler, git-sync.
+	// TODO: replace with k8s.container.name resource attribute
 	KeyContainer, _ = tag.NewKey("container")
 
 	// KeyResourceType groups metris by their resource types. Possible values: cpu, memory.
 	KeyResourceType, _ = tag.NewKey("resource")
+)
 
+// The following metric tag keys are available from the otel-collector
+// Prometheus exporter. They are created from resource attributes using the
+// resource_to_telemetry_conversion feature.
+var (
 	// ResourceKeySyncKind groups metrics by the Sync kind. Possible values: RootSync, RepoSync.
-	// This metric tag is populated from the configsync.sync.kind resource
-	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
 	ResourceKeySyncKind, _ = tag.NewKey("configsync_sync_kind")
 
 	// ResourceKeySyncName groups metrics by the Sync name.
-	// This metric tag is populated from the configsync.sync.kind resource
-	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
 	ResourceKeySyncName, _ = tag.NewKey("configsync_sync_name")
 
 	// ResourceKeySyncNamespace groups metrics by the Sync namespace.
-	// This metric tag is populated from the configsync.sync.kind resource
-	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
 	ResourceKeySyncNamespace, _ = tag.NewKey("configsync_sync_namespace")
 
 	// ResourceKeyDeploymentName groups metrics by k8s deployment name.
-	// This metric tag is populated from the configsync.sync.kind resource
-	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
 	ResourceKeyDeploymentName, _ = tag.NewKey("k8s_deployment_name")
 )
 


### PR DESCRIPTION
Fix metrics validation

- Enable resource_to_telemetry_conversion on the otel-collector.
- Use the k8s.deployment.name resource attribute to filter and
  validate metrics from specific reconcilers.
- Add a safety ClusterRole to e2e tests.
  This cluster-scoped resource is required to allow deletion of
  all other cluster-scoped resources in mono-repo mode.
  This allows for generic cleanup code, rather than needing each
  test to work around the deletion validation code.
- Rewrite e2e validation of the declared_resources metric to
  dynamically account for default resources, whether the test is
  using centralized or delegated setup.
- Fix a race condition in the TestAddUpdateRemoveClusterScopedCRDV1
  tests when deleting both the CRD and CR in the same commit.
- Shorten the metrics wait timeout to 1m from 6m.

Depends on:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/114
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/115
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/117
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/118
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/119
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/120