### PR TITLE
Support passing different types of values directly through helm.values

### DIFF
--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -37,7 +37,7 @@ var (
 	flVersion = flag.String("version", os.Getenv(reconcilermanager.HelmChartVersion),
 		"the version of the helm chart being synced")
 	flValues = flag.String("values", os.Getenv(reconcilermanager.HelmValues),
-		"set the helm chart values, will be used in helm template --set key=value")
+		"set the helm chart values, will be used to override the default values")
 	flIncludeCRDs = flag.String("include-crds", os.Getenv(reconcilermanager.HelmIncludeCRDs),
 		"include CRDs in the helm rendering output")
 	flAuth = flag.String("auth", util.EnvString(reconcilermanager.HelmAuthType, string(configsync.AuthNone)),

--- a/e2e/testcases/csr_auth_test.go
+++ b/e2e/testcases/csr_auth_test.go
@@ -290,7 +290,7 @@ func testWorkloadIdentity(t *testing.T, testSpec workloadIdentityTestSpec) {
 		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"dir": "%s", "image": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s"}, "git": null}}`,
 			v1beta1.OciSource, tenant, testSpec.sourceRepo, testSpec.gsaEmail))
 	case v1beta1.HelmSource:
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"chart": "%s", "repo": "%s", "version": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "releaseName": "my-coredns", "namespace": "coredns", "values": {"image.pullPolicy": "Always"}}, "git": null}}`,
+		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"chart": "%s", "repo": "%s", "version": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "releaseName": "my-coredns", "namespace": "coredns"}, "git": null}}`,
 			v1beta1.HelmSource, testSpec.sourceChart, testSpec.sourceRepo, testSpec.sourceVersion, testSpec.gsaEmail))
 	}
 
@@ -302,8 +302,7 @@ func testWorkloadIdentity(t *testing.T, testSpec workloadIdentityTestSpec) {
 	if testSpec.sourceType == v1beta1.HelmSource {
 		nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(testSpec.rootCommitFn),
 			nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: testSpec.sourceChart}))
