### PR TITLE
fetch all branches in release tagging script

### DIFF
--- a/scripts/tag-promotion.sh
+++ b/scripts/tag-promotion.sh
@@ -50,7 +50,7 @@ esac
 
 REMOTE="git@github.com:GoogleContainerTools/kpt-config-sync.git"
 # Fetch all existing tags
-git fetch "${REMOTE}" --tags > /dev/null
+git fetch "${REMOTE}" "${RC_TAG}" --tags > /dev/null
 echo "+++ Successfully fetched tags"
 
 echo "+++ Promoting ${RC_TAG} to ${CS_VERSION}"

--- a/scripts/tag-release-candidate.sh
+++ b/scripts/tag-release-candidate.sh
@@ -86,16 +86,17 @@ if ! [[ "${CS_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 REMOTE="git@github.com:GoogleContainerTools/kpt-config-sync.git"
-# Fetch all existing tags
-git fetch "${REMOTE}" --tags > /dev/null
-echo "+++ Successfully fetched tags"
 
 # Cut from tip of main for minor versions
 branch="main"
 # Cut from tip of release branch for patch versions
 [[ "${CS_VERSION}" =~ ^v[0-9]+\.[0-9]+\.0$ ]] || branch="${CS_VERSION%.*}"
 echo "+++ Finding latest commit from ${branch}"
-remote_sha=$(git ls-remote --exit-code --heads "${REMOTE}" "${branch}" | cut -f 1)
+
+# Fetch all existing tags
+git fetch "${REMOTE}" "${branch}" --tags > /dev/null
+echo "+++ Successfully fetched tags"
+remote_sha=$(git rev-parse FETCH_HEAD)
 
 RC=$(latest_rc_of_version "$CS_VERSION")
 echo "+++ Most recent RC of version $CS_VERSION: $RC"


### PR DESCRIPTION
By default fetch will only fetch HEAD, i.e. main. For patch releases we need to also fetch release branches. This change updates the refspec to fetch all heads from remote.