### PR TITLE
Remove the ResourceGroup option that is not used

### DIFF
--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -54,9 +54,6 @@ type MultiRepo struct {
 	// SkipMonoRepo will skip the test if run in mono repo mode.
 	SkipMonoRepo bool
 
-	// ResourceGroup indicates that NT should also install the resource-group controller
-	ResourceGroup bool
-
 	// ReconcileTimeout sets spec.override.reconcileTimeout on each R*Sync
 	// Default: 5m.
 	ReconcileTimeout *time.Duration
@@ -122,11 +119,6 @@ func SkipMonoRepo(opt *New) {
 // SkipNonLocalGitProvider will skip the test with non-local GitProvider types
 func SkipNonLocalGitProvider(opt *New) {
 	opt.SkipNonLocalGitProvider = true
-}
-
-// InstallResourceGroupController installs the resource-group controller.
-func InstallResourceGroupController(opts *New) {
-	opts.ResourceGroup = true
 }
 
 // WithDelegatedControl will specify the Delegated Control Pattern.

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestResourceGroupController(t *testing.T) {
-	nt := nomostest.New(t, ntopts.SkipMonoRepo, ntopts.InstallResourceGroupController)
+	nt := nomostest.New(t, ntopts.SkipMonoRepo)
 
 	ns := "rg-test"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/rg-test/ns.yaml",


### PR DESCRIPTION
The ResourceGroup option is not used anywhere. The option is supposed to be used to determine whether to install the resource-group-controller. However, in the installation function, it uses nt.MultiRepo to determine whether to install the resource-group-controller:
https://github.com/GoogleContainerTools/kpt-config-sync/blob/v1.13.0-rc.7/e2e/nomostest/config-sync.go#L184.