### PR TITLE
Retry the validation for the large CRD test

### DIFF
--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -512,7 +513,9 @@ func TestLargeCRD(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update label for one CRD")
 	nt.WaitForRepoSyncs()
 
-	err = nt.Validate("challenges.acme.cert-manager.io", "", fake.CustomResourceDefinitionV1Object(), nomostest.HasLabel("random-key", "random-value"))
+	_, err = nomostest.Retry(30*time.Second, func() error {
+		return nt.Validate("challenges.acme.cert-manager.io", "", fake.CustomResourceDefinitionV1Object(), nomostest.HasLabel("random-key", "random-value"))
+	})
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -412,7 +412,7 @@ func TestConflictingDefinitions_RootToRoot(t *testing.T) {
 	nt.T.Logf("Stop the admission webhook, the remediator should report the conflicts")
 	nomostest.StopWebhook(nt)
 	nt.T.Logf("The Role resource version should be changed because two reconcilers are fighting with each other")
-	if _, err := nomostest.Retry(60*time.Second, func() error {
+	if _, err := nomostest.Retry(90*time.Second, func() error {
 		return nt.Validate("pods", testNs, &rbacv1.Role{},
 			nomostest.ResourceVersionNotEquals(nt, roleResourceVersion))
 	}); err != nil {


### PR DESCRIPTION
The root-sync being synced doesn't mean the resource is reconciled. Hence, this commit adds a retry block around the validation.

One example test failure:
https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/pr-logs/pull/GoogleContainerTools_kpt-config-sync/175/kpt-config-sync-presubmit-e2e-mono-repo-test-group2/1577083658446049280.