### PR TITLE
GOPATH explicit setting

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+GOPATH="${GOPATH:-$HOME/go}"
+
 PLATFORMS=()
 VERSION=""
 while [[ $# -gt 0 ]]; do

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-GOPATH="${GOPATH:-$HOME/go}"
+GOPATH="${GOPATH:-$(go env GOPATH)}"
 
 PLATFORMS=()
 VERSION=""

--- a/scripts/generate-clientset.sh
+++ b/scripts/generate-clientset.sh
@@ -31,7 +31,7 @@
 
 set -euox pipefail
 
-GOPATH="${GOPATH:-$HOME/go}"
+GOPATH="${GOPATH:-$(go env GOPATH)}"
 
 NOMOS_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 

--- a/scripts/generate-clientset.sh
+++ b/scripts/generate-clientset.sh
@@ -31,6 +31,8 @@
 
 set -euox pipefail
 
+GOPATH="${GOPATH:-$HOME/go}"
+
 NOMOS_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # The tool doesn't gracefully handle multiple GOPATH values, so this will get


### PR DESCRIPTION
When using zsh as your default shell the GOPATH variables do not get set.

Example of how to set unset variables in bash is taken from here: 
https://unix.stackexchange.com/questions/594841/how-do-i-assign-a-value-to-a-bash-variable-if-that-variable-is-null-unassigned-f

If we do not have this a zsh user gets the following output:
```
λ make clientgen
+++ Generating clientgen directory
./scripts/generate-clientset.sh
++ dirname ./scripts/generate-clientset.sh
+ NOMOS_ROOT=./scripts/..
./scripts/generate-clientset.sh: line 38: GOPATH: unbound variable
make: *** [Makefile.gen:22: clientgen] Error 1
```

Meanwhile the variables are set:
```
λ set | grep GO 
GOBIN=/usr/local/google/home/mikebz/go/bin
GOPATH=/usr/local/google/home/mikebz/go
```

