### PR TITLE
Add k8s resource attributes to metrics

### DIFF
--- a/cmd/nomos/migrate/migrate.go
+++ b/cmd/nomos/migrate/migrate.go
@@ -359,7 +359,7 @@ func createRootSync(ctx context.Context, cm *util.ConfigManagementClient) (*v1be
 
 	return &v1beta1.RootSync{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "RootSync",
+			Kind:       configsync.RootSyncKind,
 			APIVersion: v1beta1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -93,18 +93,18 @@ func main() {
 	watchFleetMembership := fleetMembershipCRDExists(mgr.GetConfig(), mgr.GetRESTMapper())
 
 	repoSync := controllers.NewRepoSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("RepoSync"),
+		ctrl.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		mgr.GetScheme(), allowVerticalScale)
 	if err := repoSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "RepoSync")
+		setupLog.Error(err, "unable to create controller", "controller", configsync.RepoSyncKind)
 		os.Exit(1)
 	}
 
 	rootSync := controllers.NewRootSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("RootSync"),
+		ctrl.Log.WithName("controllers").WithName(configsync.RootSyncKind),
 		mgr.GetScheme(), allowVerticalScale)
 	if err := rootSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "RootSync")
+		setupLog.Error(err, "unable to create controller", "controller", configsync.RootSyncKind)
 		os.Exit(1)
 	}
 

--- a/e2e/nomostest/config-sync.go
+++ b/e2e/nomostest/config-sync.go
@@ -1129,7 +1129,7 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 				// 3 is for the resources created for every namespace: RepoSync, RoleBinding, ClusterRoleBinding
 				2+len(rsNamespaces)+rsCount*3,
 				testmetrics.ResourceCreated("Namespace"), testmetrics.ResourceCreated("ClusterRole"),
-				testmetrics.ResourceCreated("RoleBinding"), testmetrics.ResourceCreated("RepoSync"),
+				testmetrics.ResourceCreated("RoleBinding"), testmetrics.ResourceCreated(configsync.RepoSyncKind),
 				testmetrics.ResourceCreated("ClusterRoleBinding"))
 		} else {
 			err = nt.ValidateMultiRepoMetrics(DefaultRootReconcilerName,
@@ -1137,7 +1137,7 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 				// and 2 is for the resources created for every namespace: RepoSync and RoleBinding
 				2+len(rsNamespaces)+rsCount*2,
 				testmetrics.ResourceCreated("Namespace"), testmetrics.ResourceCreated("ClusterRole"),
-				testmetrics.ResourceCreated("RoleBinding"), testmetrics.ResourceCreated("RepoSync"))
+				testmetrics.ResourceCreated("RoleBinding"), testmetrics.ResourceCreated(configsync.RepoSyncKind))
 		}
 		if err != nil {
 			return err

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -237,9 +237,11 @@ func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
 		// TODO: Remove the psp related change when Kubernetes 1.25 is
 		// available on GKE.
 		if strings.Contains(os.Getenv("GCP_CLUSTER"), "psp") {
-			err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 5, metrics.ResourceDeleted("RepoSync"))
+			err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 5,
+				metrics.ResourceDeleted(configsync.RepoSyncKind))
 		} else {
-			err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 4, metrics.ResourceDeleted("RepoSync"))
+			err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName, 4,
+				metrics.ResourceDeleted(configsync.RepoSyncKind))
 		}
 		if err != nil {
 			return err

--- a/e2e/testdata/reconciler-manager-configmap-updated.yaml
+++ b/e2e/testdata/reconciler-manager-configmap-updated.yaml
@@ -45,6 +45,9 @@ data:
         labels:
           app: reconciler
           configsync.gke.io/deployment-name: "" # this field will be assigned dynamically by the reconciler-manager
+          configsync.gke.io/sync-kind: "" # this field will be assigned dynamically by the reconciler-manager
+          configsync.gke.io/sync-name: "" # this field will be assigned dynamically by the reconciler-manager
+          configsync.gke.io/sync-namespace: "" # this field will be assigned dynamically by the reconciler-manager
       spec:
         serviceAccountName: # this field will be assigned dynamically by the reconciler-manager
         containers:
@@ -237,6 +240,66 @@ data:
           terminationMessagePath: "/dev/termination-log"
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
+          # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
+          # is used by the otel-agent to populate resource attributes when
+          # emiting metrics to the otel-collector. This is more efficient than
+          # having the otel-collector look them up from the apiserver.
+          env:
+          - name: KUBE_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: KUBE_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: KUBE_POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: KUBE_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: KUBE_DEPLOYMENT_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+          - name: CONFIGSYNC_SYNC_KIND
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['configsync.gke.io/sync-kind']
+          - name: CONFIGSYNC_SYNC_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['configsync.gke.io/sync-name']
+          - name: CONFIGSYNC_SYNC_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['configsync.gke.io/sync-namespace']
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: "k8s.pod.name=$(KUBE_POD_NAME),\
+              k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
+              k8s.pod.uid=$(KUBE_POD_UID),\
+              k8s.pod.ip=$(KUBE_POD_IP),\
+              k8s.node.name=$(KUBE_NODE_NAME),\
+              k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME),\
+              configsync.sync.kind=$(CONFIGSYNC_SYNC_KIND),\
+              configsync.sync.name=$(CONFIGSYNC_SYNC_NAME),\
+              configsync.sync.namespace=$(CONFIGSYNC_SYNC_NAMESPACE)"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst

