### PR TITLE
Fix cherrypick discrepancy in #93 and #144

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -131,10 +131,6 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	if err := nt.Validate(rs.Spec.Helm.ReleaseName+"-"+privateNSHelmChart, testNs, &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
 	}
-	// Change the RepoSync to sync from the original git source to make test works in the shared test environment.
-	rs.Spec.SourceType = string(v1beta1.GitSource)
-	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs)
-	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from the original git repository")
 }
 
 // TestHelmARFleetWISameProject tests the `gcpserviceaccount` auth type with Fleet Workload Identity (in-project).


### PR DESCRIPTION
The code snippet was not removed by cherrypicking from #93 in #144. Remove it to fix multi-repo test failure on v1.13 branch.