### PR TITLE
Skip validating non-central root reconciler Pods in validateMultiRepoPods

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -60,8 +60,8 @@ func installGitServer(nt *NT) func() error {
 	for _, o := range objs {
 		err := nt.Create(o)
 		if err != nil {
-			nt.T.Fatalf("installing %v %s", o.GetObjectKind().GroupVersionKind(),
-				client.ObjectKey{Name: o.GetName(), Namespace: o.GetNamespace()})
+			nt.T.Fatalf("installing %v %s: %v", o.GetObjectKind().GroupVersionKind(),
+				client.ObjectKey{Name: o.GetName(), Namespace: o.GetNamespace()}, err)
 		}
 	}
 


### PR DESCRIPTION
Some tests failed with a namespace reconciler Pod not found error, e.g. https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/multi-repo-7-standard-stable/1583109762550075392. The root cause is that the ValidateMultiRepoDeployments function validates the Pods after the Deployment objects are ready. When validating the Pods, it checks all Pods in the c-m-s namespace, but when validating the Deployments, it only checks the default root reconciler and other controllers. It is possible that the namespace reconciler Deployment is not available yet, which results in validation error for the corresponding Pod.

This commit adds the namespace reconciler Deployment to the validation list.

It also adds the error to the log when the git-server fails to be installed:
https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/stress-test/1581530245859643392.