### PR TITLE
Remove unused UpstreamRepoURL from e2e tests

### DIFF
--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -37,11 +37,9 @@ import (
 )
 
 const (
-	// remoteUpstream git upstream repository
-	remoteUpstream = "upstream"
-
 	// remoteOrigin is static as every git repository has exactly one remote.
 	remoteOrigin = "origin"
+
 	// MainBranch is static as behavior when switching branches is never under
 	// test.
 	MainBranch = "main"
@@ -101,9 +99,6 @@ type Repository struct {
 	// It is used to set the url for the remote origin using `git remote add origin <REMOTE_URL>.
 	RemoteURL string
 
-	// UpstreamRepoURL is the URL of the seed repo
-	UpstreamRepoURL string
-
 	// Scheme used for encoding and decoding objects.
 	Scheme *runtime.Scheme
 }
@@ -112,7 +107,7 @@ type Repository struct {
 // Locally, it writes the repository to `tmpdir`/repos/`name`.
 //
 // The repo name is in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
-func NewRepository(nt *NT, repoType RepoType, nn types.NamespacedName, upstream string, sourceFormat filesystem.SourceFormat) *Repository {
+func NewRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *Repository {
 	nt.T.Helper()
 
 	namespacedName := nn.String()
@@ -140,7 +135,6 @@ func NewRepository(nt *NT, repoType RepoType, nn types.NamespacedName, upstream 
 	}
 	g.RemoteRepoName = repoName
 	g.RemoteURL = nt.GitProvider.RemoteURL(nt.gitRepoPort, repoName)
-	g.UpstreamRepoURL = upstream
 
 	g.init(nt.gitPrivateKeyPath)
 	g.initialCommit(sourceFormat)
@@ -234,13 +228,6 @@ func (g *Repository) init(privateKey string) {
 		fmt.Sprintf("ssh -q -o StrictHostKeyChecking=no -i %s", privateKey))
 	// Point the origin remote
 	g.Git("remote", "add", remoteOrigin, g.RemoteURL)
-
-	if g.UpstreamRepoURL != "" {
-		// Point the origin remote
-		g.Git("remote", "add", remoteUpstream, g.UpstreamRepoURL)
-		g.Git("fetch", remoteUpstream)
-		g.Git("merge", "upstream/"+MainBranch)
-	}
 }
 
 // Add writes a YAML or JSON representation of obj to `path` in the git

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -63,7 +63,7 @@ func NewOptStruct(testName, tmpDir string, t nomostesting.NTB, ntOptions ...ntop
 		},
 		MultiRepo: ntopts.MultiRepo{
 			NamespaceRepos: make(map[types.NamespacedName]ntopts.RepoOpts),
-			RootRepos:      map[string]ntopts.RepoOpts{configsync.RootSyncName: {UpstreamURL: ""}},
+			RootRepos:      map[string]ntopts.RepoOpts{configsync.RootSyncName: {}},
 		},
 	}
 	for _, opt := range ntOptions {
@@ -226,7 +226,7 @@ func resetSyncedRepos(nt *NT, opts *ntopts.New) {
 		nnList := nt.NonRootRepos
 		// clear the namespace resources in the namespace repo to avoid admission validation failure.
 		resetNamespaceRepos(nt)
-		resetRootRepos(nt, opts.UpstreamURL, opts.SourceFormat)
+		resetRootRepos(nt, opts.SourceFormat)
 
 		deleteRootRepos(nt)
 		deleteNamespaceRepos(nt)
@@ -251,7 +251,7 @@ func resetSyncedRepos(nt *NT, opts *ntopts.New) {
 		// else ignore, reset, and wait for sync
 
 		nt.NonRootRepos = map[types.NamespacedName]*Repository{}
-		nt.RootRepos[configsync.RootSyncName] = resetRepository(nt, RootRepo, DefaultRootRepoNamespacedName, opts.UpstreamURL, opts.SourceFormat)
+		nt.RootRepos[configsync.RootSyncName] = resetRepository(nt, RootRepo, DefaultRootRepoNamespacedName, opts.SourceFormat)
 		// It sets POLICY_DIR to always be `acme` because the initial mono-repo's sync directory is configured to be `acme`.
 		ResetMonoRepoSpec(nt, opts.SourceFormat, MainBranch, AcmeDir)
 		nt.WaitForRepoSyncs()
@@ -392,10 +392,10 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 	}
 
 	for name := range opts.RootRepos {
-		nt.RootRepos[name] = resetRepository(nt, RootRepo, RootSyncNN(name), opts.UpstreamURL, opts.SourceFormat)
+		nt.RootRepos[name] = resetRepository(nt, RootRepo, RootSyncNN(name), opts.SourceFormat)
 	}
 	for nsr := range opts.NamespaceRepos {
-		nt.NonRootRepos[nsr] = resetRepository(nt, NamespaceRepo, nsr, opts.NamespaceRepos[nsr].UpstreamURL, filesystem.SourceFormatUnstructured)
+		nt.NonRootRepos[nsr] = resetRepository(nt, NamespaceRepo, nsr, filesystem.SourceFormatUnstructured)
 	}
 
 	if opts.InitialCommit != nil {

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -20,11 +20,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// RepoOpts defines options for a Repo
-type RepoOpts struct {
-	// UpstreamURL provides the upstream repo to initialize the repo with
-	UpstreamURL string
-}
+// RepoOpts defines options for a Repository.
+// Add options as-needed for tests.
+type RepoOpts struct{}
 
 // MultiRepo configures the NT for use with multi-repo tests.
 // If NonRootRepos is non-empty, the test is assumed to be running in
@@ -70,7 +68,7 @@ func NamespaceRepo(ns, name string) func(opt *New) {
 			Namespace: ns,
 			Name:      name,
 		}
-		opt.NamespaceRepos[nn] = RepoOpts{UpstreamURL: ""}
+		opt.NamespaceRepos[nn] = RepoOpts{}
 	}
 }
 
@@ -78,26 +76,7 @@ func NamespaceRepo(ns, name string) func(opt *New) {
 // that points at the provided Repository.
 func RootRepo(name string) func(opt *New) {
 	return func(opt *New) {
-		opt.RootRepos[name] = RepoOpts{UpstreamURL: ""}
-	}
-}
-
-// NamespaceRepoWithUpstream tells the test case that a Namespace Repo should be configured
-// that points at the provided Repository.
-func NamespaceRepoWithUpstream(ns, name string, upstreamURL string) func(opt *New) {
-	return func(opt *New) {
-		nn := types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		}
-		opt.NamespaceRepos[nn] = RepoOpts{UpstreamURL: upstreamURL}
-	}
-}
-
-// UpstreamRepo tells the test case that an Upstream Repo should be used to seed the test repo
-func UpstreamRepo(upstreamURL string) func(opt *New) {
-	return func(opt *New) {
-		opt.UpstreamURL = upstreamURL
+		opt.RootRepos[name] = RepoOpts{}
 	}
 }
 

--- a/e2e/nomostest/ntopts/nomos.go
+++ b/e2e/nomostest/ntopts/nomos.go
@@ -25,9 +25,6 @@ type Nomos struct {
 	// MultiRepo indicates that NT should setup and test multi-repo behavior
 	// rather than mono-repo behavior.
 	MultiRepo bool
-
-	// UpstreamURL upstream URL of repo we need to use for seeding
-	UpstreamURL string
 }
 
 // Unstructured will set the option for unstructured repo.

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -86,12 +86,12 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	if nt.GitProvider.Type() == e2e.Local {
 		nomostest.InitGitRepos(nt, newRepos...)
 	}
-	rr2Repo := nomostest.NewRepository(nt, nomostest.RootRepo, nomostest.RootSyncNN(rr2), "", filesystem.SourceFormatUnstructured)
-	rr3Repo := nomostest.NewRepository(nt, nomostest.RootRepo, nomostest.RootSyncNN(rr3), "", filesystem.SourceFormatUnstructured)
-	nn2Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn2, "", filesystem.SourceFormatUnstructured)
-	nn3Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn3, "", filesystem.SourceFormatUnstructured)
-	nn4Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn4, "", filesystem.SourceFormatUnstructured)
-	nn5Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn5, "", filesystem.SourceFormatUnstructured)
+	rr2Repo := nomostest.NewRepository(nt, nomostest.RootRepo, nomostest.RootSyncNN(rr2), filesystem.SourceFormatUnstructured)
+	rr3Repo := nomostest.NewRepository(nt, nomostest.RootRepo, nomostest.RootSyncNN(rr3), filesystem.SourceFormatUnstructured)
+	nn2Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn2, filesystem.SourceFormatUnstructured)
+	nn3Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn3, filesystem.SourceFormatUnstructured)
+	nn4Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn4, filesystem.SourceFormatUnstructured)
+	nn5Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn5, filesystem.SourceFormatUnstructured)
 
 	nt.T.Logf("Add RootSync %s to the repository of RootSync %s", rr2, configsync.RootSyncName)
 	nt.RootRepos[rr2] = rr2Repo


### PR DESCRIPTION
This feature of the Repository abstraction was designed to allow changing the upstream git repo. It's not clear it it was once used, but it's not used now and if you tried to use it, it probably wouldn't work, because the reset code doesn't handle changing it. So we can just delete it to clean up the code a bit. And if we need it later (unlikely) we can add it back after the reset code is rewritten to be simpler/cleaner.
