### PR TITLE
Use Kustomize + Make to generate OSS manifests

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -51,56 +51,56 @@ build-cli: pull-buildenv buildenv-dirs
 # Creates a docker image for the specified nomos component.
 image-nomos: license
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
-	@echo "+++ Building the nomos image"
+	@echo "+++ Building the nomos image: $(NOMOS_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(NOMOS_IMAGE) \
 		-t $(NOMOS_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Reconciler image"
+	@echo "+++ Building the Reconciler image: $(RECONCILER_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_IMAGE) \
 		-t $(RECONCILER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Reconciler Manager image"
+	@echo "+++ Building the Reconciler Manager image: $(RECONCILER_MANAGER_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_MANAGER_IMAGE) \
 		-t $(RECONCILER_MANAGER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Admission Webhook image"
+	@echo "+++ Building the Admission Webhook image: $(ADMISSION_WEBHOOK_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(ADMISSION_WEBHOOK_IMAGE) \
 		-t $(ADMISSION_WEBHOOK_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Hydration Controller image"
+	@echo "+++ Building the Hydration Controller image: $(HYDRATION_CONTROLLER_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(HYDRATION_CONTROLLER_IMAGE) \
 		-t $(HYDRATION_CONTROLLER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Hydration Controller image with shell"
+	@echo "+++ Building the Hydration Controller image with shell: $(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(HYDRATION_CONTROLLER_WITH_SHELL_IMAGE) \
 		-t $(HYDRATION_CONTROLLER_WITH_SHELL_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the OCI-sync image"
+	@echo "+++ Building the OCI-sync image: $(OCI_SYNC_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(OCI_SYNC_IMAGE) \
 		-t $(OCI_SYNC_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
-	@echo "+++ Building the Helm-sync image"
+	@echo "+++ Building the Helm-sync image: $(HELM_SYNC_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(HELM_SYNC_IMAGE) \
 		-t $(HELM_SYNC_TAG) \

--- a/Makefile.oss
+++ b/Makefile.oss
@@ -47,29 +47,15 @@ oss-manifests: $(OSS_MANIFEST_DIR)
 	@ echo "    WEBHOOK_TAG: $(WEBHOOK_TAG)"
 	@ echo "    OCI_TAG: $(OCI_TAG)"
 	@ echo "    HELM_TAG: $(HELM_TAG)"
