### PR TITLE
Revert VPA flag and e2e test

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -33,7 +33,6 @@ import (
 	"kpt.dev/configsync/pkg/profiler"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
@@ -60,12 +59,10 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
-	var allowVerticalScale bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&allowVerticalScale, "allow-vertical-scale", util.EnvBool(reconcilermanager.AllowVerticalScale, false), "Allowing vertical scale to let VPA manage the resource")
 	flag.Parse()
 
 	profiler.Service()
@@ -83,7 +80,7 @@ func main() {
 
 	repoSync := controllers.NewRepoSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
-		mgr.GetScheme(), allowVerticalScale)
+		mgr.GetScheme())
 	if err := repoSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", configsync.RepoSyncKind)
 		os.Exit(1)
@@ -91,7 +88,7 @@ func main() {
 
 	rootSync := controllers.NewRootSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(configsync.RootSyncKind),
-		mgr.GetScheme(), allowVerticalScale)
+		mgr.GetScheme())
 	if err := rootSync.SetupWithManager(mgr, watchFleetMembership); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", configsync.RootSyncKind)
 		os.Exit(1)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -223,19 +223,6 @@ func hasGeneration(generation int64) nomostest.Predicate {
 	}
 }
 
-func minReadySecondsIs(expectedMinReadySeconds int32) nomostest.Predicate {
-	return func(o client.Object) error {
-		d, ok := o.(*appsv1.Deployment)
-		if !ok {
-			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
-		}
-		if d.Spec.MinReadySeconds != expectedMinReadySeconds {
-			return fmt.Errorf("expected minReadySeconds: %d, got: %d", expectedMinReadySeconds, d.Spec.MinReadySeconds)
-		}
-		return nil
-	}
-}
-
 func firstContainerImageIs(image string) nomostest.Predicate {
 	return func(o client.Object) error {
 		d, ok := o.(*appsv1.Deployment)
@@ -618,46 +605,5 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 			hasGeneration(generation), firstContainerCPURequestIs(expectedFirstContainerCPU),
 			firstContainerMemoryRequestIs(expectedFirstContainerMemory), firstContainerMemoryLimitIs(expectedFirstContainerMemoryLimit),
 			firstContainerCPULimitIs(expectedFirstContainerCPULimit))
-	})
-
-}
-
-func TestAllowVerticalScaleResourceAdjustment(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.ACMController, ntopts.SkipMonoRepo)
-
-	reconcilerDeployment := &appsv1.Deployment{}
-	if err := nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, reconcilerDeployment); err != nil {
-		nt.T.Fatal(err)
-	}
-	rs := &v1beta1.RootSync{}
-	if err := nt.Get(configsync.RootSyncName, configsync.ControllerNamespace, rs); err != nil {
-		nt.T.Fatal(err)
-	}
-	initialGeneration := reconcilerDeployment.Generation
-
-	// allow vertical scale
-	_, err := nt.Kubectl("patch", "deployment", "reconciler-manager", "-n", "config-management-system", "-p", "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"args\":[\"--enable-leader-election\", \"--allow-vertical-scale\"],\"name\":\"reconciler-manager\"}]}}}}")
-	if err != nil {
-		nt.T.Fatalf("Error enabling vertical scale in deployment", err)
-	}
-
-	// update numbers are compliant with autopilot requirement
-	var updatedFirstContainerCPURequest int64 = 430
-	var updatedFirstContainerMemoryRequest int64 = 200
-	initialMinReadySeconds := reconcilerDeployment.Spec.MinReadySeconds
-
-	// simulating VPA update to deployment
-	// this will increment root-reconciler generation by 1
-	_, err = nt.Kubectl("patch", "deployment", "root-reconciler", "-n", "config-management-system", "-p", fmt.Sprintf("{\"spec\":{\"minReadySeconds\":25,\"template\":{\"spec\":{\"containers\":[{\"name\":\"%s\",\"resources\":{\"requests\":{\"cpu\":\"%dm\",\"memory\":\"%dMi\"}}}]}}}}", "hydration-controller", updatedFirstContainerCPURequest, updatedFirstContainerMemoryRequest))
-	if err != nil {
-		nt.T.Fatalf("Error simulating VPA deployment update", err)
-	}
-
-	// update to container resource CPU and memory should be maintained, others (i.e minReadySeconds) will be reverted back
-	// the minReadySeconds reversal will increment root-reconciler generation by 1
-	nomostest.Wait(nt.T, "Waiting for deployment update", nt.DefaultWaitTimeout, func() error {
-		return nt.Validate("root-reconciler", v1.NSConfigManagementSystem, &appsv1.Deployment{},
-			hasGeneration(initialGeneration+2), firstContainerCPURequestIs(updatedFirstContainerCPURequest),
-			firstContainerMemoryRequestIs(updatedFirstContainerMemoryRequest), minReadySecondsIs(initialMinReadySeconds))
 	})
 }

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -77,9 +77,6 @@ const (
 	// StatusMode is to control if the kpt applier needs to inject the actuation data
 	// into the ResourceGroup object.
 	StatusMode = "STATUS_MODE"
-
-	// AllowVerticalScale indicates that resources will be managed by VPA
-	AllowVerticalScale = "ALLOW_VERTICAL_SCALE"
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -76,7 +76,6 @@ type reconcilerBase struct {
 	reconcilerPollingPeriod time.Duration
 	hydrationPollingPeriod  time.Duration
 	membership              *hubv1.Membership
-	allowVerticalScale      bool
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string
@@ -209,15 +208,12 @@ func (r *reconcilerBase) createOrPatchDeployment(ctx context.Context, declared *
 		r.isAutopilotCluster = &isAutopilot
 	}
 
-	adjusted, err := adjustContainerResources(r.allowVerticalScale, *r.isAutopilotCluster, declared, current)
+	adjusted, err := adjustContainerResources(*r.isAutopilotCluster, declared, current)
 	if err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 	if adjusted {
-		mutator := "VPA"
-		if !r.allowVerticalScale {
-			mutator = "Autopilot"
-		}
+		mutator := "Autopilot"
 		r.log.V(3).Info("Managed object container resources updated",
 			logFieldObject, dRef.String(),
 			logFieldKind, kind,
@@ -254,24 +250,16 @@ func (r *reconcilerBase) createOrPatchDeployment(ctx context.Context, declared *
 
 // adjustContainerResources adjusts the resources of all containers in the declared Deployment.
 // It returns a boolean to indicate if the declared Deployment is updated or not.
-// This function aims to address the fight among Autopilot, VPA and the reconciler since they all update the resources.
+// This function aims to address the fight among Autopilot and the reconciler since they all update the resources.
 // Below is the resolution:
-// 1. If --allow-vertical-scale flag is enabled (no matter if it is a standard cluster or an Autopilot cluster),
-//	use the current resources and ignore the override defined in the declared Deployment
-//	because VPA will scale up and down automatically.
 //
-// 2. If --allow-vertical-scale flag is not enabled, and the cluster is a standard cluster, the controller
-//	will adjust the declared resources by applying the resource override.
+//  1. If  the cluster is a standard cluster, the controller
+//     will adjust the declared resources by applying the resource override.
 //
-// 3. If --allow-vertical-scale flag is not enabled, and it is an Autopilot cluster, the controller will
-//	honor the resource override, but update the declared resources to be compliant
-//	with the Autopilot resource range constraints.
-func adjustContainerResources(allowVerticalScale, isAutopilot bool, declared, current *appsv1.Deployment) (bool, error) {
-	// If --allow-vertical-scale flag is enabled, use the current resources because VPA takes full control of them.
-	if allowVerticalScale {
-		return keepCurrentContainerResources(declared, current), nil
-	}
-
+//  2. If it is an Autopilot cluster, the controller will
+//     honor the resource override, but update the declared resources to be compliant
+//     with the Autopilot resource range constraints.
+func adjustContainerResources(isAutopilot bool, declared, current *appsv1.Deployment) (bool, error) {
 	// If it is NOT an Autopilot cluster, use the declared Deployment without adjustment.
 	if !isAutopilot {
 		return false, nil

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -69,7 +69,7 @@ type RepoSyncReconciler struct {
 }
 
 // NewRepoSyncReconciler returns a new RepoSyncReconciler.
-func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme, allowVerticalScale bool) *RepoSyncReconciler {
+func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
 	return &RepoSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
@@ -79,7 +79,6 @@ func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
 			syncKind:                configsync.RepoSyncKind,
-			allowVerticalScale:      allowVerticalScale,
 		},
 		repoSyncs: make(map[types.NamespacedName]struct{}),
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -72,7 +72,6 @@ const (
 var filesystemPollingPeriod time.Duration
 var hydrationPollingPeriod time.Duration
 var nsReconcilerName = core.NsReconcilerName(reposyncNs, reposyncName)
-var allowVerticalScale = false
 
 var parsedDeployment = func(de *appsv1.Deployment) error {
 	de.TypeMeta = fake.ToTypeMeta(kinds.Deployment())
@@ -273,7 +272,6 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 		fakeClient,
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		fakeClient.Scheme(),
-		allowVerticalScale,
 	)
 	return fakeClient, testReconciler
 }
@@ -2697,72 +2695,6 @@ func TestRepoSyncReconcileStaleClientCache(t *testing.T) {
 	require.NotNilf(t, reconcilingCondition, "status: %+v", rs.Status)
 	require.Equal(t, reconcilingCondition.Status, metav1.ConditionTrue, "unexpected Stalled condition status")
 	require.Contains(t, reconcilingCondition.Message, "RepoSyncs must specify spec.git when spec.sourceType is \"git\"", "unexpected Stalled condition message")
-}
-
-func TestUpdateReconcilerWithAllowVerticalScale(t *testing.T) {
-	// Mock out parseDeployment for testing.
-	parseDeployment = parsedDeployment
-
-	rs := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
-	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	// mock allow vertical scale setting
-	allowVerticalScale = true
-	fakeClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
-
-	// Test creating Deployment resources.
-	ctx := context.Background()
-	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
-		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
-	}
-	repoDeployment := repoSyncDeployment(
-		nsReconcilerName,
-		setServiceAccountName(nsReconcilerName),
-	)
-
-	updatedCPU := "249m"
-	updatedMemory := "259Mi"
-	deploymentCoreObject := fakeClient.Objects[core.IDOf(repoDeployment)]
-	updatedDeployment := deploymentCoreObject.(*appsv1.Deployment)
-	containerName := updatedDeployment.Spec.Template.Spec.Containers[0].Name
-	var updatedReplica int32 = 20
-	*updatedDeployment.Spec.Replicas = updatedReplica
-	// mock VPA behavior of changing deployment resources
-	updatedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse(updatedCPU),
-		corev1.ResourceMemory: resource.MustParse(updatedMemory),
-	}
-
-	if err := fakeClient.Update(ctx, updatedDeployment); err != nil {
-		t.Fatalf("failed to update the repo sync request, got error: %v", err)
-	}
-	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
-		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
-	}
-
-	// when allow vertical scale is enabled, original deployment resource should not be updated
-	// other updated deployment should be reverted
-	expectedResource := []v1beta1.ContainerResourcesSpec{
-		{
-			ContainerName: containerName,
-			CPURequest:    resource.MustParse(updatedCPU),
-			MemoryRequest: resource.MustParse(updatedMemory),
-		},
-	}
-
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
-	repoDeployment2 := repoSyncDeployment(
-		nsReconcilerName,
-		setServiceAccountName(nsReconcilerName),
-		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
-		containerResourcesMutator(expectedResource),
-		containerEnvMutator(repoContainerEnv),
-	)
-
-	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment2): repoDeployment2}
-	if err := validateDeployments(wantDeployments, fakeClient); err != nil {
-		t.Errorf("Deployment validation failed. err: %v", err)
-	}
-	allowVerticalScale = false
 }
 
 func TestPopulateRepoContainerEnvs(t *testing.T) {

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -77,7 +77,7 @@ type RootSyncReconciler struct {
 }
 
 // NewRootSyncReconciler returns a new RootSyncReconciler.
-func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme, allowVerticalScale bool) *RootSyncReconciler {
+func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
 	return &RootSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
@@ -87,7 +87,6 @@ func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
 			syncKind:                configsync.RootSyncKind,
-			allowVerticalScale:      allowVerticalScale,
 		},
 	}
 }


### PR DESCRIPTION
VPA isn't updating deployment and update the pods directly. We need to revert allowVerticalScale flag addition and revert the e2e test because they don't resemble how VPA works

https://github.com/GoogleContainerTools/kpt-config-sync/pull/20 was the original PR