### PR TITLE
Fixed test data for TestNamespaceKubePublicCanBeManaged

### DIFF
--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -319,6 +319,6 @@ func TestNamespaceKubeSystemCanBeManaged(t *testing.T) {
 
 func TestNamespaceKubePublicCanBeManaged(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	manageNamespace(nt, "kube-system")
+	manageNamespace(nt, "kube-public")
 	unmanageNamespace(nt, "kube-public")
 }


### PR DESCRIPTION
TestNamespaceKubePublicCanBeManaged should be testing for "kube-public" namespace, not "kube-system"