### PR TITLE
Support passing number only values as string directly through helm.va…

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -93,7 +93,12 @@ func (h *Hydrator) appendValuesArgs(args []string) ([]string, error) {
 		return []string{}, fmt.Errorf("failed to unmarshal helm.values, error: %w", err)
 	}
 	for key, val := range values {
-		args = append(args, "--set", fmt.Sprintf("%s=%v", key, val))
+		switch v := val.(type) {
+		case string:
+			args = append(args, "--set", fmt.Sprintf("%s=%q", key, v))
+		default:
+			args = append(args, "--set", fmt.Sprintf("%s=%v", key, v))
+		}
 	}
 	return args, nil
 }


### PR DESCRIPTION
…lues (#153)

Currently, when users need to pass in number only value as string through helm.values, they
have to set the value as "\"1234\"". After this change, user will be able to pass in the number only value directly as "1234".