-		if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
-			containerImagePullPolicy("Always")); err != nil {
+		if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{}); err != nil {
 			nt.T.Error(err)
 		}
 	} else {

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
@@ -48,14 +49,14 @@ var privateARHelmRegistry = fmt.Sprintf("oci://us-docker.pkg.dev/%s/config-sync-
 // TestPublicHelm can run on both Kind and GKE clusters.
 // It tests Config Sync can pull from public Helm repo without any authentication.
 func TestPublicHelm(t *testing.T) {
-	publicHelmRepo := "https://kubernetes.github.io/ingress-nginx"
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipMonoRepo, ntopts.Unstructured)
 	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace")
-	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "ingress-nginx", "auth": "none", "version": "4.0.5", "releaseName": "my-ingress-nginx", "namespace": "ingress-nginx"}, "git": null}}`,
-		v1beta1.HelmSource, publicHelmRepo))
+	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace and multiple inline values")
+	rootSyncFilePath := "../testdata/root-sync-helm-chart-cr.yaml"
+	nt.T.Logf("Apply the RootSync object defined in %s", rootSyncFilePath)
+	nt.MustKubectl("apply", "-f", rootSyncFilePath)
 	nt.T.Cleanup(func() {
 		// Change the rs back so that it works in the shared test environment.
 		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
@@ -63,7 +64,17 @@ func TestPublicHelm(t *testing.T) {
 	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion("ingress-nginx:4.0.5")),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "ingress-nginx"}))
-	if err := nt.Validate("my-ingress-nginx-controller", "ingress-nginx", &appsv1.Deployment{}); err != nil {
+	if err := nt.Validate("my-ingress-nginx-controller", "ingress-nginx", &appsv1.Deployment{}, containerImagePullPolicy("Always"),
+		nomostest.HasCorrectResourceRequestsLimits("controller", resource.MustParse("150m"), resource.MustParse("1"), resource.MustParse("250Mi"), resource.MustParse("300Mi")),
+		nomostest.HasExactlyImage("controller", "ingress-nginx/controller", "v1.4.0", "sha256:54f7fe2c6c5a9db9a0ebf1131797109bb7a4d91f56b9b362bde2abd237dd1974"),
+		nomostest.DeploymentHasEnvVar("controller", "TEST_1", "val1"), nomostest.DeploymentHasEnvVar("controller", "TEST_2", "val2")); err != nil {
+		nt.T.Error(err)
+	}
+	if err := nt.Validate("my-ingress-nginx-defaultbackend", "ingress-nginx", &appsv1.Deployment{},
+		nomostest.HasExactlyImage("ingress-nginx-default-backend", "defaultbackend-amd64", "1.4", "")); err != nil {
+		nt.T.Error(err)
+	}
+	if err := nt.Validate("my-ingress-nginx-controller-metrics", "ingress-nginx", &corev1.Service{}, nomostest.HasAnnotation("prometheus.io/port", "10254"), nomostest.HasAnnotation("prometheus.io/scrape", "true")); err != nil {
 		nt.T.Error(err)
 	}
 	nt.T.Log("Update RootSync to sync from a public Helm Chart without specified release namespace")
@@ -274,9 +285,7 @@ func TestHelmARTokenAuth(t *testing.T) {
 		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
 	})
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
-	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns",
-                                                                                                "values": {"image.pullPolicy": "Always", "resources.requests.memory": "250Mi", "resources.requests.cpu": "150m", "resources.limits.memory": "300Mi", "resources.limits.cpu": 1},
-                                                                                                "secretRef": {"name" : "foo"}}}}`,
+	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns", "secretRef": {"name" : "foo"}}}}`,
 		v1beta1.HelmSource, privateARHelmRegistry, privateHelmChart, privateHelmChartVersion))
 	nt.T.Cleanup(func() {
 		// Change the rs back so that it works in the shared test environment.
@@ -285,8 +294,7 @@ func TestHelmARTokenAuth(t *testing.T) {
 	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion(privateHelmChart+":"+privateHelmChartVersion)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: privateHelmChart}))
-	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
-		containerImagePullPolicy("Always"), nomostest.HasCorrectResourceRequestsLimits("coredns", resource.MustParse("150m"), resource.MustParse("1"), resource.MustParse("250Mi"), resource.MustParse("300Mi"))); err != nil {
+	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
 	}
 }

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -301,7 +301,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 
 	nt.T.Log("Check hydration controller default image name")
 	err := nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationController))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec": {"override": {"enableShellInRendering": true}}}`)
 	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "remote-base"}}}`)
 	nt.WaitForRootSyncRenderingError(configsync.RootSyncName, status.ActionableHydrationErrorCode, "")
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		nomostest.HasExactlyImageName(reconcilermanager.HydrationController, reconcilermanager.HydrationController))
+		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  sourceType: helm
+  helm:
+    repo: https://kubernetes.github.io/ingress-nginx
+    chart: ingress-nginx
+    version: 4.0.5
+    values:
+      controller:
+        resources:
+          requests:
+            cpu: 150m
+            memory: 250Mi
+          limits:
+            cpu: 1
+            memory: 300Mi
+        metrics:
+          enabled: true
+          service:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "10254"
+        image:
+          pullPolicy: Always
+          image: ingress-nginx/controller
+          tag: "v1.4.0"
+          digest: sha256:54f7fe2c6c5a9db9a0ebf1131797109bb7a4d91f56b9b362bde2abd237dd1974
+        extraEnvs:
+        - name: TEST_1
+          value: "val1"
+        - name: TEST_2
+          value: "val2"
+      defaultBackend:
+        enabled: true
+        image:
+          image: defaultbackend-amd64
+          tag: "1.4"
+    releaseName: my-ingress-nginx
+    namespace: "ingress-nginx"
+    auth: none


### PR DESCRIPTION
Instead of using helm template option --set, using option --values to set values.

After this change, users do not need to flatten the nested fields to set values, and will be able to pass special string values like "1234", "true" directly through helm.values

Add test cases to test helm.values field with different types of values.