### PR TITLE
Change the RootSync helm.namespace field default value

### DIFF
--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -190,7 +190,8 @@ spec:
                       false.'
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: 'namespace sets the target namespace for a release.
+                      Default: "default".'
                     type: string
                   period:
                     description: 'period is the time duration between consecutive
@@ -1157,7 +1158,8 @@ spec:
                       false.'
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: 'namespace sets the target namespace for a release.
+                      Default: "default".'
                     type: string
                   period:
                     description: 'period is the time duration between consecutive

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -52,6 +52,9 @@ const (
 
 	// DefaultReconcileTimeout defines the timeout of kpt applier reconcile/prune task
 	DefaultReconcileTimeout = 5 * time.Minute
+
+	// DefaultHelmReleaseNamespace is the default namespace for a Helm Release which does not have a namespace specified
+	DefaultHelmReleaseNamespace = "default"
 )
 
 // AuthType specifies the type to authenticate to a repository.

--- a/pkg/api/configsync/v1alpha1/helmconfig.go
+++ b/pkg/api/configsync/v1alpha1/helmconfig.go
@@ -23,7 +23,8 @@ import (
 // HelmRootSync contains the configuration specific to locate, download and template a Helm chart.
 type HelmRootSync struct {
 	HelmBase `json:",inline"`
-	// namespace sets the target namespace for a release
+	// namespace sets the target namespace for a release.
+	// Default: "default".
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -23,7 +23,8 @@ import (
 // HelmRootSync contains the configuration specific to locate, download and template a Helm chart for RootSync.
 type HelmRootSync struct {
 	HelmBase `json:",inline"`
-	// namespace sets the target namespace for a release
+	// namespace sets the target namespace for a release.
+	// Default: "default".
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -66,6 +66,8 @@ func (h *Hydrator) templateArgs(ctx context.Context, destDir string) ([]string, 
 	}
 	if h.Namespace != "" {
 		args = append(args, "--namespace", h.Namespace)
+	} else {
+		args = append(args, "--namespace", configsync.DefaultHelmReleaseNamespace)
 	}
 	if h.Version != "" {
 		args = append(args, "--version", h.Version)


### PR DESCRIPTION
Change the helm.namespace default value from "config-management-system"
to "default" to be consistent with other tools: Helm, Kustomize etc.