### PR TITLE
Always enable client-side throttling with QPS 20 for mono-repo mode (#180)

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -31,7 +31,7 @@ func main() {
 	log.Setup()
 	ctrl.SetLogger(klogr.New())
 
-	cfg, err := restconfig.NewRestConfigWithThrottling(restconfig.DefaultTimeout)
+	cfg, err := restconfig.MonoRepoRestClient(restconfig.DefaultTimeout)
 	if err != nil {
 		klog.Fatalf("Failed to create rest config: %v", err)
 	}

--- a/cmd/nomos/parse/parse.go
+++ b/cmd/nomos/parse/parse.go
@@ -45,7 +45,7 @@ func GetSyncedCRDs(ctx context.Context, skipAPIServer bool) ([]*v1beta1.CustomRe
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	config, err := restconfig.NewRestConfigWithThrottling(restconfig.DefaultTimeout)
+	config, err := restconfig.MonoRepoRestClient(restconfig.DefaultTimeout)
 	if err != nil {
 		return nil, getSyncedCRDsError(err, "failed to create rest config")
 	}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -31,7 +31,6 @@ import (
 	testing2 "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/testing/fake"
@@ -132,9 +131,6 @@ func NewOptStruct(testName, tmpDir string, t testing2.NTB, ntOptions ...ntopts.O
 		// This does not affect the client used by Config Sync itself.
 		optsStruct.RESTConfig.QPS = 50
 		optsStruct.RESTConfig.Burst = 75
-
-		// Disable client-side throttling for the test client, if server-side throttling is enabled.
-		restconfig.UpdateQPS(optsStruct.RESTConfig, false)
 	}
 
 	return optsStruct

--- a/pkg/client/restconfig/restconfig.go
+++ b/pkg/client/restconfig/restconfig.go
@@ -49,11 +49,12 @@ var configSources = []configSource{
 	},
 }
 
-// NewRestConfigWithThrottling will attempt to create a new rest config from all
+// MonoRepoRestClient will attempt to create a new rest config from all
 // configured options and return the first successfully created configuration.
-// It forces to enable the client-side throttling to fix the commit stuck in the
+// It always enables the client-side throttling to fix the commit stuck in the
 // inProgress state issue.
-func NewRestConfigWithThrottling(timeout time.Duration) (*rest.Config, error) {
+// It is only used in the legacy mono-repo mode.
+func MonoRepoRestClient(timeout time.Duration) (*rest.Config, error) {
 	return newRestConfig(timeout, true)
 }
 
@@ -62,11 +63,12 @@ func NewRestConfigWithThrottling(timeout time.Duration) (*rest.Config, error) {
 // The client-side throttling is only determined by if server-side flow control
 // is enabled or not. If server-side flow control is enabled, then client-side
 // throttling is disabled, vice versa.
+// It is used by the multi-repo mode.
 func NewRestConfig(timeout time.Duration) (*rest.Config, error) {
 	return newRestConfig(timeout, false)
 }
 
-func newRestConfig(timeout time.Duration, forceThrottling bool) (*rest.Config, error) {
+func newRestConfig(timeout time.Duration, isMonoRepo bool) (*rest.Config, error) {
 	var errorStrs []string
 
 	for _, source := range configSources {
@@ -75,7 +77,7 @@ func newRestConfig(timeout time.Duration, forceThrottling bool) (*rest.Config, e
 			klog.V(1).Infof("Created rest config from source %s", source.name)
 			klog.V(7).Infof("Config: %#v", *config)
 
-			UpdateQPS(config, forceThrottling)
+			UpdateQPS(config, isMonoRepo)
 
 			config.Timeout = timeout
 			return config, nil
@@ -91,40 +93,49 @@ func newRestConfig(timeout time.Duration, forceThrottling bool) (*rest.Config, e
 // UpdateQPS modifies a rest.Config to update the client-side throttling QPS and
 // Burst QPS.
 //
-// If Flow Control is enabled on the apiserver, and client-side throttling is
+// If it is running in the legacy mono-repo mode, set the client-side
+// throttling: QPS: 20, burst 40.
+//
+// If it is the new multi-repo mode:
+// - If Flow Control is enabled on the apiserver, and client-side throttling is
 // not forced to be enabled, client-side throttling is disabled!
-//
-// If Flow Control is disabled or undetected on the apiserver, client-side
+// - If Flow Control is disabled or undetected on the apiserver, client-side
 // throttling QPS will be increased to at least 30 (burst: 60).
-//
-// If client-side throttling is forced to be enabled, no matter whether Flow
-// Control is enabled or not, client-side throttling QPS will be increased to
-// at least 30 (burst: 60).
 //
 // Flow Control is enabled by default on Kubernetes v1.20+.
 // https://kubernetes.io/docs/concepts/cluster-administration/flow-control/
-func UpdateQPS(config *rest.Config, forceThrottling bool) {
+func UpdateQPS(config *rest.Config, isMonoRepo bool) {
 	// Timeout if the query takes too long, defaulting to the lower QPS limits.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	if isMonoRepo {
+		// Comfortable QPS limits for us to run smoothly.
+		// The defaults are too low. It is probably safe to increase these if
+		// we see problems in the future or need to accommodate VERY large numbers
+		// of resources.
+		//
+		// config.QPS does not apply to WATCH requests. Currently, there is no client-side
+		// or server-side rate-limiting for WATCH requests.
+		config.QPS = 20
+		config.Burst = 40
+		klog.V(1).Infof("Legacy mono-repo mode, client-side throttling: QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
+		return
+	}
 
 	flowControlEnabled, err := flowcontrol.IsEnabled(ctx, config)
 	if err != nil {
 		klog.Warning("Failed to query apiserver to check for flow control enablement: %v", err)
 		// Default to the lower QPS limits.
 	}
-	if flowControlEnabled && !forceThrottling {
+	if flowControlEnabled {
 		config.QPS = -1
 		config.Burst = -1
 		klog.V(1).Infof("Flow control enabled on apiserver: client-side throttling QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
 	} else {
 		config.QPS = maxIfNotNegative(config.QPS, 30)
 		config.Burst = int(maxIfNotNegative(float32(config.Burst), 60))
-		if !flowControlEnabled {
-			klog.V(1).Infof("Flow control disabled on apiserver, client-side throttling: QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
-		} else {
-			klog.V(1).Infof("Flow control enabled on apiserver, but force to enable client-side throttling: QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
-		}
+		klog.V(1).Infof("Flow control disabled on apiserver: client-side throttling QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
 	}
 }
 

--- a/pkg/configsync/git-importer.go
+++ b/pkg/configsync/git-importer.go
@@ -52,7 +52,7 @@ func RunImporter() {
 	reconcile.SetFightThreshold(*fightDetectionThreshold)
 
 	// Get a config to talk to the apiserver.
-	cfg, err := restconfig.NewRestConfigWithThrottling(restconfig.DefaultTimeout)
+	cfg, err := restconfig.MonoRepoRestClient(restconfig.DefaultTimeout)
 	if err != nil {
 		klog.Fatalf("failed to create rest config: %+v", err)
 	}


### PR DESCRIPTION
Related changes:

- https://github.com/GoogleContainerTools/kpt-config-sync/commit/732f94ea702a9a2f97335f0000306f4e17b363ee https://github.com/GoogleContainerTools/kpt-config-sync/pull/169