### PR TITLE
add terraform config for dev/ci clusters

### DIFF
--- a/e2e/testinfra/terraform/Makefile
+++ b/e2e/testinfra/terraform/Makefile
@@ -1,0 +1,13 @@
+.PHONY: check-install
+check-install:
+ifeq ($(shell which terraform),)
+	@echo "ERROR: Could not find 'terraform' in PATH"; exit 1
+endif
+
+.PHONY: init-no-backend
+init-no-backend: check-install
+	terraform init --backend=false
+
+.PHONY: validate
+validate: init-no-backend
+	terraform validate

--- a/e2e/testinfra/terraform/README.md
+++ b/e2e/testinfra/terraform/README.md
@@ -1,0 +1,72 @@
+# Terraform Config
+
+Config Sync uses Terraform to manage its GCP resources
+used for end-to-end testing. This is primarily used for provisioning
+test infra for CI jobs, but can also be used to provision test infra for
+development.
+
+## Install Terraform
+
+Follow the instructions to [install the Terraform CLI].
+
+# Dev Environments
+
+The Terraform config for dev environments is defined in the [dev directory].
+This configuration is designed to be configurable for an arbitrary GCP project
+for development purposes.
+As a result some variables must be provided at runtime, such as project name
+and backend bucket name.
+
+## Prerequisites
+
+### Enable Cloud Source Repositories API
+
+Follow the instructions to [enable the Cloud Source Repositories API].
+
+### Provision tfstate GCS Bucket
+
+Terraform supports a number of backends to store its state. We use GCS.
+Create a GCS bucket in your project which will be used as the backend to store
+Terraform's state. You will provide the name of this bucket during `terraform init`.
+
+e.g.
+```shell
+gcloud storage buckets create gs://<PROJECT_ID>-tfstate --project=<PROJECT_ID>
+```
+
+## Usage
+
+See the [variable definitions file] for an exhaustive list of variables.
+These can be provided as [command line variables] at runtime.
+
+For example:
+```shell
+export TF_VAR_project=my-project
+terraform init -backend-config="bucket=<bucket-name>"
+terraform plan
+terraform apply
+```
+
+To delete the provisioned resources:
+```shell
+terraform destroy
+```
+
+# Prow Environment
+
+The Terraform config for our prow environment is defined in the [prow directory].
+
+```shell
+export TF_VAR_project=oss-prow-build-kpt-config-sync
+export TF_VAR_prow=true
+terraform init -backend-config="bucket=oss-prow-build-kpt-config-sync-tfstate"
+terraform apply
+```
+
+
+[enable the Cloud Source Repositories API]: https://cloud.google.com/source-repositories/docs/create-code-repository#before-you-begin
+[variable definitions file]: ./variables.tf
+[command line variables]: https://www.terraform.io/language/values/variables#variables-on-the-command-line
+[install the Terraform CLI]: https://learn.hashicorp.com/tutorials/terraform/install-cli
+[prow directory]: ./prow
+[dev directory]: ./dev

--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "e2e-csr-reader-sa" {
+  source = "../modules/service_account"
+  gcp_sa_id = "e2e-test-csr-reader"
+  gcp_sa_display_name = "Test CSR Reader"
+  gcp_sa_description = "Service account used to read from Cloud Source Repositories"
+  role = "roles/source.reader"
+}
+
+module "e2e-gar-reader-sa" {
+  source = "../modules/service_account"
+  gcp_sa_id = "e2e-test-ar-reader"
+  gcp_sa_display_name = "Test GAR Reader"
+  gcp_sa_description = "Service account used to read from Artifact Registry"
+  role = "roles/artifactregistry.reader"
+}
+
+module "e2e-gcr-reader-sa" {
+  source = "../modules/service_account"
+  gcp_sa_id = "e2e-test-gcr-reader"
+  gcp_sa_display_name = "Test GCR Reader"
+  gcp_sa_description = "Service account used to read from Container Registry"
+  role = "roles/storage.objectViewer"
+}
+
+data "google_project" "project" {
+}
+
+data "google_compute_default_service_account" "default" {
+}
+
+resource "google_project_iam_member" "gce-default-sa-iam" {
+  for_each = toset([
+    "roles/source.reader",
+    "roles/artifactregistry.reader",
+    "roles/storage.objectViewer",
+  ])
+
+  role    = each.value
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  project = data.google_project.project.id
+}

