### PR TITLE
pass ARTIFACTS env var into kind container

### DIFF
--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -23,6 +23,7 @@ echo "+++ Running go e2e tests with" "$@"
 docker run \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$ARTIFACTS":/logs/artifacts \
+  --env ARTIFACTS="/logs/artifacts" \
   --env GCP_PROJECT="${GCP_PROJECT}" \
   --network="host" prow-image \
   ./build/test-e2e-go/e2e.sh "$@"


### PR DESCRIPTION
the artifacts env var was not being passed into the container, causing some places which look for the env var to not produce artifacts at the correct location. For example, the kind cluster logs are emitted to the artifacts dir on failure.