### PR TITLE
Filter some metrics by pod name for testing

### DIFF
--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -615,9 +615,9 @@ func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 		nt.WaitForRepoImportErrorCode(selectors.ClusterSelectorAnnotationConflictErrorCode)
 	}
 
-	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nomostest.DefaultRootReconcilerName), func() error {
+	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nt, nomostest.DefaultRootReconcilerName), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "source")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -85,9 +85,9 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 		nt.WaitForRepoImportErrorCode(nonhierarchical.UnsupportedCRDRemovalErrorCode)
 	}
 
-	err = nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nomostest.DefaultRootReconcilerName), func() error {
+	err = nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nt, nomostest.DefaultRootReconcilerName), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "source")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -110,7 +110,7 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 		if err != nil {
 			return err
 		}
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 0, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -119,7 +119,7 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ReconcilerMetrics.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 1)
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -210,7 +210,7 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ReconcilerMetrics.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 1)
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -24,6 +24,7 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
 )
@@ -37,9 +38,9 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "")
 
-	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nomostest.DefaultRootReconcilerName), func() error {
+	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nt, nomostest.DefaultRootReconcilerName), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "source")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -70,9 +71,14 @@ func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 
 	nt.WaitForRepoSyncSourceError(namespaceRepo, configsync.RepoSyncName, status.SourceErrorCode, "")
 
+	nsReconcilerName := core.NsReconcilerName(nn.Namespace, nn.Name)
 	err := nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "source")
