### PR TITLE
Log metrics recorded and received for debugging

### DIFF
--- a/e2e/nomostest/metrics/parse.go
+++ b/e2e/nomostest/metrics/parse.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.opencensus.io/tag"
 )
 
 // ParseMetrics connects to the local port where metrics are being forwarded to
@@ -71,8 +70,8 @@ func parseMetricName(m string) (string, error) {
 }
 
 // parseTags filters for the metric tag keys and values.
-func parseTags(m string) []tag.Tag {
-	var tags []tag.Tag
+func parseTags(m string) []Tag {
+	var tags []Tag
 	// match all tags: {operation="create",status="success",type="Namespace"}
 	regex := regexp.MustCompile(`{(.*?)}`)
 	ss := regex.FindStringSubmatch(m)
@@ -83,9 +82,8 @@ func parseTags(m string) []tag.Tag {
 			regex = regexp.MustCompile(`(.*?)="(.*?)"`)
 			ss = regex.FindStringSubmatch(t)
 			if ss != nil {
-				key, _ := tag.NewKey(ss[1])
-				tags = append(tags, tag.Tag{
-					Key:   key,
+				tags = append(tags, Tag{
+					Key:   ss[1],
 					Value: ss[2],
 				})
 			}

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"go.opencensus.io/tag"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/metrics"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -31,7 +31,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/metrics"
 	ocmetrics "kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
@@ -262,10 +261,10 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 		if err := nt.ValidateResourceOverrideCount(string(controllers.RootReconcilerType), "git-sync", "cpu", 1); err != nil {
 			return err
 		}
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
-			{Key: metrics.KeyContainer, Value: "reconciler"},
-			{Key: metrics.KeyResourceType, Value: "memory"},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
+			{Key: ocmetrics.KeyContainer.Name(), Value: "reconciler"},
+			{Key: ocmetrics.KeyResourceType.Name(), Value: "memory"},
 		}); err != nil {
 			return err
 		}
@@ -344,8 +343,8 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
 		}); err != nil {
 			return err
 		}
@@ -568,10 +567,10 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 		if err := nt.ValidateResourceOverrideCount(string(controllers.RootReconcilerType), "git-sync", "cpu", 1); err != nil {
 			return err
 		}
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
-			{Key: metrics.KeyContainer, Value: "reconciler"},
-			{Key: metrics.KeyResourceType, Value: "memory"},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
+			{Key: ocmetrics.KeyContainer.Name(), Value: "reconciler"},
+			{Key: ocmetrics.KeyResourceType.Name(), Value: "memory"},
 		}); err != nil {
 			return err
 		}
@@ -650,8 +649,8 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		if err := nt.ValidateResourceOverrideCountMissingTags([]tag.Tag{
-			{Key: metrics.KeyReconcilerType, Value: string(controllers.RootReconcilerType)},
+		if err := nt.ValidateResourceOverrideCountMissingTags([]metrics.Tag{
+			{Key: ocmetrics.KeyReconcilerType.Name(), Value: string(controllers.RootReconcilerType)},
 		}); err != nil {
 			return err
 		}

--- a/pkg/kmetrics/record.go
+++ b/pkg/kmetrics/record.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -46,21 +47,30 @@ func RecordKustomizeFieldCountData(ctx context.Context, fieldCountData *Kustomiz
 	recordKustomizeTopTierMetrics(ctx, fieldCountData.TopTierCount)
 }
 
+func record(ctx context.Context, ms ...stats.Measurement) {
+	stats.Record(ctx, ms...)
+	if klog.V(5).Enabled() {
+		for _, m := range ms {
+			klog.Infof("Metric recorded: { \"Name\": %q, \"Value\": %#v, \"Tags\": %s }", m.Measure().Name(), m.Value(), tag.FromContext(ctx))
+		}
+	}
+}
+
 // RecordKustomizeResourceCount produces measurement for KustomizeResourceCount view
 func RecordKustomizeResourceCount(ctx context.Context, resourceCount int) {
-	stats.Record(ctx, KustomizeResourceCount.M(int64(resourceCount)))
+	record(ctx, KustomizeResourceCount.M(int64(resourceCount)))
 }
 
 // RecordKustomizeExecutionTime produces measurement for KustomizeExecutionTime view
 func RecordKustomizeExecutionTime(ctx context.Context, executionTime float64) {
-	stats.Record(ctx, KustomizeExecutionTime.M(executionTime))
+	record(ctx, KustomizeExecutionTime.M(executionTime))
 }
 
 // recordKustomizeFieldCount produces measurement for KustomizeFieldCount view
 func recordKustomizeFieldCount(ctx context.Context, fieldCount map[string]int) {
 	for field, count := range fieldCount {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyFieldName, field))
-		stats.Record(tagCtx, KustomizeFieldCount.M(int64(count)))
+		record(tagCtx, KustomizeFieldCount.M(int64(count)))
 	}
 }
 
