### PR TITLE
Update a test git repository

### DIFF
--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -72,7 +72,7 @@ func TestSyncingThroughAProxy(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(nomostest.RemoteRootRepoSha1Fn),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "foo-corp"}))
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "hierarchical-format/config"}))
 }
 
 func hasReadyReplicas(replicas int32) nomostest.Predicate {

--- a/e2e/testdata/proxy/proxy-enabled.yaml
+++ b/e2e/testdata/proxy/proxy-enabled.yaml
@@ -20,9 +20,9 @@ metadata:
 spec:
   sourceFormat: "hierarchy"
   git:
-    repo: https://github.com/GoogleCloudPlatform/csp-config-management/
-    branch: 1.0.0
-    dir: "foo-corp"
+    repo: https://github.com/GoogleCloudPlatform/anthos-config-management-samples
+    branch: main
+    dir: "hierarchical-format/config"
     auth: ssh
     secretRef:
       name: git-creds

--- a/e2e/testdata/reconciler-manager/rootsync-sample.yaml
+++ b/e2e/testdata/reconciler-manager/rootsync-sample.yaml
@@ -20,9 +20,9 @@ metadata:
 spec:
   sourceFormat: "hierarchy"
   git:
-    repo: https://github.com/GoogleCloudPlatform/csp-config-management/
-    branch: 1.0.0
-    dir: "foo-corp"
+    repo: https://github.com/GoogleCloudPlatform/anthos-config-management-samples
+    branch: main
+    dir: "hierarchical-format/config"
     auth: ssh
     secretRef:
       name: root-ssh-key


### PR DESCRIPTION
The proxy test uses an archived Git repository, which includes a PSP resource whose API was removed from Kubernetes 1.25. This results in a test failure in the rapid channel:
https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/multi-repo-7-standard-rapid-latest/1582080124612775936.

This commit replaces the archived test repo with the official example.