### PR TITLE
Use timers instead of tickers

### DIFF
--- a/pkg/configsync/git-importer.go
+++ b/pkg/configsync/git-importer.go
@@ -76,12 +76,14 @@ func RunImporter() {
 	// expected.
 	dir := strings.TrimPrefix(*policyDirRelative, "/")
 
+	ctx := signals.SetupSignalHandler()
+
 	// Set up controllers.
 	if err := meta.AddControllers(mgr); err != nil {
 		klog.Fatalf("Error adding Sync controller: %+v", err)
 	}
 
-	if err := filesystem.AddController(*clusterName, mgr, *gitDir,
+	if err := filesystem.AddController(ctx, *clusterName, mgr, *gitDir,
 		dir, *pollPeriod); err != nil {
 		klog.Fatalf("Error adding Importer controller: %+v", err)
 	}
@@ -90,7 +92,6 @@ func RunImporter() {
 		klog.Fatalf("Error adding RepoStatus controller: %+v", err)
 	}
 
-	ctx := signals.SetupSignalHandler()
 	if err := policycontroller.AddControllers(ctx, mgr); err != nil {
 		klog.Fatalf("Error adding PolicyController controller: %+v", err)
 	}


### PR DESCRIPTION
Tickers can cause memory leaks and continuous execution, when execution takes longer than the tick duration. This is especially problematic in e2e where the timers are set very short and at scale when the sync can take longer than the retry/polling/resync period.

Timers with resets function more as a delay between executions, which is preferable, rather than something tied to a wall-clock.