### PR TITLE
Revert "Fix repoless.bats test cleanup"

### DIFF
--- a/e2e/testcases/repoless.bats
+++ b/e2e/testcases/repoless.bats
@@ -11,6 +11,10 @@ load "../lib/nomos"
 
 FILE_NAME="$(basename "${BATS_TEST_FILENAME}" '.bats')"
 
+test_teardown() {
+  nomos::reset_mono_repo_configmaps
+}
+
 @test "${FILE_NAME}: Syncs correctly with explicit namespace declarations" {
   kubectl apply -f "${MANIFEST_DIR}/source-format_unstructured.yaml"
   kubectl apply -f "${MANIFEST_DIR}/importer_repoless.yaml"


### PR DESCRIPTION
Reverts GoogleContainerTools/kpt-config-sync#198

Reason: CI tests were continuously failing after this PR was merged. It seems like other failing tests rely on the clean-up code that is removed in PR #198.