### PR TITLE
Change the RootSync helm.namespace field default value

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -51,7 +52,7 @@ func TestPublicHelm(t *testing.T) {
 	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	nt.T.Log("Update RootSync to sync from a public Helm Chart")
+	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "ingress-nginx", "auth": "none", "version": "4.0.5", "releaseName": "my-ingress-nginx", "namespace": "ingress-nginx"}, "git": null}}`,
 		v1beta1.HelmSource, publicHelmRepo))
 	nt.T.Cleanup(func() {
@@ -63,6 +64,19 @@ func TestPublicHelm(t *testing.T) {
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "ingress-nginx"}))
 	if err := nt.Validate("my-ingress-nginx-controller", "ingress-nginx", &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
+	}
+	nt.T.Log("Update RootSync to sync from a public Helm Chart without specified release namespace")
+	nt.MustMergePatch(rs, `{"spec": {"helm": {"namespace": ""}}}`)
+	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion("ingress-nginx:4.0.5")),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "ingress-nginx"}))
+	if err := nt.Validate("my-ingress-nginx-controller", configsync.DefaultHelmReleaseNamespace, &appsv1.Deployment{}); err != nil {
+		nt.T.Error(err)
+	}
+	_, err := nomostest.Retry(90*time.Second, func() error {
+		return nt.ValidateNotFound("my-ingress-nginx-controller", "ingress-nginx", &appsv1.Deployment{})
+	})
+	if err != nil {
+		nt.T.Fatal(err)
 	}
 }
 

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -190,7 +190,8 @@ spec:
                       false.'
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: 'namespace sets the target namespace for a release.
+                      Default: "default".'
                     type: string
                   period:
                     description: 'period is the time duration between consecutive
@@ -1157,7 +1158,8 @@ spec:
                       false.'
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: 'namespace sets the target namespace for a release.
+                      Default: "default".'
                     type: string
                   period:
                     description: 'period is the time duration between consecutive

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -56,6 +56,9 @@ const (
 
 	// DefaultReconcileTimeout defines the timeout of kpt applier reconcile/prune task
 	DefaultReconcileTimeout = 5 * time.Minute
+
+	// DefaultHelmReleaseNamespace is the default namespace for a Helm Release which does not have a namespace specified
+	DefaultHelmReleaseNamespace = "default"
 )
 
 // AuthType specifies the type to authenticate to a repository.

--- a/pkg/api/configsync/v1alpha1/helmconfig.go
+++ b/pkg/api/configsync/v1alpha1/helmconfig.go
@@ -23,7 +23,8 @@ import (
 // HelmRootSync contains the configuration specific to locate, download and template a Helm chart.
 type HelmRootSync struct {
 	HelmBase `json:",inline"`
-	// namespace sets the target namespace for a release
+	// namespace sets the target namespace for a release.
+	// Default: "default".
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -23,7 +23,8 @@ import (
 // HelmRootSync contains the configuration specific to locate, download and template a Helm chart for RootSync.
 type HelmRootSync struct {
 	HelmBase `json:",inline"`
-	// namespace sets the target namespace for a release
+	// namespace sets the target namespace for a release.
+	// Default: "default".
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -66,6 +66,8 @@ func (h *Hydrator) templateArgs(ctx context.Context, destDir string) ([]string, 
 	}
 	if h.Namespace != "" {
 		args = append(args, "--namespace", h.Namespace)
+	} else {
+		args = append(args, "--namespace", configsync.DefaultHelmReleaseNamespace)
 	}
 	if h.Version != "" {
 		args = append(args, "--version", h.Version)


### PR DESCRIPTION
Change the helm.namespace default value from "config-management-system"
to "default" to be consistent with other tools: Helm, Kustomize etc.