### PR TITLE
add registries and enable APIs in terraform

### DIFF
--- a/e2e/testinfra/terraform/common/registries.tf
+++ b/e2e/testinfra/terraform/common/registries.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# GCR Registries
+resource "google_container_registry" "gcr" {
+}
+resource "google_container_registry" "gcr-us" {
+  location = "US"
+}
+
+# GAR Registries
+resource "google_artifact_registry_repository" "gar" {
+  for_each = toset([
+    "config-sync-test-private",
+    "config-sync-test-ar-helm",
+  ])
+  location      = "us"
+  repository_id = each.value
+  description   = "A private AR repository used for Config Sync e2e tests"
+  format        = "DOCKER"
+}

--- a/e2e/testinfra/terraform/common/services.tf
+++ b/e2e/testinfra/terraform/common/services.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_service" "services" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "sourcerepo.googleapis.com",
+    "containerregistry.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "secretmanager.googleapis.com",
+    "container.googleapis.com",
+  ])
+  service = each.value
+  disable_on_destroy = false
+}

--- a/e2e/testinfra/terraform/prow/registries.tf
+++ b/e2e/testinfra/terraform/prow/registries.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_artifact_registry_repository" "ar-public" {
+  location      = "us"
+  repository_id = "config-sync-test-public"
+  description   = "A public AR repository used for Config Sync e2e tests"
+  format        = "DOCKER"
+}
+
+# Grant public access to this registry by granting reader to allUsers.
+# Note this will fail if the project enforces Domain Restricted Sharing. See:
+# https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains
+resource "google_artifact_registry_repository_iam_member" "member" {
+  project = google_artifact_registry_repository.ar-public.project
+  location = google_artifact_registry_repository.ar-public.location
+  repository = google_artifact_registry_repository.ar-public.name
+  role = "roles/artifactregistry.reader"
+  member = "allUsers"
+}

--- a/e2e/testinfra/terraform/prow/services.tf
+++ b/e2e/testinfra/terraform/prow/services.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_service" "services" {
+  for_each = toset([
+    "gkehub.googleapis.com",
+  ])
+  service = each.value
+  disable_on_destroy = false
+}


### PR DESCRIPTION
This updates the terraform config to create the docker registristries used by the e2e tests. Also enable the APIs which are required for the e2e tests.