### PR TITLE
Add GCP+GKE metric attributes

### DIFF
--- a/docs/metric-resource-attributes.md
+++ b/docs/metric-resource-attributes.md
@@ -1,0 +1,53 @@
+# Config Sync Metric Resource Attributes
+
+Config Sync uses the Open Telemetry Collector (otel-collector) to collect and
+export metrics from its various components to one or more destinations. 
+
+Open Telemetry resource attributes uniquely identify a metrics source. 
+
+## Pipeline
+
+The metric pipeline:
+
+component binary -> otel agent sidecar -> otel collector
+
+## Agent Resource Attributes
+
+Since the Component and Agent share the same Pod, most of the resource
+attributes can be added by the Agent without needing to program the capability
+into each component binary. So these resource attributes are added to metrics
+from all components.
+
+The GCP resource processor in the otel agent sidecar adds the following
+resource attributes, if using GKE:
+
+- cloud.provider
+- cloud.platform
+- cloud.account.id
+- cloud.region OR cloud.availability_zone
+- host.id
+- host.name (when not using workload identity)
+- k8s.cluster.name
+
+## Component Resource Attributes
+
+### Reconciler Resource Attributes
+
+The reconciler binary currently adds the following resource attrbutes:
+
+- k8s.pod.name (the name of the reconciler Deployment)
+- k8s.pod.namespace (the namespace of the RootSync or RepoSync)
+
+**WARNING:** These resource attributes are pending change to match open
+telemetry conventions.
+
+### Reconciler Resource Attributes
+
+The hydration-controller binary (a reconciler sidecar) currently adds the
+following resource attrbutes:
+
+- k8s.pod.name ("kmetrics-manager")
+- k8s.pod.namespace ("kmetrics-system")
+
+**WARNING:** These resource attributes are pending change to match open
+telemetry conventions.

--- a/manifests/otel-agent-cm.yaml
+++ b/manifests/otel-agent-cm.yaml
@@ -33,6 +33,9 @@ data:
           insecure: true
     processors:
       batch:
+      # Populate resource attributes using the GCE metadata service, if available.
+      resourcedetection:
+        detectors: [gcp]
     extensions:
       health_check:
     service:
@@ -40,5 +43,5 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch]
+          processors: [batch, resourcedetection]
           exporters: [opencensus]

--- a/manifests/test-resources/resourcegroup-manifest.yaml
+++ b/manifests/test-resources/resourcegroup-manifest.yaml
@@ -452,6 +452,9 @@ data:
           insecure: true
     processors:
       batch:
+      # Populate resource attributes using the GCE metadata service, if available.
+      resourcedetection:
+        detectors: [gcp]
     extensions:
       health_check:
     service:
@@ -459,7 +462,7 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch]
+          processors: [batch, resourcedetection]
           exporters: [opencensus]
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
- Enable the GCP resource processor on the opentelemetry agent. This adds the following resource attributes:
  * cloud.provider
  * cloud.platform
  * cloud.account.id
  * cloud.region OR cloud.availability_zone
  * host.id
  * host.name (when not using workload identity)
- When then GCE metadata server is unavailable, the resource processor exits without modifying the resource attributes. So it's safe to enable globally.
- Enabling the resource processor on the agent sidecars allows for more accurate attributes, like the host.id of the node the reconciler is on, instead of the host.id of the otel-collector.

For more details, see the docs:
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
