### PR TITLE
add new operator/oss build manifest targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,9 @@ lint-license: pull-buildenv buildenv-dirs
 "$(GOBIN)/addlicense":
 	go install github.com/google/addlicense@v1.0.0
 
+"$(GOBIN)/kustomize":
+	go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
+
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"
 	"$(GOBIN)/addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE -ignore=vendor/** -ignore=third_party/** . 2>&1 | sed '/ skipping: / d'

--- a/Makefile.build
+++ b/Makefile.build
@@ -49,7 +49,12 @@ build-cli: pull-buildenv buildenv-dirs
 		$(PLATFORMS)
 
 # Build Config Sync docker images
-build-images: license
+.PHONY: build-images
+build-images: build-images-monorepo build-images-multirepo
+
+# Build Config Sync docker images for monorepo mode
+.PHONY: build-images-monorepo
+build-images-monorepo: license
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
 	@echo "+++ Building the nomos image: $(NOMOS_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
@@ -58,6 +63,10 @@ build-images: license
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
+
+# Build Config Sync docker images for multirepo mode
+.PHONY: build-images-multirepo
+build-images-multirepo: license
 	@echo "+++ Building the Reconciler image: $(RECONCILER_TAG)"
 	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_IMAGE) \
@@ -113,12 +122,23 @@ build-images: license
 image-nomos: build-images
 
 # Pushes Config Sync docker images to REGISTRY.
-push-images:
+.PHONY: push-images
+push-images: push-images-monorepo push-images-multirepo
+
+.PHONY: push-images-monorepo
+push-images-monorepo:
 	@echo "+++ Pushing Config Sync images to $(REGISTRY)"
 	@echo "+++ Using account:"
 	gcloud config get-value account
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
 	docker push $(NOMOS_TAG)
+
+.PHONY: push-images-multirepo
+push-images-multirepo:
+	@echo "+++ Pushing Config Sync images to $(REGISTRY)"
+	@echo "+++ Using account:"
+	gcloud config get-value account
+	@gcloud $(GCLOUD_QUIET) auth configure-docker
 	docker push $(RECONCILER_TAG)
 	docker push $(RECONCILER_MANAGER_TAG)
 	docker push $(ADMISSION_WEBHOOK_TAG)
@@ -133,7 +153,17 @@ push-to-gcr-nomos: push-images
 
 # Pulls all Config Sync images from REGISTRY
 .PHONY: pull-images
-pull-images:
+pull-images: pull-images-monorepo pull-images-multirepo
+
+# Pulls monorepo Config Sync images from REGISTRY
+.PHONY: pull-images-monorepo
+pull-images-monorepo:
+	@echo "+++ Pulling Config Sync images from $(REGISTRY)"
+	docker pull $(NOMOS_TAG)
+
+# Pulls multirepo Config Sync images from REGISTRY
+.PHONY: pull-images-multirepo
+pull-images-multirepo:
 	@echo "+++ Pulling Config Sync images from $(REGISTRY)"
 	docker pull $(NOMOS_TAG)
 	docker pull $(RECONCILER_TAG)
@@ -149,9 +179,18 @@ pull-config-sync-images: pull-images
 
 # Retags previously built Config Sync images
 .PHONY: retag-images
-retag-images:
+retag-images: retag-images-monorepo retag-images-multirepo
+
+# Retags previously built Config Sync images for monorepo mode
+.PHONY: retag-images-monorepo
+retag-images-monorepo:
 	@echo "+++ Retagging Config Sync images from $(OLD_REGISTRY)/*:$(OLD_IMAGE_TAG) to $(REGISTRY)/*:$(IMAGE_TAG)"
 	docker tag $(OLD_REGISTRY)/$(NOMOS_IMAGE):$(OLD_IMAGE_TAG) $(NOMOS_TAG)
+
+# Retags previously built Config Sync images for multirepo mode
+.PHONY: retag-images-multirepo
+retag-images-multirepo:
+	@echo "+++ Retagging Config Sync images from $(OLD_REGISTRY)/*:$(OLD_IMAGE_TAG) to $(REGISTRY)/*:$(IMAGE_TAG)"
 	docker tag $(OLD_REGISTRY)/$(RECONCILER_IMAGE):$(OLD_IMAGE_TAG) $(RECONCILER_TAG)
 	docker tag $(OLD_REGISTRY)/$(RECONCILER_MANAGER_IMAGE):$(OLD_IMAGE_TAG) $(RECONCILER_MANAGER_TAG)
 	docker tag $(OLD_REGISTRY)/$(ADMISSION_WEBHOOK_IMAGE):$(OLD_IMAGE_TAG) $(ADMISSION_WEBHOOK_TAG)
