### PR TITLE
Support passing number only values as string directly through helm.va…

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
@@ -53,7 +54,7 @@ func TestPublicHelm(t *testing.T) {
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace")
-	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "ingress-nginx", "auth": "none", "version": "4.0.5", "releaseName": "my-ingress-nginx", "namespace": "ingress-nginx"}, "git": null}}`,
+	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "ingress-nginx", "auth": "none", "version": "4.0.5", "releaseName": "my-ingress-nginx", "namespace": "ingress-nginx", "values": {"serviceAccount.name": "1234"}}, "git": null}}`,
 		v1beta1.HelmSource, publicHelmRepo))
 	nt.T.Cleanup(func() {
 		// Change the rs back so that it works in the shared test environment.
@@ -63,6 +64,9 @@ func TestPublicHelm(t *testing.T) {
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion("ingress-nginx:4.0.5")),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "ingress-nginx"}))
 	if err := nt.Validate("my-ingress-nginx-controller", "ingress-nginx", &appsv1.Deployment{}); err != nil {
+		nt.T.Error(err)
+	}
+	if err := nt.Validate("1234", "ingress-nginx", &corev1.ServiceAccount{}); err != nil {
 		nt.T.Error(err)
 	}
 	nt.T.Log("Update RootSync to sync from a public Helm Chart without specified release namespace")

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -93,7 +93,12 @@ func (h *Hydrator) appendValuesArgs(args []string) ([]string, error) {
 		return []string{}, fmt.Errorf("failed to unmarshal helm.values, error: %w", err)
 	}
 	for key, val := range values {
-		args = append(args, "--set", fmt.Sprintf("%s=%v", key, val))
+		switch v := val.(type) {
+		case string:
+			args = append(args, "--set", fmt.Sprintf("%s=%q", key, v))
+		default:
+			args = append(args, "--set", fmt.Sprintf("%s=%v", key, v))
+		}
 	}
 	return args, nil
 }


### PR DESCRIPTION
…lues

Currently, when users need to pass in number only value as string through helm.values, they
have to set the value as "\\"1234\\"". After this change, user will be able to pass in the number only value directly as "1234".