### PR TITLE
Fix repoless.bats test cleanup

### DIFF
--- a/e2e/testcases/repoless.bats
+++ b/e2e/testcases/repoless.bats
@@ -11,10 +11,6 @@ load "../lib/nomos"
 
 FILE_NAME="$(basename "${BATS_TEST_FILENAME}" '.bats')"
 
-test_teardown() {
-  nomos::reset_mono_repo_configmaps
-}
-
 @test "${FILE_NAME}: Syncs correctly with explicit namespace declarations" {
   kubectl apply -f "${MANIFEST_DIR}/source-format_unstructured.yaml"
   kubectl apply -f "${MANIFEST_DIR}/importer_repoless.yaml"


### PR DESCRIPTION
Previous test teardown was resetting the POLICY_DIR to "acme" without having created the acme directory. So if the git-importer started up before the nomostest cleanup finished, it could cause the Repo to enter an unrecoverable error state.

The fix is to let nomostest handle the cleanup, because it already handles initializing the repo and directory before resetting the POLICY_DIR.