--- a/manifests/otel-agent-cm.yaml
+++ b/manifests/otel-agent-cm.yaml
@@ -33,9 +33,10 @@ data:
           insecure: true
     processors:
       batch:
-      # Populate resource attributes using the GCE metadata service, if available.
+      # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
+      # the GCE metadata service, if available.
       resourcedetection:
-        detectors: [gcp]
+        detectors: [env, gcp]
     extensions:
       health_check:
     service:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -45,6 +45,9 @@ data:
          labels:
            app: reconciler
            configsync.gke.io/deployment-name: "" # this field will be assigned dynamically by the reconciler-manager
+           configsync.gke.io/sync-kind: "" # this field will be assigned dynamically by the reconciler-manager
+           configsync.gke.io/sync-name: "" # this field will be assigned dynamically by the reconciler-manager
+           configsync.gke.io/sync-namespace: "" # this field will be assigned dynamically by the reconciler-manager
          annotations:
            cluster-autoscaler.kubernetes.io/safe-to-evict: "true" # this annotation is needed so that pods doesn't block scale down
        spec:
@@ -227,6 +230,66 @@ data:
            terminationMessagePath: "/dev/termination-log"
            terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
+           # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
+           # is used by the otel-agent to populate resource attributes when
+           # emiting metrics to the otel-collector. This is more efficient than
+           # having the otel-collector look them up from the apiserver.
+           env:
+           - name: KUBE_POD_NAME
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.name
+           - name: KUBE_POD_NAMESPACE
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.namespace
+           - name: KUBE_POD_UID
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.uid
+           - name: KUBE_POD_IP
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: status.podIP
+           - name: KUBE_NODE_NAME
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: spec.nodeName
+           - name: KUBE_DEPLOYMENT_NAME
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+           - name: CONFIGSYNC_SYNC_KIND
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.labels['configsync.gke.io/sync-kind']
+           - name: CONFIGSYNC_SYNC_NAME
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.labels['configsync.gke.io/sync-name']
+           - name: CONFIGSYNC_SYNC_NAMESPACE
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.labels['configsync.gke.io/sync-namespace']
+           - name: OTEL_RESOURCE_ATTRIBUTES
+             value: "k8s.pod.name=$(KUBE_POD_NAME),\
+               k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
+               k8s.pod.uid=$(KUBE_POD_UID),\
+               k8s.pod.ip=$(KUBE_POD_IP),\
+               k8s.node.name=$(KUBE_NODE_NAME),\
+               k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME),\
+               configsync.sync.kind=$(CONFIGSYNC_SYNC_KIND),\
+               configsync.sync.name=$(CONFIGSYNC_SYNC_NAME),\
+               configsync.sync.namespace=$(CONFIGSYNC_SYNC_NAMESPACE)"
          restartPolicy: Always
          terminationGracePeriodSeconds: 30
          dnsPolicy: ClusterFirst

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: reconciler-manager
+        configsync.gke.io/deployment-name: reconciler-manager
     spec:
       serviceAccountName: reconciler-manager
       containers:
