### PR TITLE
remove async reconciler status updates

### DIFF
--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -60,9 +60,6 @@ type opts struct {
 	// objects in Git.
 	converter *declared.ValueConverter
 
-	// reconciling indicates whether the reconciler is reconciling a change.
-	reconciling bool
-
 	// mux prevents status update conflicts.
 	mux *sync.Mutex
 
@@ -77,10 +74,6 @@ type Parser interface {
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
 	SetSyncStatus(ctx context.Context, errs status.MultiError) error
 	options() *opts
-	// SetReconciling sets the field indicating whether the reconciler is reconciling a change.
-	SetReconciling(value bool)
-	// Reconciling returns whether the reconciler is reconciling a change.
-	Reconciling() bool
 	// ApplierErrors returns the errors surfaced by the applier.
 	ApplierErrors() status.MultiError
 	// RemediatorConflictErrors returns the conflict errors detected by the remediator.
@@ -95,12 +88,4 @@ func (o *opts) k8sClient() client.Client {
 
 func (o *opts) discoveryClient() discovery.ServerResourcer {
 	return o.discoveryInterface
-}
-
-func (o *opts) SetReconciling(value bool) {
-	o.reconciling = value
-}
-
-func (o *opts) Reconciling() bool {
-	return o.reconciling
 }

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -114,11 +114,6 @@ func Run(ctx context.Context, p Parser) {
 }
 
 func run(ctx context.Context, p Parser, trigger string, state *reconcilerState) {
-	p.SetReconciling(true)
-	defer func() {
-		p.SetReconciling(false)
-	}()
-
 	var syncDir cmpath.Absolute
 	gs := sourceStatus{}
 	gs.commit, syncDir, gs.errs = hydrate.SourceCommitAndDir(p.options().SourceType, p.options().SourceDir, p.options().SyncDir, p.options().reconcilerName)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -15,7 +15,6 @@
 package reconciler
 
 import (
-	"context"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -220,40 +219,9 @@ func Run(opts Options) {
 	// Start the Remediator (non-blocking).
 	rem.Start(ctx)
 
-	// Create a new context with its cancellation function.
-	ctxForUpdateStatus, cancel := context.WithCancel(context.Background())
-
-	go updateStatus(ctxForUpdateStatus, parser)
-
 	// Start the Parser (blocking).
 	// This will not return until:
 	// - the Context is cancelled, or
 	// - its Done channel is closed.
 	parse.Run(ctx, parser)
-
-	// This is to terminate `updateSyncStatus`.
-	cancel()
-}
-
-// updateStatus update the status periodically until the cancellation function of the context is called.
-func updateStatus(ctx context.Context, p parse.Parser) {
-	updatePeriod := 5 * time.Second
-	updateTimer := time.NewTimer(updatePeriod)
-	defer updateTimer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			// ctx.Done() is closed when the cancellation function of the context is called.
-			return
-		case <-updateTimer.C:
-			if !p.Reconciling() {
-				if err := p.SetSyncStatus(ctx, p.ApplierErrors()); err != nil {
-					klog.Warningf("failed to update remediator errors: %v", err)
-				}
-				parse.UpdateConflictManagerStatus(ctx, p.RemediatorConflictErrors(), p.K8sClient())
-			}
-			// else if `p.Reconciling` is true, `parse.Run` will update the status periodically.
-			updateTimer.Reset(updatePeriod)
-		}
-	}
 }


### PR DESCRIPTION
this async status update was leading to unpredictable behavior where Syncing conditions set by other statuses (e.g. Rendering) were being overwritten. This made it so that the Conditions for such errors would be transient. There is another async status update inside of the parseAndUpdate function which should handle real time updates for the applier.

This is the root cause of the TestHydrateKustomizeComponents test flake that we've observed.