### PR TITLE
Harmonize CLI args

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -16,6 +16,8 @@
 package main
 
 import (
+	"flag"
+
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"kpt.dev/configsync/pkg/client/restconfig"
@@ -31,7 +33,9 @@ func main() {
 	log.Setup()
 	ctrl.SetLogger(klogr.New())
 
-	cfg, err := restconfig.MonoRepoRestClient(restconfig.DefaultTimeout)
+	apiServerTimeout := flag.Duration("api-server-timeout", restconfig.DefaultTimeout, "Client-side timeout for talking to the API server")
+
+	cfg, err := restconfig.MonoRepoRestClient(*apiServerTimeout)
 	if err != nil {
 		klog.Fatalf("Failed to create rest config: %v", err)
 	}

--- a/cmd/nomos/flags/flags.go
+++ b/cmd/nomos/flags/flags.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 )
@@ -74,6 +75,9 @@ var (
 
 	// ClientTimeout is a flag value to specify how long to wait before timeout of client connection.
 	ClientTimeout time.Duration
+
+	// APIServerTimeout specifies the timeout for requests to the cluster API servers
+	APIServerTimeout = restconfig.DefaultTimeout
 )
 
 // AddContexts adds the --contexts flag.
@@ -116,4 +120,9 @@ func AddSourceFormat(cmd *cobra.Command) {
 func AddOutputFormat(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&OutputFormat, "format", "yaml",
 		`Output format. Accepts 'yaml' and 'json'.`)
+}
+
+// AddAPIServerTimeout adds the --api-server-timeout flag
+func AddAPIServerTimeout(cmd *cobra.Command) {
+	cmd.Flags().DurationVar(&APIServerTimeout, "api-server-timeout", restconfig.DefaultTimeout, fmt.Sprintf("Client-side timeout for talking to the API server; defaults to %s", restconfig.DefaultTimeout))
 }

--- a/cmd/nomos/hydrate/hydrate.go
+++ b/cmd/nomos/hydrate/hydrate.go
@@ -41,6 +41,7 @@ func init() {
 	flags.AddSkipAPIServerCheck(Cmd)
 	flags.AddSourceFormat(Cmd)
 	flags.AddOutputFormat(Cmd)
+	flags.AddAPIServerTimeout(Cmd)
 	Cmd.Flags().BoolVar(&flat, "flat", false,
 		`If enabled, print all output to a single file`)
 	Cmd.Flags().StringVar(&outPath, "output", flags.DefaultHydrationOutput,
@@ -97,7 +98,7 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 
 		parser := filesystem.NewParser(&reader.File{})
 
-		options, err := hydrate.ValidateOptions(cmd.Context(), rootDir)
+		options, err := hydrate.ValidateOptions(cmd.Context(), rootDir, flags.APIServerTimeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/nomos/parse/parse.go
+++ b/cmd/nomos/parse/parse.go
@@ -34,7 +34,7 @@ const timeout = time.Second * 15
 // GetSyncedCRDs returns the CRDs synced to the cluster in the current context.
 //
 // Times out after 15 seconds.
-func GetSyncedCRDs(ctx context.Context, skipAPIServer bool) ([]*v1beta1.CustomResourceDefinition, status.MultiError) {
+func GetSyncedCRDs(ctx context.Context, skipAPIServer bool, apiServerTimeout time.Duration) ([]*v1beta1.CustomResourceDefinition, status.MultiError) {
 	if skipAPIServer {
 		return nil, nil
 	}
@@ -42,7 +42,7 @@ func GetSyncedCRDs(ctx context.Context, skipAPIServer bool) ([]*v1beta1.CustomRe
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	config, err := restconfig.MonoRepoRestClient(restconfig.DefaultTimeout)
+	config, err := restconfig.MonoRepoRestClient(apiServerTimeout)
 	if err != nil {
 		return nil, getSyncedCRDsError(err, "failed to create rest config")
 	}

--- a/cmd/nomos/vet/vet.go
+++ b/cmd/nomos/vet/vet.go
@@ -34,6 +34,7 @@ func init() {
 	flags.AddSkipAPIServerCheck(Cmd)
 	flags.AddSourceFormat(Cmd)
 	flags.AddOutputFormat(Cmd)
+	flags.AddAPIServerTimeout(Cmd)
 	Cmd.Flags().StringVar(&namespaceValue, "namespace", "",
 		fmt.Sprintf(
 			"If set, validate the repository as a Namespace Repo with the provided name. Automatically sets --source-format=%s",
@@ -63,6 +64,6 @@ returns a non-zero error code if any issues are found.
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true
 
-		return runVet(cmd.Context(), namespaceValue, filesystem.SourceFormat(flags.SourceFormat))
+		return runVet(cmd.Context(), namespaceValue, filesystem.SourceFormat(flags.SourceFormat), flags.APIServerTimeout)
 	},
 }

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"kpt.dev/configsync/cmd/nomos/flags"
@@ -47,7 +48,7 @@ import (
 // allClusters is whether we are implicitly vetting every cluster.
 // clusters is the set of clusters we are checking.
 //   Only used if allClusters is false.
-func runVet(ctx context.Context, namespace string, sourceFormat filesystem.SourceFormat) error {
+func runVet(ctx context.Context, namespace string, sourceFormat filesystem.SourceFormat, apiServerTimeout time.Duration) error {
 	if sourceFormat == "" {
 		if namespace == "" {
 			// Default to hierarchical if --namespace is not provided.
@@ -81,7 +82,7 @@ func runVet(ctx context.Context, namespace string, sourceFormat filesystem.Sourc
 
 	parser := filesystem.NewParser(&reader.File{})
 
-	options, err := hydrate.ValidateOptions(ctx, rootDir)
+	options, err := hydrate.ValidateOptions(ctx, rootDir, apiServerTimeout)
 	if err != nil {
 		return err
 	}

--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -34,6 +34,7 @@ import (
 	configmanagementv1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/client/restconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -97,7 +98,7 @@ func RestConfig(t testing.NTB, optsStruct *ntopts.New) {
 	case e2e.Kind:
 		ntopts.Kind(t, *e2e.KubernetesVersion)(optsStruct)
 	case e2e.GKE:
-		ntopts.GKECluster(t)(optsStruct)
+		ntopts.GKECluster(t, restconfig.DefaultTimeout)(optsStruct)
 	default:
 		t.Fatalf("unsupported test cluster config %s. Allowed values are %s and %s.", *e2e.TestCluster, e2e.GKE, e2e.Kind)
 	}

--- a/e2e/nomostest/ntopts/gke.go
+++ b/e2e/nomostest/ntopts/gke.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/testing"
@@ -26,7 +27,7 @@ import (
 )
 
 // GKECluster tells the test to use the GKE cluster pointed to by the config flags.
-func GKECluster(t testing.NTB) Opt {
+func GKECluster(t testing.NTB, apiServerTimeout time.Duration) Opt {
 	return func(opt *New) {
 		t.Helper()
 
@@ -43,7 +44,7 @@ func GKECluster(t testing.NTB) Opt {
 		}
 
 		forceAuthRefresh(t)
-		restConfig, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+		restConfig, err := restconfig.NewRestConfig(apiServerTimeout)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
@@ -281,9 +282,9 @@ func ValidateHydrateFlags(sourceFormat filesystem.SourceFormat) (cmpath.Absolute
 }
 
 // ValidateOptions returns the validate options for nomos hydrate and vet commands.
-func ValidateOptions(ctx context.Context, rootDir cmpath.Absolute) (validate.Options, error) {
+func ValidateOptions(ctx context.Context, rootDir cmpath.Absolute, apiServerTimeout time.Duration) (validate.Options, error) {
 	var options = validate.Options{}
-	syncedCRDs, err := nomosparse.GetSyncedCRDs(ctx, flags.SkipAPIServer)
+	syncedCRDs, err := nomosparse.GetSyncedCRDs(ctx, flags.SkipAPIServer, apiServerTimeout)
 	if err != nil {
 		return options, err
 	}
@@ -291,7 +292,7 @@ func ValidateOptions(ctx context.Context, rootDir cmpath.Absolute) (validate.Opt
 	var serverResourcer discovery.ServerResourcer = discovery.NoOpServerResourcer{}
 	var converter *declared.ValueConverter
 	if !flags.SkipAPIServer {
-		cfg, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+		cfg, err := restconfig.NewRestConfig(apiServerTimeout)
 		if err != nil {
 			return options, fmt.Errorf("failed to create rest config: %w", err)
 		}


### PR DESCRIPTION
This follows up on https://github.com/GoogleContainerTools/kpt-config-sync/pull/141#issuecomment-1261588575, in the simplest way possible: I just searched the project for references to `restconfig.DefaultTimeout` and replaced them with something coming form a CLI arg in the simplest way I could.
