### PR TITLE
fix: Use opencensus based exporter for monitoring

### DIFF
--- a/e2e/testdata/reconciler-manager-configmap-updated.yaml
+++ b/e2e/testdata/reconciler-manager-configmap-updated.yaml
@@ -192,6 +192,9 @@ data:
           - /otelcol-contrib
           args:
           - "--config=/conf/otel-agent-config.yaml"
+          # TODO: Remove this feature gate when opentelemetry semantic conventions are used
+          # in the collector code.
+          - "--feature-gates=-exporter.googlecloud.OTLPDirect"
           resources:
             limits:
               cpu: 500m

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -133,6 +133,9 @@ spec:
         - /otelcol-contrib
         args:
         - "--config=/conf/otel-collector-config.yaml"
+        # TODO: Remove this feature gate when opentelemetry semantic conventions are used
+        # in the collector code.
+        - "--feature-gates=-exporter.googlecloud.OTLPDirect"
         resources:
           limits:
             cpu: 1

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -182,6 +182,9 @@ data:
            - /otelcol-contrib
            args:
            - "--config=/conf/otel-agent-config.yaml"
+           # TODO: Remove this feature gate when opentelemetry semantic conventions are used
+           # in the collector code.
+           - "--feature-gates=-exporter.googlecloud.OTLPDirect"
            resources:
              limits:
                cpu: 1

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -63,6 +63,9 @@ spec:
         - /otelcol-contrib
         args:
         - "--config=/conf/otel-agent-config.yaml"
+        # TODO: Remove this feature gate when opentelemetry semantic conventions are used
+        # in the collector code.
+        - "--feature-gates=-exporter.googlecloud.OTLPDirect"
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
When we upgraded to otel v0.58, we introduced a regression in the metrics being exported with a `generic_node` type instead of `k8s_pod`. This happened as our codebase uses opencensus semantic conventions for resource attributes instead of opentelemetry semantic conventions.

This workaround runs our collector with a flag to disable the newer exporter logic until we can upgrade our codebase to use opentelemetry conventions.

See https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/breaking-changes.md for more details about the rewritten exporter.