### PR TITLE
fix terraform config for fresh projects

### DIFF
--- a/e2e/testinfra/terraform/README.md
+++ b/e2e/testinfra/terraform/README.md
@@ -47,6 +47,12 @@ terraform plan
 terraform apply
 ```
 
+> **_Note:_**
+If running on a new project, the first apply may fail due to google APIs not yet
+being enabled. If this occurs, wait briefly and re-run `terraform apply`.
+The APIs will have been enabled from the first apply and available for the
+second apply.
+
 To delete the provisioned resources:
 ```shell
 terraform destroy

--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -42,6 +42,9 @@ data "google_project" "project" {
 }
 
 data "google_compute_default_service_account" "default" {
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"]
+  ]
 }
 
 resource "google_project_iam_member" "gce-default-sa-iam" {

--- a/e2e/testinfra/terraform/common/services.tf
+++ b/e2e/testinfra/terraform/common/services.tf
@@ -22,6 +22,7 @@ resource "google_project_service" "services" {
     "artifactregistry.googleapis.com",
     "secretmanager.googleapis.com",
     "container.googleapis.com",
+    "compute.googleapis.com",
   ])
   service = each.value
   disable_on_destroy = false


### PR DESCRIPTION
A fresh GCP project may not have all required APIs enabled, leading to certain resources not being available (such as the default compute account).

terraform apply will enable all of the required APIs, but they may not be available in time to create the actual resources. This adds a note to instruct the user that they may need to run apply twice for new projects.