### PR TITLE
Use deletion propagation for e2e test cleanup

### DIFF
--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -67,7 +67,11 @@ type FailOnError bool
 // It is unnecessary to run this on Kind clusters that exist only for the
 // duration of a single test.
 func Clean(nt *NT, failOnError FailOnError) {
-	nt.T.Helper()
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		nt.T.Logf("[CLEANUP] Test environment cleanup took %v", elapsed)
+	}()
 
 	// Delete remote repos that were created 24 hours ago on the Git provider.
 	if err := nt.GitProvider.DeleteObsoleteRepos(); err != nil {

--- a/e2e/nomostest/deletion_propagation.go
+++ b/e2e/nomostest/deletion_propagation.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/metadata"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnableDeletionPropagation enables foreground deletion propagation on a
+// RootSync or RepoSync. The object is annotated locally, but not applied.
+// Returns true if a change was made, false if already enabled.
+func EnableDeletionPropagation(rs client.Object) bool {
+	return SetDeletionPropagationPolicy(rs, metadata.DeletionPropagationPolicyForeground)
+}
+
+// DisableDeletionPropagation disables foreground deletion propagation on a
+// RootSync or RepoSync. The object annotated is removed locally, but not applied.
+// Returns true if a change was made, false if already enabled.
+func DisableDeletionPropagation(rs client.Object) bool {
+	return RemoveDeletionPropagationPolicy(rs)
+}
+
+// IsDeletionPropagationEnabled returns true if deletion propagation annotation
+// is set to Foreground.
+func IsDeletionPropagationEnabled(rs client.Object) bool {
+	return HasDeletionPropagationPolicy(rs, metadata.DeletionPropagationPolicyForeground)
+}
+
+// HasDeletionPropagationPolicy returns true if deletion propagation annotation
+// is set to the specified policy. Returns false if not set.
+func HasDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
+	annotations := obj.GetAnnotations()
+	// don't panic if nil
+	if len(annotations) == 0 {
+		return false
+	}
+	foundPolicy, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]
+	return found && foundPolicy == string(policy)
+}
+
+// SetDeletionPropagationPolicy sets the value of the deletion propagation
+// annotation locally (does not apply). Returns true if the object was modified.
+func SetDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
+	if HasDeletionPropagationPolicy(obj, policy) {
+		return false
+	}
+	core.SetAnnotation(obj, metadata.DeletionPropagationPolicyAnnotationKey, string(policy))
+	return true
+}
+
+// RemoveDeletionPropagationPolicy removes the deletion propagation annotation
+// locally (does not apply). Returns true if the object was modified.
+func RemoveDeletionPropagationPolicy(obj client.Object) bool {
+	annotations := obj.GetAnnotations()
+	// don't panic if nil
+	if len(annotations) == 0 {
+		return false
+	}
+	if _, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; !found {
+		return false
+	}
+	delete(annotations, metadata.DeletionPropagationPolicyAnnotationKey)
+	obj.SetAnnotations(annotations)
+	return true
+}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -204,40 +204,23 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	t.Cleanup(func() {
 		// Reset the otel-collector pod name to get a new forwarding port because the current process is killed.
 		nt.otelCollectorPodName = ""
-		nt.T.Log("`resetSyncedRepos` after a test as a part of `Cleanup` on SharedTestEnv")
-		resetSyncedRepos(nt, opts)
+		nt.T.Log("[RESET] Post-test `Reset` in SharedTestEnv")
+		if err := Reset(nt); err != nil {
+			nt.T.Errorf("[RESET] Failed to reset test environment: %v", err)
+		}
 	})
 
 	skipTestOnAutopilotCluster(nt, opts.SkipAutopilot)
 
-	nt.T.Log("`resetSyncedRepos` before a test on SharedTestEnv")
-	resetSyncedRepos(nt, opts)
+	nt.T.Log("[RESET] Pre-test `Reset` in SharedTestEnv")
+	if err := Reset(nt); err != nil {
+		nt.T.Fatalf("[RESET] Failed to reset test environment: %v", err)
+	}
 	// a previous e2e test may stop the Config Sync webhook, so always call `installWebhook` here to make sure the test starts
 	// with the webhook enabled.
 	installWebhook(nt)
 	setupTestCase(nt, opts)
 	return nt
