### PR TITLE
Validate metrics after Sync, not just Apply

### DIFF
--- a/e2e/nomostest/metrics/validate.go
+++ b/e2e/nomostest/metrics/validate.go
@@ -114,7 +114,7 @@ func ResourceDeleted(gvk string) GVKMetric {
 func (csm ConfigSyncMetrics) ValidateReconcilerManagerMetrics() error {
 	metric := ocmetrics.ReconcileDurationView.Name
 	validation := hasTags(metric, []Tag{
-		{Key: ocmetrics.KeyStatus.Name(), Value: "success"},
+		{Key: ocmetrics.KeyStatus.Name(), Value: ocmetrics.StatusSuccess},
 	})
 	return csm.validateMetric(metric, validation)
 }
@@ -126,6 +126,8 @@ func (csm ConfigSyncMetrics) ValidateReconcilerMetrics(reconciler string, numRes
 	// metric exists for the correct reconciler and has a "success" status tag.
 	metrics := []string{
 		ocmetrics.ApplyDurationView.Name,
+		ocmetrics.LastApplyTimestampView.Name,
+		ocmetrics.LastSyncTimestampView.Name,
 	}
 	for _, m := range metrics {
 		if err := csm.validateSuccessTag(reconciler, m); err != nil {
@@ -150,10 +152,10 @@ func (csm ConfigSyncMetrics) ValidateGVKMetrics(reconciler string, gvkMetric GVK
 	return csm.validateRemediateDuration(reconciler, gvkMetric.GVK)
 }
 
-// ValidateMetricsCommitApplied checks that the `last_apply_timestamp` metric has been
-// recorded for a particular commit hash.
-func (csm ConfigSyncMetrics) ValidateMetricsCommitApplied(commitHash string) error {
-	metric := ocmetrics.LastApplyTimestampView.Name
+// ValidateMetricsCommitSynced checks that the `last_sync_timestamp` metric has
+// been recorded for a particular commit hash.
+func (csm ConfigSyncMetrics) ValidateMetricsCommitSynced(commitHash string) error {
+	metric := ocmetrics.LastSyncTimestampView.Name
 	validation := hasTags(metric, []Tag{
 		{Key: ocmetrics.KeyCommit.Name(), Value: commitHash},
 	})
@@ -272,7 +274,7 @@ func (csm ConfigSyncMetrics) ValidateNoSSLVerifyCount(count int) error {
 // and has a "success" tag value.
 func (csm ConfigSyncMetrics) validateSuccessTag(reconciler, metric string) error {
 	validation := hasTags(metric, []Tag{
-		{Key: ocmetrics.KeyStatus.Name(), Value: "success"},
+		{Key: ocmetrics.KeyStatus.Name(), Value: ocmetrics.StatusSuccess},
 	})
 	return csm.validateMetric(metric, validation)
 }
@@ -283,7 +285,7 @@ func (csm ConfigSyncMetrics) validateAPICallDuration(reconciler, operation, gvk 
 	metric := ocmetrics.APICallDurationView.Name
 	validation := hasTags(metric, []Tag{
 		{Key: ocmetrics.KeyOperation.Name(), Value: operation},
-		{Key: ocmetrics.KeyStatus.Name(), Value: "success"},
+		{Key: ocmetrics.KeyStatus.Name(), Value: ocmetrics.StatusSuccess},
 	})
 	return errors.Wrapf(csm.validateMetric(metric, validation), "%s %s operation", gvk, operation)
 }
@@ -307,7 +309,7 @@ func (csm ConfigSyncMetrics) validateApplyOperations(reconciler, operation, gvk 
 	validations := []Validation{
 		hasTags(metric, []Tag{
 			{Key: ocmetrics.KeyOperation.Name(), Value: operation},
-			{Key: ocmetrics.KeyStatus.Name(), Value: "success"},
+			{Key: ocmetrics.KeyStatus.Name(), Value: ocmetrics.StatusSuccess},
 		}),
 		valueGTE(metric, value),
 	}
@@ -320,7 +322,7 @@ func (csm ConfigSyncMetrics) validateRemediateDuration(reconciler, gvk string) e
 	metric := ocmetrics.RemediateDurationView.Name
 	validations := []Validation{
 		hasTags(metric, []Tag{
-			{Key: ocmetrics.KeyStatus.Name(), Value: "success"},
+			{Key: ocmetrics.KeyStatus.Name(), Value: ocmetrics.StatusSuccess},
 		}),
 	}
 	return errors.Wrap(csm.validateMetric(metric, validations...), gvk)

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -345,6 +345,8 @@ func (nt *NT) updateMetrics(prev testmetrics.ConfigSyncMetrics, parsedMetrics te
 		ocmetrics.ReconcileDurationView.Name,
 		ocmetrics.RemediateDurationView.Name,
 		ocmetrics.DeclaredResourcesView.Name,
+		ocmetrics.LastApplyTimestampView.Name,
+		ocmetrics.LastSyncTimestampView.Name,
 	}
 
 	// Diff the metrics if previous metrics exist
@@ -1466,17 +1468,17 @@ func Wait(t testing.NTB, opName string, timeout time.Duration, condition func() 
 // MetricsSyncOption determines where metrics will be synced to
 type MetricsSyncOption func(csm *testmetrics.ConfigSyncMetrics) error
 
-// SyncMetricsToLatestCommit syncs metrics to the latest commit
+// SyncMetricsToLatestCommit syncs metrics to the latest synced commit
 func SyncMetricsToLatestCommit(nt *NT) MetricsSyncOption {
 	return func(metrics *testmetrics.ConfigSyncMetrics) error {
 		for nn := range nt.RootRepos {
-			if err := metrics.ValidateMetricsCommitApplied(nt.RootRepos[nn].Hash()); err != nil {
+			if err := metrics.ValidateMetricsCommitSynced(nt.RootRepos[nn].Hash()); err != nil {
 				return err
 			}
 		}
 
 		for ns := range nt.NonRootRepos {
-			if err := metrics.ValidateMetricsCommitApplied(nt.NonRootRepos[ns].Hash()); err != nil {
+			if err := metrics.ValidateMetricsCommitSynced(nt.NonRootRepos[ns].Hash()); err != nil {
 				return err
 			}
 		}

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -86,9 +86,12 @@ func RecordParserDuration(ctx context.Context, trigger, source, status string, s
 }
 
 // RecordLastSync produces a measurement for the LastSync view.
-func RecordLastSync(ctx context.Context, commit string, timestamp time.Time) {
+func RecordLastSync(ctx context.Context, status, commit string, timestamp time.Time) {
+	tagCtx, _ := tag.New(ctx,
+		tag.Upsert(KeyStatus, status),
+		tag.Upsert(KeyCommit, commit))
 	measurement := LastSync.M(timestamp.Unix())
-	record(ctx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordDeclaredResources produces a measurement for the DeclaredResources view.

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"go.opencensus.io/tag"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 )
 
 var (
@@ -63,10 +64,26 @@ var (
 	KeyResourceType, _ = tag.NewKey("resource")
 )
 
+const (
+	// StatusSuccess is the string value for the status key indicating success
+	StatusSuccess = "success"
+	// StatusError is the string value for the status key indicating failure/errors
+	StatusError = "error"
+)
+
 // StatusTagKey returns a string representation of the error, if it exists, otherwise success.
 func StatusTagKey(err error) string {
 	if err == nil {
-		return "success"
+		return StatusSuccess
 	}
-	return "error"
+	return StatusError
+}
+
+// StatusTagValueFromSummary returns error if the summary indicates at least 1
+// error, otherwise success.
+func StatusTagValueFromSummary(summary *v1beta1.ErrorSummary) string {
+	if summary.TotalCount == 0 {
+		return StatusSuccess
+	}
+	return StatusError
 }

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -72,6 +72,7 @@ var (
 		Name:        LastSync.Name(),
 		Measure:     LastSync,
 		Description: "The timestamp of the most recent sync from Git",
+		TagKeys:     []tag.Key{KeyStatus, KeyCommit},
 		Aggregation: view.LastValue(),
 	}
 

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -283,7 +283,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 	metrics.RecordReconcilerErrors(ctx, "sync", status.ToCSE(errs))
 	metrics.RecordPipelineError(ctx, configsync.RepoSyncName, "sync", rs.Status.Sync.ErrorSummary.TotalCount)
 	if !syncing {
-		metrics.RecordLastSync(ctx, rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
+		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 
 	if klog.V(5).Enabled() {

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -379,7 +379,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, errs status.MultiEr
 	metrics.RecordReconcilerErrors(ctx, "sync", status.ToCSE(errs))
 	metrics.RecordPipelineError(ctx, configsync.RootSyncName, "sync", rs.Status.Sync.ErrorSummary.TotalCount)
 	if !syncing {
-		metrics.RecordLastSync(ctx, rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
+		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 
 	if klog.V(5).Enabled() {

--- a/pkg/syncer/metrics/metrics.go
+++ b/pkg/syncer/metrics/metrics.go
@@ -90,11 +90,18 @@ func init() {
 	)
 }
 
+const (
+	// StatusSuccess is the string value for the status key indicating success
+	StatusSuccess = "success"
+	// StatusError is the string value for the status key indicating failure/errors
+	StatusError = "error"
+)
+
 // StatusLabel returns a string representation of the given error appropriate for the status label
 // of a Prometheus metric.
 func StatusLabel(err error) string {
 	if err == nil {
-		return "success"
+		return StatusSuccess
 	}
-	return "error"
+	return StatusError
 }


### PR DESCRIPTION
- Add `"status"` tag to `last_sync_timestamp` so it can be used to check whether a sync had either source or sync errors. Because, `last_apply_timestamp` only represents sync errors, not source errors.
- Change e2e metrics validation to wait for `last_sync_timestamp`, instead of `last_apply_timestamp`. This more correctly waits until sync is complete, not just apply, and has an error status that includes source errors.
- Add constants for status metric tag values.
- These changes should reduce flakey errors.

Depends onhttps://github.com/GoogleContainerTools/kpt-config-sync/pull/115