### PR TITLE
exclude monitor and git-importer from oss manifest

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -289,6 +289,8 @@ build-manifests: __config-sync-manifest
 	mkdir -p $(OUTPUT_DIR)/oss/cloned
 	rsync \
 		--exclude='admission-webhook.yaml' \
+		--exclude='git-importer.yaml' \
+		--exclude='monitor.yaml' \
 		.output/deployment/* .output/oss/cloned/deployment/
 	rsync \
 		--exclude='acm-psp.yaml' \


### PR DESCRIPTION
these are deployments for monorepo mode and do not belong in the OSS/multirepo deployment.

This is already handled in the new make targets, but this fixes the old make target in the meantime.