### PR TITLE
Support passing number only values as string directly through helm.values

### DIFF
--- a/e2e/nomostest/predicates.go
+++ b/e2e/nomostest/predicates.go
@@ -169,8 +169,8 @@ func HasExactlyLabelKeys(wantKeys ...string) Predicate {
 	}
 }
 
-// HasExactlyImageName ensures a container has the expected image name
-func HasExactlyImageName(containerName string, expectImageName string) Predicate {
+// HasExactlyImage ensures a container has the expected image.
+func HasExactlyImage(containerName string, expectImageName string, expectImageTag string, expectImageDigest string) Predicate {
 	return func(o client.Object) error {
 		dep, ok := o.(*appsv1.Deployment)
 		if !ok {
@@ -178,15 +178,24 @@ func HasExactlyImageName(containerName string, expectImageName string) Predicate
 		}
 		for _, container := range dep.Spec.Template.Spec.Containers {
 			if containerName == container.Name {
-				if !strings.Contains(container.Image, "/"+expectImageName+":") {
-					return errors.Errorf(" Expected %q container image name is %q, however the actual image is %q", container.Name, expectImageName, container.Image)
+				expectImage := ""
+				if expectImageName != "" {
+					expectImage = "/" + expectImageName
+				}
+				if expectImageTag != "" {
+					expectImage += ":" + expectImageTag
+				}
+				if expectImageDigest != "" {
+					expectImage += "@" + expectImageDigest
+				}
+				if !strings.Contains(container.Image, expectImage) {
+					return errors.Errorf(" Expected %q container image contains %q, however the actual image is %q", container.Name, expectImage, container.Image)
 				}
 				return nil
 			}
 		}
 		return errors.Errorf("Container %q not found", containerName)
 	}
-
 }
 
 // HasCorrectResourceRequestsLimits verify a root/namespace reconciler container has the correct resource requests and limits.

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -301,7 +301,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 
 	nt.T.Log("Check hydration controller default image name")
 	err := nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationController))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec": {"override": {"enableShellInRendering": true}}}`)
 	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "remote-base"}}}`)
 	nt.WaitForRootSyncRenderingError(configsync.RootSyncName, status.ActionableHydrationErrorCode, "")
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationController))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  sourceType: helm
+  helm:
+    repo: https://kubernetes.github.io/ingress-nginx
+    chart: ingress-nginx
+    version: 4.0.5
+    values:
+      controller.resources.requests.cpu: 150m
+      controller.resources.requests.memory: 250Mi
+      controller.resources.limits.cpu: 1
+      controller.resources.limits.memory: 300Mi
+      controller.metrics.enabled: true
+      controller.metrics.service.annotations.prometheus\.io/scrape: "true"
+      controller.metrics.service.annotations.prometheus\.io/port: "10254"
+      controller.image.pullPolicy: Always
+      controller.image.image: ingress-nginx/controller
+      controller.image.tag: "v1.4.0"
+      controller.image.digest: sha256:54f7fe2c6c5a9db9a0ebf1131797109bb7a4d91f56b9b362bde2abd237dd1974
+      defaultBackend.enabled: true
+      defaultBackend.image.image: defaultbackend-amd64
+      defaultBackend.image.tag: "1.4"
+    releaseName: my-ingress-nginx
+    namespace: "ingress-nginx"
+    auth: none

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -93,7 +93,12 @@ func (h *Hydrator) appendValuesArgs(args []string) ([]string, error) {
 		return []string{}, fmt.Errorf("failed to unmarshal helm.values, error: %w", err)
 	}
 	for key, val := range values {
-		args = append(args, "--set", fmt.Sprintf("%s=%v", key, val))
+		switch v := val.(type) {
+		case string:
+			args = append(args, "--set-string", fmt.Sprintf("%s=%v", key, v))
+		default:
+			args = append(args, "--set", fmt.Sprintf("%s=%v", key, v))
+		}
 	}
 	return args, nil
 }


### PR DESCRIPTION
Currently, when users need to pass in number only value as string through helm.values, they have to set the value as "\\"1234\\"". After this change, users will be able to pass in the number only value directly as "1234".

The solution is that instead of using helm template option --set for all the different types of values, now we use option --set-string for string values to force the values type.

Modify current TestPublicHelm e2e test to test different types of values.