-	@ cp manifests/test-resources/00-namespace.yaml $(OSS_MANIFEST_DIR)/00-namespace.yaml
-	@ cp manifests/namespace-selector-crd.yaml $(OSS_MANIFEST_DIR)/namespace-selector-crd.yaml
-	@ cp manifests/cluster-selector-crd.yaml $(OSS_MANIFEST_DIR)/cluster-selector-crd.yaml
-	@ cp manifests/cluster-registry-crd.yaml $(OSS_MANIFEST_DIR)/cluster-registry-crd.yaml
-	@ cp manifests/reconciler-manager-service-account.yaml $(OSS_MANIFEST_DIR)/reconciler-manager-service-account.yaml
-	@ cp manifests/otel-agent-cm.yaml $(OSS_MANIFEST_DIR)/otel-agent-cm.yaml
-	@ cp manifests/test-resources/resourcegroup-manifest.yaml $(OSS_MANIFEST_DIR)/resourcegroup-manifest.yaml
-	@ sed -e "s|RECONCILER_IMAGE_NAME|$(REC_TAG)|" \
-		-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_TAG)|" \
-		-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_TAG)|" \
-		-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HC_TAG)|" \
-		manifests/templates/reconciler-manager-configmap.yaml \
-		> $(OSS_MANIFEST_DIR)/reconciler-manager-configmap.yaml
-	@ cp manifests/reposync-crd.yaml $(OSS_MANIFEST_DIR)/reposync-crd.yaml
-	@ cp manifests/rootsync-crd.yaml $(OSS_MANIFEST_DIR)/rootsync-crd.yaml
-	@ sed -e "s|IMAGE_NAME|$(MGR_TAG)|g" manifests/templates/reconciler-manager.yaml \
-		> $(OSS_MANIFEST_DIR)/reconciler-manager.yaml
-
-	@ cp manifests/templates/otel-collector.yaml $(OSS_MANIFEST_DIR)/otel-collector.yaml
-	@ cp manifests/templates/reconciler-manager/dev.yaml $(OSS_MANIFEST_DIR)/dev.yaml
-
-	@ sed -e "s|IMAGE_NAME|$(WEBHOOK_TAG)|g" manifests/templates/admission-webhook.yaml \
-		> $(OSS_MANIFEST_DIR)/admission-webhook.yaml
+	@ rm $(OSS_MANIFEST_DIR)/*
+	@ kustomize build --load-restrictor=LoadRestrictionsNone manifests/oss \
+	| sed -e "s|RECONCILER_IMAGE_NAME|$(REC_TAG)|" \
+				-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_TAG)|" \
+				-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_TAG)|" \
+				-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HC_TAG)|" \
+				-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(MGR_TAG)|g" \
+				-e "s|WEBHOOK_IMAGE_NAME|$(WEBHOOK_TAG)|g" \
+		> $(OSS_MANIFEST_DIR)/config-sync.yaml
 
 	@ echo "+++ Manifests generated in $(OSS_MANIFEST_DIR)"
 

--- a/Makefile.oss
+++ b/Makefile.oss
@@ -27,6 +27,52 @@ $(OSS_MANIFEST_DIR): $(OUTPUT_DIR)
 build-oss: $(OSS_MANIFEST_DIR) pull-buildenv
 	MANIFEST_DIR=$(OSS_MANIFEST_DIR) ./scripts/build-oss.sh
 
+.PHONY: oss-manifest
+oss-manifests: NOMOS_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/nomos:$(TAG)
+oss-manifests: MGR_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler-manager:$(TAG)
+oss-manifests: HC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller:$(TAG)
+oss-manifests: HC_WITH_SHELL_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller-with-shell:$(TAG)
+oss-manifests: REC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler:$(TAG)
+oss-manifests: WEBHOOK_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/admission-webhook:$(TAG)
+oss-manifests: OCI_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/oci-sync:$(TAG)
+oss-manifests: HELM_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/helm-sync:$(TAG)
+oss-manifests: $(OSS_MANIFEST_DIR)
+	@ echo "+++ Generating manifests in $(OSS_MANIFEST_DIR)"
+	@ echo "    Using these tags:"
+	@ echo "    NOMOS_TAG: $(NOMOS_TAG)"
+	@ echo "    MGR_TAG: $(MGR_TAG)"
+	@ echo "    HC_TAG: $(HC_TAG)"
+	@ echo "    HC_WITH_SHELL_TAG: $(HC_WITH_SHELL_TAG)"
+	@ echo "    REC_TAG: $(REC_TAG)"
+	@ echo "    WEBHOOK_TAG: $(WEBHOOK_TAG)"
+	@ echo "    OCI_TAG: $(OCI_TAG)"
+	@ echo "    HELM_TAG: $(HELM_TAG)"
+	@ cp manifests/test-resources/00-namespace.yaml $(OSS_MANIFEST_DIR)/00-namespace.yaml
+	@ cp manifests/namespace-selector-crd.yaml $(OSS_MANIFEST_DIR)/namespace-selector-crd.yaml
+	@ cp manifests/cluster-selector-crd.yaml $(OSS_MANIFEST_DIR)/cluster-selector-crd.yaml
+	@ cp manifests/cluster-registry-crd.yaml $(OSS_MANIFEST_DIR)/cluster-registry-crd.yaml
+	@ cp manifests/reconciler-manager-service-account.yaml $(OSS_MANIFEST_DIR)/reconciler-manager-service-account.yaml
+	@ cp manifests/otel-agent-cm.yaml $(OSS_MANIFEST_DIR)/otel-agent-cm.yaml
+	@ cp manifests/test-resources/resourcegroup-manifest.yaml $(OSS_MANIFEST_DIR)/resourcegroup-manifest.yaml
+	@ sed -e "s|RECONCILER_IMAGE_NAME|$(REC_TAG)|" \
+		-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_TAG)|" \
+		-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_TAG)|" \
+		-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HC_TAG)|" \
+		manifests/templates/reconciler-manager-configmap.yaml \
+		> $(OSS_MANIFEST_DIR)/reconciler-manager-configmap.yaml
+	@ cp manifests/reposync-crd.yaml $(OSS_MANIFEST_DIR)/reposync-crd.yaml
+	@ cp manifests/rootsync-crd.yaml $(OSS_MANIFEST_DIR)/rootsync-crd.yaml
+	@ sed -e "s|IMAGE_NAME|$(MGR_TAG)|g" manifests/templates/reconciler-manager.yaml \
+		> $(OSS_MANIFEST_DIR)/reconciler-manager.yaml
+
+	@ cp manifests/templates/otel-collector.yaml $(OSS_MANIFEST_DIR)/otel-collector.yaml
+	@ cp manifests/templates/reconciler-manager/dev.yaml $(OSS_MANIFEST_DIR)/dev.yaml
+
+	@ sed -e "s|IMAGE_NAME|$(WEBHOOK_TAG)|g" manifests/templates/admission-webhook.yaml \
+		> $(OSS_MANIFEST_DIR)/admission-webhook.yaml
+
+	@ echo "+++ Manifests generated in $(OSS_MANIFEST_DIR)"
+
 .PHONY: run-oss
 run-oss: build-oss
 	kubectl apply -f $(OSS_MANIFEST_DIR)

--- a/Makefile.oss
+++ b/Makefile.oss
@@ -59,6 +59,24 @@ oss-manifests: $(OSS_MANIFEST_DIR)
 
 	@ echo "+++ Manifests generated in $(OSS_MANIFEST_DIR)"
 
+.PHONY: oss-push-images
+oss-push-images: NOMOS_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/nomos:$(TAG)
+oss-push-images: MGR_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler-manager:$(TAG)
+oss-push-images: HC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller:$(TAG)
+oss-push-images: HC_WITH_SHELL_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller-with-shell:$(TAG)
+oss-push-images: REC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler:$(TAG)
+oss-push-images: WEBHOOK_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/admission-webhook:$(TAG)
+oss-push-images: OCI_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/oci-sync:$(TAG)
+oss-push-images: HELM_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/helm-sync:$(TAG)
+oss-push-images: image-nomos
+	@ docker push "$(MGR_TAG)"
+	@ docker push "$(HC_TAG)"
+	@ docker push "$(HC_WITH_SHELL_TAG)"
+	@ docker push "$(REC_TAG)"
+	@ docker push "$(WEBHOOK_TAG)"
+	@ docker push "$(OCI_TAG)"
+	@ docker push "$(HELM_TAG)"
+
 .PHONY: run-oss
 run-oss: build-oss
 	kubectl apply -f $(OSS_MANIFEST_DIR)

--- a/Makefile.oss
+++ b/Makefile.oss
@@ -28,54 +28,38 @@ build-oss: $(OSS_MANIFEST_DIR) pull-buildenv
 	MANIFEST_DIR=$(OSS_MANIFEST_DIR) ./scripts/build-oss.sh
 
 .PHONY: oss-manifest
-oss-manifests: NOMOS_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/nomos:$(TAG)
-oss-manifests: MGR_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler-manager:$(TAG)
-oss-manifests: HC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller:$(TAG)
-oss-manifests: HC_WITH_SHELL_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller-with-shell:$(TAG)
-oss-manifests: REC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler:$(TAG)
-oss-manifests: WEBHOOK_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/admission-webhook:$(TAG)
-oss-manifests: OCI_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/oci-sync:$(TAG)
-oss-manifests: HELM_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/helm-sync:$(TAG)
 oss-manifests: $(OSS_MANIFEST_DIR)
 	@ echo "+++ Generating manifests in $(OSS_MANIFEST_DIR)"
 	@ echo "    Using these tags:"
-	@ echo "    NOMOS_TAG: $(NOMOS_TAG)"
-	@ echo "    MGR_TAG: $(MGR_TAG)"
-	@ echo "    HC_TAG: $(HC_TAG)"
-	@ echo "    HC_WITH_SHELL_TAG: $(HC_WITH_SHELL_TAG)"
-	@ echo "    REC_TAG: $(REC_TAG)"
-	@ echo "    WEBHOOK_TAG: $(WEBHOOK_TAG)"
-	@ echo "    OCI_TAG: $(OCI_TAG)"
-	@ echo "    HELM_TAG: $(HELM_TAG)"
+	@ echo "    $(NOMOS_IMAGE): $(NOMOS_TAG)"
+	@ echo "    $(RECONCILER_MANAGER_IMAGE): $(RECONCILER_MANAGER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_IMAGE): $(HYDRATION_CONTROLLER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_WITH_SHELL_IMAGE): $(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
+	@ echo "    $(RECONCILER_IMAGE): $(RECONCILER_TAG)"
+	@ echo "    $(ADMISSION_WEBHOOK_IMAGE): $(ADMISSION_WEBHOOK_TAG)"
+	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
+	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
 	@ rm $(OSS_MANIFEST_DIR)/*
 	@ kustomize build --load-restrictor=LoadRestrictionsNone manifests/oss \
-	| sed -e "s|RECONCILER_IMAGE_NAME|$(REC_TAG)|" \
-				-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_TAG)|" \
-				-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_TAG)|" \
-				-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HC_TAG)|" \
-				-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(MGR_TAG)|g" \
-				-e "s|WEBHOOK_IMAGE_NAME|$(WEBHOOK_TAG)|g" \
+	| sed -e "s|RECONCILER_IMAGE_NAME|$(RECONCILER_TAG)|" \
+				-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_SYNC_TAG)|" \
+				-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_SYNC_TAG)|" \
+				-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HYDRATION_CONTROLLER_TAG)|" \
+				-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|g" \
+				-e "s|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|g" \
 		> $(OSS_MANIFEST_DIR)/config-sync.yaml
 
 	@ echo "+++ Manifests generated in $(OSS_MANIFEST_DIR)"
 
 .PHONY: oss-push-images
-oss-push-images: NOMOS_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/nomos:$(TAG)
-oss-push-images: MGR_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler-manager:$(TAG)
-oss-push-images: HC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller:$(TAG)
-oss-push-images: HC_WITH_SHELL_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/hydration-controller-with-shell:$(TAG)
-oss-push-images: REC_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/reconciler:$(TAG)
-oss-push-images: WEBHOOK_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/admission-webhook:$(TAG)
-oss-push-images: OCI_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/oci-sync:$(TAG)
-oss-push-images: HELM_TAG ?= gcr.io/$(GCP_PROJECT)/configsync/helm-sync:$(TAG)
 oss-push-images: image-nomos
-	@ docker push "$(MGR_TAG)"
-	@ docker push "$(HC_TAG)"
-	@ docker push "$(HC_WITH_SHELL_TAG)"
-	@ docker push "$(REC_TAG)"
-	@ docker push "$(WEBHOOK_TAG)"
-	@ docker push "$(OCI_TAG)"
-	@ docker push "$(HELM_TAG)"
+	@ docker push "$(RECONCILER_MANAGER_TAG)"
+	@ docker push "$(HYDRATION_CONTROLLER_TAG)"
+	@ docker push "$(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
+	@ docker push "$(RECONCILER_TAG)"
+	@ docker push "$(ADMISSION_WEBHOOK_TAG)"
+	@ docker push "$(OCI_SYNC_TAG)"
+	@ docker push "$(HELM_SYNC_TAG)"
 
 .PHONY: run-oss
 run-oss: build-oss

--- a/manifests/oss/kustomization.yaml
+++ b/manifests/oss/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../test-resources/00-namespace.yaml
+- ../namespace-selector-crd.yaml
+- ../cluster-selector-crd.yaml
+- ../cluster-registry-crd.yaml
+- ../reconciler-manager-service-account.yaml
+- ../otel-agent-cm.yaml
+- ../test-resources/resourcegroup-manifest.yaml
+- ../templates/reconciler-manager-configmap.yaml
+- ../reposync-crd.yaml
+- ../rootsync-crd.yaml
+- ../templates/reconciler-manager.yaml
+- ../templates/otel-collector.yaml
+- ../templates/admission-webhook.yaml
+- ../ns-reconciler-cluster-role.yaml

--- a/manifests/oss/kustomization.yaml
+++ b/manifests/oss/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
 - ../test-resources/00-namespace.yaml
 - ../namespace-selector-crd.yaml

--- a/manifests/templates/admission-webhook.yaml
+++ b/manifests/templates/admission-webhook.yaml
@@ -39,7 +39,7 @@ spec:
         - /admission-webhook
         - --graceful-shutdown-timeout=10s
         - --health-probe-bind-addr=:10258
-        image: IMAGE_NAME
+        image: WEBHOOK_IMAGE_NAME
         ports:
           - name: admission
             containerPort: 10250

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - /reconciler-manager
         args:
         - --enable-leader-election
-        image: IMAGE_NAME
+        image: RECONCILER_MANAGER_IMAGE_NAME
         name: reconciler-manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/scripts/build-oss.sh
+++ b/scripts/build-oss.sh
@@ -32,19 +32,4 @@ fi
 TAG="${TAG:-"latest"}"
 
 echo "+++ Building and pushing images"
-make -C "${REPO_DIR}" image-nomos oss-manifests \
-  NOMOS_TAG="${NOMOS_TAG}" \
-  RECONCILER_TAG="${REC_TAG}" \
-  HYDRATION_CONTROLLER_TAG="${HC_TAG}" \
-  HYDRATION_CONTROLLER_WITH_SHELL_TAG="${HC_WITH_SHELL_TAG}"\
-  RECONCILER_MANAGER_TAG="${MGR_TAG}" \
-  ADMISSION_WEBHOOK_TAG="${WEBHOOK_TAG}" \
-  OCI_SYNC_TAG="${OCI_TAG}" \
-  HELM_SYNC_TAG="${HELM_TAG}"
-docker push "${MGR_TAG}"
-docker push "${HC_TAG}"
-docker push "${HC_WITH_SHELL_TAG}"
-docker push "${REC_TAG}"
-docker push "${WEBHOOK_TAG}"
-docker push "${OCI_TAG}"
-docker push "${HELM_TAG}"
+make -C "${REPO_DIR}" oss-manifests oss-push-images GCP_PROJECT="${GCP_PROJECT}" TAG="${TAG}"


### PR DESCRIPTION
Following [the instructions to build from source](https://github.com/GoogleContainerTools/kpt-config-sync/blob/main/docs/installation.md#building-and-installing-from-source), I found that the process was a bit cumbersome and error-prone, for a few reasons:

* Not all required manifests were included (the [ns reconciler cluster role](../ns-reconciler-cluster-role.yaml) was missing)
* The setup required me to build the images every time I exported manifests, even if I knew that nothing had changed that would render different images (which hurt iteration speed on my scripting downstream)
* The output was a jumble of files, with unclear/nonexistent naming conventions

Using Kustomize and moving most of the actual code into `Makefile.oss`, I was able to greatly simplify `scripts/build-oss.sh`, and also make it possible to run parts of that process directly through `make` (as long as `GCP_PROJECT` and `TAG` are provided). For example, you can now bundle the manifests required to install Config Sync with `make -C <repo root> oss-manifests GCP_PROJECT=<your project> TAG=latest`, without triggering Docker builds or pushes.
