### PR TITLE
add test-resources to OSS manifest (#128)

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -255,6 +255,8 @@ __config-sync-manifest-oss:
 		--exclude='nomos-repo-crd.yaml' \
 		--exclude='sync-declaration-crd.yaml' \
 		.output/manifests/* .output/oss/cloned/manifests/
+	rsync \
+		manifests/test-resources/* .output/oss/cloned/manifests/
 	@echo "++++ Add OSS yaml files to config-sync-manifest.yaml"
 	env GO111MODULE=on go run -mod=vendor ./scripts/append_manifests/append_manifests.go \
 		--destination=${OSS_MANIFEST_STAGING_DIR}/config-sync-manifest.yaml \


### PR DESCRIPTION
This includes both the Config Management namespaces and the ResourceGroup manifests, which are needed for OSS installation.