@@ -222,7 +261,7 @@ $(GEN_DEPLOYMENT_DIR)/reconciler-manager.yaml: \
 		manifests/templates/reconciler-manager.yaml
 	@echo "+++ Generating yaml $@"
 	@mkdir -p $(dir $@)
-	@sed -e 's|IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|' < $< > $@
+	@sed -e 's|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|' < $< > $@
 
 .PHONY: $(GEN_DEPLOYMENT_DIR)/otel-collector.yaml
 $(GEN_DEPLOYMENT_DIR)/otel-collector.yaml: \
@@ -236,7 +275,7 @@ $(GEN_DEPLOYMENT_DIR)/admission-webhook.yaml: \
 		manifests/templates/admission-webhook.yaml
 	@echo "+++ Generating yaml $@"
 	@mkdir -p $(dir $@)
-	@sed -e 's|IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|' < $< > $@
+	@sed -e 's|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|' < $< > $@
 
 ###################################
 # Config Sync manifest
@@ -272,6 +311,64 @@ build-manifests: __config-sync-manifest
 	@echo "+++ Add separate acm-psp.yaml manifest so it can be applied independently"
 	rsync \
 		.output/manifests/acm-psp.yaml ${OSS_MANIFEST_STAGING_DIR}/acm-psp.yaml
