### PR TITLE
only create e2e psp resources on psp clusters

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -119,13 +119,18 @@ func isAvailableDeployment(o client.Object) error {
 func gitServer() []client.Object {
 	// Remember that we've already created the git-server's Namespace since the
 	// SSH key must exist before we apply the Deployment.
-	return []client.Object{
-		gitPodSecurityPolicy(),
-		gitRole(),
-		gitRoleBinding(),
+	objs := []client.Object{
 		gitService(),
 		gitDeployment(),
 	}
+	if isPSPCluster() {
+		objs = append(objs, []client.Object{
+			gitPodSecurityPolicy(),
+			gitRole(),
+			gitRoleBinding(),
+		}...)
+	}
+	return objs
 }
 
 func gitNamespace() *corev1.Namespace {

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -404,7 +404,7 @@ func (nt *NT) DefaultRootSyncObjectCount() int {
 		numObjects += nt.NumRepoSyncNamespaces() // 1 for each unique RepoSync Namespace
 		numObjects += numRepoSyncs               // 1 for each RepoSync
 		numObjects += numRepoSyncs               // 1 for each RepoSync RoleBinding
-		if strings.Contains(testing.GCPClusterFromEnv, "psp") {
+		if isPSPCluster() {
 			numObjects += numRepoSyncs // 1 for each RepoSync ClusterRoleBinding
 		}
 	}


### PR DESCRIPTION
PSP is removed as of k8s 1.25, causing tests to fail when they try to apply these PSP resources on 1.25 clusters. This change intends to make all PSP-related resources conditionally created based on whether the cluster has PSP enabled. We currently perform this check by checking whether psp is in the cluster name.