--- a/e2e/testinfra/terraform/common/source_repositories.tf
+++ b/e2e/testinfra/terraform/common/source_repositories.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_sourcerepo_repository" "configsync-kcc" {
+  name = "configsync-kcc"
+}
+
+resource "google_sourcerepo_repository" "kustomize-components" {
+  name = "kustomize-components"
+}

--- a/e2e/testinfra/terraform/dev/clusters.tf
+++ b/e2e/testinfra/terraform/dev/clusters.tf
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Standard dev clusters
+module "dev-stable" {
+  source = "../modules/testgroup"
+  prefix = "dev"
+  channel = "stable"
+  num_clusters = var.num_clusters
+}
+
+module "dev-regular" {
+  source = "../modules/testgroup"
+  prefix = "dev"
+  channel = "regular"
+  num_clusters = var.num_clusters
+}
+
+module "dev-rapid" {
+  source = "../modules/testgroup"
+  prefix = "dev"
+  channel = "rapid"
+  num_clusters = var.num_clusters
+}
+
+module "dev-rapid-latest" {
+  source = "../modules/testgroup"
+  prefix = "dev"
+  channel = "rapid"
+  min_master_version = "latest"
+  num_clusters = var.num_clusters
+}
+
+# Autopilot dev clusters
+module "dev-autopilot-stable" {
+  source = "../modules/testgroup_autopilot"
+  prefix = "dev"
+  channel = "stable"
+  num_clusters = var.num_clusters
+}
+
+module "dev-autopilot-regular" {
+  source = "../modules/testgroup_autopilot"
+  prefix = "dev"
+  channel = "regular"
+  num_clusters = var.num_clusters
+}
+
+module "dev-autopilot-rapid" {
+  source = "../modules/testgroup_autopilot"
+  prefix = "dev"
+  channel = "rapid"
+  num_clusters = var.num_clusters
+}
+
+module "dev-autopilot-rapid-latest" {
+  source = "../modules/testgroup_autopilot"
+  prefix = "dev"
+  channel = "rapid"
+  min_master_version = "latest"
+  num_clusters = var.num_clusters
+}

--- a/e2e/testinfra/terraform/dev/variables.tf
+++ b/e2e/testinfra/terraform/dev/variables.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "num_clusters" {
+  type = number
+  description = "How many user clusters to provision for each dev testgroup."
+  default = 1
+}

--- a/e2e/testinfra/terraform/environments.tf
+++ b/e2e/testinfra/terraform/environments.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+module "prow_environment" {
+  source = "./prow"
+  count = var.prow ? 1 : 0
+}
+
+module "dev_environment" {
+  source = "./dev"
+  count = var.prow ? 0 : 1
+  num_clusters = var.num_clusters
+}
+
+module "common" {
+  source = "./common"
+}

--- a/e2e/testinfra/terraform/main.tf
+++ b/e2e/testinfra/terraform/main.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.36.0"
+    }
+  }
+  backend "gcs" {
+    # bucket variable must be provided at runtime
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  # project variable must be provided at runtime
+  project = var.project
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}

