### PR TITLE
Send correct number of declared_resources

### DIFF
--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -63,6 +63,9 @@ func (r *Resources) Update(ctx context.Context, objects []client.Object) ([]clie
 		newObjects = append(newObjects, obj)
 	}
 
+	// Record the declared_resources metric, after parsing but before validation.
+	metrics.RecordDeclaredResources(ctx, len(newObjects))
+
 	previousSet := r.getObjectSet()
 	if err := deletesAllNamespaces(previousSet, newSet); err != nil {
 		return nil, err


### PR DESCRIPTION
- This fixes an edge case where declared_resources was zero when more than zero resources were declared.
- The reason this wasn't caught before is because TestDontDeleteAllNamespaces expects zero resources when it tests deletion of all namespaces.
- This unblocks adding a new cluster-scoped safety resource in a future change.