### PR TITLE
Add retries to mitigate the flakiness

### DIFF
--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -479,11 +479,16 @@ func TestLargeCRD(t *testing.T) {
 	nt.WaitForRepoSyncs()
 	nt.RenewClient()
 
-	err := nt.Validate("challenges.acme.cert-manager.io", "", fake.CustomResourceDefinitionV1Object())
+	_, err := nomostest.Retry(30*time.Second, func() error {
+		return nt.Validate("challenges.acme.cert-manager.io", "", fake.CustomResourceDefinitionV1Object())
+	})
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate("solrclouds.solr.apache.org", "", fake.CustomResourceDefinitionV1Object())
+
+	_, err = nomostest.Retry(30*time.Second, func() error {
+		return nt.Validate("solrclouds.solr.apache.org", "", fake.CustomResourceDefinitionV1Object())
+	})
 	if err != nil {
 		nt.T.Fatal(err)
 	}


### PR DESCRIPTION
The flakiness of `TestLargeCRD` was identified while working on https://github.com/GoogleContainerTools/kpt-config-sync/pull/215: 

https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/pr-logs/pull/GoogleContainerTools_kpt-config-sync/215/kpt-config-sync-presubmit-e2e-mono-repo-test-group2/1582107528844546048 