--- a/e2e/testinfra/terraform/modules/e2ecluster/e2ecluster.tf
+++ b/e2e/testinfra/terraform/modules/e2ecluster/e2ecluster.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "project" {
+}
+
+resource "google_container_cluster" "e2e" {
+  provider = google-beta
+  project = data.google_project.project.project_id
+  name               = var.name
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block = "/19"
+  }
+  location           = "us-central1-a"
+  network = var.network
+  subnetwork = var.subnetwork
+  release_channel {
+    channel = upper(var.channel)
+  }
+  # https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version
+  min_master_version = var.min_master_version
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+  workload_identity_config {
+    workload_pool = var.enable_workload_identity ? "${data.google_project.project.project_id}.svc.id.goog" : null
+  }
+  addons_config {
+    config_connector_config {
+      enabled = var.enable_config_connector
+    }
+  }
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+  # Remove default node pool
+  remove_default_node_pool = true
+  initial_node_count = 1
+}
+
+resource "google_container_node_pool" "pool" {
+  name = "pool"
+  node_count = var.node_count
+  cluster = google_container_cluster.e2e.name
+  location = "us-central1-a"
+  node_config {
+    machine_type = var.machine_type
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+}

--- a/e2e/testinfra/terraform/modules/e2ecluster/variables.tf
+++ b/e2e/testinfra/terraform/modules/e2ecluster/variables.tf
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "name" {
+  type = string
+  description = "The cluster name"
+}
+
+variable "channel" {
+  type = string
+  description = "The cluster release channel. One of RAPID, REGULAR, STABLE, UNSPECIFIED"
+  default = "UNSPECIFIED"
+}
+
+variable "min_master_version" {
+  type = string
+  description = "Pin to this master version for the cluster"
+  default = null
+}
+
+variable "machine_type" {
+  type = string
+  default = "e2-standard-4"
+}
+
+variable "node_count" {
+  type = number
+  default = 3
+}
+
+variable "network" {
+  type = string
+  default = "e2e-network"
+}
+
+variable "subnetwork" {
+  type = string
+  default = "e2e-subnetwork-1"
+}
+
+variable "enable_workload_identity" {
+  type = bool
+  default = true
+}
+
+variable "enable_config_connector" {
+  type = bool
+  default = false
+}

--- a/e2e/testinfra/terraform/modules/e2ecluster_autopilot/e2ecluster.tf
+++ b/e2e/testinfra/terraform/modules/e2ecluster_autopilot/e2ecluster.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "project" {
+}
+
+resource "google_container_cluster" "e2e" {
+  name               = var.name
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block = "/19"
+  }
+  location           = "us-central1"
+  network = var.network
+  subnetwork = var.subnetwork
+  enable_autopilot = true
+  release_channel {
+    channel = upper(var.channel)
+  }
+  # https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version
+  min_master_version = var.min_master_version
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/e2e/testinfra/terraform/modules/e2ecluster_autopilot/variables.tf
+++ b/e2e/testinfra/terraform/modules/e2ecluster_autopilot/variables.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "name" {
+  type = string
+  description = "The cluster name"
+}
+
+variable "channel" {
+  type = string
+  description = "The cluster release channel. One of RAPID, REGULAR, STABLE, UNSPECIFIED"
+  default = "UNSPECIFIED"
+}
+
+variable "min_master_version" {
+  type = string
+  description = "Pin to this master version for the cluster"
+  default = null
+}
+
+variable "network" {
+  type = string
+  default = "e2e-network"
+}
+
+variable "subnetwork" {
+  type = string
+  default = "e2e-subnetwork-1"
+}

--- a/e2e/testinfra/terraform/modules/service_account/service_account.tf
+++ b/e2e/testinfra/terraform/modules/service_account/service_account.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "project" {
+}
+
+resource "google_service_account" "gcp_sa" {
+  account_id   = var.gcp_sa_id
+  display_name = var.gcp_sa_display_name
+  description = var.gcp_sa_description
+}
+
+resource "google_service_account_iam_member" "k8s_sa_binding" {
+  service_account_id = google_service_account.gcp_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler]"
+}
+
+resource "google_project_iam_member" "gcp_sa_role" {
+  role    = var.role
+  member  = "serviceAccount:${google_service_account.gcp_sa.email}"
+  project = data.google_project.project.id
+}

--- a/e2e/testinfra/terraform/modules/service_account/variables.tf
+++ b/e2e/testinfra/terraform/modules/service_account/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "gcp_sa_id" {
+  type = string
+  description = "The account id of the GCP service account"
+}
+
+variable "gcp_sa_display_name" {
+  type = string
+  description = "The display name of the GCP service account"
+}
+
+variable "gcp_sa_description" {
+  type = string
+  description = "The description of the GCP service account"
+}
+
+variable "role" {
+  type = string
+  description = "The GCP project role to grant to the GCP service account"
+}

--- a/e2e/testinfra/terraform/modules/testgroup/networks.tf
+++ b/e2e/testinfra/terraform/modules/testgroup/networks.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_network" "e2e-network" {
+  name                    = "${var.prefix}-e2e-network-${local.suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "e2e-subnetwork-default" {
+  name          = "${var.prefix}-e2e-subnetwork-${local.suffix}"
+  ip_cidr_range = "10.0.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.e2e-network.id
+  description = "Subnetwork for use in e2e test clusters"
+  private_ip_google_access = false
+}

--- a/e2e/testinfra/terraform/modules/testgroup/testgroup.tf
+++ b/e2e/testinfra/terraform/modules/testgroup/testgroup.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "project" {
+}
+
+module "e2e-cluster-test-group" {
+  for_each = toset(formatlist("%s", range(1, var.num_clusters+1)))
+
+  source = "../e2ecluster"
+  name = "${var.prefix}-${each.value}-${local.suffix}"
+  channel = var.channel
+  min_master_version = var.min_master_version
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-default.name
+  network = google_compute_network.e2e-network.name
+}

