### PR TITLE
fix helm.values field to support multiple values

### DIFF
--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -15,15 +15,12 @@
 package controllers
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -212,16 +209,8 @@ const (
 func helmSyncEnvs(helmBase *v1beta1.HelmBase, releaseNamespace string) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	helmValues := ""
-	var values map[string]interface{}
-
 	if helmBase.Values != nil {
-		err := json.Unmarshal(helmBase.Values.Raw, &values)
-		klog.Errorf("failed to unmarshal helm.values, error: %w", err)
-		var vals []string
-		for key, val := range values {
-			vals = append(vals, fmt.Sprintf("%s=%v", key, val))
-		}
-		helmValues = strings.Join(vals, ",")
+		helmValues = string(helmBase.Values.Raw)
 	}
 	result = append(result, corev1.EnvVar{
 		Name:  reconcilermanager.HelmRepo,

--- a/pkg/validate/raw/validate/source_spec_validator.go
+++ b/pkg/validate/raw/validate/source_spec_validator.go
@@ -268,7 +268,7 @@ func validGCPServiceAccountEmail(email string) bool {
 func InvalidSourceType(o client.Object) status.Error {
 	kind := o.GetObjectKind().GroupVersionKind().Kind
 	return invalidSyncBuilder.
-		Sprintf("%ss must specify spec.sourceType to be either %q or %q", kind, v1beta1.GitSource, v1beta1.OciSource).
+		Sprintf("%ss must specify spec.sourceType to be one of %q, %q, %q", kind, v1beta1.GitSource, v1beta1.OciSource, v1beta1.HelmSource).
 		BuildWithResources(o)
 }
 


### PR DESCRIPTION
helm.values field type used to be map[string]interface{}. Looping through the map to generate a env variable leads to a inconsistent env variable issue. Since we change the helm.values field type to JSON already, we can pass it through env variable directly, and process it later in helm-sync.