+		err := nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 0, 0)
+		if err != nil {
+			return err
+		}
+		return nt.ValidateReconcilerErrors(nsReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -231,7 +231,7 @@ func TestConflictingDefinitions_RootToNamespace(t *testing.T) {
 
 	nt.T.Logf("Validate reconciler error metric is emitted from namespace reconciler %s", repoSyncNN)
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		return nt.ValidateReconcilerErrors(nsReconcilerName, "sync")
+		return nt.ValidateReconcilerErrors(nsReconcilerName, 0, 1)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -326,7 +326,7 @@ func TestConflictingDefinitions_NamespaceToRoot(t *testing.T) {
 
 	// Validate reconciler error metric is emitted from namespace reconciler.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		return nt.ValidateReconcilerErrors(nsReconcilerName, "sync")
+		return nt.ValidateReconcilerErrors(nsReconcilerName, 0, 1)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -503,7 +503,7 @@ func TestConflictingDefinitions_NamespaceToNamespace(t *testing.T) {
 
 	nt.T.Logf("Validate reconciler error metric is emitted from Namespace reconciler %s", repoSyncNN2)
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		return nt.ValidateReconcilerErrors(nsReconcilerName2, "sync")
+		return nt.ValidateReconcilerErrors(nsReconcilerName2, 0, 1)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -768,7 +768,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	numDeclaredObjs -= 2 // -2 for the removed test Namespaces
 	numDeclaredObjs--    // -1 for the removed safety Namespace
 
-	err = nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSyncError(nomostest.DefaultRootReconcilerName), func() error {
+	err = nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSyncError(nt, nomostest.DefaultRootReconcilerName), func() error {
 		rootReconcilerMetrics := nt.ReconcilerMetrics.FilterByReconciler(nomostest.DefaultRootReconcilerName)
 		err := rootReconcilerMetrics.ValidateDeclaredResources(numDeclaredObjs)
 		return errors.Wrapf(err, "for reconciler %s", nomostest.DefaultRootReconcilerName)

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -311,9 +311,9 @@ func TestForceRevert(t *testing.T) {
 
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, system.MissingRepoErrorCode, "")
 
-	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nomostest.DefaultRootReconcilerName), func() error {
+	err := nt.ValidateMetrics(nomostest.SyncMetricsToReconcilerSourceError(nt, nomostest.DefaultRootReconcilerName), func() error {
 		// Validate reconciler error metric is emitted.
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "source")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 1, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)
@@ -325,7 +325,7 @@ func TestForceRevert(t *testing.T) {
 	nt.WaitForRepoSyncs()
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
-		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, "")
+		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 0, 0)
 	})
 	if err != nil {
 		nt.T.Error(err)

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -87,6 +87,10 @@ func RecordParserDuration(ctx context.Context, trigger, source, status string, s
 
 // RecordLastSync produces a measurement for the LastSync view.
 func RecordLastSync(ctx context.Context, status, commit string, timestamp time.Time) {
+	if commit == "" {
+		// TODO: Remove default value when otel-collector supports empty tag values correctly.
+		commit = CommitNone
+	}
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyStatus, status),
 		tag.Upsert(KeyCommit, commit))
@@ -113,6 +117,10 @@ func RecordApplyOperation(ctx context.Context, operation, status string, gvk sch
 
 // RecordApplyDuration produces measurements for the ApplyDuration and LastApplyTimestamp views.
 func RecordApplyDuration(ctx context.Context, status, commit string, startTime time.Time) {
+	if commit == "" {
+		// TODO: Remove default value when otel-collector supports empty tag values correctly.
+		commit = CommitNone
+	}
 	now := time.Now()
 	lastApplyTagCtx, _ := tag.New(ctx, tag.Upsert(KeyStatus, status), tag.Upsert(KeyCommit, commit))
 	tagCtx, _ := tag.New(ctx,

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -81,6 +81,9 @@ var (
 
 	// ResourceKeyDeploymentName groups metrics by k8s deployment name.
 	ResourceKeyDeploymentName, _ = tag.NewKey("k8s_deployment_name")
+
+	// ResourceKeyDeploymentName groups metrics by k8s pod name.
+	ResourceKeyPodName, _ = tag.NewKey("k8s_pod_name")
 )
 
 const (
@@ -88,6 +91,9 @@ const (
 	StatusSuccess = "success"
 	// StatusError is the string value for the status key indicating failure/errors
 	StatusError = "error"
+	// CommitNone is the string value for the commit key indicating that no
+	// commit has been synced.
+	CommitNone = "NONE"
 )
 
 // StatusTagKey returns a string representation of the error, if it exists, otherwise success.

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -170,7 +170,7 @@ func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus so
 	reposync.SetSyncing(&rs, continueSyncing, "Source", "Source", newStatus.commit, errorSource, rs.Status.Source.ErrorSummary, newStatus.lastUpdate)
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Source.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping source status update for RepoSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}
@@ -232,7 +232,7 @@ func (p *namespace) setRenderingStatusWithRetires(ctx context.Context, newStatus
 	reposync.SetSyncing(&rs, continueSyncing, "Rendering", newStatus.message, newStatus.commit, errorSource, rs.Status.Rendering.ErrorSummary, newStatus.lastUpdate)
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Rendering.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping rendering status update for RepoSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}
@@ -305,7 +305,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 	}
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Sync.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping status update for RepoSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -181,7 +181,7 @@ func (p *root) setSourceStatusWithRetries(ctx context.Context, newStatus sourceS
 	rootsync.SetSyncing(&rs, continueSyncing, "Source", "Source", newStatus.commit, errorSource, rs.Status.Source.ErrorSummary, newStatus.lastUpdate)
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Source.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping source status update for RootSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}
@@ -282,7 +282,7 @@ func (p *root) setRenderingStatusWithRetires(ctx context.Context, newStatus rend
 	rootsync.SetSyncing(&rs, continueSyncing, "Rendering", newStatus.message, newStatus.commit, errorSource, rs.Status.Rendering.ErrorSummary, newStatus.lastUpdate)
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Rendering.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping rendering status update for RootSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}
@@ -401,7 +401,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, errs status.MultiEr
 	}
 
 	// Avoid unnecessary status updates.
-	if cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
+	if !currentRS.Status.Sync.LastUpdate.IsZero() && cmp.Equal(currentRS.Status, rs.Status, compare.IgnoreTimestampUpdates) {
 		klog.V(5).Infof("Skipping sync status update for RootSync %s/%s", rs.Namespace, rs.Name)
 		return nil
 	}


### PR DESCRIPTION
- Fix some failing tests that were erroring because their expectations
  were assuming all the metrics for the same deployment would be
  reported with the same tags. Now they filter by pod names instead of
  delpoyment name, using the latest reconciler pod for that deployment.
- Add debug logging for SyncMetricOptions
- Fix status updates that were being skipped too agressively.
  They now record metrics and status if the status has never been
  updated before.
- Remove unnecessary metrics diff on update
- Add NONE value for commit tag in last_sync_timestamp and
  last_apply_timestamp metrics, to work around a bug in the
  otel-collector which causes invalid output by the Prometheus exporter.
  Without this fix, the commit value gets parsed to the status value, and the status
  tag is ignored as invalid.
- Fix metric expectation in TestCRDDeleteBeforeRemoveCustomResourceV1Beta1
  and TestCRDDeleteBeforeRemoveCustomResourceV1 to expect source but not
  sync error. Only non-blocking source errors cause sync errors. Blocking source
  errors cause early exit, which skips reporting of sync status.
- Fix metric expectation in TestInvalidRepoSyncBranchStatus to expect
  source error in the RepoSync, not the RootSync.