### PR TITLE
Force to enable client-side throttling for mono-repo mode

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -31,7 +31,7 @@ func main() {
 	log.Setup()
 	ctrl.SetLogger(klogr.New())
 
-	cfg, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+	cfg, err := restconfig.NewRestConfigWithThrottling(restconfig.DefaultTimeout)
 	if err != nil {
 		klog.Fatalf("Failed to create rest config: %v", err)
 	}

--- a/cmd/nomos/parse/parse.go
+++ b/cmd/nomos/parse/parse.go
@@ -42,7 +42,7 @@ func GetSyncedCRDs(ctx context.Context, skipAPIServer bool) ([]*v1beta1.CustomRe
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	config, err := restconfig.NewRestConfig(restconfig.DefaultTimeout)
+	config, err := restconfig.NewRestConfigWithThrottling(restconfig.DefaultTimeout)
 	if err != nil {
 		return nil, getSyncedCRDsError(err, "failed to create rest config")
 	}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -136,7 +136,7 @@ func NewOptStruct(testName, tmpDir string, t nomostesting.NTB, ntOptions ...ntop
 		optsStruct.RESTConfig.Burst = 75
 
 		// Disable client-side throttling for the test client, if server-side throttling is enabled.
-		restconfig.UpdateQPS(optsStruct.RESTConfig)
+		restconfig.UpdateQPS(optsStruct.RESTConfig, false)
 	}
 
 	return optsStruct

--- a/pkg/configsync/git-importer.go
+++ b/pkg/configsync/git-importer.go
@@ -53,7 +53,7 @@ func RunImporter() {
 	reconcile.SetFightThreshold(*fightDetectionThreshold)
 
 	// Get a config to talk to the apiserver.
-	cfg, err := restconfig.NewRestConfig(*apiServerTimeout)
+	cfg, err := restconfig.NewRestConfigWithThrottling(*apiServerTimeout)
 	if err != nil {
 		klog.Fatalf("failed to create rest config: %+v", err)
 	}


### PR DESCRIPTION
https://github.com/GoogleContainerTools/kpt-config-sync/commit/732f94ea702a9a2f97335f0000306f4e17b363ee disabled client-side throttling, which then caused the monorepo CI jobs to start becoming flaky and then constantly failing.

This commit forces to enable the client-side throttling for mono-repo only. Compared with 1.12.x releases, the client-side throttling QPS was
increased from 20 (burst: 40) to 30 (burst: 60).