-}
-
-func resetSyncedRepos(nt *NT, opts *ntopts.New) {
-	nnList := nt.NonRootRepos
-	// clear the namespace resources in the namespace repo to avoid admission validation failure.
-	resetNamespaceRepos(nt)
-	resetRootRepos(nt, opts.SourceFormat)
-
-	deleteRootRepos(nt)
-	deleteNamespaceRepos(nt)
-	// delete the out-of-sync namespaces in case they're set up in the delegated mode.
-	for nn := range nnList {
-		revokeRepoSyncNamespace(nt, nn.Namespace)
-	}
-	nt.NonRootRepos = map[types.NamespacedName]*Repository{}
-	for name := range nt.RootRepos {
-		if name != configsync.RootSyncName {
-			delete(nt.RootRepos, name)
-		}
-	}
-	nt.WaitForRepoSyncs()
 }
 
 // FreshTestEnv establishes a connection to a test cluster based on the passed
@@ -306,11 +289,11 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	} else {
 		// We aren't using an ephemeral Kind cluster, so make sure the cluster is
 		// clean before and after running the test.
-		t.Log("`Clean` before running the test on FreshTestEnv")
+		t.Log("[CLEANUP] Pre-test `Clean` in FreshTestEnv")
 		Clean(nt, true)
 		t.Cleanup(func() {
 			// Clean the cluster now that the test is over.
-			t.Log("`Clean` after running the test on FreshTestEnv")
+			t.Log("[CLEANUP] Post-test `Clean` in FreshTestEnv")
 			Clean(nt, false)
 		})
 	}
@@ -353,12 +336,13 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	})
 
 	installConfigSync(nt, opts.Nomos)
