### PR TITLE
make openapi test file not depend on dir structure

### DIFF
--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -46,6 +46,7 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/testing/testmetrics"
 	discoveryutil "kpt.dev/configsync/pkg/util/discovery"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
@@ -415,7 +416,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 	}
 
-	converter, err := declared.ValueConverterForTest()
+	converter, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -660,7 +661,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 		},
 	}
 
-	converter, err := declared.ValueConverterForTest()
+	converter, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
@@ -19,8 +19,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/clientgen/apis/scheme"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/validate/objects"
 )
 
@@ -364,7 +364,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			converter, err := declared.ValueConverterForTest()
+			converter, err := openapitest.ValueConverterForTest()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/validate/raw/hydrate/declared_field_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator_test.go
@@ -21,15 +21,15 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/validate/objects"
 )
 
 func TestDeclaredFields(t *testing.T) {
-	converter, err := declared.ValueConverterForTest()
+	converter, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/hnc"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation"
@@ -43,6 +42,7 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/discoverytest"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/util/discovery"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -873,7 +873,7 @@ func TestHierarchical(t *testing.T) {
 		},
 	}
 
-	converter, err := declared.ValueConverterForTest()
+	converter, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1169,7 +1169,7 @@ func TestUnstructured(t *testing.T) {
 		},
 	}
 
-	converter, err := declared.ValueConverterForTest()
+	converter, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/webhook/fields_test.go
+++ b/pkg/webhook/fields_test.go
@@ -20,9 +20,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/declared"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -110,7 +110,7 @@ func TestObjectDiffer_Structured(t *testing.T) {
 		},
 	}
 
-	vc, err := declared.ValueConverterForTest()
+	vc, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatalf("Failed to create ValueConverter: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestObjectDiffer_Unstructured(t *testing.T) {
 		},
 	}
 
-	vc, err := declared.ValueConverterForTest()
+	vc, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatalf("Failed to create ValueConverter: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestConfigSyncMetadata(t *testing.T) {
 		},
 	}
 
-	vc, err := declared.ValueConverterForTest()
+	vc, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatalf("Failed to create ValueConverter: %v", err)
 	}

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -28,10 +28,10 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/openapitest"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -638,7 +638,7 @@ func TestValidator_Handle(t *testing.T) {
 }
 
 func validatorForTest(t *testing.T) *Validator {
-	vc, err := declared.ValueConverterForTest()
+	vc, err := openapitest.ValueConverterForTest()
 	if err != nil {
 		t.Fatalf("Failed to create ValueConverter: %v", err)
 	}


### PR DESCRIPTION
This previously assumed that there was a kpt.dev parent directory to reach, which adds an unnecessary constraint to dev environment setups. This could probably be improved further, but this makes it so that the file can be found regardless of the parent directory structure.