### PR TITLE
Add e2e tests for Helm support (#93)

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -25,6 +25,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/gitproviders"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
@@ -98,6 +99,12 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	}}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from a public Helm Chart with cluster-scoped type")
+	// Change the RepoSync to sync from the original git source to make test works in the shared test environment.
+	nt.T.Cleanup(func() {
+		rs.Spec.SourceType = string(v1beta1.GitSource)
+		nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs)
+		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from the original git repository")
+	})
 	nt.WaitForRepoSyncSourceError(repoSyncNN.Namespace, repoSyncNN.Name, nonhierarchical.BadScopeErrCode, "must be Namespace-scoped type")
 	nt.T.Log("Fetch password from Secret Manager")
 	key, err := gitproviders.FetchCloudSecret("config-sync-ci-ar-key")
@@ -157,6 +164,90 @@ func TestHelmARFleetWISameProject(t *testing.T) {
 	})
 }
 
+// TestHelmARFleetWIDifferentProject tests the `gcpserviceaccount` auth type with Fleet Workload Identity (cross-project).
+//
+//	The test will run on a GKE cluster only with following pre-requisites
+//
+// 1. Workload Identity is enabled.
+// 2. The Google service account `e2e-test-ar-reader@stolos-dev.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for access image in Artifact Registry.
+// 3. An IAM policy binding is created between the Google service account and the Kubernetes service accounts with the `roles/iam.workloadIdentityUser` role.
+//
+//	gcloud iam service-accounts add-iam-policy-binding --project=stolos-dev \
+//	   --role roles/iam.workloadIdentityUser \
+//	   --member="serviceAccount:cs-dev-hub.svc.id.goog[config-management-system/root-reconciler]" \
+//	   e2e-test-ar-reader@stolos-dev.iam.gserviceaccount.com
+//
+// 4. The cross-project fleet host project 'cs-dev-hub' is created.
+// 5. The following environment variables are set: GCP_PROJECT, GCP_CLUSTER, GCP_REGION|GCP_ZONE.
+func TestHelmARFleetWIDifferentProject(t *testing.T) {
+	testWorkloadIdentity(t, workloadIdentityTestSpec{
+		fleetWITest:   true,
+		crossProject:  true,
+		sourceRepo:    privateARHelmRegistry,
+		sourceVersion: privateHelmChartVersion,
+		sourceChart:   privateHelmChart,
+		sourceType:    v1beta1.HelmSource,
+		gsaEmail:      gsaARReaderEmail,
+		rootCommitFn:  helmChartVersion(privateHelmChart + ":" + privateHelmChartVersion),
+	})
+}
+
+// TestHelmARGKEWorkloadIdentity tests the `gcpserviceaccount` auth type with GKE Workload Identity.
+//
+//	The test will run on a GKE cluster only with following pre-requisites
+//
+// 1. Workload Identity is enabled.
+// 2. The Google service account `e2e-test-ar-reader@stolos-dev.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for access image in Artifact Registry.
+// 3. An IAM policy binding is created between the Google service account and the Kubernetes service accounts with the `roles/iam.workloadIdentityUser` role.
+//
+//	gcloud iam service-accounts add-iam-policy-binding --project=stolos-dev \
+//	   --role roles/iam.workloadIdentityUser \
+//	   --member "serviceAccount:stolos-dev.svc.id.goog[config-management-system/root-reconciler]" \
+//	   e2e-test-ar-reader@stolos-dev.iam.gserviceaccount.com
+//
+// 4. The following environment variables are set: GCP_PROJECT, GCP_CLUSTER, GCP_REGION|GCP_ZONE.
+func TestHelmARGKEWorkloadIdentity(t *testing.T) {
+	testWorkloadIdentity(t, workloadIdentityTestSpec{
+		fleetWITest:   false,
+		crossProject:  false,
+		sourceRepo:    privateARHelmRegistry,
+		sourceVersion: privateHelmChartVersion,
+		sourceChart:   privateHelmChart,
+		sourceType:    v1beta1.HelmSource,
+		gsaEmail:      gsaARReaderEmail,
+		rootCommitFn:  helmChartVersion(privateHelmChart + ":" + privateHelmChartVersion),
+	})
+}
+
+// TestHelmGCENode tests the `gcenode` auth type for the Helm repository.
+// The test will run on a GKE cluster only with following pre-requisites:
+// 1. Workload Identity is NOT enabled
+// 2. The Compute Engine default service account `PROJECT_ID-compute@developer.gserviceaccount.com` needs to have the following role:
+//   - `roles/artifactregistry.reader` for access image in Artifact Registry.
+func TestHelmGCENode(t *testing.T) {
+	nt := nomostest.New(t, ntopts.SkipMonoRepo, ntopts.Unstructured,
+		ntopts.RequireGKE(t), ntopts.GCENodeTest)
+
+	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
+
+	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
+	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "%s", "auth": "gcenode", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns"}, "git": null}}`,
+		v1beta1.HelmSource, privateARHelmRegistry, privateHelmChart, privateHelmChartVersion))
+	nt.T.Cleanup(func() {
+		// Change the rs back so that it works in the shared test environment.
+		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
+			v1beta1.GitSource, origRepoURL))
+	})
+
+	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion(privateHelmChart+":"+privateHelmChartVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: privateHelmChart}))
+	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
+		containerImagePullPolicy("IfNotPresent")); err != nil {
+		nt.T.Error(err)
+	}
+}
+
 // TestHelmARTokenAuth verifies Config Sync can pull Helm chart from private Artifact Registry with Token auth type.
 // This test will work only with following pre-requisites:
 // Google service account `e2e-test-ar-reader@stolos-dev.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
@@ -176,10 +267,13 @@ func TestHelmARTokenAuth(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 	nt.T.Log("Create secret for authentication")
-	_, err = nt.Kubectl("create", "secret", "generic", "foo", "--namespace=config-management-system", "--from-literal=username=_json_key", fmt.Sprintf("--from-literal=password=%s", key))
+	_, err = nt.Kubectl("create", "secret", "generic", "foo", fmt.Sprintf("--namespace=%s", v1.NSConfigManagementSystem), "--from-literal=username=_json_key", fmt.Sprintf("--from-literal=password=%s", key))
 	if err != nil {
 		nt.T.Fatalf("failed to create secret, err: %v", err)
 	}
+	nt.T.Cleanup(func() {
+		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
+	})
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns",
                                                                                                 "values": {"image.pullPolicy": "Always", "resources.requests.memory": "250Mi", "resources.requests.cpu": "150m", "resources.limits.memory": "300Mi", "resources.limits.cpu": 1},


### PR DESCRIPTION
Add more e2e tests to verify `gcenode` and `gcpserviceaccount` auth types work with Artifact Registry.