### PR TITLE
Make client-side timeout when talking to API Server configurable

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2/klogr"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -87,6 +88,8 @@ var (
 	// Enable the applier to inject actuation status data into the ResourceGroup object
 	statusMode = flag.String(flags.statusMode, os.Getenv(reconcilermanager.StatusMode),
 		"When the value is enabled or empty, the applier injects actuation status data into the ResourceGroup object")
+
+	apiServerTimeout = flag.Duration("api-server-timeout", restconfig.DefaultTimeout, "The client-side timeout for requests to the API server")
 
 	debug = flag.Bool("debug", false,
 		"Enable debug mode, panicking in many scenarios where normally an InternalError would be logged. "+
@@ -178,6 +181,7 @@ func main() {
 		ReconcilerName:             *reconcilerName,
 		StatusMode:                 *statusMode,
 		ReconcileTimeout:           *reconcileTimeout,
+		APIServerTimeout:           *apiServerTimeout,
 	}
 
 	if declared.Scope(*scope) == declared.RootReconciler {

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog/v2/klogr"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
-	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -89,7 +88,7 @@ var (
 	statusMode = flag.String(flags.statusMode, os.Getenv(reconcilermanager.StatusMode),
 		"When the value is enabled or empty, the applier injects actuation status data into the ResourceGroup object")
 
-	apiServerTimeout = flag.Duration("api-server-timeout", restconfig.DefaultTimeout, "The client-side timeout for requests to the API server")
+	apiServerTimeout = flag.String("api-server-timeout", os.Getenv(reconcilermanager.APIServerTimeout), "The client-side timeout for requests to the API server")
 
 	debug = flag.Bool("debug", false,
 		"Enable debug mode, panicking in many scenarios where normally an InternalError would be logged. "+

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -271,6 +271,13 @@ spec:
                 description: override allows to override the settings for a reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: 'apiServerTimeout allows one to override the client-side
+                      timeout for requests to the API server. Default: 5s. Use string
+                      to specify this field value, like "30s", "1m". More details
+                      about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended
+                      apiServerTimeout range is from "3s" to "1m".'
+                    type: string
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.
@@ -1236,6 +1243,13 @@ spec:
                   reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: 'apiServerTimeout allows one to override the client-side
+                      timeout for requests to the API server. Default: 5s. Use string
+                      to specify this field value, like "30s", "1m". More details
+                      about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended
+                      apiServerTimeout range is from "3s" to "1m".'
+                    type: string
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -274,6 +274,13 @@ spec:
                 description: override allows to override the settings for a reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: 'apiServerTimeout allows one to override the client-side
+                      timeout for requests to the API server. Default: 5s. Use string
+                      to specify this field value, like "30s", "1m". More details
+                      about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended
+                      apiServerTimeout range is from "3s" to "1m".'
+                    type: string
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.
@@ -1241,6 +1248,13 @@ spec:
                 description: override allows to override the settings for a root reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: 'apiServerTimeout allows one to override the client-side
+                      timeout for requests to the API server. Default: 5s. Use string
+                      to specify this field value, like "30s", "1m". More details
+                      about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended
+                      apiServerTimeout range is from "3s" to "1m".'
+                    type: string
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.

--- a/pkg/api/configsync/v1alpha1/resource_override.go
+++ b/pkg/api/configsync/v1alpha1/resource_override.go
@@ -54,6 +54,14 @@ type OverrideSpec struct {
 	// +optional
 	ReconcileTimeout *metav1.Duration `json:"reconcileTimeout,omitempty"`
 
+	// apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+	// Default: 5s.
+	// Use string to specify this field value, like "30s", "1m".
+	// More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+	// Recommended apiServerTimeout range is from "3s" to "1m".
+	// +optional
+	APIServerTimeout *metav1.Duration `json:"apiServerTimeout,omitempty"`
+
 	// enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
 	// Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
 	// support pulling remote bases from public repositories.

--- a/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *OverrideSpec) DeepCopyInto(out *OverrideSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.APIServerTimeout != nil {
+		in, out := &in.APIServerTimeout, &out.APIServerTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.EnableShellInRendering != nil {
 		in, out := &in.EnableShellInRendering, &out.EnableShellInRendering
 		*out = new(bool)

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/client/restconfig"
 )
 
 // OverrideSpec allows to override the settings for a reconciler pod
@@ -95,6 +96,14 @@ type ContainerResourcesSpec struct {
 func GetReconcileTimeout(d *metav1.Duration) string {
 	if d == nil || d.Duration == 0 {
 		return configsync.DefaultReconcileTimeout.String()
+	}
+	return d.Duration.String()
+}
+
+// GetAPIServerTimeout returns the API server timeout in string, defaulting to 5s if empty
+func GetAPIServerTimeout(d *metav1.Duration) string {
+	if d == nil || d.Duration == 0 {
+		return restconfig.DefaultTimeout.String()
 	}
 	return d.Duration.String()
 }

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -54,6 +54,14 @@ type OverrideSpec struct {
 	// +optional
 	ReconcileTimeout *metav1.Duration `json:"reconcileTimeout,omitempty"`
 
+	// apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+	// Default: 5s.
+	// Use string to specify this field value, like "30s", "1m".
+	// More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+	// Recommended apiServerTimeout range is from "3s" to "1m".
+	// +optional
+	APIServerTimeout *metav1.Duration `json:"apiServerTimeout,omitempty"`
+
 	// enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
 	// Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
 	// support pulling remote bases from public repositories.

--- a/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *OverrideSpec) DeepCopyInto(out *OverrideSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.APIServerTimeout != nil {
+		in, out := &in.APIServerTimeout, &out.APIServerTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.EnableShellInRendering != nil {
 		in, out := &in.EnableShellInRendering, &out.EnableShellInRendering
 		*out = new(bool)

--- a/pkg/configsync/git-importer.go
+++ b/pkg/configsync/git-importer.go
@@ -45,6 +45,7 @@ var (
 	fightDetectionThreshold = flag.Float64(
 		"fight_detection_threshold", 5.0,
 		"The rate of updates per minute to an API Resource at which the Syncer logs warnings about too many updates to the resource.")
+	apiServerTimeout = flag.Duration("api-server-timeout", restconfig.DefaultTimeout, "The client-side timeout for requests to the API server")
 )
 
 // RunImporter encapsulates the main() logic for the importer.
@@ -52,7 +53,7 @@ func RunImporter() {
 	reconcile.SetFightThreshold(*fightDetectionThreshold)
 
 	// Get a config to talk to the apiserver.
-	cfg, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+	cfg, err := restconfig.NewRestConfig(*apiServerTimeout)
 	if err != nil {
 		klog.Fatalf("failed to create rest config: %+v", err)
 	}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -93,12 +93,12 @@ type Options struct {
 	StatusMode string
 	// ReconcileTimeout controls the reconcile/prune Timeout in kpt applier
 	ReconcileTimeout string
+	// APIServerTimeout is the client-side timeout used for talking to the API server
+	APIServerTimeout string
 	// RootOptions is the set of options to fill in if this is configuring the
 	// Root reconciler.
 	// Unset for Namespace repositories.
 	*RootOptions
-	// APIServerTimeout is the client-side timeout used for talking to the API server
-	APIServerTimeout time.Duration
 }
 
 // RootOptions are the options specific to parsing Root repositories.
@@ -112,7 +112,14 @@ func Run(opts Options) {
 	reconcile.SetFightThreshold(opts.FightDetectionThreshold)
 
 	// Get a config to talk to the apiserver.
-	cfg, err := restconfig.NewRestConfig(opts.APIServerTimeout)
+	apiServerTimeout, err := time.ParseDuration(opts.APIServerTimeout)
+	if err != nil {
+		klog.Fatalf("Error parsing applier reconcile/prune task timeout: %v", err)
+	}
+	if apiServerTimeout <= 0 {
+		klog.Fatalf("Invalid apiServerTimeout: %v, timeout should be positive", apiServerTimeout)
+	}
+	cfg, err := restconfig.NewRestConfig(apiServerTimeout)
 	if err != nil {
 		klog.Fatalf("Error creating rest config: %v", err)
 	}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -97,6 +97,8 @@ type Options struct {
 	// Root reconciler.
 	// Unset for Namespace repositories.
 	*RootOptions
+	// APIServerTimeout is the client-side timeout used for talking to the API server
+	APIServerTimeout time.Duration
 }
 
 // RootOptions are the options specific to parsing Root repositories.
@@ -110,7 +112,7 @@ func Run(opts Options) {
 	reconcile.SetFightThreshold(opts.FightDetectionThreshold)
 
 	// Get a config to talk to the apiserver.
-	cfg, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+	cfg, err := restconfig.NewRestConfig(opts.APIServerTimeout)
 	if err != nil {
 		klog.Fatalf("Error creating rest config: %v", err)
 	}

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -71,6 +71,9 @@ const (
 	// ReconcileTimeout is to control the kpt applier reconcile/prune task timeout
 	ReconcileTimeout = "RECONCILE_TIMEOUT"
 
+	// APIServerTimeout is to control the client-side timeout when talking to the API server
+	APIServerTimeout = "API_SERVER_TIMEOUT"
+
 	// StatusMode is to control if the kpt applier needs to inject the actuation data
 	// into the ResourceGroup object.
 	StatusMode = "STATUS_MODE"

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -352,12 +352,6 @@ func (r *reconcilerBase) deployment(ctx context.Context, dRef client.ObjectKey) 
 	return depObj, nil
 }
 
-func mutateContainerArgs(ctx context.Context, c *corev1.Container, override v1beta1.OverrideSpec, reconcilerType string) {
-	if override.APIServerTimeout != nil {
-		c.Args = append(c.Args, "--api-server-timeout", override.APIServerTimeout.Duration.String())
-	}
-}
-
 func mutateContainerResource(ctx context.Context, c *corev1.Container, override v1beta1.OverrideSpec, reconcilerType string) {
 	for _, override := range override.Resources {
 		if override.ContainerName == c.Name {

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -352,6 +352,12 @@ func (r *reconcilerBase) deployment(ctx context.Context, dRef client.ObjectKey) 
 	return depObj, nil
 }
 
+func mutateContainerArgs(ctx context.Context, c *corev1.Container, override v1beta1.OverrideSpec, reconcilerType string) {
+	if override.APIServerTimeout != nil {
+		c.Args = append(c.Args, "--api-server-timeout", override.APIServerTimeout.Duration.String())
+	}
+}
+
 func mutateContainerResource(ctx context.Context, c *corev1.Container, override v1beta1.OverrideSpec, reconcilerType string) {
 	for _, override := range override.Resources {
 		if override.ContainerName == c.Name {

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -873,6 +873,7 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 			switch container.Name {
 			case reconcilermanager.Reconciler:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)
+				mutateContainerArgs(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 				mutateContainerResource(ctx, &container, rs.Spec.Override, string(NamespaceReconcilerType))
 			case reconcilermanager.HydrationController:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -670,7 +670,7 @@ func requeueRepoSyncRequest(obj client.Object, rs *v1beta1.RepoSync) []reconcile
 func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RepoSync, reconcilerName string) map[string][]corev1.EnvVar {
 	result := map[string][]corev1.EnvVar{
 		reconcilermanager.HydrationController: hydrationEnvs(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, declared.Scope(rs.Namespace), reconcilerName, r.hydrationPollingPeriod.String()),
-		reconcilermanager.Reconciler:          reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.Scope(rs.Namespace), rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, reposync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.Override.StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.Override.ReconcileTimeout)),
+		reconcilermanager.Reconciler:          reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.Scope(rs.Namespace), rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, reposync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.Override.StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.Override.ReconcileTimeout), v1beta1.GetAPIServerTimeout(rs.Spec.Override.APIServerTimeout)),
 	}
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
 	case v1beta1.GitSource:
@@ -873,7 +873,6 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 			switch container.Name {
 			case reconcilermanager.Reconciler:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)
-				mutateContainerArgs(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 				mutateContainerResource(ctx, &container, rs.Spec.Override, string(NamespaceReconcilerType))
 			case reconcilermanager.HydrationController:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -462,7 +462,7 @@ func (r *RootSyncReconciler) mapSecretToRootSyncs(secret client.Object) []reconc
 func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string) map[string][]corev1.EnvVar {
 	result := map[string][]corev1.EnvVar{
 		reconcilermanager.HydrationController: hydrationEnvs(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, declared.RootReconciler, reconcilerName, r.hydrationPollingPeriod.String()),
-		reconcilermanager.Reconciler:          append(reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.RootReconciler, rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, rootsync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.Override.StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.Override.ReconcileTimeout)), sourceFormatEnv(rs.Spec.SourceFormat)),
+		reconcilermanager.Reconciler:          append(reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.RootReconciler, rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, rootsync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.Override.StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.Override.ReconcileTimeout), v1beta1.GetAPIServerTimeout(rs.Spec.Override.APIServerTimeout)), sourceFormatEnv(rs.Spec.SourceFormat)),
 	}
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
 	case v1beta1.GitSource:
@@ -656,7 +656,6 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 			switch container.Name {
 			case reconcilermanager.Reconciler:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)
-				mutateContainerArgs(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 				mutateContainerResource(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 			case reconcilermanager.HydrationController:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -656,6 +656,7 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 			switch container.Name {
 			case reconcilermanager.Reconciler:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)
+				mutateContainerArgs(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 				mutateContainerResource(ctx, &container, rs.Spec.Override, string(RootReconcilerType))
 			case reconcilermanager.HydrationController:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -77,7 +77,7 @@ func hydrationEnvs(sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1
 }
 
 // reconcilerEnvs returns environment variables for namespace reconciler.
-func reconcilerEnvs(clusterName, syncName, reconcilerName string, reconcilerScope declared.Scope, sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1.Oci, helmConfig *v1beta1.HelmBase, pollPeriod, statusMode string, reconcileTimeout string) []corev1.EnvVar {
+func reconcilerEnvs(clusterName, syncName, reconcilerName string, reconcilerScope declared.Scope, sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1.Oci, helmConfig *v1beta1.HelmBase, pollPeriod, statusMode string, reconcileTimeout string, apiServerTimeout string) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	if statusMode == "" {
 		statusMode = applier.StatusEnabled
@@ -158,7 +158,12 @@ func reconcilerEnvs(clusterName, syncName, reconcilerName string, reconcilerScop
 		corev1.EnvVar{
 			Name:  reconcilermanager.ReconcilerPollingPeriod,
 			Value: pollPeriod,
-		})
+		},
+		corev1.EnvVar{
+			Name:  reconcilermanager.APIServerTimeout,
+			Value: apiServerTimeout,
+		},
+	)
 
 	if syncBranch != "" {
 		result = append(result, corev1.EnvVar{


### PR DESCRIPTION
We have a few hundreds of CRDs in our clusters, and are seeing Config Sync reconciliation fail with API Server timeouts due to the client-side timeout parameter being too aggressive.

This makes the client-side timeout for API server requests configurable under `.spec.override` (next to things like `gitSyncDepth` and `statusMode`; if you'd like it to be somewhere else, feel free to recommend something and I'll adjust the PR). I tried to mimic patterns already in use for other parameters, both in implementation and tests (but oh, god, does this test suite need some work...!) so I hope it looks OK.

I [added](https://github.com/GoogleContainerTools/kpt-config-sync/pull/141/files#diff-96d9758339603eab1bf5deb9d64abf4acb751b8474cd85e2cd4d790a76514291R2384-R2480) two [new tests](https://github.com/GoogleContainerTools/kpt-config-sync/pull/141/files#diff-4e452cd48e11abd5a08fa09505577300d00a536c7c57d7ebc492a9b166be3f55R2783-R2878) for the actual expansion of config into environment variables, because I realized that all the tests of the public API that already existed [were using](https://github.com/GoogleContainerTools/kpt-config-sync/blob/main/pkg/reconcilermanager/controllers/reposync_controller_test.go#L329) the [production implementation](https://github.com/GoogleContainerTools/kpt-config-sync/blob/5c250076186a138434505dbe54fa425a08a78189/pkg/reconcilermanager/controllers/reposync_controller.go#L670) also to create the expected results, which in practice means that a bug there would never be exposed by the tests. There's room to add a lot more test cases in these two, to ensure that the set of expected env vars in the all the other tests match the intention. I'll leave that work for someone else 😅 

A couple of questions:

* Given that 1.13 was released quite recently, I expect that 1.14 is still a few weeks out. What's the easiest way I can re-generate all the manifets and locally build a Docker image to use in a deployment of Config Sync to test this out in one of our clusters, and see if it works?
* I've run `make generate`; are there any other code-generation commands I should run?
* Should I - and if so, how do I - write a changelog entry somewhere?