--- a/e2e/testinfra/terraform/modules/testgroup/variables.tf
+++ b/e2e/testinfra/terraform/modules/testgroup/variables.tf
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "channel" {
+  type = string
+  description = "The cluster release channel. One of RAPID, REGULAR, STABLE, UNSPECIFIED"
+  default = "UNSPECIFIED"
+}
+
+variable "min_master_version" {
+  type = string
+  description = "Pin to this master version for the cluster"
+  default = null
+}
+
+variable "subnetwork" {
+  type = string
+  default = "e2e-subnetwork-1"
+}
+
+variable "network" {
+  type = string
+  default = "prow-e2e-network"
+}
+
+variable "prefix" {
+  type = string
+  description = "Prefix to use for test group name"
+  default = "multi-repo"
+}
+
+variable "suffix" {
+  type = string
+  description = "Suffix to use for test group name"
+  default = null
+}
+
+variable "num_clusters" {
+  type = number
+  description = "Number of test group clusters to create"
+  default = 8
+}
+
+locals {
+  suffix = var.suffix != null ? "standard-${var.channel}-${var.suffix}" : (var.min_master_version != null ? "standard-${var.channel}-${var.min_master_version}" : "standard-${var.channel}")
+}
+

--- a/e2e/testinfra/terraform/modules/testgroup_autopilot/networks.tf
+++ b/e2e/testinfra/terraform/modules/testgroup_autopilot/networks.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_network" "e2e-network" {
+  name                    = "${var.prefix}-e2e-network-${local.suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "e2e-subnetwork-default" {
+  name          = "${var.prefix}-e2e-subnetwork-${local.suffix}"
+  ip_cidr_range = "10.0.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.e2e-network.id
+  description = "Subnetwork for use in e2e test clusters"
+  private_ip_google_access = false
+}

--- a/e2e/testinfra/terraform/modules/testgroup_autopilot/testgroup.tf
+++ b/e2e/testinfra/terraform/modules/testgroup_autopilot/testgroup.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_project" "project" {
+}
+
+module "e2e-cluster-test-group" {
+  for_each = toset(formatlist("%s", range(1, var.num_clusters+1)))
+
+  source = "../e2ecluster_autopilot"
+  name = "${var.prefix}-${each.value}-${local.suffix}"
+  channel = var.channel
+  min_master_version = var.min_master_version
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-default.name
+  network = google_compute_network.e2e-network.name
+}

--- a/e2e/testinfra/terraform/modules/testgroup_autopilot/variables.tf
+++ b/e2e/testinfra/terraform/modules/testgroup_autopilot/variables.tf
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "channel" {
+  type = string
+  description = "The cluster release channel. One of RAPID, REGULAR, STABLE, UNSPECIFIED"
+  default = "UNSPECIFIED"
+}
+
+variable "min_master_version" {
+  type = string
+  description = "Pin to this master version for the cluster"
+  default = null
+}
+
+variable "subnetwork" {
+  type = string
+  default = "e2e-subnetwork-1"
+}
+
+variable "network" {
+  type = string
+  default = "prow-e2e-network"
+}
+
+variable "prefix" {
+  type = string
+  description = "Prefix to use for test group name"
+  default = "multi-repo"
+}
+
+variable "suffix" {
+  type = string
+  description = "Suffix to use for test group name"
+  default = null
+}
+
+variable "num_clusters" {
+  type = number
+  description = "Number of test group clusters to create"
+  default = 8
+}
+
+locals {
+  suffix = var.suffix != null ? "autopilot-${var.channel}-${var.suffix}" : (var.min_master_version != null ? "autopilot-${var.channel}-${var.min_master_version}" : "autopilot-${var.channel}")
+}

--- a/e2e/testinfra/terraform/prow/networks.tf
+++ b/e2e/testinfra/terraform/prow/networks.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_network" "e2e-network" {
+  name                    = "prow-e2e-network-1"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "e2e-subnetwork-1" {
+  name          = "prow-e2e-subnetwork-1"
+  ip_cidr_range = "10.0.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.e2e-network.id
+  description = "Subnetwork for use in e2e test clusters"
+  private_ip_google_access = false
+}

