### PR TITLE
add support for shared kind clusters

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -47,10 +47,10 @@ var GceNode = flag.Bool("gcenode", false,
 
 // Debug enables running the test in debug mode.
 // In debug mode:
-// 1) Test execution immediately stops on a call to t.Fatal.
-// 2) The test prints the absolute path to the test temporary directory, and
-//      not delete it.
-// 3) The test prints out how to connect to the kind cluster.
+//  1. Test execution immediately stops on a call to t.Fatal.
+//  2. The test prints the absolute path to the test temporary directory, and
+//     not delete it.
+//  3. The test prints out how to connect to the kind cluster.
 var Debug = flag.Bool("debug", false,
 	"If true, do not destroy cluster and clean up temporary directory after test.")
 
@@ -137,10 +137,14 @@ const (
 	CSR = "csr"
 )
 
+// NumParallel returns the number of parallel test threads
+func NumParallel() int {
+	return flag.Lookup("test.parallel").Value.(flag.Getter).Get().(int)
+}
+
 // RunInParallel indicates whether the test is running in parallel.
 func RunInParallel() bool {
-	parallel := flag.Lookup("test.parallel").Value.(flag.Getter).Get().(int)
-	return parallel > 1
+	return NumParallel() > 1
 }
 
 // EnableParallel allows parallel execution of test functions that call t.Parallel

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -155,7 +155,14 @@ func New(t *testing.T, testFeature nomostesting.Feature, ntOptions ...ntopts.Opt
 	e2e.EnableParallel(t)
 	tw := nomostesting.New(t, testFeature)
 
+	if *e2e.ShareTestEnv {
+		sharedNt := SharedNT(tw)
+		t.Logf("using shared test env %s", sharedNt.ClusterName)
+		ntOptions = append(ntOptions, ntopts.WithRestConfig(sharedNt.Config))
+	}
+
 	optsStruct := newOptStruct(TestClusterName(tw), TestDir(tw), tw, ntOptions...)
+
 	if *e2e.ShareTestEnv {
 		return SharedTestEnv(tw, optsStruct)
 	}
@@ -166,7 +173,7 @@ func New(t *testing.T, testFeature nomostesting.Feature, ntOptions ...ntopts.Opt
 func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	t.Helper()
 
-	sharedNt := SharedNT()
+	sharedNt := SharedNT(t)
 	nt := &NT{
 		Context:                 sharedNt.Context,
 		T:                       t,
@@ -180,8 +187,8 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		DefaultMetricsTimeout:   sharedNt.DefaultMetricsTimeout,
 		kubeconfigPath:          sharedNt.kubeconfigPath,
 		MultiRepo:               sharedNt.MultiRepo,
-		ReconcilerPollingPeriod: sharedNT.ReconcilerPollingPeriod,
-		HydrationPollingPeriod:  sharedNT.HydrationPollingPeriod,
+		ReconcilerPollingPeriod: sharedNt.ReconcilerPollingPeriod,
+		HydrationPollingPeriod:  sharedNt.HydrationPollingPeriod,
 		RootRepos:               sharedNt.RootRepos,
 		NonRootRepos:            make(map[types.NamespacedName]*Repository),
 		gitPrivateKeyPath:       sharedNt.gitPrivateKeyPath,
@@ -191,8 +198,8 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		otelCollectorPort:       sharedNt.otelCollectorPort,
 		otelCollectorPodName:    sharedNt.otelCollectorPodName,
 		ReconcilerMetrics:       make(testmetrics.ConfigSyncMetrics),
-		GitProvider:             sharedNT.GitProvider,
-		RemoteRepositories:      sharedNT.RemoteRepositories,
+		GitProvider:             sharedNt.GitProvider,
+		RemoteRepositories:      sharedNt.RemoteRepositories,
 		WebhookDisabled:         sharedNt.WebhookDisabled,
 	}
 

--- a/e2e/nomostest/ntopts/kind.go
+++ b/e2e/nomostest/ntopts/kind.go
@@ -114,7 +114,7 @@ func newKind(t testing.NTB, name, tmpDir string, version KindVersion) string {
 	kcfgPath := filepath.Join(tmpDir, Kubeconfig)
 
 	start := time.Now()
-	t.Logf("started creating cluster at %s", start.Format(time.RFC3339))
+	t.Logf("started creating cluster %s at %s", name, start.Format(time.RFC3339))
 
 	err := createKindCluster(p, name, kcfgPath, version)
 	creationSuccessful := err == nil

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -103,6 +103,13 @@ func WithInitialCommit(initialCommit Commit) func(opt *New) {
 	}
 }
 
+// WithRestConfig uses the provided rest.Config
+func WithRestConfig(restConfig *rest.Config) Opt {
+	return func(opt *New) {
+		opt.RESTConfig = restConfig
+	}
+}
+
 // SkipConfigSyncInstall skip installation of Config Sync components in cluster
 func SkipConfigSyncInstall(opt *New) {
 	opt.SkipConfigSyncInstall = true

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -37,13 +37,13 @@ func TestMain(m *testing.M) {
 	rand.Seed(time.Now().UnixNano())
 
 	if *e2e.ShareTestEnv {
-		if e2e.RunInParallel() {
-			fmt.Println("The test cannot use a shared test environment if it is running in parallel")
+		if *e2e.TestCluster == e2e.GKE && e2e.RunInParallel() {
+			fmt.Println("The test cannot use a shared test environment if it is running in parallel on GKE")
 			os.Exit(1)
 		}
-		sharedNT := nomostest.NewSharedNT()
+		nomostest.InitSharedEnvironments()
 		exitCode := m.Run()
-		nomostest.Clean(sharedNT, false)
+		nomostest.CleanSharedNTs()
 		os.Exit(exitCode)
 	} else {
 		os.Exit(m.Run())

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -193,7 +193,7 @@ func resetReconcilerDeploymentManifests(nt *nomostest.NT, origImg string, genera
 	nt.T.Log("Reset the Deployment manifest in the ConfigMap")
 	var originalManifestFile string
 	if *e2e.ShareTestEnv {
-		originalManifestFile = filepath.Join(nomostest.SharedNT().TmpDir, nomostest.Manifests, "reconciler-manager-configmap.yaml")
+		originalManifestFile = filepath.Join(nomostest.SharedNT(nt.T).TmpDir, nomostest.Manifests, "reconciler-manager-configmap.yaml")
 	} else {
 		originalManifestFile = filepath.Join(nt.TmpDir, nomostest.Manifests, "reconciler-manager-configmap.yaml")
 	}


### PR DESCRIPTION
this change adds support to run kind clusters with a shared test environment. This can be run either sequentially or in parallel. The clusters are created at the beginning of the suite, reused between tests, and deleted at the end of the suite.

This is intended to:
- Speed up the presubmit jobs by reducing time spent creating kind clusters
- Make it easier to run tests with a shared test environment (e.g. reproducing test cleanup issues locally)
- Shift-left the shared environment testing to the presubmits so issues with test cleanup can be found before reaching periodics

It occurred to me while implementing this that we could use the same approach for the GKE testing, where we treat a set of GKE clusters as a shared pool in the tests. This approach could potentially replace the test group configuration, which would simplify the prow configuration. For now this does not make any changes to how GKE shared tests are run.