### PR TITLE
add test-resources to OSS manifest

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -249,6 +249,8 @@ __config-sync-manifest-oss: __config-sync-manifest
 		--exclude='nomos-repo-crd.yaml' \
 		--exclude='sync-declaration-crd.yaml' \
 		.output/manifests/* .output/oss/cloned/manifests/
+	rsync \
+		manifests/test-resources/* .output/oss/cloned/manifests/
 	@echo "++++ Add OSS yaml files to config-sync-manifest.yaml"
 	env GO111MODULE=on go run -mod=vendor ./scripts/append_manifests/append_manifests.go \
 		--destination=${OSS_MANIFEST_STAGING_DIR}/config-sync-manifest.yaml \


### PR DESCRIPTION
This includes both the Config Management namespaces and the ResourceGroup manifests, which are needed for OSS installation.

https://github.com/GoogleContainerTools/kpt-config-sync/issues/127
