### PR TITLE
separate acm-psp manifest from OSS config-sync-manifest

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -254,6 +254,7 @@ __config-sync-manifest-oss: __config-sync-manifest
 		--exclude='admission-webhook.yaml' \
 		.output/deployment/* .output/oss/cloned/deployment/
 	rsync \
+		--exclude='acm-psp.yaml' \
 		--exclude='policy-controller-psp.yaml' \
 		--exclude='cluster-config-crd.yaml' \
 		--exclude='hierarchyconfig-crd.yaml' \

--- a/Makefile.build
+++ b/Makefile.build
@@ -271,6 +271,9 @@ __config-sync-manifest-oss: __config-sync-manifest
 		--destination=${OSS_MANIFEST_STAGING_DIR}/config-sync-manifest.yaml \
 		$(OUTPUT_DIR)/oss/cloned/manifests \
 		$(OUTPUT_DIR)/oss/cloned/deployment
+	@echo "+++ Add separate acm-psp.yaml manifest so it can be applied independently"
+	rsync \
+		.output/manifests/acm-psp.yaml ${OSS_MANIFEST_STAGING_DIR}/acm-psp.yaml
 
 # __config-sync-manifest creates the config-sync-manifest.yaml for release and incorporation into ACM Operator
 .PHONY: __config-sync-manifest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,12 +9,10 @@ kubernetes cluster.
 manifest bundle from the release assets.
 2. Install the released version by applying the manifest to your cluster.
 ```shell
-# Create a directory to store the manifest bundle
-mkdir -p <MANIFEST_DIR>
-# Extract the manifest bundle
-tar -xzf <MANIFEST_BUNDLE> -C <MANIFEST_DIR>
-# Apply the manifests to your cluster
-kubectl apply -f <MANIFEST_DIR>
+# Apply core Config Sync manifests to your cluster
+kubectl apply -f path/to/config-sync-manifest.yaml
+# Optional: apply acm-psp.yaml to your cluster (for k8s < 1.25)
+kubectl apply -f path/to/acm-psp.yaml
 ```
 
 ## Building and Installing from source


### PR DESCRIPTION
Cherry picked from https://github.com/GoogleContainerTools/kpt-config-sync/pull/182