### PR TITLE
remove GH_TOKEN functionality from tagging scripts

### DIFF
--- a/scripts/tag-promotion.sh
+++ b/scripts/tag-promotion.sh
@@ -49,8 +49,6 @@ case "${choice}" in
 esac
 
 REMOTE="git@github.com:GoogleContainerTools/kpt-config-sync.git"
-# Use Github access token if provided
-[[ -n "${GH_TOKEN}" ]] && REMOTE="https://${GH_TOKEN}@github.com/GoogleContainerTools/kpt-config-sync.git"
 # Fetch all existing tags
 git fetch "${REMOTE}" --tags > /dev/null
 echo "+++ Successfully fetched tags"

--- a/scripts/tag-release-candidate.sh
+++ b/scripts/tag-release-candidate.sh
@@ -86,8 +86,6 @@ if ! [[ "${CS_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 REMOTE="git@github.com:GoogleContainerTools/kpt-config-sync.git"
-# Use Github access token if provided
-[[ -n "${GH_TOKEN}" ]] && REMOTE="https://${GH_TOKEN}@github.com/GoogleContainerTools/kpt-config-sync.git"
 # Fetch all existing tags
 git fetch "${REMOTE}" --tags > /dev/null
 echo "+++ Successfully fetched tags"


### PR DESCRIPTION
There is no longer a use case for using a github access token with the tagging scripts/targets, so the functionality is removed.