-
 	setupTestCase(nt, opts)
 	return nt
 }
 
 func setupTestCase(nt *NT, opts *ntopts.New) {
+	nt.T.Log("[SETUP] New test case")
+
 	// allRepos specifies the slice all repos for port forwarding.
 	var allRepos []types.NamespacedName
 	for repo := range opts.RootRepos {
@@ -373,9 +357,19 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 	}
 
 	for name := range opts.RootRepos {
-		nt.RootRepos[name] = resetRepository(nt, RootRepo, RootSyncNN(name), opts.SourceFormat)
+		if name == configsync.RootSyncName {
+			// Create or reset and reconfigure the Repository and the RootSync
+			err := resetRootRepo(nt, name, opts.SourceFormat)
+			if err != nil {
+				nt.T.Fatal(err)
+			}
+		} else {
+			// Configure the Repository (Repo/RootSync should not exist yet)
+			nt.RootRepos[name] = resetRepository(nt, RootRepo, RootSyncNN(name), opts.SourceFormat)
+		}
 	}
 	for nsr := range opts.NamespaceRepos {
+		// Configure the Repository (RepoSync should not exist yet)
 		nt.NonRootRepos[nsr] = resetRepository(nt, NamespaceRepo, nsr, filesystem.SourceFormatUnstructured)
 	}
 

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -561,13 +561,15 @@ func (nt *NT) PodLogs(namespace, deployment, container string, previousPodLog bo
 
 // printTestLogs prints test logs and pods information for debugging.
 func (nt *NT) printTestLogs() {
-	// Print the logs for the current container instances.
+	nt.T.Log("[CLEANUP] Printing test logs for current container instances")
 	nt.testLogs(false)
-	// print the logs for the previous container instances if they exist.
+	nt.T.Log("[CLEANUP] Printing test logs for previous container instances")
 	nt.testLogs(true)
+	nt.T.Log("[CLEANUP] Printing test logs for running pods")
 	for _, ns := range CSNamespaces {
 		nt.testPods(ns)
 	}
+	nt.T.Log("[CLEANUP] Describing not-ready pods")
 	for _, ns := range CSNamespaces {
 		nt.describeNotRunningTestPods(ns)
 	}

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -1,0 +1,564 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e/nomostest/taskgroup"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/syncer/differ"
+	"kpt.dev/configsync/pkg/util/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reset performs multi-repo test reset:
+// - Delete unmanaged RootSyncs & RepoSyncs (with deletion propagation)
+// - Validate managed RepoSyncs & RootSyncs are deleted
+// - Delete all test namespaces not containing config-sync itself
+// - Delete NonRootRepos & RootRepos (except the default RootRepo)
+//
+// This should cleanly delete or reset all registered RSyncs.
+// Any managed RSyncs must have deletion propagation enabled by the test that
+// created them, otherwise their managed resources will not be deleted when the
+// RSync is deleted.
+// Any unregistered Repos must be reset by individual test Cleanup.
+func Reset(nt *NT) error {
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		nt.T.Logf("[RESET] Test environment reset took %v", elapsed)
+	}()
+
+	// Delete all existing RootSyncs with the test label.
+	// Enable deletion propagation first, to clean up managed resources.
+	rootSyncList, err := listRootSyncs(nt)
+	if err != nil {
+		return err
+	}
+	if err := ResetRootSyncs(nt, rootSyncList.Items); err != nil {
+		return err
+	}
+
+	// Delete all existing RepoSyncs with the test label.
+	// Enable deletion propagation first, to clean up managed resources.
+	repoSyncList, err := listRepoSyncs(nt)
+	if err != nil {
+		return err
+	}
+	if err := ResetRepoSyncs(nt, repoSyncList.Items); err != nil {
+		return err
+	}
+
+	// Delete all Namespaces with the test label (except shared).
+	nsList, err := listNamespaces(nt)
+	if err != nil {
+		return err
+	}
+	// Error if any protected namespace was modified by a test (test label added)
+	// and not reverted by the test.
+	protectedNamespaces, nsListItems := filterNamespaces(nsList.Items,
+		protectedNamespaceList()...)
+	if len(protectedNamespaces) > 0 {
+		return errors.Errorf("protected namespace(s) modified by test: %+v",
+			protectedNamespaces)
+	}
+	// Skip deleting namespaces that contain test infra or Config Sync itself.
+	_, nsListItems = filterNamespaces(nsListItems,
+		configsync.ControllerNamespace,
+		configmanagement.RGControllerNamespace,
+		metrics.MonitoringNamespace,
+		testGitNamespace)
+	if err := ResetNamespaces(nt, nsListItems); err != nil {
+		return err
+	}
+
+	// NOTE: These git repos are not actually being deleted here, just forgotten.
+	// Repos are deleted by `Clean` for environment setup and teardown.
+
+	nt.T.Log("[RESET] Resetting NonRootRepos")
+	nt.NonRootRepos = make(map[types.NamespacedName]*Repository)
+
+	nt.T.Log("[RESET] Resetting RootRepos")
+	// Retain the root-sync repo (speeds up reset a bit when there are no changes)
+	rootRepo := nt.RootRepos[configsync.RootSyncName]
+	nt.RootRepos = make(map[string]*Repository)
+	nt.RootRepos[configsync.RootSyncName] = rootRepo
+
+	return nil
+}
+
+func protectedNamespaceList() []string {
+	list := make([]string, 0, len(differ.SpecialNamespaces))
+	for ns := range differ.SpecialNamespaces {
+		list = append(list, ns)
+	}
+	return list
+}
+
+type resetRecord struct {
+	Objects          map[types.NamespacedName]struct{}
+	ManagedObjects   map[types.NamespacedName]struct{}
+	ObjectNamespaces map[string]struct{}
+}
+
+func newResetRecord() *resetRecord {
+	return &resetRecord{
+		Objects:          make(map[types.NamespacedName]struct{}),
+		ManagedObjects:   make(map[types.NamespacedName]struct{}),
+		ObjectNamespaces: make(map[string]struct{}),
+	}
+}
+
+// ResetRootSyncs cleans up one or more RootSyncs and all their managed objects.
+// Use this for cleaning up RootSyncs in tests that use delegated control.
+func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
+	if len(rsList) == 0 {
+		return nil
+	}
+
+	nt.T.Logf("[RESET] Deleting RootSyncs (%d)", len(rsList))
+
+	record := newResetRecord()
+
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		record.Objects[rsNN] = struct{}{}
+		record.ObjectNamespaces[rsNN.Namespace] = struct{}{}
+
+		if manager, found := rs.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[rsNN] = struct{}{}
+			nt.T.Logf("[RESET] RootSync %s managed by %q", rsNN, manager)
+			if !IsDeletionPropagationEnabled(rs) {
+				// If you go this error, make sure your test cleanup ensures
+				// that the managed RootSync has deletion propagation enabled.
+				return errors.Errorf("RootSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+			}
+			continue
+		}
+
+		// Enable deletion propagation, if not enabled
+		if EnableDeletionPropagation(rs) {
+			nt.T.Logf("[RESET] Enabling deletion propagation on RootSync %s", rsNN)
+			if err := nt.Update(rs); err != nil {
+				return err
+			}
+			if err := WatchObject(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace, []Predicate{
+				HasFinalizer(metadata.ReconcilerFinalizer),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Print reconciler logs in case of failure.
+		// This ensures the logs are printed, even if the reconciler is deleted.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go TailReconcilerLogs(ctx, nt, RootReconcilerObjectKey(rsNN.Name))
+
+		// DeletePropagationBackground is required when deleting RSyncs with
+		// dependencies that have owners references. Otherwise the reconciler
+		// and dependenencies will be garbage collected before the finalizer
+		// can delete the managed resources.
+		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+		nt.T.Logf("[RESET] Deleting RootSync %s", rsNN)
+		if err := nt.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return err
+		}
+	}
+	tg := taskgroup.New()
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		nt.T.Logf("[RESET] Waiting for deletion of RootSync %s ...", rsNN)
+		tg.Go(func() error {
+			return WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace)
+		})
+	}
+	return tg.Wait()
+}
+
+// ResetRepoSyncs cleans up one or more RepoSyncs and all their managed objects.
+// Use this for cleaning up RepoSyncs in tests that use delegated control.
+//
+// To ensure the reconcile finalizer has permission to delete managed resources,
+// ClusterRole and RoleBindings will be created and then later deleted.
+// This also cleans up any CRs, RBs, and CRBs left behind by delegated control.
+func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
+	if len(rsList) == 0 {
+		// Clean up after `setupDelegatedControl`
+		return deleteRepoSyncClusterRole(nt)
+	}
+
+	nt.T.Logf("[RESET] Deleting RepoSyncs (%d)", len(rsList))
+
+	record := newResetRecord()
+
+	// Create ClusterRole, if not found.
+	rsCR := nt.RepoSyncClusterRole()
+	if err := nt.Create(rsCR); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		record.Objects[rsNN] = struct{}{}
+		record.ObjectNamespaces[rsNN.Namespace] = struct{}{}
+
+		// If managed, skip direct deletion
+		if manager, found := rs.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[rsNN] = struct{}{}
+			nt.T.Logf("[RESET] RepoSync %s managed by %q", rsNN, manager)
+			if !IsDeletionPropagationEnabled(rs) {
+				// If you go this error, make sure your test cleanup ensures
+				// that the managed RepoSync has deletion propagation enabled.
+				return errors.Errorf("RepoSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+			}
+			continue
+		}
+
+		// Enable deletion propagation, if not enabled
+		if EnableDeletionPropagation(rs) {
+			nt.T.Logf("[RESET] Enabling deletion propagation on RepoSync %s", rsNN)
+			if err := nt.Update(rs); err != nil {
+				return err
+			}
+			if err := WatchObject(nt, kinds.RepoSyncV1Beta1(), rs.Name, rs.Namespace, []Predicate{
+				HasFinalizer(metadata.ReconcilerFinalizer),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Create RoleBinding, if not found (ensure finalizer has permission)
+		rsCRB := RepoSyncRoleBinding(rsNN)
+		if err := nt.Create(rsCRB); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+
+		// Print reconciler logs in case of failure.
+		// This ensures the logs are printed, even if the reconciler is deleted.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go TailReconcilerLogs(ctx, nt, NsReconcilerObjectKey(rsNN.Namespace, rsNN.Name))
+
+		// DeletePropagationBackground is required when deleting RSyncs with
+		// dependencies that have owners references. Otherwise the reconciler
+		// and dependenencies will be garbage collected before the finalizer
+		// can delete the managed resources.
+		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+		nt.T.Logf("[RESET] Deleting RepoSync %s", rsNN)
+		if err := nt.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return err
+		}
+	}
+	tg := taskgroup.New()
+	for _, item := range rsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		nt.T.Logf("[RESET] Waiting for deletion of RepoSync %s ...", nn)
+		tg.Go(func() error {
+			return WatchForNotFound(nt, kinds.RepoSyncV1Beta1(), obj.Name, obj.Namespace)
+		})
+	}
+	if err := tg.Wait(); err != nil {
+		return err
+	}
+
+	// Delete any RoleBindings left behind.
+	// For central control, the parent RSync _should_ handle deleting the RB,
+	// but for delegated control and other edge cases clean them up regardless.
+	nt.T.Log("[RESET] Deleting test RoleBindings")
+	var rbs []client.Object
+	for rsNN := range record.Objects {
+		rbs = append(rbs, RepoSyncRoleBinding(rsNN))
+	}
+	// Skip deleting managed RoleBindings
+	rbs, err := findUnmanaged(nt, rbs...)
+	if err != nil {
+		return err
+	}
+	if err := batchDeleteAndWait(nt, rbs...); err != nil {
+		return err
+	}
+
+	// Delete any ClusterRoleBindings left behind.
+	// CRBs are usually only applied if PSP was enabled, but clean them up regardless.
+	nt.T.Log("[RESET] Deleting test ClusterRoleBindings")
+	var crbs []client.Object
+	for rsNN := range record.Objects {
+		crbs = append(crbs, repoSyncClusterRoleBinding(rsNN))
+	}
+	// Skip deleting managed ClusterRoleBindings
+	crbs, err = findUnmanaged(nt, crbs...)
+	if err != nil {
+		return err
+	}
+	if err := batchDeleteAndWait(nt, crbs...); err != nil {
+		return err
+	}
+
+	return deleteRepoSyncClusterRole(nt)
+}
+
+// ResetNamespaces cleans up one or more Namespaces and all their namespaced objects.
+// Use this for cleaning up Namespaces in tests that use delegated control.
+func ResetNamespaces(nt *NT, nsList []corev1.Namespace) error {
+	if len(nsList) == 0 {
+		return nil
+	}
+
+	nt.T.Logf("[RESET] Deleting Namespaces (%d)", len(nsList))
+
+	record := newResetRecord()
+
+	for _, item := range nsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		record.Objects[nn] = struct{}{}
+		record.ObjectNamespaces[nn.Namespace] = struct{}{}
+
+		// If managed, skip direct deletion
+		if manager, found := obj.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[nn] = struct{}{}
+			nt.T.Logf("[RESET] Namespace %s managed by %q", nn, manager)
+			continue
+		}
+
+		nt.T.Logf("[RESET] Deleting Namespace %s", nn)
+		if err := nt.Delete(obj, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			return err
+		}
+	}
+	for _, item := range nsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		nt.T.Logf("[RESET] Waiting for deletion of Namespace %s ...", nn)
+		if err := WatchForNotFound(nt, kinds.Namespace(), obj.Name, obj.Namespace); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteRepoSyncClusterRole deletes the ClusterRole used by RepoSync
+// reconcilers, if it exists.
+func deleteRepoSyncClusterRole(nt *NT) error {
+	nt.T.Log("[RESET] Deleting RepoSync ClusterRole")
+	return batchDeleteAndWait(nt, nt.RepoSyncClusterRole())
+}
+
+func findUnmanaged(nt *NT, objs ...client.Object) ([]client.Object, error) {
+	var unmanaged []client.Object
+	for _, obj := range objs {
+		if err := nt.Get(obj.GetName(), obj.GetNamespace(), obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+		} else if _, found := obj.GetAnnotations()[string(metadata.ResourceManagerKey)]; !found {
+			unmanaged = append(unmanaged, obj)
+		} // else managed
+	}
+	return unmanaged, nil
+}
+
+func batchDeleteAndWait(nt *NT, objs ...client.Object) error {
+	for _, obj := range objs {
+		if err := nt.Delete(obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	tg := taskgroup.New()
+	for _, obj := range objs {
+		gvk, err := kinds.Lookup(obj, nt.scheme)
+		if err != nil {
+			return err
+		}
+		tg.Go(func() error {
+			return WatchForNotFound(nt, gvk, obj.GetName(), obj.GetNamespace())
+		})
+	}
+	return tg.Wait()
+}
+
+func listRootSyncs(nt *NT, opts ...client.ListOption) (*v1beta1.RootSyncList, error) {
+	rsList := &v1beta1.RootSyncList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(rsList, opts...); err != nil {
+		return rsList, err
+	}
+	return rsList, nil
+}
+
+func listRepoSyncs(nt *NT, opts ...client.ListOption) (*v1beta1.RepoSyncList, error) {
+	rsList := &v1beta1.RepoSyncList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(rsList, opts...); err != nil {
+		return rsList, err
+	}
+	return rsList, nil
+}
+
+func listNamespaces(nt *NT, opts ...client.ListOption) (*corev1.NamespaceList, error) {
+	nsList := &corev1.NamespaceList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(nsList, opts...); err != nil {
+		return nsList, err
+	}
+	return nsList, nil
+}
+
+func withLabelListOption(key, value string) client.MatchingLabelsSelector {
+	labelSelector := labels.Set{key: value}.AsSelector()
+	return client.MatchingLabelsSelector{Selector: labelSelector}
+}
+
+func filterNamespaces(nsList []corev1.Namespace, excludes ...string) (found []corev1.Namespace, remaining []corev1.Namespace) {
+	for _, ns := range nsList {
+		if stringSliceContains(excludes, ns.Name) {
+			found = append(found, ns)
+		} else {
+			remaining = append(remaining, ns)
+		}
+	}
+	return found, remaining
+}
+
+func stringSliceContains(list []string, value string) bool {
+	for _, elem := range list {
+		if elem == value {
+			return true
+		}
+	}
+	return false
+}
+
+// resetRepository re-initializes an existing remote repository or creates a new remote repository.
+func resetRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *Repository {
+	if repo, found := nt.RemoteRepositories[nn]; found {
+		repo.ReInit(nt, sourceFormat)
+		return repo
+	}
+	return NewRepository(nt, repoType, nn, sourceFormat)
+}
+
+// resetRootRepo resets the RootSync and its Repository, but only if they need
+// to change.
+func resetRootRepo(nt *NT, rsName string, sourceFormat filesystem.SourceFormat) error {
+	// Reset the Git repo.
+	// This may cause temporary errors in the RootSync until it's reconfigured too.
+	nt.RootRepos[rsName] = resetRepository(nt, RootRepo, RootSyncNN(rsName), sourceFormat)
+	defaultRS := RootSyncObjectV1Beta1FromRootRepo(nt, rsName)
+
+	rs := &v1beta1.RootSync{}
+	err := nt.Get(defaultRS.Name, defaultRS.Namespace, rs)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		// RootSync NotFound
+		// This can happen if it was managed by another RootSync which has
+		// already been reset.
+		nt.T.Logf("Creating new RootSync (%s): %s", defaultRS.Name, log.AsJSON(defaultRS.Spec))
+		err = nt.Create(defaultRS)
+		if err != nil {
+			return err
+		}
+		return WatchForCurrentStatus(nt, kinds.RootSyncV1Beta1(), defaultRS.Name, defaultRS.Namespace)
+	}
+
+	// Avoid unnecessary updates
+	if cmp.Equal(rs.Spec, defaultRS.Spec) {
+		nt.T.Logf("Skipping reset for RootSync (%s): no change required", defaultRS.Name)
+		return nil
+	}
+
+	// Reset the RootSync spec to match the config from nt.RootRepos
+	defaultRS.Spec.DeepCopyInto(&rs.Spec)
+	nt.T.Logf("Resetting RootSync (%s): %s", rs.Name, log.AsJSON(rs.Spec))
+	if err = nt.Update(rs); err != nil {
+		return err
+	}
+	return WatchForCurrentStatus(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace)
+}
+
+// TailReconcilerLogs starts tailing a reconciler's logs.
+// The logs are stored in memory until either the context is cancelled or the
+// kubectl command exits (usually because the container exited).
+// This allows capturing logs even if the reconciler is deleted before the
+// test ends.
+// The logs will only be printed if the test has failed when the command exits.
+// Run in an goroutine to capture logs in the background while deleting RSyncs.
+func TailReconcilerLogs(ctx context.Context, nt *NT, reconcilerNN types.NamespacedName) {
+	out, err := nt.KubectlContext(ctx, "logs",
+		fmt.Sprintf("deployment/%s", reconcilerNN.Name),
+		"-n", reconcilerNN.Namespace,
+		"-c", reconcilermanager.Reconciler,
+		"-f")
+	// Expect the logs to tail until the context is cancelled, or exit early if
+	// the reconciler container exited.
+	if err != nil && err.Error() != "signal: killed" {
+		// We're only using this for debugging, so don't trigger test failure.
+		nt.T.Logf("Failed to tail logs from reconciler %s: %v", reconcilerNN, err)
+	}
+	// Only print the logs if the test has failed
+	if nt.T.Failed() {
+		nt.T.Logf("Reconciler deployment logs (%s):\n%s", reconcilerNN, string(out))
+	}
+}
+
+// RootReconcilerObjectKey returns an ObjectKey for interracting with the
+// RootReconciler for the specified RootSync.
+func RootReconcilerObjectKey(syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.RootReconcilerName(syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}
+
+// NsReconcilerObjectKey returns an ObjectKey for interracting with the
+// NsReconciler for the specified RepoSync.
+func NsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.NsReconcilerName(namespace, syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}

--- a/e2e/nomostest/watch.go
+++ b/e2e/nomostest/watch.go
@@ -202,6 +202,7 @@ func WatchObject(nt *NT, gvk schema.GroupVersionKind, name, namespace string, pr
 					Namespace:        namespace,
 				}
 			}
+			// Else, continue watching. The object may be re-created.
 		case watch.Added, watch.Modified:
 			eType := event.Type
 			if eType == watch.Added && prevObj != nil {

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -36,7 +36,6 @@ import (
 // are removed successfully.
 func TestKCCResourcesOnCSR(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.KccTest, ntopts.RequireGKE(t))
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("sync to the kcc resources from a CSR repo")
@@ -82,9 +81,6 @@ func TestKCCResourcesOnCSR(t *testing.T) {
 	validateKCCResourceNotFound(nt, gvkPubSubSubscription, "test-cs-read", "foo")
 	validateKCCResourceNotFound(nt, gvkServiceAccount, "pubsub-app", "foo")
 	validateKCCResourceNotFound(nt, gvkPolicyMember, "policy-member-binding", "foo")
-
-	// Change the rs back so that it works in the shared test environment.
-	defer nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}, "sourceFormat": "hierarchy"}}`, origRepoURL))
 }
 
 func validateKCCResourceReady(nt *nomostest.NT, gvk schema.GroupVersionKind, name, namespace string) {

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -88,11 +88,9 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	// RepoSyncs, which could block deletion if their finalizer hangs.
 	// This also replaces depends-on deletion ordering (RoleBinding -> RepoSync),
 	// which can't be used by unmanaged syncs or objects in different repos.
-	// Stop the webhook to allow deletion of managed resources.
 	nt.T.Cleanup(func() {
-		nt.T.Log("[CLEANUP] Stopping webhook")
-		nomostest.StopWebhook(nt)
 		nt.T.Log("[CLEANUP] Deleting test RepoSyncs")
+		var rsList []v1beta1.RepoSync
 		rsNNs := []types.NamespacedName{nn1, nn2, nn4}
 		for _, rsNN := range rsNNs {
 			rs := &v1beta1.RepoSync{}
@@ -102,12 +100,11 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 					nt.T.Error(err)
 				}
 			} else {
-				if err := nt.Delete(rs); err != nil {
-					if !apierrors.IsNotFound(err) {
-						nt.T.Error(err)
-					}
-				}
+				rsList = append(rsList, *rs)
 			}
+		}
+		if err := nomostest.ResetRepoSyncs(nt, rsList); err != nil {
+			nt.T.Error(err)
 		}
 	})
 

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -77,17 +77,11 @@ func TestPublicOCI(t *testing.T) {
 		publicARImage = fmt.Sprintf("us-docker.pkg.dev/%s/config-sync-test-public/kustomize-components", publicProject)
 	}
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a public OCI image in AR")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"image": "%s", "auth": "none"}, "git": null}}`,
 		v1beta1.OciSource, publicARImage))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(imageDigestFunc(publicARImage, true)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "."}))
 	validateAllTenants(nt, string(declared.RootReconciler), "base", "tenant-a", "tenant-b", "tenant-c")