@@ -68,7 +78,7 @@ func recordKustomizeFieldCount(ctx context.Context, fieldCount map[string]int) {
 func recordKustomizeDeprecatingFields(ctx context.Context, deprecationMetrics map[string]int) {
 	for field, count := range deprecationMetrics {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyDeprecatingField, field))
-		stats.Record(tagCtx, KustomizeDeprecatingFields.M(int64(count)))
+		record(tagCtx, KustomizeDeprecatingFields.M(int64(count)))
 	}
 }
 
@@ -76,7 +86,7 @@ func recordKustomizeDeprecatingFields(ctx context.Context, deprecationMetrics ma
 func recordKustomizeSimplification(ctx context.Context, simplMetrics map[string]int) {
 	for field, count := range simplMetrics {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keySimplificationAdoption, field))
-		stats.Record(tagCtx, KustomizeSimplification.M(int64(count)))
+		record(tagCtx, KustomizeSimplification.M(int64(count)))
 	}
 }
 
@@ -84,7 +94,7 @@ func recordKustomizeSimplification(ctx context.Context, simplMetrics map[string]
 func recordKustomizeK8sMetadata(ctx context.Context, k8sMetadata map[string]int) {
 	for field, count := range k8sMetadata {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyK8sMetadata, field))
-		stats.Record(tagCtx, KustomizeK8sMetadata.M(int64(count)))
+		record(tagCtx, KustomizeK8sMetadata.M(int64(count)))
 	}
 }
 
@@ -92,7 +102,7 @@ func recordKustomizeK8sMetadata(ctx context.Context, k8sMetadata map[string]int)
 func recordKustomizeHelmMetrics(ctx context.Context, helmMetrics map[string]int) {
 	for helmInflator, count := range helmMetrics {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyHelmMetrics, helmInflator))
-		stats.Record(tagCtx, KustomizeHelmMetrics.M(int64(count)))
+		record(tagCtx, KustomizeHelmMetrics.M(int64(count)))
 	}
 }
 
@@ -100,7 +110,7 @@ func recordKustomizeHelmMetrics(ctx context.Context, helmMetrics map[string]int)
 func recordKustomizeBaseCount(ctx context.Context, baseCount map[string]int) {
 	for baseSource, count := range baseCount {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyBaseCount, baseSource))
-		stats.Record(tagCtx, KustomizeBaseCount.M(int64(count)))
+		record(tagCtx, KustomizeBaseCount.M(int64(count)))
 	}
 }
 
@@ -108,7 +118,7 @@ func recordKustomizeBaseCount(ctx context.Context, baseCount map[string]int) {
 func recordKustomizePatchCount(ctx context.Context, patchCount map[string]int) {
 	for patchType, count := range patchCount {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyPatchCount, patchType))
-		stats.Record(tagCtx, KustomizePatchCount.M(int64(count)))
+		record(tagCtx, KustomizePatchCount.M(int64(count)))
 	}
 }
 
@@ -116,6 +126,6 @@ func recordKustomizePatchCount(ctx context.Context, patchCount map[string]int) {
 func recordKustomizeTopTierMetrics(ctx context.Context, topTierCount map[string]int) {
 	for field, count := range topTierCount {
 		tagCtx, _ := tag.New(ctx, tag.Upsert(keyTopTierCount, field))
-		stats.Record(tagCtx, KustomizeTopTierMetrics.M(int64(count)))
+		record(tagCtx, KustomizeTopTierMetrics.M(int64(count)))
 	}
 }


### PR DESCRIPTION
- Enable recorded metric logging with -v=5 (component binary)
- Enable received metric logging with --debug (nomostest)
- Fix existing Tag printout in test validation failure by using a custom Tag struct which is serializable with fmt %v (no private fields)
