### PR TITLE
Fix the test failure for TestResourceConditionAnnotations (#88)

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -1345,9 +1345,10 @@ func (nt *NT) WaitForRepoSyncStalledError(rsNamespace, rsName, reason, message s
 		})
 }
 
-// SupportV1Beta1CRD checks if v1beta1 CRD is supported
+// SupportV1Beta1CRDAndRBAC checks if v1beta1 CRD and RBAC resources are supported
 // in the current testing cluster.
-func (nt *NT) SupportV1Beta1CRD() (bool, error) {
+// v1beta1 APIs for CRD and RBAC resources are deprecated in K8s 1.22.
+func (nt *NT) SupportV1Beta1CRDAndRBAC() (bool, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(nt.Config)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to create discoveryclient")

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -97,7 +97,7 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 }
 func TestMustRemoveCustomResourceWithDefinitionV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -168,7 +168,7 @@ func TestAddAndRemoveCustomResourceV1(t *testing.T) {
 
 func TestAddAndRemoveCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -231,7 +231,7 @@ func TestMustRemoveUnManagedCustomResourceV1(t *testing.T) {
 
 func TestMustRemoveUnManagedCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -316,7 +316,7 @@ func TestAddUpdateRemoveClusterScopedCRDV1(t *testing.T) {
 
 func TestAddUpdateRemoveClusterScopedCRDV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -414,7 +414,7 @@ func TestAddUpdateNamespaceScopedCRDV1(t *testing.T) {
 
 func TestAddUpdateNamespaceScopedCRDV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -34,7 +34,7 @@ import (
 func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
 
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -222,7 +222,7 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 
 func TestSyncUpdateCustomResource(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t)
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -293,7 +293,7 @@ func anvilCR(version, name string, weight int64) *unstructured.Unstructured {
 
 func TestMultipleVersions_RoleBinding(t *testing.T) {
 	nt := nomostest.New(t)
-	supportV1beta1, err := nt.SupportV1Beta1CRD()
+	supportV1beta1, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}

--- a/e2e/testcases/resource_conditions_test.go
+++ b/e2e/testcases/resource_conditions_test.go
@@ -92,16 +92,29 @@ func TestResourceConditionAnnotations(t *testing.T) {
 	nt.MustKubectl("annotate", "configmap", cmName, "-n", ns,
 		`configmanagement.gke.io/errors=["CrashLoopBackOff"]`)
 
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
+	if err != nil {
+		nt.T.Fatal("failed to check the supported RBAC versions")
+	}
 	// Ensure error conditions are added.
-	_, err1 = nomostest.Retry(20*time.Second, func() error {
-		// We expect three errors even though we only supplied two.
+	_, err1 = nomostest.Retry(40*time.Second, func() error {
+		if support {
+			// We expect three errors even though we only supplied two.
+			return nt.Validate("repo", "", &v1.Repo{},
+				hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError), string(v1.ResourceStateError)))
+		}
 		return nt.Validate("repo", "", &v1.Repo{},
-			hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError), string(v1.ResourceStateError)))
+			hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError)))
 	})
 	// The ClusterConfig error from the ClusterRole gets duplicated.
 	// This will be obsolete with ConfigSync v2, so no need to fix (b/154226839).
-	err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
-		hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError)))
+	if support {
+		err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
+			hasConditions(string(v1.ResourceStateError), string(v1.ResourceStateError)))
+	} else {
+		err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
+			hasConditions(string(v1.ResourceStateError)))
+	}
 	err3 = nt.Validate(ns, "", &v1.NamespaceConfig{},
 		hasConditions(string(v1.ResourceStateError)))
 	if err1 != nil || err2 != nil || err3 != nil {
@@ -154,15 +167,24 @@ func TestResourceConditionAnnotations(t *testing.T) {
 		`configmanagement.gke.io/reconciling=["ClusterRole needs... something..."]`)
 
 	// Ensure reconciling conditions are added.
-	_, err1 = nomostest.Retry(20*time.Second, func() error {
-		// We expect three reconciling conditions even though we only supplied two.
+	_, err1 = nomostest.Retry(40*time.Second, func() error {
+		if support {
+			// We expect three reconciling conditions even though we only supplied two.
+			return nt.Validate("repo", "", &v1.Repo{},
+				hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
+		}
 		return nt.Validate("repo", "", &v1.Repo{},
-			hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
+			hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
 	})
 	// The ClusterConfig condition from the ClusterRole gets duplicated.
 	// This will be obsolete with ConfigSync v2, so no need to fix (b/154226839).
-	err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
-		hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
+	if support {
+		err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
+			hasConditions(string(v1.ResourceStateReconciling), string(v1.ResourceStateReconciling)))
+	} else {
+		err2 = nt.Validate(v1.ClusterConfigName, "", &v1.ClusterConfig{},
+			hasConditions(string(v1.ResourceStateReconciling)))
+	}
 	err3 = nt.Validate(ns, "", &v1.NamespaceConfig{},
 		hasConditions(string(v1.ResourceStateReconciling)))
 	if err1 != nil || err2 != nil || err3 != nil {
@@ -185,7 +207,7 @@ func TestResourceConditionAnnotations(t *testing.T) {
 		`configmanagement.gke.io/reconciling-`)
 
 	// Ensure reconciling conditions are removed.
-	_, err1 = nomostest.Retry(20*time.Second, func() error {
+	_, err1 = nomostest.Retry(40*time.Second, func() error {
 		return nt.Validate("repo", "", &v1.Repo{},
 			hasConditions())
 	})
@@ -211,7 +233,7 @@ func TestConstraintTemplateStatusAnnotations(t *testing.T) {
 	// TODO: Re-enable this test if/when multi-repo supports resource condition annotations.
 	nt := nomostest.New(t, ntopts.SkipMultiRepo)
 
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}
@@ -280,7 +302,7 @@ func TestConstraintStatusAnnotations(t *testing.T) {
 	// TODO: Re-enable this test when multi-repo supports resource condition annotations.
 	nt := nomostest.New(t, ntopts.SkipMultiRepo)
 
-	support, err := nt.SupportV1Beta1CRD()
+	support, err := nt.SupportV1Beta1CRDAndRBAC()
 	if err != nil {
 		nt.T.Fatal("failed to check the supported CRD versions")
 	}


### PR DESCRIPTION
TestResourceConditionAnnotations failed on clusters with K8s 1.22+ because the v1beta1 API for the RBAC resources are deprecated and the k8s-api-server only returns one copy of the RBAC resource.

b/240334486