### PR TITLE
Added additional annotation validation to TestPreventDeletionRole

### DIFF
--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -134,7 +134,8 @@ func TestPreventDeletionRole(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Role with prevent deletion lifecycle annotation")
 	nt.WaitForRepoSyncs()
 
-	err = nt.Validate("shipping-admin", "shipping", &rbacv1.Role{})
+	// ensure that the Role is created with the preventDeletion annotation
+	err = nt.Validate("shipping-admin", "shipping", &rbacv1.Role{}, nomostest.HasAnnotation(common.LifecycleDeleteAnnotation, common.PreventDeletion))
 	if err != nil {
 		nt.T.Fatal(err)
 	}


### PR DESCRIPTION
The test `TestPreventDeletionRole` has been flakey on MonoRepo. The test sets up a Role with `client.lifecycle.config.k8s.io/deletion: detach` annotation so it can't be deleted, but when the test is flaky it gets deleted anyway. The other tests in this suite have more validation to the annotation, so I added the annotation validation to this test too. If the test is still failing/flaky, this additional validation should help us isolate the root cause