@@ -90,6 +91,48 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+        # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
+        # is used by the otel-agent to populate resource attributes when
+        # emiting metrics to the otel-collector. This is more efficient than
+        # having the otel-collector look them up from the apiserver.
+        env:
+        - name: KUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: KUBE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBE_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: KUBE_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: KUBE_DEPLOYMENT_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.pod.name=$(KUBE_POD_NAME),\
+            k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
+            k8s.pod.uid=$(KUBE_POD_UID),\
+            k8s.pod.ip=$(KUBE_POD_IP),\
+            k8s.node.name=$(KUBE_NODE_NAME),\
+            k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)"
       terminationGracePeriodSeconds: 10
       volumes:
       - name: configs

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -36,6 +36,10 @@ const (
 	RepoSyncName = "repo-sync"
 	// RootSyncName is the expected name of any RootSync CR.
 	RootSyncName = "root-sync"
+	// RepoSyncKind is the kind of the RepoSync resource.
+	RepoSyncKind = "RepoSync"
+	// RootSyncKind is the kind of the RepoSync resource.
+	RootSyncKind = "RootSync"
 )
 
 const (

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	"kpt.dev/configsync/pkg/testing/fake"
@@ -171,7 +172,7 @@ func TestRemoveFrom(t *testing.T) {
 }
 
 func TestGetObjectSize(t *testing.T) {
-	u := newInventoryUnstructured("inv-1", "test", "disabled")
+	u := newInventoryUnstructured(configsync.RootSyncKind, "inv-1", "test", "disabled")
 	size, err := getObjectSize(u)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/diff/precedence_test.go
+++ b/pkg/diff/precedence_test.go
@@ -135,11 +135,11 @@ func TestValidateManager(t *testing.T) {
 		ObjectKey: client.ObjectKey{Namespace: "ns-1", Name: "cm-1"},
 	}
 	rootSyncID := core.ID{
-		GroupKind: schema.GroupKind{Group: configsync.GroupName, Kind: "RootSync"},
+		GroupKind: schema.GroupKind{Group: configsync.GroupName, Kind: configsync.RootSyncKind},
 		ObjectKey: client.ObjectKey{Namespace: "ns-1", Name: "rootsync-1"},
 	}
 	repoSyncID := core.ID{
-		GroupKind: schema.GroupKind{Group: configsync.GroupName, Kind: "RepoSync"},
+		GroupKind: schema.GroupKind{Group: configsync.GroupName, Kind: configsync.RepoSyncKind},
 		ObjectKey: client.ObjectKey{Namespace: "ns-1", Name: "reposync-1"},
 	}
 	testCases := []struct {

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 )
@@ -208,22 +209,22 @@ func StatefulSet() schema.GroupVersionKind {
 
 // RepoSyncV1Alpha1 returns the canonical RepoSync GroupVersionKind.
 func RepoSyncV1Alpha1() schema.GroupVersionKind {
-	return v1alpha1.SchemeGroupVersion.WithKind("RepoSync")
+	return v1alpha1.SchemeGroupVersion.WithKind(configsync.RepoSyncKind)
 }
 
 // RepoSyncV1Beta1 returns the v1beta1 RepoSync GroupVersionKind.
 func RepoSyncV1Beta1() schema.GroupVersionKind {
-	return configsyncv1beta1.SchemeGroupVersion.WithKind("RepoSync")
+	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RepoSyncKind)
 }
 
 // RootSyncV1Alpha1 returns the canonical RootSync GroupVersionKind.
 func RootSyncV1Alpha1() schema.GroupVersionKind {
-	return v1alpha1.SchemeGroupVersion.WithKind("RootSync")
+	return v1alpha1.SchemeGroupVersion.WithKind(configsync.RootSyncKind)
 }
 
 // RootSyncV1Beta1 returns the v1beta1 RootSync GroupVersionKind.
 func RootSyncV1Beta1() schema.GroupVersionKind {
-	return configsyncv1beta1.SchemeGroupVersion.WithKind("RootSync")
+	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RootSyncKind)
 }
 
 // Service returns the canonical Service GroupVersionKind.

--- a/pkg/kmetrics/register.go
+++ b/pkg/kmetrics/register.go
@@ -15,26 +15,12 @@
 package kmetrics
 
 import (
-	"os"
-
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
 )
 
-const (
-	kmResourceNamespaceName = "kmetrics-system"
-	kmResourcePodName       = "kmetrics-manager"
-)
-
 // RegisterOCAgentExporter creates the OC Agent metrics exporter.
 func RegisterOCAgentExporter() (*ocagent.Exporter, error) {
-	err := os.Setenv(
-		"OC_RESOURCE_LABELS",
-		"k8s.namespace.name=\""+kmResourceNamespaceName+"\",k8s.pod.name=\""+kmResourcePodName+"\"")
-	if err != nil {
-		return nil, err
-	}
-
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 	)

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -46,6 +46,9 @@ const (
 	// SyncNameLabel indicates the name of RootSync or RepoSync.
 	SyncNameLabel = configsync.ConfigSyncPrefix + "sync-name"
 
+	// SyncKindLabel indicates the RSync kind: RootSync or RepoSync.
+	SyncKindLabel = configsync.ConfigSyncPrefix + "sync-kind"
+
 	// DeploymentNameLabel indicates the name of the Deployment.
 	// This is used to enable selecting pods by label, primarily for printing logs.
 	// Example: kubectl logs deployment/<deploy-name> <container-name> -n config-management-system

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -15,26 +15,12 @@
 package metrics
 
 import (
-	"fmt"
-	"os"
-
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
-	"kpt.dev/configsync/pkg/reconcilermanager"
 )
 
 // RegisterOCAgentExporter creates the OC Agent metrics exporter.
 func RegisterOCAgentExporter() (*ocagent.Exporter, error) {
-	// Update OC_RESOURCE_LABELS defined in go.opencensus.io/resource/resource.go
-	// So that each OC agent will have corresponding resource labels
-	// Adding pod name and namespace name can have metrics identified as container_pod
-	// Cluster name & cluster location & project name are attached automatically
-	reconcilerName := os.Getenv(reconcilermanager.ReconcilerNameKey)
-	namespace := os.Getenv(reconcilermanager.NamespaceNameKey)
-	err := os.Setenv("OC_RESOURCE_LABELS", fmt.Sprintf("k8s.namespace.name=%q,k8s.pod.name=%q", namespace, reconcilerName))
-	if err != nil {
-		return nil, err
-	}
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 	)

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -62,6 +62,26 @@ var (
 
 	// KeyResourceType groups metris by their resource types. Possible values: cpu, memory.
 	KeyResourceType, _ = tag.NewKey("resource")
+
+	// ResourceKeySyncKind groups metrics by the Sync kind. Possible values: RootSync, RepoSync.
+	// This metric tag is populated from the configsync.sync.kind resource
+	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
+	ResourceKeySyncKind, _ = tag.NewKey("configsync_sync_kind")
+
+	// ResourceKeySyncName groups metrics by the Sync name.
+	// This metric tag is populated from the configsync.sync.kind resource
+	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
+	ResourceKeySyncName, _ = tag.NewKey("configsync_sync_name")
+
+	// ResourceKeySyncNamespace groups metrics by the Sync namespace.
+	// This metric tag is populated from the configsync.sync.kind resource
+	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
+	ResourceKeySyncNamespace, _ = tag.NewKey("configsync_sync_namespace")
+
+	// ResourceKeyDeploymentName groups metrics by k8s deployment name.
+	// This metric tag is populated from the configsync.sync.kind resource
+	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
+	ResourceKeyDeploymentName, _ = tag.NewKey("k8s_deployment_name")
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -58,8 +58,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const kindRepoSync = "RepoSync"
-
 // RepoSyncReconciler reconciles a RepoSync object.
 type RepoSyncReconciler struct {
 	reconcilerBase
@@ -79,7 +77,7 @@ func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			scheme:                  scheme,
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
-			syncKind:                kindRepoSync,
+			syncKind:                configsync.RepoSyncKind,
 			allowVerticalScale:      allowVerticalScale,
 		},
 		repoSyncs: make(map[types.NamespacedName]struct{}),
@@ -228,6 +226,7 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	labelMap := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
 		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      r.syncKind,
 	}
 
 	// Overwrite reconciler pod ServiceAccount.

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -280,7 +280,7 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
 		fakeClient,
-		controllerruntime.Log.WithName("controllers").WithName("RepoSync"),
+		controllerruntime.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		s,
 		allowVerticalScale,
 	)
@@ -1109,6 +1109,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	label := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
 		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(
@@ -1288,13 +1289,13 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	label1 := map[string]string{
 		metadata.SyncNamespaceLabel: rs1.Namespace,
 		metadata.SyncNameLabel:      rs1.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	serviceAccount1 := fake.ServiceAccountObject(
 		nsReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.Label(metadata.SyncNamespaceLabel, label1[metadata.SyncNamespaceLabel]),
-		core.Label(metadata.SyncNameLabel, label1[metadata.SyncNameLabel]),
+		core.Labels(label1),
 	)
 	wantServiceAccounts := map[core.ID]*corev1.ServiceAccount{core.IDOf(serviceAccount1): serviceAccount1}
 
@@ -1341,6 +1342,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	label2 := map[string]string{
 		metadata.SyncNamespaceLabel: rs2.Namespace,
 		metadata.SyncNameLabel:      rs2.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	repoContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
@@ -1393,6 +1395,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	label3 := map[string]string{
 		metadata.SyncNamespaceLabel: rs3.Namespace,
 		metadata.SyncNameLabel:      rs3.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	repoContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
@@ -1448,6 +1451,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	label4 := map[string]string{
 		metadata.SyncNamespaceLabel: rs4.Namespace,
 		metadata.SyncNameLabel:      rs4.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	repoContainerEnv4 := testReconciler.populateContainerEnvs(ctx, rs4, nsReconcilerName4)
@@ -1503,6 +1507,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	label5 := map[string]string{
 		metadata.SyncNamespaceLabel: rs5.Namespace,
 		metadata.SyncNameLabel:      rs5.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	repoContainerEnv5 := testReconciler.populateContainerEnvs(ctx, rs5, nsReconcilerName5)
@@ -2171,6 +2176,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	label := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
 		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -59,8 +59,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const kindRootSync = "RootSync"
-
 // ReconcilerType defines the type of a reconciler
 type ReconcilerType string
 
@@ -88,7 +86,7 @@ func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			scheme:                  scheme,
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
-			syncKind:                kindRootSync,
+			syncKind:                configsync.RootSyncKind,
 			allowVerticalScale:      allowVerticalScale,
 		},
 	}
@@ -179,6 +177,7 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	labelMap := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
 		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      r.syncKind,
 	}
 
 	// Overwrite reconciler pod ServiceAccount.

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1048,6 +1048,12 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
+	labels := map[string]string{
+		metadata.SyncNamespaceLabel: rs.Namespace,
+		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
+	}
+
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
@@ -1055,8 +1061,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
 		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
-		core.Label(metadata.SyncNamespaceLabel, configsync.ControllerNamespace),
-		core.Label(metadata.SyncNameLabel, rootsyncName),
+		core.Labels(labels),
 	)
 
 	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
@@ -1217,6 +1222,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	label1 := map[string]string{
 		metadata.SyncNamespaceLabel: rs1.Namespace,
 		metadata.SyncNameLabel:      rs1.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	serviceAccount1 := fake.ServiceAccountObject(
@@ -1262,6 +1268,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	label2 := map[string]string{
 		metadata.SyncNamespaceLabel: rs2.Namespace,
 		metadata.SyncNameLabel:      rs2.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	rootContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, rootReconcilerName2)
@@ -1307,6 +1314,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	label3 := map[string]string{
 		metadata.SyncNamespaceLabel: rs3.Namespace,
 		metadata.SyncNameLabel:      rs3.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	rootContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, rootReconcilerName3)
@@ -1356,6 +1364,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	label4 := map[string]string{
 		metadata.SyncNamespaceLabel: rs4.Namespace,
 		metadata.SyncNameLabel:      rs4.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	rootContainerEnvs4 := testReconciler.populateContainerEnvs(ctx, rs4, rootReconcilerName4)
@@ -1405,6 +1414,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	label5 := map[string]string{
 		metadata.SyncNamespaceLabel: rs5.Namespace,
 		metadata.SyncNameLabel:      rs5.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
 	rootContainerEnvs5 := testReconciler.populateContainerEnvs(ctx, rs5, rootReconcilerName5)
@@ -1833,14 +1843,19 @@ func TestRootSyncWithOCI(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
+	labels := map[string]string{
+		metadata.SyncNamespaceLabel: rs.Namespace,
+		metadata.SyncNameLabel:      rs.Name,
+		metadata.SyncKindLabel:      testReconciler.syncKind,
+	}
+
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
 			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
 		}),
-		core.Label(metadata.SyncNamespaceLabel, configsync.ControllerNamespace),
-		core.Label(metadata.SyncNameLabel, rootsyncName),
+		core.Labels(labels),
 	)
 
 	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
@@ -1906,8 +1921,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
 		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
-		core.Label(metadata.SyncNamespaceLabel, configsync.ControllerNamespace),
-		core.Label(metadata.SyncNameLabel, rootsyncName),
+		core.Labels(labels),
 	)
 	// compare ServiceAccount.
 	if diff := cmp.Diff(fakeClient.Objects[core.IDOf(wantServiceAccount)], wantServiceAccount, cmpopts.EquateEmpty()); diff != "" {


### PR DESCRIPTION
- The following resource attributes were added to all metrics from the reconciler and reconciler-manager:
  - k8s.pod.name
  - k8s.pod.namespace
  - k8s.pod.uid
  - k8s.pod.ip
  - k8s.node.name
  - k8s.deployment.name
- The following resource attributes were added to all metrics from the reconciler:
  - configsync.sync.kind
  - configsync.sync.name
  - configsync.sync.namespace
- The above resource attributes are injected via the OTEL_RESOURCE_ATTRIBUTES env var in the Deployment yaml for the otel-agent container.
- The following labels are used to inject resource attribute values:
  - configsync.gke.io/deployment-name
  - configsync.gke.io/sync-kind
  - configsync.gke.io/sync-name
  - configsync.gke.io/sync-namespace
- The following env vars are use to inject values from the k8s downward API into resource attribute values:
  - KUBE_POD_NAME
  - KUBE_POD_NAMESPACE
  - KUBE_POD_UID
  - KUBE_POD_IP
  - KUBE_NODE_NAME
  - KUBE_DEPLOYMENT_NAME
  - CONFIGSYNC_SYNC_KIND
  - CONFIGSYNC_SYNC_NAME
  - CONFIGSYNC_SYNC_NAMESPACE
- Added constants for RootSyncKind and RepoSyncKind

Unit tests were added for the new labels. e2e tests will come in a separate follow up PR, because it requires enabling resource_to_telemetry_conversion to make the resource attributes testable in Prometheus. 