@@ -110,18 +104,12 @@ func TestGCENodeOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest)
 
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 	tenant := "tenant-a"
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from an OCI image in Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"dir": "%s", "image": "%s", "auth": "gcenode"}, "git": null}}`,
 		v1beta1.OciSource, tenant, privateARImage))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(imageDigestFunc(privateARImage, false)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: tenant}))
 	validateAllTenants(nt, string(declared.RootReconciler), "../base", tenant)
@@ -478,14 +466,8 @@ func isSourceType(sourceType v1beta1.SourceType) nomostest.Predicate {
 // The test uses the current credentials (gcloud auth) when running on the GKE clusters to push new images.
 func TestDigestUpdate(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured, ntopts.RequireGKE(t))
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 
 	nt.T.Log("Test oci-sync pulling the latest image from AR when digest changes")
 	testDigestUpdate(nt, "us-docker.pkg.dev/${GCP_PROJECT}/config-sync-test-public/digest-update")

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -38,7 +38,6 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -87,7 +86,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Disabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -95,7 +94,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyOrphan) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyOrphan) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -173,7 +172,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -181,7 +180,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -276,8 +275,8 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
-	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -285,7 +284,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -299,7 +298,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 
 	nt.T.Log("Enabling RepoSync deletion propagation")
 	repoSync := rootRepo.Get(repoSyncPath)
-	if setDeletionPropagationPolicy(repoSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(repoSync, metadata.DeletionPropagationPolicyForeground) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Enabling RepoSync deletion propagation")
 	}
@@ -396,8 +395,8 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
-	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -405,7 +404,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -419,7 +418,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 
 	nt.T.Log("Disabling RepoSync deletion propagation")
 	repoSync := rootRepo.Get(repoSyncPath)
-	if removeDeletionPropagationPolicy(repoSync) {
+	if nomostest.RemoveDeletionPropagationPolicy(repoSync) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Disabling RepoSync deletion propagation")
 		nt.WaitForRepoSyncs()
@@ -466,31 +465,6 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 			return errs
 		},
 	)
-}
-
-// tailReconcilerLogs starts tailing a reconciler's logs.
-// The logs are stored in memory until either the context is cancelled or the
-// kubectl command exits (usually because the container exited).
-// This allows capturing logs even if the reconciler is deleted before the
-// test ends.
-// The logs will only be printed if the test has failed when the command exits.
-// Run in an goroutine to capture logs in the background while deleting RSyncs.
-func tailReconcilerLogs(ctx context.Context, nt *nomostest.NT, reconcilerNN types.NamespacedName) {
-	out, err := nt.KubectlContext(ctx, "logs",
-		fmt.Sprintf("deployment/%s", reconcilerNN.Name),
-		"-n", reconcilerNN.Namespace,
-		"-c", reconcilermanager.Reconciler,
-		"-f")
-	// Expect the logs to tail until the context is cancelled, or exit early if
-	// the reconciler container exited.
-	if err != nil && err.Error() != "signal: killed" {
-		// We're only using this for debugging, so don't trigger test failure.
-		nt.T.Logf("Failed to tail logs from reconciler %s: %v", reconcilerNN, err)
-	}
-	// Only print the logs if the test has failed
-	if nt.T.Failed() {
-		nt.T.Logf("Reconciler deployment logs (%s):\n%s", reconcilerNN, string(out))
-	}
 }
 
 func cleanupSingleLevel(nt *nomostest.NT,
@@ -540,7 +514,7 @@ func cleanupSyncsAndObjects(nt *nomostest.NT, syncObjs []client.Object, objs []c
 	nomostest.StopWebhook(nt)
 
 	// For the purposes of these finalizer tests, we assume the finalizer may
-	// not work correctly. So we delete the deletion propegation annotation,
+	// not work correctly. So we delete the deletion propagation annotation,
 	// the syncs, and all the managed objects.
 	for _, syncObj := range syncObjs {
 		if err := deleteSyncWithOrphanPolicy(nt, syncObj); err != nil {
@@ -611,7 +585,7 @@ func deleteSyncWithOrphanPolicy(nt *nomostest.NT, obj client.Object) error {
 	}
 
 	nt.T.Log("Removing deletion propagation annotation")
-	if removeDeletionPropagationPolicy(obj) {
+	if nomostest.RemoveDeletionPropagationPolicy(obj) {
 		err = nt.Update(obj)
 		if err != nil {
 			return err
@@ -645,49 +619,6 @@ func deleteObject(nt *nomostest.NT, obj client.Object) error {
 		return err
 	}
 	return nil
-}
-
-// rootReconcilerObjectKey returns an ObjectKey for interacting with the
-// RootReconciler for the specified RootSync.
-func rootReconcilerObjectKey(syncName string) client.ObjectKey {
-	return client.ObjectKey{
-		Name:      core.RootReconcilerName(syncName),
-		Namespace: configsync.ControllerNamespace,
-	}
-}
-
-// nsReconcilerObjectKey returns an ObjectKey for interacting with the
-// NsReconciler for the specified RepoSync.
-func nsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
-	return client.ObjectKey{
-		Name:      core.NsReconcilerName(namespace, syncName),
-		Namespace: configsync.ControllerNamespace,
-	}
-}
-
-func setDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
-	annotations := obj.GetAnnotations()
-	if len(annotations) == 0 {
-		annotations = make(map[string]string, 1)
-	} else if val, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; found && val == string(policy) {
-		return false
-	}
-	annotations[metadata.DeletionPropagationPolicyAnnotationKey] = string(policy)
-	obj.SetAnnotations(annotations)
-	return true
-}
-
-func removeDeletionPropagationPolicy(obj client.Object) bool {
-	annotations := obj.GetAnnotations()
-	if len(annotations) == 0 {
-		return false
-	}
-	if _, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; !found {
-		return false
-	}
-	delete(annotations, metadata.DeletionPropagationPolicyAnnotationKey)
-	obj.SetAnnotations(annotations)
-	return true
 }
 
 func loadDeployment(nt *nomostest.NT, path string) *appsv1.Deployment {

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/testing/fake"
@@ -51,11 +52,9 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 		nt.T.Fatalf("deleting RootSync: %v", err)
 	}
 
-	_, err = nomostest.Retry(5*time.Second, func() error {
-		return nt.ValidateNotFound(configsync.RootSyncName, v1.NSConfigManagementSystem, fake.RootSyncObjectV1Beta1(configsync.RootSyncName))
-	})
-	if err != nil {
-		nt.T.Errorf("RootSync present after deletion: %v", err)
+	// Verify RootSync no longer present.
+	if err := nomostest.WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.GetName(), rs.GetNamespace()); err != nil {
+		nt.T.Fatal(err)
 	}
 
 	// Verify Root Reconciler deployment no longer present.


### PR DESCRIPTION
- Rewrite test cleanup to use the RSync finalizer to delete all
  managed resources by default (for e2e tests only)
- Add deletion propagation helper functions
- Fix TestDeleteRootSyncAndRootSyncV1Alpha1 to handle longer RSync
  deletion timeout
- Log elapsed time for Clean and Reset
- Add more logging for test setup and teardown
- Remove test cleanup blocks that are no longer necessary.
  Most of these involved resetting the sync config, which is now
  being deleted and re-created with the required settings by test
  Reset.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/351
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/352
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/354
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/355 (rejected. non-blocking)
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/356
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/357
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/358
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/361
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/363