### PR TITLE
Reduce the parallel setting of presubmit mono/multi jobs to 15

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -172,7 +172,7 @@ test-e2e-kind: __push-local-image
 # This target runs all the e2e tests with the mono-repo mode.
 test-e2e-kind-mono-repo: __push-local-image
 	kind delete clusters --all
-	./scripts/e2e-kind.sh --timeout 60m --parallel 18 --image-tag=$(LATEST_IMAGE_TAG) $(E2E_ARGS)
+	./scripts/e2e-kind.sh --timeout 60m --parallel 15 --image-tag=$(LATEST_IMAGE_TAG) $(E2E_ARGS)
 
 # This target runs the first group of e2e tests with the mono-repo mode.
 test-e2e-kind-mono-repo-test-group1:
@@ -189,7 +189,7 @@ test-e2e-kind-mono-repo-test-group3:
 # This target runs all the e2e tests with the multi-repo mode.
 test-e2e-kind-multi-repo: __push-local-image
 	kind delete clusters --all
-	./scripts/e2e-kind.sh --multirepo --timeout 60m --parallel 18 --image-tag=$(LATEST_IMAGE_TAG) $(E2E_ARGS)
+	./scripts/e2e-kind.sh --multirepo --timeout 60m --parallel 15 --image-tag=$(LATEST_IMAGE_TAG) $(E2E_ARGS)
 
 # This target runs the first group of e2e tests with the multi-repo mode.
 test-e2e-kind-multi-repo-test-group1:


### PR DESCRIPTION
Currently, the presubmit jobs may fail due to CPU/mem resource shortage. This change reduces the parallel setting from 18 to 15 to see whether it helps.