### PR TITLE
Fix mono-repo e2e test cleanup to reset the branch

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -253,7 +253,7 @@ func resetSyncedRepos(nt *NT, opts *ntopts.New) {
 		nt.NonRootRepos = map[types.NamespacedName]*Repository{}
 		nt.RootRepos[configsync.RootSyncName] = resetRepository(nt, RootRepo, DefaultRootRepoNamespacedName, opts.UpstreamURL, opts.SourceFormat)
 		// It sets POLICY_DIR to always be `acme` because the initial mono-repo's sync directory is configured to be `acme`.
-		ResetMonoRepoSpec(nt, opts.SourceFormat, AcmeDir)
+		ResetMonoRepoSpec(nt, opts.SourceFormat, MainBranch, AcmeDir)
 		nt.WaitForRepoSyncs()
 	}
 }

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -238,22 +238,9 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 		nt.T.Errorf("%s present: %v", testNS, err)
 	}
 
-	// Update RootSync.
-	//
-	// Get RootSync and then perform Update.
-	rootsync := &v1beta1.RootSync{}
-	err = nt.Get(configsync.RootSyncName, v1.NSConfigManagementSystem, rootsync)
-	if err != nil {
-		nt.T.Fatalf("%v", err)
-	}
+	// Set branch to "test-branch"
+	nomostest.SetGitBranch(nt, configsync.RootSyncName, testBranch)
 
-	// Update the branch in RootSync Custom Resource.
-	rootsync.Spec.Git.Branch = testBranch
-
-	err = nt.Update(rootsync)
-	if err != nil {
-		nt.T.Fatalf("%v", err)
-	}
 	nt.WaitForRepoSyncs()
 
 	// Validate namespace 'audit-test' created after updating rootsync.
@@ -262,20 +249,9 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 		nt.T.Error(err)
 	}
 
-	// Get RootSync and then perform Update.
-	rs := &v1beta1.RootSync{}
-	err = nt.Get(configsync.RootSyncName, v1.NSConfigManagementSystem, rs)
-	if err != nil {
-		nt.T.Fatalf("%v", err)
-	}
+	// Set branch to "main"
+	nomostest.SetGitBranch(nt, configsync.RootSyncName, nomostest.MainBranch)
 
-	// Switch back to 'main' branch.
-	rs.Spec.Git.Branch = nomostest.MainBranch
-
-	err = nt.Update(rs)
-	if err != nil {
-		nt.T.Fatalf("%v", err)
-	}
 	// Checkout back to 'main' branch to get the correct HEAD commit sha1.
 	nt.RootRepos[configsync.RootSyncName].CheckoutBranch(nomostest.MainBranch)
 	nt.WaitForRepoSyncs()


### PR DESCRIPTION
This should fix some mono-repo tests that were using a different branch, without affecting the fragile multi-repo cleanup.

Update: I've confirmed this code passes the multi-repo tests that were failing from https://github.com/GoogleContainerTools/kpt-config-sync/pull/187:
```
GCP_PROJECT=stolos-dev GCP_CLUSTER=karlisenberg-cluster-1 GCP_REGION=us-central1 GCP_ZONE="" make E2E_ARGS="--share-test-env --multirepo --test-features=acm-controller,nomos-cli" test-e2e-go-gke-local
```

This PR is a subset of [that PR](https://github.com/GoogleContainerTools/kpt-config-sync/pull/187) with some modifications, excluding the `resetRootRepo` changes that affected multi-repo.