+
+# Build Config Sync manifests for OSS installations
+.PHONY: build-manifests-oss
+build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
+	@ echo "+++ Generating manifests in $(OSS_MANIFEST_STAGING_DIR)"
+	@ echo "    Using these tags:"
+	@ echo "    $(RECONCILER_MANAGER_IMAGE): $(RECONCILER_MANAGER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_IMAGE): $(HYDRATION_CONTROLLER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_WITH_SHELL_IMAGE): $(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
+	@ echo "    $(RECONCILER_IMAGE): $(RECONCILER_TAG)"
+	@ echo "    $(ADMISSION_WEBHOOK_IMAGE): $(ADMISSION_WEBHOOK_TAG)"
+	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
+	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
+	@ rm -f $(OSS_MANIFEST_STAGING_DIR)/*
+	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/oss \
+		| sed \
+			-e "s|RECONCILER_IMAGE_NAME|$(RECONCILER_TAG)|g" \
+			-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_SYNC_TAG)|g" \
+			-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_SYNC_TAG)|g" \
+			-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HYDRATION_CONTROLLER_TAG)|g" \
+			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|g" \
+		> $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+	@ "$(GOBIN)/addlicense" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+
+	@ # Additional optional OSS manifests
+	@ rsync \
+		.output/manifests/acm-psp.yaml $(OSS_MANIFEST_STAGING_DIR)/acm-psp.yaml
+	@ cat "manifests/templates/admission-webhook.yaml" \
+		| sed -e "s|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|g" \
+		> $(OSS_MANIFEST_STAGING_DIR)/admission-webhook.yaml
+
+	@ echo "+++ Manifests generated in $(OSS_MANIFEST_STAGING_DIR)"
+
+# Build Config Sync manifests for ACM operator
+.PHONY: build-manifests-operator
+build-manifests-operator: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
+	@ echo "+++ Generating manifests in $(NOMOS_MANIFEST_STAGING_DIR)"
+	@ echo "    Using these tags:"
+	@ echo "    $(RECONCILER_MANAGER_IMAGE): $(RECONCILER_MANAGER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_IMAGE): $(HYDRATION_CONTROLLER_TAG)"
+	@ echo "    $(HYDRATION_CONTROLLER_WITH_SHELL_IMAGE): $(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
+	@ echo "    $(RECONCILER_IMAGE): $(RECONCILER_TAG)"
+	@ echo "    $(ADMISSION_WEBHOOK_IMAGE): $(ADMISSION_WEBHOOK_TAG)"
+	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
+	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
+	@ rm -f $(NOMOS_MANIFEST_STAGING_DIR)/*
+	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/operator \
+		| sed \
+			-e "s|RECONCILER_IMAGE_NAME|$(RECONCILER_TAG)|g" \
+			-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_SYNC_TAG)|g" \
+			-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_SYNC_TAG)|g" \
+			-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HYDRATION_CONTROLLER_TAG)|g" \
+			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|g" \
+			-e "s|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|g" \
+		> $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+	@ "$(GOBIN)/addlicense" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+
+	@ echo "+++ Manifests generated in $(NOMOS_MANIFEST_STAGING_DIR)"
 
 # Deprecated alias of build-manifests. Remove this once unused.
 .PHONY: __config-sync-manifest-oss

--- a/e2e/nomostest/config-sync.go
+++ b/e2e/nomostest/config-sync.go
@@ -351,6 +351,7 @@ func installationManifests(nt *NT, tmpManifestsDir string, nomos ntopts.Nomos) [
 		case "reconciler-manager.yaml":
 			// For the reconciler manager template, we want the latest image for the reconciler manager.
 			imgName = fmt.Sprintf("%s/reconciler-manager:%s", *e2e.ImagePrefix, *e2e.ImageTag)
+			replaced = strings.ReplaceAll(replaced, "RECONCILER_MANAGER_IMAGE_NAME", imgName)
 		case "reconciler-manager-configmap.yaml":
 			// For the reconciler deployment template, we want the latest image for the reconciler and hydration-controller.
 			reconcilerImgName := fmt.Sprintf("%s/reconciler:%s", *e2e.ImagePrefix, *e2e.ImageTag)
@@ -363,12 +364,10 @@ func installationManifests(nt *NT, tmpManifestsDir string, nomos ntopts.Nomos) [
 			replaced = strings.ReplaceAll(replaced, "HELM_SYNC_IMAGE_NAME", helmSyncImgName)
 		case "admission-webhook.yaml":
 			imgName = fmt.Sprintf("%s/admission-webhook:%s", *e2e.ImagePrefix, *e2e.ImageTag)
+			replaced = strings.ReplaceAll(replaced, "WEBHOOK_IMAGE_NAME", imgName)
 		default:
 			// For any other template, we want the latest image for the nomos binary (mono-repo).
 			imgName = fmt.Sprintf("%s/nomos:%s", *e2e.ImagePrefix, *e2e.ImageTag)
-		}
-
-		if template != "reconciler-manager-configmap.yaml" {
 			replaced = strings.ReplaceAll(replaced, "IMAGE_NAME", imgName)
 		}
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- ../cluster-selector-crd.yaml
+- ../cluster-registry-crd.yaml
+- ../container-default-limits.yaml
+- ../namespace-selector-crd.yaml
+- ../ns-reconciler-cluster-role.yaml
+- ../otel-agent-cm.yaml
+- ../reconciler-manager-service-account.yaml
+- ../reposync-crd.yaml
+- ../rootsync-crd.yaml
+- ../templates/otel-collector.yaml
+- ../templates/reconciler-manager.yaml
+- ../templates/reconciler-manager-configmap.yaml

--- a/manifests/operator/kustomization.yaml
+++ b/manifests/operator/kustomization.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- ../base
+- ../acm-psp.yaml
+- ../templates/admission-webhook.yaml

--- a/manifests/oss/kustomization.yaml
+++ b/manifests/oss/kustomization.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- ../base
+- ../test-resources/00-namespace.yaml
+- ../test-resources/resourcegroup-manifest.yaml

--- a/manifests/templates/admission-webhook.yaml
+++ b/manifests/templates/admission-webhook.yaml
@@ -39,7 +39,7 @@ spec:
         - /admission-webhook
         - --graceful-shutdown-timeout=10s
         - --health-probe-bind-addr=:10258
-        image: IMAGE_NAME
+        image: WEBHOOK_IMAGE_NAME
         ports:
           - name: admission
             containerPort: 10250

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - /reconciler-manager
         args:
         - --enable-leader-election
-        image: IMAGE_NAME
+        image: RECONCILER_MANAGER_IMAGE_NAME
         name: reconciler-manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
This change adds two new targets for building operator/oss manifests using kustomize. The move to kustomize is intended to improve readability of the manifest scaffolding.

A critical difference of the new build-manifests-operator target is that it only builds manifests for the multirepo mode. This is in preparation of migrating the legacy monorepo code to a separate repository. Since this will be a breaking change, it is implemented as a new make target. The old manifest related targets will be cleaned up and refactored once the monorepo migration is complete.