--- a/e2e/testinfra/terraform/prow/prow_clusters.tf
+++ b/e2e/testinfra/terraform/prow/prow_clusters.tf
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Multi repo standard clusters
+module "multi-repo-stable" {
+  source = "../modules/testgroup"
+  channel = "stable"
+}
+
+module "multi-repo-regular" {
+  source = "../modules/testgroup"
+  channel = "regular"
+}
+
+module "multi-repo-rapid" {
+  source = "../modules/testgroup"
+  channel = "rapid"
+}
+
+module "multi-repo-rapid-latest" {
+  source = "../modules/testgroup"
+  channel = "rapid"
+  min_master_version = "latest"
+}
+
+module "multi-repo-psp" {
+  source = "../modules/testgroup"
+  channel = "regular"
+  suffix = "psp"
+}
+
+module "multi-repo-bitbucket" {
+  source = "../modules/testgroup"
+  channel = "regular"
+  suffix = "bitbucket"
+}
+
+module "multi-repo-gitlab" {
+  source = "../modules/testgroup"
+  channel = "regular"
+  suffix = "gitlab"
+}
+
+# Multi repo autopilot clusters
+module "multi-repo-autopilot-stable" {
+  source = "../modules/testgroup_autopilot"
+  channel = "stable"
+}
+
+module "multi-repo-autopilot-regular" {
+  source = "../modules/testgroup_autopilot"
+  channel = "regular"
+}
+
+module "multi-repo-autopilot-rapid" {
+  source = "../modules/testgroup_autopilot"
+  channel = "rapid"
+}
+
+module "multi-repo-autopilot-rapid-latest" {
+  source = "../modules/testgroup_autopilot"
+  channel = "rapid"
+  min_master_version = "latest"
+}
+
+# Mono repo clusters
+module "mono-repo-stable" {
+  source = "../modules/testgroup"
+  prefix = "mono-repo"
+  channel = "stable"
+  num_clusters = 3
+}
+
+module "mono-repo-regular" {
+  source = "../modules/testgroup"
+  prefix = "mono-repo"
+  channel = "regular"
+  num_clusters = 3
+}
+
+module "mono-repo-rapid" {
+  source = "../modules/testgroup"
+  prefix = "mono-repo"
+  channel = "rapid"
+  num_clusters = 3
+}
+
+module "mono-repo-rapid-latest" {
+  source = "../modules/testgroup"
+  prefix = "mono-repo"
+  channel = "rapid"
+  min_master_version = "latest"
+  num_clusters = 3
+}
+
+# One off clusters
+module "multi-repo-kind" {
+  source = "../modules/e2ecluster"
+  name = "multi-repo-kind"
+  channel = "regular"
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-1.name
+  network = google_compute_network.e2e-network.name
+}
+
+module "mono-repo-kind" {
+  source = "../modules/e2ecluster"
+  name = "mono-repo-kind"
+  channel = "regular"
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-1.name
+  network = google_compute_network.e2e-network.name
+}
+
+module "multi-repo-kcc" {
+  source = "../modules/e2ecluster"
+  name = "multi-repo-kcc"
+  channel = "regular"
+  enable_config_connector = true
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-1.name
+  network = google_compute_network.e2e-network.name
+}
+
+module "multi-repo-gcenode" {
+  source = "../modules/e2ecluster"
+  name = "multi-repo-gcenode"
+  channel = "regular"
+  enable_workload_identity = false
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-1.name
+  network = google_compute_network.e2e-network.name
+}
+
+module "stress-test" {
+  source = "../modules/e2ecluster"
+  name = "stress-test"
+  channel = "regular"
+  subnetwork = google_compute_subnetwork.e2e-subnetwork-1.name
+  network = google_compute_network.e2e-network.name
+}
+

--- a/e2e/testinfra/terraform/variables.tf
+++ b/e2e/testinfra/terraform/variables.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project" {
+  type = string
+  description = "Name of GCP project"
+}
+
+variable "prow" {
+  type = bool
+  description = "Whether to provision prow e2e clusters"
+  default = false
+}
+
+variable "num_clusters" {
+  type = number
+  description = "How many user clusters to provision. Used for dev clusters (prow=false)."
+  default = 1
+}


### PR DESCRIPTION
This terraform config is intended to automate the provisioning of test infra resources needed to run the e2e tests. It can be used for the use case of our prow periodic jobs as well as development workflows.