### PR TITLE
Add reconciler finalizer to optionally destroy user objects

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -480,6 +480,17 @@ func (nt *NT) Kubectl(args ...string) ([]byte, error) {
 	return exec.Command("kubectl", args...).CombinedOutput()
 }
 
+// KubectlContext is similar to nt.Kubectl but allows using a context to cancel
+// (kill signal) the kubectl command.
+func (nt *NT) KubectlContext(ctx context.Context, args ...string) ([]byte, error) {
+	nt.T.Helper()
+
+	prefix := []string{"--kubeconfig", nt.kubeconfigPath}
+	args = append(prefix, args...)
+	nt.DebugLogf("kubectl %s", strings.Join(args, " "))
+	return exec.CommandContext(ctx, "kubectl", args...).CombinedOutput()
+}
+
 // Command is a convenience method for invoking a subprocess with the
 // KUBECONFIG environment variable set. Setting the environment variable
 // directly in the test process is not thread safe.

--- a/e2e/nomostest/policy/reposync.go
+++ b/e2e/nomostest/policy/reposync.go
@@ -15,6 +15,7 @@
 package policy
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -34,6 +35,16 @@ func RBACAdmin() rbacv1.PolicyRule {
 func CoreAdmin() rbacv1.PolicyRule {
 	policy := rbacv1.PolicyRule{
 		APIGroups: []string{corev1.GroupName},
+		Resources: []string{rbacv1.ResourceAll},
+		Verbs:     []string{rbacv1.VerbAll},
+	}
+	return policy
+}
+
+// AppsAdmin returns a PolicyRule that grants admin for appsv1 APIGroup
+func AppsAdmin() rbacv1.PolicyRule {
+	policy := rbacv1.PolicyRule{
+		APIGroups: []string{appsv1.GroupName},
 		Resources: []string{rbacv1.ResourceAll},
 		Verbs:     []string{rbacv1.VerbAll},
 	}

--- a/e2e/nomostest/predicates.go
+++ b/e2e/nomostest/predicates.go
@@ -685,3 +685,27 @@ func RepoSyncHasSyncError(nt *NT, errCode, errMessage string) Predicate {
 		return validateError(rs.Status.Sync.Errors, errCode, errMessage)
 	}
 }
+
+// HasFinalizer returns a predicate that tests that an Object has the specified finalizer.
+func HasFinalizer(name string) Predicate {
+	return func(o client.Object) error {
+		for _, finalizer := range o.GetFinalizers() {
+			if finalizer == name {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected finalizer %q not found", name)
+	}
+}
+
+// MissingFinalizer returns a predicate that tests that an Object does NOT have the specified finalizer.
+func MissingFinalizer(name string) Predicate {
+	return func(o client.Object) error {
+		for _, finalizer := range o.GetFinalizers() {
+			if finalizer == name {
+				return fmt.Errorf("expected finalizer %q to be missing", name)
+			}
+		}
+		return nil
+	}
+}

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	"kpt.dev/configsync/e2e/nomostest/policy"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -202,8 +203,11 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	repoSyncNN := nomostest.RepoSyncNN(testNs, "rs-test")
-	nt := nomostest.New(t, nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+	nt := nomostest.New(t,
+		nomostesting.MultiRepos,
+		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name),
+		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
+	)
 
 	rootRepo := nt.RootRepos[rootSyncNN.Name]
 	nsRepo := nt.NonRootRepos[repoSyncNN]
@@ -318,8 +322,11 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	repoSyncNN := nomostest.RepoSyncNN(testNs, "rs-test")
-	nt := nomostest.New(t, nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+	nt := nomostest.New(t,
+		nomostesting.MultiRepos,
+		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name),
+		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
+	)
 
 	rootRepo := nt.RootRepos[rootSyncNN.Name]
 	nsRepo := nt.NonRootRepos[repoSyncNN]

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -1,0 +1,664 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestReconcilerFinalizer_Orphan tests that the reconciler's finalizer
+// correctly handles Orphan deletion propagation.
+func TestReconcilerFinalizer_Orphan(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt := nomostest.New(t, nomostesting.MultiRepos)
+
+	rootRepo := nt.RootRepos[rootSyncNN.Name]
+	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: testNs}
+	namespace1NN := types.NamespacedName{Name: testNs}
+
+	nt.T.Cleanup(func() {
+		cleanupSingleLevel(nt, rootSyncNN, deployment1NN, namespace1NN)
+	})
+
+	// Add namespace to RootSync
+	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+	rootRepo.Add(nomostest.StructuredNSPath(namespace1NN.Name, namespace1NN.Name), namespace1)
+
+	// Add deployment-helloworld-1 to RootSync
+	deployment1Path := nomostest.StructuredNSPath(deployment1NN.Namespace, "deployment-helloworld-1")
+	rootRepo.Copy("../testdata/deployment-helloworld.yaml", deployment1Path)
+	deployment1 := rootRepo.Get(deployment1Path)
+	deployment1.SetName(deployment1NN.Name)
+	deployment1.SetNamespace(deployment1NN.Namespace)
+	rootRepo.Add(deployment1Path, deployment1)
+	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment1.GetName(), deployment1.GetNamespace())
+
+	// Tail reconciler logs and print if there's an error.
+	// This is necessary because if the RootSync are deleted, the
+	// normal Cleanup won't be able to find the reconciler.
+	// Start here to catch both the finalizer injection and deletion behavior.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+
+	nt.T.Log("Disabling RootSync deletion propagation")
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	err := nt.Get(rootSync.GetName(), rootSync.GetNamespace(), rootSync)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyOrphan) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), rootSync.GetName(), rootSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.MissingFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	// Delete the RootSync
+	// DeletePropagationBackground is required when deleting RootSync, to
+	// avoid causing the reconciler Deployment to be deleted before the RootSync
+	// finishes finalizing.
+	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nomostest.Wait(nt.T, fmt.Sprintf("%T %s finalization", rootSync, client.ObjectKeyFromObject(rootSync)), nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			// The RootSync should skip finalizing and be deleted immediately
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			// Namespace1 should NOT have been deleted, because it was orphaned by the RootSync.
+			errs = status.Append(errs, nt.Validate(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{},
+				nomostest.HasAllNomosMetadata())) // metadata NOT removed when orphaned
+			// Deployment1 should NOT have been deleted, because it was orphaned by the RootSync.
+			errs = status.Append(errs, nt.Validate(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{},
+				nomostest.HasAllNomosMetadata())) // metadata NOT removed when orphaned
+			return errs
+		},
+	)
+}
+
+// TestReconcilerFinalizer_Foreground tests that the reconciler's finalizer
+// correctly handles Foreground deletion propagation.
+func TestReconcilerFinalizer_Foreground(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt := nomostest.New(t, nomostesting.MultiRepos)
+
+	rootRepo := nt.RootRepos[rootSyncNN.Name]
+	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: testNs}
+	namespace1NN := types.NamespacedName{Name: testNs}
+
+	nt.T.Cleanup(func() {
+		cleanupSingleLevel(nt, rootSyncNN, deployment1NN, namespace1NN)
+	})
+
+	// Add namespace to RootSync
+	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+	rootRepo.Add(nomostest.StructuredNSPath(namespace1NN.Name, namespace1NN.Name), namespace1)
+
+	// Add deployment-helloworld-1 to RootSync
+	deployment1Path := nomostest.StructuredNSPath(deployment1NN.Namespace, "deployment-helloworld-1")
+	rootRepo.Copy("../testdata/deployment-helloworld.yaml", deployment1Path)
+	deployment1 := rootRepo.Get(deployment1Path)
+	deployment1.SetName(deployment1NN.Name)
+	deployment1.SetNamespace(deployment1NN.Namespace)
+	rootRepo.Add(deployment1Path, deployment1)
+	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment1.GetName(), deployment1.GetNamespace())
+
+	// Tail reconciler logs and print if there's an error.
+	// This is necessary because if the RootSync are deleted, the
+	// normal Cleanup won't be able to find the reconciler.
+	// Start here to catch both the finalizer injection and deletion behavior.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+
+	nt.T.Log("Enabling RootSync deletion propagation")
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	err := nt.Get(rootSync.Name, rootSync.Namespace, rootSync)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), rootSync.GetName(), rootSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.HasFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	// Delete the RootSync
+	// DeletePropagationBackground is required when deleting RootSync, to
+	// avoid causing the reconciler Deployment to be deleted before the RootSync
+	// finishes finalizing.
+	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nomostest.Wait(nt.T, fmt.Sprintf("%T %s finalization", rootSync, client.ObjectKeyFromObject(rootSync)), nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			// Deleting the RootSync should trigger the RootSync's finalizer to delete the Deployment1 and Namespace
+			errs = status.Append(errs, nt.ValidateNotFound(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{}))
+			errs = status.Append(errs, nt.ValidateNotFound(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{}))
+			// After Deployment1 is deleted, the RootSync should have its finalizer removed and be garbage collected
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			return errs
+		},
+	)
+}
+
+// TestReconcilerFinalizer_MultiLevelForeground tests that the reconciler's
+// finalizer correctly handles multiple layers of Foreground deletion propagation.
+func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	repoSyncNN := nomostest.RepoSyncNN(testNs, "rs-test")
+	nt := nomostest.New(t, nomostesting.MultiRepos,
+		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+
+	rootRepo := nt.RootRepos[rootSyncNN.Name]
+	nsRepo := nt.NonRootRepos[repoSyncNN]
+	repoSyncPath := nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name)
+	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: repoSyncNN.Namespace}
+	deployment2NN := types.NamespacedName{Name: "helloworld-2", Namespace: repoSyncNN.Namespace}
+	namespace1NN := types.NamespacedName{Name: repoSyncNN.Namespace}
+
+	nt.T.Cleanup(func() {
+		cleanupMultiLevel(nt,
+			rootSyncNN,
+			repoSyncNN,
+			deployment1NN,
+			deployment2NN,
+			namespace1NN)
+	})
+
+	// Namespace created for the RepoSync by test setup
+	namespace1 := rootRepo.Get(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Namespace))
+
+	// Add deployment-helloworld-1 to RootSync
+	deployment1Path := nomostest.StructuredNSPath(deployment1NN.Namespace, "deployment-helloworld-1")
+	rootRepo.Copy("../testdata/deployment-helloworld.yaml", deployment1Path)
+	deployment1 := rootRepo.Get(deployment1Path)
+	deployment1.SetName(deployment1NN.Name)
+	deployment1.SetNamespace(deployment1NN.Namespace)
+	rootRepo.Add(deployment1Path, deployment1)
+	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment1.GetName(), deployment1.GetNamespace())
+
+	// Add deployment-helloworld-2 to RepoSync
+	deployment2Path := nomostest.StructuredNSPath(deployment1NN.Namespace, "deployment-helloworld-2")
+	nsRepo.Copy("../testdata/deployment-helloworld.yaml", deployment2Path)
+	deployment2 := nsRepo.Get(deployment2Path)
+	deployment2.SetName(deployment2NN.Name)
+	deployment2.SetNamespace(deployment1NN.Namespace)
+	nsRepo.Add(deployment2Path, deployment2)
+	nsRepo.CommitAndPush("Adding deployment helloworld-2 to RepoSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment2.GetName(), deployment2.GetNamespace())
+
+	// Tail reconciler logs and print if there's an error.
+	// This is necessary because if the RootSync/RepoSync are deleted, the
+	// normal Cleanup won't be able to find the reconcilers.
+	// Start here to catch both the finalizer injection and deletion behavior.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+
+	nt.T.Log("Enabling RootSync deletion propagation")
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	err := nt.Get(rootSync.Name, rootSync.Namespace, rootSync)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), rootSync.GetName(), rootSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.HasFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	nt.T.Log("Enabling RepoSync deletion propagation")
+	repoSync := rootRepo.Get(repoSyncPath)
+	if setDeletionPropagationPolicy(repoSync, metadata.DeletionPropagationPolicyForeground) {
+		rootRepo.Add(repoSyncPath, repoSync)
+		rootRepo.CommitAndPush("Enabling RepoSync deletion propagation")
+		nt.WaitForRepoSyncs()
+	}
+	nomostest.WatchForObject(nt, kinds.RepoSyncV1Beta1(), repoSync.GetName(), repoSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.HasFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	// Delete the RootSync
+	// DeletePropagationBackground is required when deleting RootSync, to
+	// avoid causing the reconciler Deployment to be deleted before the RootSync
+	// finishes finalizing.
+	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nomostest.Wait(nt.T, fmt.Sprintf("%T %s finalization", rootSync, client.ObjectKeyFromObject(rootSync)), nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			// Deleting the RootSync should trigger the RootSync's finalizer to delete the RepoSync and Deployment1
+			errs = status.Append(errs, nt.ValidateNotFound(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{}))
+			// Deleting the RepoSync should trigger the RepoSync's finalizer to delete Deployment2
+			errs = status.Append(errs, nt.ValidateNotFound(deployment2.GetName(), deployment2.GetNamespace(), &appsv1.Deployment{}))
+			// After Deployment2 is deleted, the RepoSync should have its finalizer removed and be garbage collected
+			errs = status.Append(errs, nt.ValidateNotFound(repoSync.GetName(), repoSync.GetNamespace(), &v1beta1.RepoSync{}))
+			// After the RepoSync is gone, the garbage collector can finish finalizing the Namespace
+			errs = status.Append(errs, nt.ValidateNotFound(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{}))
+			// After RepoSync is deleted, the RootSync should have its finalizer removed and be garbage collected
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			return errs
+		},
+	)
+}
+
+// TestReconcilerFinalizer_MultiLevelMixed tests that the reconciler's finalizer
+// correctly handles multiple layers of deletion propagation.
+// The RootSync has Foreground policy, but manages a RepoSync with Orphan policy.
+func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	repoSyncNN := nomostest.RepoSyncNN(testNs, "rs-test")
+	nt := nomostest.New(t, nomostesting.MultiRepos,
+		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+
+	rootRepo := nt.RootRepos[rootSyncNN.Name]
+	nsRepo := nt.NonRootRepos[repoSyncNN]
+	repoSyncPath := nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name)
+	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: repoSyncNN.Namespace}
+	deployment2NN := types.NamespacedName{Name: "helloworld-2", Namespace: repoSyncNN.Namespace}
+	namespace1NN := types.NamespacedName{Name: repoSyncNN.Namespace}
+
+	nt.T.Cleanup(func() {
+		cleanupMultiLevel(nt,
+			rootSyncNN,
+			repoSyncNN,
+			deployment1NN,
+			deployment2NN,
+			namespace1NN)
+	})
+
+	// Add deployment-helloworld-1 to RootSync
+	deployment1Path := nomostest.StructuredNSPath(deployment2NN.Namespace, "deployment-helloworld-1")
+	rootRepo.Copy("../testdata/deployment-helloworld.yaml", deployment1Path)
+	deployment1 := rootRepo.Get(deployment1Path)
+	deployment1.SetName(deployment1NN.Name)
+	deployment1.SetNamespace(deployment2NN.Namespace)
+	rootRepo.Add(deployment1Path, deployment1)
+	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment1.GetName(), deployment1.GetNamespace())
+
+	// Add deployment-helloworld-2 to RepoSync
+	deployment2Path := nomostest.StructuredNSPath(deployment2NN.Namespace, "deployment-helloworld-2")
+	nsRepo.Copy("../testdata/deployment-helloworld.yaml", deployment2Path)
+	deployment2 := nsRepo.Get(deployment2Path)
+	deployment2.SetName(deployment2NN.Name)
+	deployment2.SetNamespace(deployment2NN.Namespace)
+	nsRepo.Add(deployment2Path, deployment2)
+	nsRepo.CommitAndPush("Adding deployment helloworld-2 to RepoSync")
+	nt.WaitForRepoSyncs()
+	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), deployment2.GetName(), deployment2.GetNamespace())
+
+	// Tail reconciler logs and print if there's an error.
+	// This is necessary because if the RootSync/RepoSync are deleted, the
+	// normal Cleanup won't be able to find the reconcilers.
+	// Start here to catch both the finalizer injection and deletion behavior.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+
+	nt.T.Log("Enabling RootSync deletion propagation")
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	err := nt.Get(rootSync.Name, rootSync.Namespace, rootSync)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), rootSync.GetName(), rootSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.HasFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	nt.T.Log("Disabling RepoSync deletion propagation")
+	repoSync := rootRepo.Get(repoSyncPath)
+	if removeDeletionPropagationPolicy(repoSync) {
+		rootRepo.Add(repoSyncPath, repoSync)
+		rootRepo.CommitAndPush("Disabling RepoSync deletion propagation")
+		nt.WaitForRepoSyncs()
+	}
+	nomostest.WatchForObject(nt, kinds.RepoSyncV1Beta1(), repoSync.GetName(), repoSync.GetNamespace(), []nomostest.Predicate{
+		nomostest.StatusEquals(nt, kstatus.CurrentStatus),
+		nomostest.MissingFinalizer(metadata.ReconcilerFinalizer),
+	})
+
+	// Abandon the test namespace, otherwise it will block the finalizer
+	namespace1Path := nomostest.StructuredNSPath(namespace1NN.Name, namespace1NN.Name)
+	namespace1 := rootRepo.Get(namespace1Path)
+	core.SetAnnotation(namespace1, common.LifecycleDeleteAnnotation, common.PreventDeletion)
+	rootRepo.Add(namespace1Path, namespace1)
+	rootRepo.CommitAndPush("Adding annotation to keep test namespace on removal from git")
+	nt.WaitForRepoSyncs()
+
+	// Delete the RootSync
+	// DeletePropagationBackground is required when deleting RootSync, to
+	// avoid causing the reconciler Deployment to be deleted before the RootSync
+	// finishes finalizing.
+	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nomostest.Wait(nt.T, fmt.Sprintf("%T %s finalization", rootSync, client.ObjectKeyFromObject(rootSync)), nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			// Deleting the RootSync should trigger the RootSync's finalizer to delete the RepoSync and Deployment1
+			errs = status.Append(errs, nt.ValidateNotFound(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{}))
+			// RepoSync should delete quickly without finalizing
+			errs = status.Append(errs, nt.ValidateNotFound(repoSync.GetName(), repoSync.GetNamespace(), &v1beta1.RepoSync{}))
+			// After RepoSync and Deployment1 are deleted, the RootSync should have its finalizer removed and be garbage collected
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			// Namespace1 should NOT have been deleted, because it was abandoned by the RootSync.
+			// TODO: Use NoConfigSyncMetadata predicate once metadata removal is fixed (b/256043590)
+			errs = status.Append(errs, nt.Validate(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{}))
+			// Deployment2 should NOT have been deleted, because it was orphaned by the RepoSync.
+			errs = status.Append(errs, nt.Validate(deployment2.GetName(), deployment2.GetNamespace(), &appsv1.Deployment{},
+				nomostest.HasAllNomosMetadata())) // metadata NOT removed when orphaned
+			return errs
+		},
+	)
+}
+
+// tailReconcilerLogs starts tailing a reconciler's logs.
+// The logs are stored in memory until either the context is cancelled or the
+// kubectl command exits (usually because the container exited).
+// This allows capturing logs even if the reconciler is deleted before the
+// test ends.
+// The logs will only be printed if the test has failed when the command exits.
+// Run in an goroutine to capture logs in the background while deleting RSyncs.
+func tailReconcilerLogs(ctx context.Context, nt *nomostest.NT, reconcilerNN types.NamespacedName) {
+	out, err := nt.KubectlContext(ctx, "logs",
+		fmt.Sprintf("deployment/%s", reconcilerNN.Name),
+		"-n", reconcilerNN.Namespace,
+		"-c", reconcilermanager.Reconciler,
+		"-f")
+	// Expect the logs to tail until the context is cancelled, or exit early if
+	// the reconciler container exited.
+	if err != nil && err.Error() != "signal: killed" {
+		// We're only using this for debugging, so don't trigger test failure.
+		nt.T.Logf("Failed to tail logs from reconciler %s: %v", reconcilerNN, err)
+	}
+	// Only print the logs if the test has failed
+	if nt.T.Failed() {
+		nt.T.Logf("Reconciler logs:\n%s", string(out))
+	}
+}
+
+func cleanupSingleLevel(nt *nomostest.NT, rootSyncNN, deployment1NN, namespace1NN types.NamespacedName) {
+	nt.T.Log("Stopping webhook")
+	// Stop webhook to avoid deletion prevention.
+	// Webhook will be re-enabled by test setup, if the next test needs it.
+	nomostest.StopWebhook(nt)
+
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	deployment1 := fake.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace))
+	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+
+	nt.T.Log("Resetting RootSync deletion propagation")
+	err := nt.Get(rootSync.Name, rootSync.Namespace, rootSync)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// ValidateMultiRepoDeployments called by WaitForRepoSyncs handles RootSync re-creation
+			return
+		}
+		nt.T.Fatal(err)
+	}
+	if removeDeletionPropagationPolicy(rootSync) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+
+	nt.T.Logf("Deleting RootSync %s", rootSyncNN)
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	// Delete Deployment 1
+	nt.T.Logf("Deleting Deployment %s", deployment1NN)
+	err = nt.Delete(deployment1, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	// Delete Namespace 1
+	nt.T.Logf("Deleting Namespace %s", namespace1NN)
+	err = nt.Delete(namespace1, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	nomostest.Wait(nt.T, "test cleanup", nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			errs = status.Append(errs, nt.ValidateNotFound(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{}))
+			errs = status.Append(errs, nt.ValidateNotFound(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{}))
+			return errs
+		},
+	)
+}
+
+func cleanupMultiLevel(nt *nomostest.NT, rootSyncNN, repoSyncNN, deployment1NN, deployment2NN, namespace1NN types.NamespacedName) {
+	nt.T.Log("Stopping webhook")
+	// Stop webhook to avoid deletion prevention.
+	// Webhook will be re-enabled by test setup, if the next test needs it.
+	nomostest.StopWebhook(nt)
+
+	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	repoSync := fake.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	deployment1 := fake.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace))
+	deployment2 := fake.DeploymentObject(core.Name(deployment2NN.Name), core.Namespace(deployment2NN.Namespace))
+	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+
+	nt.T.Log("Resetting RootSync deletion propagation")
+	err := nt.Get(rootSync.Name, rootSync.Namespace, rootSync)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// ValidateMultiRepoDeployments called by WaitForRepoSyncs handles RootSync re-creation
+			return
+		}
+		nt.T.Fatal(err)
+	}
+	if removeDeletionPropagationPolicy(rootSync) {
+		err = nt.Update(rootSync)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+
+	nt.T.Logf("Deleting RootSync %s", rootSyncNN)
+	err = nt.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	nt.T.Log("Resetting RepoSync deletion propagation")
+	err = nt.Get(repoSync.Name, repoSync.Namespace, repoSync)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	} else if removeDeletionPropagationPolicy(repoSync) {
+		err = nt.Update(repoSync)
+		if err != nil {
+			nt.T.Error(err)
+		}
+	}
+
+	nt.T.Logf("Deleting RepoSync %s", repoSyncNN)
+	err = nt.Delete(repoSync, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	// Delete Deployment 1
+	nt.T.Logf("Deleting Deployment %s", deployment1NN)
+	err = nt.Delete(deployment1, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	// Delete Deployment 2
+	nt.T.Logf("Deleting Deployment %s", deployment2NN)
+	err = nt.Delete(deployment2, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	// Delete Namespace 1
+	nt.T.Logf("Deleting Namespace %s", namespace1NN)
+	err = nt.Delete(namespace1, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	}
+
+	nomostest.Wait(nt.T, "test cleanup", nt.DefaultWaitTimeout,
+		func() error {
+			var errs status.MultiError
+			errs = status.Append(errs, nt.ValidateNotFound(rootSync.GetName(), rootSync.GetNamespace(), &v1beta1.RootSync{}))
+			errs = status.Append(errs, nt.ValidateNotFound(repoSync.GetName(), repoSync.GetNamespace(), &v1beta1.RepoSync{}))
+			errs = status.Append(errs, nt.ValidateNotFound(deployment1.GetName(), deployment1.GetNamespace(), &appsv1.Deployment{}))
+			errs = status.Append(errs, nt.ValidateNotFound(deployment2.GetName(), deployment2.GetNamespace(), &appsv1.Deployment{}))
+			errs = status.Append(errs, nt.ValidateNotFound(namespace1.GetName(), namespace1.GetNamespace(), &corev1.Namespace{}))
+			return errs
+		},
+	)
+}
+
+// rootReconcilerObjectKey returns an ObjectKey for interacting with the
+// RootReconciler for the specified RootSync.
+func rootReconcilerObjectKey(syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.RootReconcilerName(syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}
+
+// nsReconcilerObjectKey returns an ObjectKey for interacting with the
+// NsReconciler for the specified RepoSync.
+func nsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.NsReconcilerName(namespace, syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}
+
+func setDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
+	annotations := obj.GetAnnotations()
+	if len(annotations) == 0 {
+		annotations = map[string]string{}
+	} else if val, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; found && val == string(policy) {
+		return false
+	}
+	annotations[metadata.DeletionPropagationPolicyAnnotationKey] = string(policy)
+	obj.SetAnnotations(annotations)
+	return true
+}
+
+func removeDeletionPropagationPolicy(obj client.Object) bool {
+	annotations := obj.GetAnnotations()
+	if len(annotations) == 0 {
+		return false
+	}
+	if _, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; !found {
+		return false
+	}
+	delete(annotations, metadata.DeletionPropagationPolicyAnnotationKey)
+	obj.SetAnnotations(annotations)
+	return true
+}

--- a/manifests/ns-reconciler-cluster-role.yaml
+++ b/manifests/ns-reconciler-cluster-role.yaml
@@ -22,10 +22,10 @@ metadata:
 rules:
 - apiGroups: ["configsync.gke.io"]
   resources: ["reposyncs"]
-  verbs: ["get"]
+  verbs: ["get","list","watch","update","patch"]
 - apiGroups: ["configsync.gke.io"]
   resources: ["reposyncs/status"]
-  verbs: ["get","list","update"]
+  verbs: ["get","list","watch","update","patch"]
 - apiGroups: ["kpt.dev"]
   resources: ["resourcegroups"]
   verbs: ["*"]

--- a/pkg/api/configsync/v1beta1/reposync_types.go
+++ b/pkg/api/configsync/v1beta1/reposync_types.go
@@ -106,6 +106,10 @@ const (
 	RepoSyncStalled RepoSyncConditionType = "Stalled"
 	// RepoSyncSyncing means that the namespace reconciler is processing a hash (git commit hash or OCI image digest).
 	RepoSyncSyncing RepoSyncConditionType = "Syncing"
+	// RepoSyncReconcilerFinalizing means that the namespace reconciler finalizer is processing deletion of managed resources.
+	RepoSyncReconcilerFinalizing RepoSyncConditionType = "ReconcilerFinalizing"
+	// RepoSyncReconcilerFinalizerFailure means that the namespace reconciler finalizer has errored, blocking deletion.
+	RepoSyncReconcilerFinalizerFailure RepoSyncConditionType = "ReconcilerFinalizerFailure"
 )
 
 // ErrorSource indicates the origination of errors.

--- a/pkg/api/configsync/v1beta1/rootsync_types.go
+++ b/pkg/api/configsync/v1beta1/rootsync_types.go
@@ -106,6 +106,10 @@ const (
 	RootSyncStalled RootSyncConditionType = "Stalled"
 	// RootSyncSyncing means that the root reconciler is processing a hash (git commit hash or OCI image digest).
 	RootSyncSyncing RootSyncConditionType = "Syncing"
+	// RootSyncReconcilerFinalizing means that the root reconciler finalizer is processing deletion of managed resources.
+	RootSyncReconcilerFinalizing RootSyncConditionType = "ReconcilerFinalizing"
+	// RootSyncReconcilerFinalizerFailure means that the root reconciler finalizer has errored, blocking deletion.
+	RootSyncReconcilerFinalizerFailure RootSyncConditionType = "ReconcilerFinalizerFailure"
 )
 
 // RootSyncCondition describes the state of a RootSync at a certain point.

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -551,14 +551,22 @@ func (a *supervisor) applyInner(ctx context.Context, objs []client.Object) (map[
 			if e.WaitEvent.Status == event.ReconcilePending {
 				klog.V(4).Info(e.WaitEvent)
 			} else {
-				klog.Info(e.WaitEvent)
+				klog.V(1).Info(e.WaitEvent)
 			}
 			a.addError(processWaitEvent(e.WaitEvent, s.WaitEvent, objStatusMap))
 		case event.ApplyType:
-			klog.Info(e.ApplyEvent)
+			if e.ApplyEvent.Error != nil {
+				klog.Info(e.ApplyEvent)
+			} else {
+				klog.V(1).Info(e.ApplyEvent)
+			}
 			a.addError(processApplyEvent(ctx, e.ApplyEvent, s.ApplyEvent, objStatusMap, unknownTypeResources))
 		case event.PruneType:
-			klog.Info(e.PruneEvent)
+			if e.PruneEvent.Error != nil {
+				klog.Info(e.PruneEvent)
+			} else {
+				klog.V(1).Info(e.PruneEvent)
+			}
 			a.addError(a.processPruneEvent(ctx, e.PruneEvent, s.PruneEvent, objStatusMap))
 		default:
 			klog.Infof("Unhandled event (%s): %v", e.Type, e)
@@ -663,11 +671,15 @@ func (a *supervisor) destroyInner(ctx context.Context) status.MultiError {
 			if e.WaitEvent.Status == event.ReconcilePending {
 				klog.V(4).Info(e.WaitEvent)
 			} else {
-				klog.Info(e.WaitEvent)
+				klog.V(1).Info(e.WaitEvent)
 			}
 			a.addError(processWaitEvent(e.WaitEvent, s.WaitEvent, objStatusMap))
 		case event.DeleteType:
-			klog.Info(e.DeleteEvent)
+			if e.DeleteEvent.Error != nil {
+				klog.Info(e.DeleteEvent)
+			} else {
+				klog.V(1).Info(e.DeleteEvent)
+			}
 			a.addError(a.processDeleteEvent(ctx, e.DeleteEvent, s.DeleteEvent, objStatusMap))
 		default:
 			klog.Infof("Unhandled event (%s): %v", e.Type, e)

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -211,7 +211,6 @@ func wrapInventoryObj(obj *unstructured.Unstructured) (*live.InventoryResourceGr
 
 func processApplyEvent(ctx context.Context, e event.ApplyEvent, s *stats.ApplyEventStats, objectStatusMap ObjectStatusMap, unknownTypeResources map[core.ID]struct{}) status.Error {
 	id := idFrom(e.Identifier)
-	klog.V(4).Infof("apply %v for object: %v", e.Status, id)
 	s.Add(e.Status)
 
 	objectStatus, ok := objectStatusMap[id]
@@ -254,10 +253,6 @@ func processApplyEvent(ctx context.Context, e event.ApplyEvent, s *stats.ApplyEv
 
 func processWaitEvent(e event.WaitEvent, s *stats.WaitEventStats, objectStatusMap ObjectStatusMap) error {
 	id := idFrom(e.Identifier)
-	if e.Status != event.ReconcilePending {
-		// Don't log pending. It's noisy and only fires in certain conditions.
-		klog.V(4).Infof("Reconcile %v: %v", e.Status, id)
-	}
 	s.Add(e.Status)
 
 	objectStatus, ok := objectStatusMap[id]
@@ -310,7 +305,6 @@ func handleApplySkippedEvent(obj *unstructured.Unstructured, id core.ID, err err
 // processPruneEvent handles PruneEvents from the Applier
 func (a *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, s *stats.PruneEventStats, objectStatusMap ObjectStatusMap) status.Error {
 	id := idFrom(e.Identifier)
-	klog.V(4).Infof("prune %v for object: %v", e.Status, id)
 	s.Add(e.Status)
 
 	objectStatus, ok := objectStatusMap[id]
@@ -348,7 +342,6 @@ func (a *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, 
 // processDeleteEvent handles DeleteEvents from the Destroyer
 func (a *supervisor) processDeleteEvent(ctx context.Context, e event.DeleteEvent, s *stats.DeleteEventStats, objectStatusMap ObjectStatusMap) status.Error {
 	id := idFrom(e.Identifier)
-	klog.V(4).Infof("delete %v for object: %v", e.Status, id)
 	s.Add(e.Status)
 
 	objectStatus, ok := objectStatusMap[id]

--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -45,6 +45,12 @@ func PruneErrorForResource(err error, id core.ID) status.Error {
 	return applierErrorBuilder.Wrap(fmt.Errorf("failed to prune %v: %w", id, err)).Build()
 }
 
+// DeleteErrorForResource indicates that the applier failed to delete
+// the given resource.
+func DeleteErrorForResource(err error, id core.ID) status.Error {
+	return applierErrorBuilder.Wrap(fmt.Errorf("failed to delete %v: %w", id, err)).Build()
+}
+
 // SkipErrorForResource indicates that the applier skipped apply or delete of
 // the given resource.
 func SkipErrorForResource(err error, id core.ID, strategy actuation.ActuationStrategy) status.Error {

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -251,7 +251,7 @@ func TestApply(t *testing.T) {
 				// TODO: Add tests to cover disabling objects
 				// TODO: Add tests to cover status mode
 			}
-			applier, err := NewNamespaceApplier(cs, "test-namespace", "rs", 5*time.Minute)
+			applier, err := NewNamespaceSupervisor(cs, "test-namespace", "rs", 5*time.Minute)
 			require.NoError(t, err)
 
 			gvks, errs := applier.Apply(context.Background(), objs)
@@ -450,7 +450,7 @@ func TestProcessPruneEvent(t *testing.T) {
 	s := stats.NewSyncStats()
 	objStatusMap := make(ObjectStatusMap)
 	cs := &ClientSet{}
-	applier := &applier{
+	applier := &supervisor{
 		clientSet: cs,
 	}
 

--- a/pkg/applier/destroyer_test.go
+++ b/pkg/applier/destroyer_test.go
@@ -1,0 +1,263 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applier
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/kpt/pkg/live"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/status"
+	testingfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
+	"sigs.k8s.io/cli-utils/pkg/apply"
+	applyerror "sigs.k8s.io/cli-utils/pkg/apply/error"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/filter"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeKptDestroyer struct {
+	events []event.Event
+}
+
+func newFakeKptDestroyer(events []event.Event) *fakeKptDestroyer {
+	return &fakeKptDestroyer{
+		events: events,
+	}
+}
+
+func (a *fakeKptDestroyer) Run(_ context.Context, _ inventory.Info, _ apply.DestroyerOptions) <-chan event.Event {
+	events := make(chan event.Event, len(a.events))
+	go func() {
+		for _, e := range a.events {
+			events <- e
+		}
+		close(events)
+	}()
+	return events
+}
+
+func TestDestroy(t *testing.T) {
+	deploymentObj := newDeploymentObj()
+	deploymentObj.SetName("deployment-1")
+	deploymentID := object.UnstructuredToObjMetadata(deploymentObj)
+
+	deployment2Obj := newDeploymentObj()
+	deployment2Obj.SetName("deployment-2")
+	deployment2ID := object.UnstructuredToObjMetadata(deployment2Obj)
+
+	testObj := newTestObj()
+	testID := object.UnstructuredToObjMetadata(testObj)
+
+	namespaceObj := fake.UnstructuredObject(kinds.Namespace(),
+		core.Name("test-namespace"))
+	namespaceID := object.UnstructuredToObjMetadata(namespaceObj)
+
+	uid := core.ID{
+		GroupKind: live.ResourceGroupGVK.GroupKind(),
+		ObjectKey: client.ObjectKey{
+			Name:      "rs",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Use sentinel errors so erors.Is works for comparison.
+	testError1 := errors.New("test error 1")
+	testError2 := errors.New("test error 2")
+	etcdError := errors.New("etcdserver: request is too large") // satisfies util.IsRequestTooLargeError
+
+	testcases := []struct {
+		name     string
+		events   []event.Event
+		multiErr error
+	}{
+		{
+			name: "unknown type for some resource",
+			events: []event.Event{
+				formDeleteEvent(event.DeleteFailed, &testID, applyerror.NewUnknownTypeError(testError1)),
+				formDeleteEvent(event.DeletePending, nil, nil),
+			},
+			multiErr: newMultiError(DeleteErrorForResource(testError1, idFrom(testID))),
+		},
+		{
+			name: "conflict error for some resource",
+			events: []event.Event{
+				formDeleteSkipEvent(testID, testObj.DeepCopy(), &inventory.PolicyPreventedActuationError{
+					Strategy: actuation.ActuationStrategyDelete,
+					Policy:   inventory.PolicyMustMatch,
+					Status:   inventory.NoMatch,
+				}),
+				formDeleteEvent(event.DeletePending, nil, nil),
+			},
+			// Prunes and Deletes ignore PolicyPreventedActuationErrors.
+			// This allows abandoning of managed objects.
+			multiErr: nil,
+		},
+		{
+			name: "inventory object is too large",
+			events: []event.Event{
+				formErrorEvent(etcdError),
+			},
+			multiErr: newMultiError(largeResourceGroupError(etcdError, uid)),
+		},
+		{
+			name: "failed to delete",
+			events: []event.Event{
+				formDeleteEvent(event.DeleteFailed, &testID, testError1),
+				formDeleteEvent(event.DeletePending, nil, nil),
+			},
+			multiErr: newMultiError(DeleteErrorForResource(testError1, idFrom(testID))),
+		},
+		{
+			name: "skipped delete",
+			events: []event.Event{
+				formDeleteEvent(event.DeleteSuccessful, &testID, nil),
+				formDeleteEvent(event.DeleteSkipped, &namespaceID, &filter.NamespaceInUseError{
+					Namespace: "test-namespace",
+				}),
+				formDeleteEvent(event.DeleteSuccessful, nil, nil),
+			},
+			multiErr: newMultiError(SkipErrorForResource(
+				errors.New("namespace still in use: test-namespace"),
+				idFrom(namespaceID),
+				actuation.ActuationStrategyDelete)),
+		},
+		{
+			name: "all passed",
+			events: []event.Event{
+				formDeleteEvent(event.DeletePending, nil, nil),
+				formDeleteEvent(event.DeleteSuccessful, &testID, nil),
+				formDeleteEvent(event.DeleteSuccessful, &deploymentID, nil),
+			},
+		},
+		{
+			name: "all failed",
+			events: []event.Event{
+				formDeleteEvent(event.DeletePending, nil, nil),
+				formDeleteEvent(event.DeleteFailed, &testID, testError1),
+				formDeleteEvent(event.DeleteFailed, &deploymentID, testError2),
+			},
+			multiErr: newMultiError(
+				DeleteErrorForResource(testError1, idFrom(testID)),
+				DeleteErrorForResource(testError2, idFrom(deploymentID))),
+		},
+		{
+			name: "failed dependency during delete",
+			events: []event.Event{
+				formDeleteSkipEventWithDependent(deploymentObj.DeepCopy(), deployment2Obj.DeepCopy()),
+			},
+			multiErr: newMultiError(
+				SkipErrorForResource(
+					&filter.DependencyPreventedActuationError{
+						Object:                  deploymentID,
+						Strategy:                actuation.ActuationStrategyDelete,
+						Relationship:            filter.RelationshipDependent,
+						Relation:                deployment2ID,
+						RelationPhase:           filter.PhaseReconcile,
+						RelationActuationStatus: actuation.ActuationSucceeded,
+						RelationReconcileStatus: actuation.ReconcileTimeout,
+					},
+					idFrom(deploymentID),
+					actuation.ActuationStrategyDelete)),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := testingfake.NewClient(t, core.Scheme)
+			cs := &ClientSet{
+				KptDestroyer: newFakeKptDestroyer(tc.events),
+				Client:       fakeClient,
+				// TODO: Add tests to cover disabling objects
+				// TODO: Add tests to cover status mode
+			}
+			applier, err := NewNamespaceApplier(cs, "test-namespace", "rs", 5*time.Minute)
+			require.NoError(t, err)
+
+			errs := applier.Destroy(context.Background())
+			testutil.AssertEqual(t, tc.multiErr, errs)
+		})
+	}
+}
+
+// newMultiError wraps an error as a multiError that's comparable using
+// `testutil.AssertEqual`.
+func newMultiError(errs ...error) error {
+	var multiErr status.MultiError
+	for _, err := range errs {
+		multiErr = status.Append(multiErr, err)
+	}
+	return testutil.EqualError(multiErr)
+}
+
+func formDeleteEvent(status event.DeleteEventStatus, id *object.ObjMetadata, err error) event.Event {
+	e := event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Status: status,
+			Error:  err,
+		},
+	}
+	if id != nil {
+		e.DeleteEvent.Identifier = *id
+		e.DeleteEvent.Object = &unstructured.Unstructured{}
+	}
+	return e
+}
+
+func formDeleteSkipEvent(id object.ObjMetadata, obj *unstructured.Unstructured, err error) event.Event {
+	return event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Status:     event.DeleteSkipped,
+			Identifier: id,
+			Object:     obj,
+			Error:      err,
+		},
+	}
+}
+
+func formDeleteSkipEventWithDependent(obj, dependent *unstructured.Unstructured) event.Event {
+	id := object.UnstructuredToObjMetadata(obj)
+	e := event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Status:     event.DeleteSkipped,
+			Identifier: id,
+			Object:     obj,
+			Error: &filter.DependencyPreventedActuationError{
+				Object:                  id,
+				Strategy:                actuation.ActuationStrategyDelete,
+				Relationship:            filter.RelationshipDependent,
+				Relation:                object.UnstructuredToObjMetadata(dependent),
+				RelationPhase:           filter.PhaseReconcile,
+				RelationActuationStatus: actuation.ActuationSucceeded,
+				RelationReconcileStatus: actuation.ReconcileTimeout,
+			},
+		},
+	}
+	return e
+}

--- a/pkg/applier/destroyer_test.go
+++ b/pkg/applier/destroyer_test.go
@@ -194,10 +194,10 @@ func TestDestroy(t *testing.T) {
 				// TODO: Add tests to cover disabling objects
 				// TODO: Add tests to cover status mode
 			}
-			applier, err := NewNamespaceApplier(cs, "test-namespace", "rs", 5*time.Minute)
+			destroyer, err := NewNamespaceSupervisor(cs, "test-namespace", "rs", 5*time.Minute)
 			require.NoError(t, err)
 
-			errs := applier.Destroy(context.Background())
+			errs := destroyer.Destroy(context.Background())
 			testutil.AssertEqual(t, tc.multiErr, errs)
 		})
 	}

--- a/pkg/applier/stats/stats_test.go
+++ b/pkg/applier/stats/stats_test.go
@@ -99,6 +99,48 @@ func TestPruneEventStats(t *testing.T) {
 	}
 }
 
+func TestDeleteEventStats(t *testing.T) {
+	testcases := []struct {
+		name       string
+		stats      DeleteEventStats
+		wantEmpty  bool
+		wantString string
+	}{
+		{
+			name: "empty DeleteEventStats",
+			stats: DeleteEventStats{
+				EventByOp: map[event.DeleteEventStatus]uint64{},
+			},
+			wantEmpty:  true,
+			wantString: "",
+		},
+		{
+			name: "non-empty DeleteEventStats",
+			stats: DeleteEventStats{
+				EventByOp: map[event.DeleteEventStatus]uint64{
+					event.DeleteSkipped:    4,
+					event.DeleteSuccessful: 0,
+					event.DeleteFailed:     1,
+				},
+			},
+			wantEmpty:  false,
+			wantString: "DeleteEvents: 5 (Skipped: 4, Failed: 1)",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.stats.Empty() != tc.wantEmpty {
+				t.Errorf("stats.empty() = %t, wanted %t", tc.stats.Empty(), tc.wantEmpty)
+			}
+
+			if tc.stats.String() != tc.wantString {
+				t.Errorf("stats.string() = %q, wanted %q", tc.stats.String(), tc.wantString)
+			}
+
+		})
+	}
+}
+
 func TestApplyEventStats(t *testing.T) {
 	testcases := []struct {
 		name       string

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -132,6 +132,11 @@ const (
 	// UnknownScopeAnnotationValue is the value for UnknownScopeAnnotationKey
 	// to indicate that the scope of a resource is unknown.
 	UnknownScopeAnnotationValue = "true"
+
+	// DeletionPropagationPolicyAnnotationKey is the annotation key set on
+	// RootSync/RepoSync objects to indicate what do do with the managed
+	// resources when the RootSync/RepoSync object is deleted.
+	DeletionPropagationPolicyAnnotationKey = configsync.ConfigSyncPrefix + "deletion-propagation-policy"
 )
 
 // Lifecycle annotations
@@ -194,3 +199,24 @@ const KustomizeOrigin = "config.kubernetes.io/origin"
 
 // FleetWorkloadIdentityCredentials is the key for the credentials file of the Fleet Workload Identity.
 const FleetWorkloadIdentityCredentials = "config.kubernetes.io/fleet-workload-identity"
+
+// DeletionPropagationPolicy is the type used to identify value enums to use
+// with the deletion-propagation-policy annotation.
+type DeletionPropagationPolicy string
+
+const (
+	// DeletionPropagationPolicyForeground indicates that the managed resources
+	// should all be deleted/pruned before the RootSync/RepoSync object is deleted.
+	// This will block deletion of the RootSync/RepoSync using a finalizer.
+	DeletionPropagationPolicyForeground = DeletionPropagationPolicy("Foreground")
+
+	// DeletionPropagationPolicyOrphan indicates that the managed resources
+	// should all be orphanned (not deleted) when the RootSync/RepoSync object
+	// is deleted.
+	// This will NOT block deletion of the RootSync/RepoSync AND will not
+	// remove or modify any config sync managed annotations.
+	// This allows the RootSync/RepoSync to be deleted and re-created without
+	// affecting the managed resources.
+	// This is the default behavior if the annotation is not specified.
+	DeletionPropagationPolicyOrphan = DeletionPropagationPolicy("Orphan")
+)

--- a/pkg/metadata/finalizers.go
+++ b/pkg/metadata/finalizers.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+)
+
+const (
+	// ReconcilerFinalizer is the finalizer added to the RootSync/RepoSync by
+	// the reconciler when the deletion-propagation-policy is Foreground.
+	ReconcilerFinalizer = configsync.ConfigSyncPrefix + reconcilermanager.Reconciler
+)

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -48,11 +48,12 @@ func GetNomosAnnotationKeys() []string {
 // in the source repository.
 // These annotations are set by Config Sync users.
 var sourceAnnotations = map[string]bool{
-	NamespaceSelectorAnnotationKey:     true,
-	LegacyClusterSelectorAnnotationKey: true,
-	ClusterNameSelectorAnnotationKey:   true,
-	ResourceManagementKey:              true,
-	LifecycleMutationAnnotation:        true,
+	NamespaceSelectorAnnotationKey:         true,
+	LegacyClusterSelectorAnnotationKey:     true,
+	ClusterNameSelectorAnnotationKey:       true,
+	ResourceManagementKey:                  true,
+	LifecycleMutationAnnotation:            true,
+	DeletionPropagationPolicyAnnotationKey: true,
 }
 
 // IsSourceAnnotation returns true if the annotation is a ConfigSync source
@@ -71,7 +72,8 @@ func HasConfigSyncPrefix(s string) bool {
 func IsConfigSyncAnnotationKey(k string) bool {
 	return HasConfigSyncPrefix(k) ||
 		strings.HasPrefix(k, LifecycleMutationAnnotation) ||
-		k == OwningInventoryKey
+		k == OwningInventoryKey ||
+		k == DeletionPropagationPolicyAnnotationKey
 }
 
 // isConfigSyncAnnotation returns whether an annotation is a Config Sync annotation.

--- a/pkg/reconciler/finalizer/controller.go
+++ b/pkg/reconciler/finalizer/controller.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/declared"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/status"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Controller that watches a RootSync or RepoSync, injects a finalizer when
+// deletion propagation is enabled via annotation, handles deletion propagation
+// when the RSync is marked for deletion, and removes the finalizer when
+// deletion propagation is complete.
+//
+// Use `configsync.gke.io/deletion-propagation-policy: Foreground` to enable
+// deletion propagation.
+//
+// Use `configsync.gke.io/deletion-propagation-policy: Orphan` or remove the
+// annotation to disable deletion propagation (default behavior).
+//
+// The `configsync.gke.io/reconciler` finalizer is used to block deletion until
+// all the managed objects can be deleted.
+type Controller struct {
+	SyncScope declared.Scope
+	SyncName  string
+	Client    client.Client
+	Mapper    meta.RESTMapper
+	Scheme    *runtime.Scheme
+	Finalizer *Finalizer
+}
+
+// SetupWithManager registers the finalizer Controller with reconciler-manager.
+func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
+	exampleObj := c.newExampleObject()
+	exampleKey := client.ObjectKeyFromObject(exampleObj)
+
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+		Named("Finalizer").
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		For(exampleObj, builder.WithPredicates(
+			// Only send one event for each ResourceVersion
+			predicate.ResourceVersionChangedPredicate{},
+			// Filter the watch down to a single object
+			SingleObjectPredicate(exampleKey),
+		))
+
+	return controllerBuilder.Complete(c)
+}
+
+// newExampleObject returns new example object with GVK, name, and namespace.
+// This returns either a RootSync or RepoSync as Unstructured.
+func (c *Controller) newExampleObject() *unstructured.Unstructured {
+	exampleObj := &unstructured.Unstructured{}
+	exampleObj.SetName(c.SyncName)
+	if c.SyncScope == declared.RootReconciler {
+		exampleObj.SetGroupVersionKind(kinds.RootSyncV1Beta1())
+		exampleObj.SetNamespace(configmanagement.ControllerNamespace)
+	} else {
+		exampleObj.SetGroupVersionKind(kinds.RepoSyncV1Beta1())
+		exampleObj.SetNamespace(string(c.SyncScope))
+	}
+	return exampleObj
+}
+
+// Reconcile responds to changes in the RootSync/RepoSync being watched.
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	// Returned error triggers retry, so we rarely need to populate the result.
+	var result reconcile.Result
+
+	rs := c.newExampleObject()
+	rsKey := client.ObjectKeyFromObject(rs)
+	reqKey := req.NamespacedName
+
+	// This should never happen, if the controller is configured correctly.
+	if reqKey.Name != rsKey.Name || reqKey.Namespace != rsKey.Namespace {
+		klog.Errorf("Controller misconfiguration: reconciler called for the wrong %s: expected %q, but got %q",
+			rs.GroupVersionKind().Kind, rsKey, reqKey)
+		// Programmer error. Retry won't help, so don't return the error.
+		return result, nil
+	}
+
+	// Get the latest RSync from the client cache
+	if err := c.Client.Get(ctx, rsKey, rs); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Do nothing. After the RSync is NotFound is too late to finalize.
+			// The finalizer should have run already in OnUpdate when the
+			// deletionTimestamp was added. If we tried to run the destroyer
+			// now, it would probably fail, because the reconciler-manager will
+			// probably have deleted the dependencies. And even if the
+			// dependencies were still around, the reconciler will soon be
+			// deleted by the reconciler-manager, if it hasn't already.
+			return result, nil
+		}
+		return result, status.APIServerError(err, fmt.Sprintf("failed to get %s", objSummary(rs)))
+	}
+
+	if !rs.GetDeletionTimestamp().IsZero() {
+		// Object being deleted.
+		if controllerutil.ContainsFinalizer(rs, metadata.ReconcilerFinalizer) {
+			if err := c.Finalizer.Finalize(ctx, rs); err != nil {
+				return result, errors.Wrapf(err, "finalizing")
+			}
+		}
+	} else {
+		if err := c.reconcileFinalizer(ctx, rs); err != nil {
+			return result, errors.Wrapf(err, "reconciling finalizer")
+		}
+	}
+	return result, nil
+}
+
+// reconcileFinalizer adds or removes the `configsync.gke.io/reconciler`
+// finalizer, depending on the existance and value of the
+// `configsync.gke.io/deletion-propagation-policy` annotation.
+func (c *Controller) reconcileFinalizer(ctx context.Context, obj *unstructured.Unstructured) error {
+	policyStr, found := obj.GetAnnotations()[metadata.DeletionPropagationPolicyAnnotationKey]
+	policy := metadata.DeletionPropagationPolicy(policyStr)
+	if !found {
+		// Orphan is the default policy
+		policy = metadata.DeletionPropagationPolicyOrphan
+	}
+	switch policy {
+	case metadata.DeletionPropagationPolicyForeground:
+		if _, err := c.Finalizer.AddFinalizer(ctx, obj); err != nil {
+			return err
+		}
+	case metadata.DeletionPropagationPolicyOrphan:
+		if _, err := c.Finalizer.RemoveFinalizer(ctx, obj); err != nil {
+			return err
+		}
+	default:
+		klog.Warningf("%s %s has an invalid value for the annotation %q: %q",
+			obj.GetKind(), client.ObjectKeyFromObject(obj), metadata.DeletionPropagationPolicyAnnotationKey, policy)
+		// User error. Retry won't help, so don't return the error.
+	}
+	return nil
+}

--- a/pkg/reconciler/finalizer/finalizer.go
+++ b/pkg/reconciler/finalizer/finalizer.go
@@ -18,278 +18,51 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog/v2"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
-	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/reposync"
-	"kpt.dev/configsync/pkg/rootsync"
-	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/util/mutate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Finalizer handles finalizing a RootSync or RepoSync for the reconciler.
-type Finalizer struct {
-	Destroyer applier.Destroyer
-	Client    client.Client
-
-	// StopControllers will be called by the Finalize() method to stop the Parser and Remediator.
-	StopControllers context.CancelFunc
-
-	// ControllersStopped will be closed by the caller when the parser and
-	// remediator have fully stopped. This unblocks Finalize() to destroy
-	// managed resource objects.
-	ControllersStopped <-chan struct{}
+type Finalizer interface {
+	Finalize(ctx context.Context, syncObj client.Object) error
+	AddFinalizer(ctx context.Context, syncObj client.Object) (bool, error)
+	RemoveFinalizer(ctx context.Context, syncObj client.Object) (bool, error)
 }
 
-// Finalize performs the following actions on the RootSync or RepoSync:
-// - Stop other controllers
-// - Wait for other controllers to stop
-// - Sets the Finalizing condition
-// - Uses the Destroyer to delete managed objects
-// - Removes the Finalizing condition
-// - Removes the Finalizer (unblocking deletion)
-func (f *Finalizer) Finalize(ctx context.Context, obj *unstructured.Unstructured) error {
-	// Stop the parser & remediator
-	klog.Info("Finalizer scheduled: Parser & Remediator stopping")
-	f.StopControllers()
-
-	// Wait for parser & remediator to stop
-	<-f.ControllersStopped
-	klog.Info("Finalizer executing: Parser & Remediator stopped")
-
-	if _, err := f.setFinalizingCondition(ctx, obj); err != nil {
-		return errors.Wrap(err, "setting Finalizing condition")
+// New constructs a new RootSyncFinalizer or RepoSyncFinalizer, depending on the
+// specified scope.
+func New(scope declared.Scope, destroyer applier.Destroyer, c client.Client, stopControllers context.CancelFunc, controllersStopped <-chan struct{}) Finalizer {
+	if scope == declared.RootReconciler {
+		return &RootSyncFinalizer{
+			Destroyer:          destroyer,
+			Client:             c,
+			StopControllers:    stopControllers,
+			ControllersStopped: controllersStopped,
+		}
 	}
-
-	if err := f.deleteManagedObjects(ctx, obj); err != nil {
-		return errors.Wrap(err, "deleting managed objects")
+	return &RepoSyncFinalizer{
+		Destroyer:          destroyer,
+		Client:             c,
+		StopControllers:    stopControllers,
+		ControllersStopped: controllersStopped,
 	}
-	klog.Infof("Deletion of managed objects successful")
-
-	// TODO: optimize by combining these updates into a single update
-	if _, err := f.removeFinalizingCondition(ctx, obj); err != nil {
-		return errors.Wrap(err, "removing Finalizing condition")
-	}
-	if _, err := f.RemoveFinalizer(ctx, obj); err != nil {
-		return errors.Wrap(err, "removing finalizer")
-	}
-	return nil
 }
 
-// AddFinalizer adds the `configsync.gke.io/reconciler` finalizer to the specified
-// object.
-func (f *Finalizer) AddFinalizer(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, obj, func() error {
-		if !controllerutil.AddFinalizer(obj, metadata.ReconcilerFinalizer) {
-			// Already added. No change necessary.
-			return &mutate.NoUpdateError{}
-		}
-		return nil
-	})
-	if err != nil {
-		return updated, errors.Wrapf(err, "failed to remove finalizer")
-	}
-	if updated {
-		klog.Info("Finalizer injection successful")
-	} else {
-		klog.V(5).Info("Finalizer injection skipped: already exists")
-	}
-	return updated, nil
+// addFinalizer adds the `configsync.gke.io/reconciler` finalizer to the
+// specified object, locally.
+// Returns true, if the object was modified.
+func addFinalizer(syncObj client.Object) bool {
+	return controllerutil.AddFinalizer(syncObj, metadata.ReconcilerFinalizer)
 }
 
-// RemoveFinalizer removes the `configsync.gke.io/reconciler` finalizer from the
-// specified object.
-func (f *Finalizer) RemoveFinalizer(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, obj, func() error {
-		if !controllerutil.RemoveFinalizer(obj, metadata.ReconcilerFinalizer) {
-			// Already removed. No change necessary.
-			return &mutate.NoUpdateError{}
-		}
-		return nil
-	})
-	if err != nil {
-		return updated, errors.Wrapf(err, "failed to remove finalizer")
-	}
-	if updated {
-		klog.Info("Finalizer removal successful")
-	} else {
-		klog.V(5).Info("Finalizer removal skipped: already removed")
-	}
-	return updated, nil
-}
-
-// setFinalizingCondition sets the ReconcilerFinalizing condition on the
-// specified object.
-func (f *Finalizer) setFinalizingCondition(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, obj, func() error {
-		// Convert to RootSync/RepoSync to make it easier to update the conditions.
-		// TODO: Optimize by avoiding multiple type conversions.
-		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		switch tObj := rObj.(type) {
-		case *v1beta1.RootSync:
-			if !rootsync.SetReconcilerFinalizing(tObj, "ResourcesDeleting", "Deleting managed resource objects") {
-				// Already removed. No change necessary.
-				return &mutate.NoUpdateError{}
-			}
-		case *v1beta1.RepoSync:
-			if !reposync.SetReconcilerFinalizing(tObj, "ResourcesDeleting", "Deleting managed resource objects") {
-				// Already removed. No change necessary.
-				return &mutate.NoUpdateError{}
-			}
-		case client.Object:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
-		default:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
-		}
-		// Copy updates back into the original unstructured object
-		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		uObj.DeepCopyInto(obj)
-		return nil
-	})
-	if err != nil {
-		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizing condition")
-	}
-	if updated {
-		klog.Info("ReconcilerFinalizing condition update successful")
-	} else {
-		klog.V(5).Info("ReconcilerFinalizing condition update skipped: already set")
-	}
-	return updated, nil
-}
-
-// removeFinalizingCondition removes the ReconcilerFinalizing condition from the
-// specified object.
-func (f *Finalizer) removeFinalizingCondition(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, obj, func() error {
-		// Convert to RootSync/RepoSync to make it easier to update the conditions.
-		// TODO: Optimize by avoiding multiple type conversions.
-		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		switch tObj := rObj.(type) {
-		case *v1beta1.RootSync:
-			if !rootsync.RemoveCondition(tObj, v1beta1.RootSyncReconcilerFinalizing) {
-				// Already removed. No change necessary.
-				return &mutate.NoUpdateError{}
-			}
-		case *v1beta1.RepoSync:
-			if !reposync.RemoveCondition(tObj, v1beta1.RepoSyncReconcilerFinalizing) {
-				// Already removed. No change necessary.
-				return &mutate.NoUpdateError{}
-			}
-		case client.Object:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
-		default:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
-		}
-		// Copy updates back into the original unstructured object
-		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		uObj.DeepCopyInto(obj)
-		return nil
-	})
-	if err != nil {
-		return updated, errors.Wrapf(err, "failed to remove ReconcilerFinalizing condition")
-	}
-	if updated {
-		klog.Info("ReconcilerFinalizing condition removal successful")
-	} else {
-		klog.V(5).Info("ReconcilerFinalizing condition removal skipped: already removed")
-	}
-	return updated, nil
-}
-
-// deleteManagedObjects uses the destroyer to delete managed objects and then
-// updates the ReconcilerFinalizerFailure condition on the specified object.
-func (f *Finalizer) deleteManagedObjects(ctx context.Context, syncObj *unstructured.Unstructured) error {
-	destroyErrs := f.Destroyer.Destroy(ctx)
-	// Update the FinalizerFailure condition whether the destroy succeeded or failed
-	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
-		updateErr = errors.Wrap(updateErr, "updating FinalizerFailure condition")
-		if destroyErrs != nil {
-			return status.Append(destroyErrs, updateErr)
-		}
-		return updateErr
-	}
-	if destroyErrs != nil {
-		return destroyErrs
-	}
-	return nil
-}
-
-// updateFailureCondition sets or removes the ReconcilerFinalizerFailure
-// condition on the specified object, depending if errors were specified or not.
-func (f *Finalizer) updateFailureCondition(ctx context.Context, obj *unstructured.Unstructured, destroyErrs status.MultiError) (bool, error) {
-	updated, err := mutate.Status(ctx, f.Client, obj, func() error {
-		// Convert to RootSync/RepoSync to make it easier to update the conditions.
-		// TODO: Optimize by avoiding multiple type conversions.
-		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		switch tObj := rObj.(type) {
-		case *v1beta1.RootSync:
-			if destroyErrs != nil {
-				if !rootsync.SetReconcilerFinalizerFailure(tObj, destroyErrs) {
-					// Already removed. No change necessary.
-					return &mutate.NoUpdateError{}
-				}
-			} else {
-				if !rootsync.RemoveCondition(tObj, v1beta1.RootSyncReconcilerFinalizerFailure) {
-					// Already updated. No change necessary.
-					return &mutate.NoUpdateError{}
-				}
-			}
-		case *v1beta1.RepoSync:
-			if destroyErrs != nil {
-				if !reposync.SetReconcilerFinalizerFailure(tObj, destroyErrs) {
-					// Already updated. No change necessary.
-					return &mutate.NoUpdateError{}
-				}
-			} else {
-				if !reposync.RemoveCondition(tObj, v1beta1.RepoSyncReconcilerFinalizerFailure) {
-					// Already removed. No change necessary.
-					return &mutate.NoUpdateError{}
-				}
-			}
-		case client.Object:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
-		default:
-			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
-		}
-		// Copy updates back into the original unstructured object
-		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
-		if err != nil {
-			return err
-		}
-		uObj.DeepCopyInto(obj)
-		return nil
-	})
-	if err != nil {
-		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizerFailure condition")
-	}
-	if updated {
-		klog.Info("ReconcilerFinalizerFailure condition update successful")
-	} else {
-		klog.V(5).Info("ReconcilerFinalizerFailure condition update skipped: already set")
-	}
-	return updated, nil
+// removeFinalizer removes the `configsync.gke.io/reconciler` finalizer from the
+// specified object, locally.
+// Returns true, if the object was modified.
+func removeFinalizer(syncObj client.Object) bool {
+	return controllerutil.RemoveFinalizer(syncObj, metadata.ReconcilerFinalizer)
 }
 
 func objSummary(obj client.Object) string {

--- a/pkg/reconciler/finalizer/finalizer.go
+++ b/pkg/reconciler/finalizer/finalizer.go
@@ -1,0 +1,298 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reposync"
+	"kpt.dev/configsync/pkg/rootsync"
+	"kpt.dev/configsync/pkg/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Finalizer handles finalizing a RootSync or RepoSync for the reconciler.
+type Finalizer struct {
+	Destroyer applier.Destroyer
+	Client    client.Client
+
+	// StopControllers will be called by the Finalize() method to stop the Parser and Remediator.
+	StopControllers context.CancelFunc
+
+	// ControllersStopped will be closed by the caller when the parser and
+	// remediator have fully stopped. This unblocks Finalize() to destroy
+	// managed resource objects.
+	ControllersStopped <-chan struct{}
+}
+
+// Finalize performs the following actions on the RootSync or RepoSync:
+// - Stop other controllers
+// - Wait for other controllers to stop
+// - Sets the Finalizing condition
+// - Uses the Destroyer to delete managed objects
+// - Removes the Finalizing condition
+// - Removes the Finalizer (unblocking deletion)
+func (f *Finalizer) Finalize(ctx context.Context, obj *unstructured.Unstructured) error {
+	// Stop the parser & remediator
+	klog.Info("Finalizer scheduled: Parser & Remediator stopping")
+	f.StopControllers()
+
+	// Wait for parser & remediator to stop
+	<-f.ControllersStopped
+	klog.Info("Finalizer executing: Parser & Remediator stopped")
+
+	if _, err := f.setFinalizingCondition(ctx, obj); err != nil {
+		return errors.Wrap(err, "setting Finalizing condition")
+	}
+
+	if err := f.deleteManagedObjects(ctx, obj); err != nil {
+		return errors.Wrap(err, "deleting managed objects")
+	}
+	klog.Infof("Deletion of managed objects successful")
+
+	// TODO: optimize by combining these updates into a single update
+	if _, err := f.removeFinalizingCondition(ctx, obj); err != nil {
+		return errors.Wrap(err, "removing Finalizing condition")
+	}
+	if _, err := f.RemoveFinalizer(ctx, obj); err != nil {
+		return errors.Wrap(err, "removing finalizer")
+	}
+	return nil
+}
+
+// AddFinalizer adds the `configsync.gke.io/reconciler` finalizer to the specified
+// object.
+func (f *Finalizer) AddFinalizer(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	updated, err := updateObjectWithRetry(ctx, f.Client, obj, func() error {
+		if !controllerutil.AddFinalizer(obj, metadata.ReconcilerFinalizer) {
+			// Already added. No change necessary.
+			return &NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer injection successful")
+	} else {
+		klog.Warning("Finalizer injection skipped: already exists")
+	}
+	return updated, nil
+}
+
+// RemoveFinalizer removes the `configsync.gke.io/reconciler` finalizer from the
+// specified object.
+func (f *Finalizer) RemoveFinalizer(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	updated, err := updateObjectWithRetry(ctx, f.Client, obj, func() error {
+		if !controllerutil.RemoveFinalizer(obj, metadata.ReconcilerFinalizer) {
+			// Already removed. No change necessary.
+			return &NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer removal successful")
+	} else {
+		klog.Warning("Finalizer removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// setFinalizingCondition sets the ReconcilerFinalizing condition on the
+// specified object.
+func (f *Finalizer) setFinalizingCondition(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	updated, err := updateObjectWithRetry(ctx, f.Client, obj, func() error {
+		// Convert to RootSync/RepoSync to make it easier to update the conditions.
+		// TODO: Optimize by avoiding multiple type conversions.
+		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		switch tObj := rObj.(type) {
+		case *v1beta1.RootSync:
+			if !rootsync.SetReconcilerFinalizing(tObj, "ResourcesDeleting", "Deleting managed resource objects") {
+				// Already removed. No change necessary.
+				return &NoUpdateError{}
+			}
+		case *v1beta1.RepoSync:
+			if !reposync.SetReconcilerFinalizing(tObj, "ResourcesDeleting", "Deleting managed resource objects") {
+				// Already removed. No change necessary.
+				return &NoUpdateError{}
+			}
+		case client.Object:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
+		default:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
+		}
+		// Copy updates back into the original unstructured object
+		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		uObj.DeepCopyInto(obj)
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition update successful")
+	} else {
+		klog.Warning("ReconcilerFinalizing condition update skipped: already set")
+	}
+	return updated, nil
+}
+
+// removeFinalizingCondition removes the ReconcilerFinalizing condition from the
+// specified object.
+func (f *Finalizer) removeFinalizingCondition(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	updated, err := updateObjectWithRetry(ctx, f.Client, obj, func() error {
+		// Convert to RootSync/RepoSync to make it easier to update the conditions.
+		// TODO: Optimize by avoiding multiple type conversions.
+		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		switch tObj := rObj.(type) {
+		case *v1beta1.RootSync:
+			if !rootsync.RemoveCondition(tObj, v1beta1.RootSyncReconcilerFinalizing) {
+				// Already removed. No change necessary.
+				return &NoUpdateError{}
+			}
+		case *v1beta1.RepoSync:
+			if !reposync.RemoveCondition(tObj, v1beta1.RepoSyncReconcilerFinalizing) {
+				// Already removed. No change necessary.
+				return &NoUpdateError{}
+			}
+		case client.Object:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
+		default:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
+		}
+		// Copy updates back into the original unstructured object
+		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		uObj.DeepCopyInto(obj)
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition removal successful")
+	} else {
+		klog.Warning("ReconcilerFinalizing condition removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// deleteManagedObjects uses the destroyer to delete managed objects and then
+// updates the ReconcilerFinalizerFailure condition on the specified object.
+func (f *Finalizer) deleteManagedObjects(ctx context.Context, syncObj *unstructured.Unstructured) error {
+	destroyErrs := f.Destroyer.Destroy(ctx)
+	// Update the FinalizerFailure condition whether the destroy succeeded or failed
+	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
+		updateErr = errors.Wrap(updateErr, "updating FinalizerFailure condition")
+		if destroyErrs != nil {
+			return status.Append(destroyErrs, updateErr)
+		}
+		return updateErr
+	}
+	if destroyErrs != nil {
+		return destroyErrs
+	}
+	return nil
+}
+
+// updateFailureCondition sets or removes the ReconcilerFinalizerFailure
+// condition on the specified object, depending if errors were specified or not.
+func (f *Finalizer) updateFailureCondition(ctx context.Context, obj *unstructured.Unstructured, destroyErrs status.MultiError) (bool, error) {
+	updated, err := updateObjectStatus(ctx, f.Client, obj, func() error {
+		// Convert to RootSync/RepoSync to make it easier to update the conditions.
+		// TODO: Optimize by avoiding multiple type conversions.
+		rObj, err := kinds.ToTypedObject(obj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		switch tObj := rObj.(type) {
+		case *v1beta1.RootSync:
+			if destroyErrs != nil {
+				if !rootsync.SetReconcilerFinalizerFailure(tObj, destroyErrs) {
+					// Already removed. No change necessary.
+					return &NoUpdateError{}
+				}
+			} else {
+				if !rootsync.RemoveCondition(tObj, v1beta1.RootSyncReconcilerFinalizerFailure) {
+					// Already updated. No change necessary.
+					return &NoUpdateError{}
+				}
+			}
+		case *v1beta1.RepoSync:
+			if destroyErrs != nil {
+				if !reposync.SetReconcilerFinalizerFailure(tObj, destroyErrs) {
+					// Already updated. No change necessary.
+					return &NoUpdateError{}
+				}
+			} else {
+				if !reposync.RemoveCondition(tObj, v1beta1.RepoSyncReconcilerFinalizerFailure) {
+					// Already removed. No change necessary.
+					return &NoUpdateError{}
+				}
+			}
+		case client.Object:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %s", objSummary(tObj))
+		default:
+			return fmt.Errorf("invalid object type: expected v1beta1.RootSync or v1beta1.RepoSync: %T", rObj)
+		}
+		// Copy updates back into the original unstructured object
+		uObj, err := kinds.ToUnstructured(rObj, core.Scheme)
+		if err != nil {
+			return err
+		}
+		uObj.DeepCopyInto(obj)
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizerFailure condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizerFailure condition update successful")
+	} else {
+		klog.Warning("ReconcilerFinalizerFailure condition update skipped: already set")
+	}
+	return updated, nil
+}
+
+func objSummary(obj client.Object) string {
+	return fmt.Sprintf("%T %s %s/%s",
+		obj, obj.GetObjectKind().GroupVersionKind(),
+		obj.GetNamespace(), obj.GetName())
+}

--- a/pkg/reconciler/finalizer/finalizer.go
+++ b/pkg/reconciler/finalizer/finalizer.go
@@ -98,7 +98,7 @@ func (f *Finalizer) AddFinalizer(ctx context.Context, obj *unstructured.Unstruct
 	if updated {
 		klog.Info("Finalizer injection successful")
 	} else {
-		klog.Warning("Finalizer injection skipped: already exists")
+		klog.V(5).Info("Finalizer injection skipped: already exists")
 	}
 	return updated, nil
 }
@@ -119,7 +119,7 @@ func (f *Finalizer) RemoveFinalizer(ctx context.Context, obj *unstructured.Unstr
 	if updated {
 		klog.Info("Finalizer removal successful")
 	} else {
-		klog.Warning("Finalizer removal skipped: already removed")
+		klog.V(5).Info("Finalizer removal skipped: already removed")
 	}
 	return updated, nil
 }
@@ -164,7 +164,7 @@ func (f *Finalizer) setFinalizingCondition(ctx context.Context, obj *unstructure
 	if updated {
 		klog.Info("ReconcilerFinalizing condition update successful")
 	} else {
-		klog.Warning("ReconcilerFinalizing condition update skipped: already set")
+		klog.V(5).Info("ReconcilerFinalizing condition update skipped: already set")
 	}
 	return updated, nil
 }
@@ -209,7 +209,7 @@ func (f *Finalizer) removeFinalizingCondition(ctx context.Context, obj *unstruct
 	if updated {
 		klog.Info("ReconcilerFinalizing condition removal successful")
 	} else {
-		klog.Warning("ReconcilerFinalizing condition removal skipped: already removed")
+		klog.V(5).Info("ReconcilerFinalizing condition removal skipped: already removed")
 	}
 	return updated, nil
 }
@@ -286,7 +286,7 @@ func (f *Finalizer) updateFailureCondition(ctx context.Context, obj *unstructure
 	if updated {
 		klog.Info("ReconcilerFinalizerFailure condition update successful")
 	} else {
-		klog.Warning("ReconcilerFinalizerFailure condition update skipped: already set")
+		klog.V(5).Info("ReconcilerFinalizerFailure condition update skipped: already set")
 	}
 	return updated, nil
 }

--- a/pkg/reconciler/finalizer/predicates.go
+++ b/pkg/reconciler/finalizer/predicates.go
@@ -15,11 +15,6 @@
 package finalizer
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
-	syncfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -30,18 +25,7 @@ import (
 // Use this for client-side filtering when you can't use server-side
 // fieldSelectors, like when an informer is shared between controllers.
 func SingleObjectPredicate(key client.ObjectKey) predicate.Predicate {
-	fieldSelector := fields.AndSelectors(
-		fields.OneTermEqualSelector("metadata.name", key.Name),
-		fields.OneTermEqualSelector("metadata.namespace", key.Namespace),
-	)
-
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		uObj, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			panic(fmt.Sprintf("Predicate received unexpected object type %T", obj))
-		}
-		return fieldSelector.Matches(&syncfake.UnstructuredFields{
-			Object: uObj,
-		})
+		return obj.GetName() == key.Name && obj.GetNamespace() == key.Namespace
 	})
 }

--- a/pkg/reconciler/finalizer/predicates.go
+++ b/pkg/reconciler/finalizer/predicates.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	syncfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// SingleObjectPredicate returns a Predicate which filters events by both
+// name & namespace. The Predicate methods return true if the object matches.
+//
+// Use this for client-side filtering when you can't use server-side
+// fieldSelectors, like when an informer is shared between controllers.
+func SingleObjectPredicate(key client.ObjectKey) predicate.Predicate {
+	fieldSelector := fields.AndSelectors(
+		fields.OneTermEqualSelector("metadata.name", key.Name),
+		fields.OneTermEqualSelector("metadata.namespace", key.Namespace),
+	)
+
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		uObj, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			panic(fmt.Sprintf("Predicate received unexpected object type %T", obj))
+		}
+		return fieldSelector.Matches(&syncfake.UnstructuredFields{
+			Object: uObj,
+		})
+	})
+}

--- a/pkg/reconciler/finalizer/reposync_finalizer.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer.go
@@ -1,0 +1,220 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/reposync"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/mutate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RepoSyncFinalizer handles finalizing RepoSync objects, using the Destroyer
+// to destroy all managed user objects previously applied from source.
+// Impliments the Finalizer interface.
+type RepoSyncFinalizer struct {
+	Destroyer applier.Destroyer
+	Client    client.Client
+
+	// StopControllers will be called by the Finalize() method to stop the Parser and Remediator.
+	StopControllers context.CancelFunc
+
+	// ControllersStopped will be closed by the caller when the parser and
+	// remediator have fully stopped. This unblocks Finalize() to destroy
+	// managed resource objects.
+	ControllersStopped <-chan struct{}
+}
+
+// Finalize performs the following actions on the syncObj (RepoSync):
+// - Stop other controllers
+// - Wait for other controllers to stop
+// - Sets the Finalizing condition
+// - Uses the Destroyer to delete managed objects
+// - Removes the Finalizing condition
+// - Removes the Finalizer (unblocking deletion)
+//
+// The specified syncObj must be of type `*v1beta1.RepoSync`.
+func (f *RepoSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object) error {
+	rs, ok := syncObj.(*v1beta1.RepoSync)
+	if !ok {
+		return errors.Errorf("invalid syncObj type: expected *v1beta1.RepoSync, but got %T", syncObj)
+	}
+
+	// Stop the parser & remediator
+	klog.Info("Finalizer scheduled: Parser & Remediator stopping")
+	f.StopControllers()
+
+	// Wait for parser & remediator to stop
+	<-f.ControllersStopped
+	klog.Info("Finalizer executing: Parser & Remediator stopped")
+
+	if _, err := f.setFinalizingCondition(ctx, rs); err != nil {
+		return errors.Wrap(err, "setting Finalizing condition")
+	}
+
+	if err := f.deleteManagedObjects(ctx, rs); err != nil {
+		return errors.Wrap(err, "deleting managed objects")
+	}
+	klog.Infof("Deletion of managed objects successful")
+
+	// TODO: optimize by combining these updates into a single update
+	if _, err := f.removeFinalizingCondition(ctx, rs); err != nil {
+		return errors.Wrap(err, "removing Finalizing condition")
+	}
+	if _, err := f.RemoveFinalizer(ctx, rs); err != nil {
+		return errors.Wrap(err, "removing finalizer")
+	}
+	return nil
+}
+
+// AddFinalizer adds the `configsync.gke.io/reconciler` finalizer to the
+// specified object, and updates the server.
+//
+// The specified syncObj must be of type `*v1beta1.RepoSync`.
+func (f *RepoSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
+	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+		if !addFinalizer(syncObj) {
+			// Already added. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to add finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer injection successful")
+	} else {
+		klog.V(5).Info("Finalizer injection skipped: already exists")
+	}
+	return updated, nil
+}
+
+// RemoveFinalizer removes the `configsync.gke.io/reconciler` finalizer from the
+// specified object, and updates the server.
+//
+// The specified syncObj must be of type `*v1beta1.RepoSync`.
+func (f *RepoSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
+	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+		if !removeFinalizer(syncObj) {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer removal successful")
+	} else {
+		klog.V(5).Info("Finalizer removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// setFinalizingCondition sets the ReconcilerFinalizing condition on the
+// specified object.
+func (f *RepoSyncFinalizer) setFinalizingCondition(ctx context.Context, syncObj *v1beta1.RepoSync) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if !reposync.SetReconcilerFinalizing(syncObj, "ResourcesDeleting", "Deleting managed resource objects") {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition update successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizing condition update skipped: already set")
+	}
+	return updated, nil
+}
+
+// removeFinalizingCondition removes the ReconcilerFinalizing condition from the
+// specified object.
+func (f *RepoSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncObj *v1beta1.RepoSync) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if !reposync.RemoveCondition(syncObj, v1beta1.RepoSyncReconcilerFinalizing) {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition removal successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizing condition removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// deleteManagedObjects uses the destroyer to delete managed objects and then
+// updates the ReconcilerFinalizerFailure condition on the specified object.
+func (f *RepoSyncFinalizer) deleteManagedObjects(ctx context.Context, syncObj *v1beta1.RepoSync) error {
+	destroyErrs := f.Destroyer.Destroy(ctx)
+	// Update the FinalizerFailure condition whether the destroy succeeded or failed
+	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
+		updateErr = errors.Wrap(updateErr, "updating FinalizerFailure condition")
+		if destroyErrs != nil {
+			return status.Append(destroyErrs, updateErr)
+		}
+		return updateErr
+	}
+	if destroyErrs != nil {
+		return destroyErrs
+	}
+	return nil
+}
+
+// updateFailureCondition sets or removes the ReconcilerFinalizerFailure
+// condition on the specified object, depending if errors were specified or not.
+func (f *RepoSyncFinalizer) updateFailureCondition(ctx context.Context, syncObj *v1beta1.RepoSync, destroyErrs status.MultiError) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if destroyErrs != nil {
+			if !reposync.SetReconcilerFinalizerFailure(syncObj, destroyErrs) {
+				// Already removed. No change necessary.
+				return &mutate.NoUpdateError{}
+			}
+		} else {
+			if !reposync.RemoveCondition(syncObj, v1beta1.RepoSyncReconcilerFinalizerFailure) {
+				// Already updated. No change necessary.
+				return &mutate.NoUpdateError{}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizerFailure condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizerFailure condition update successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizerFailure condition update skipped: already set")
+	}
+	return updated, nil
+}

--- a/pkg/reconciler/finalizer/reposync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer_test.go
@@ -1,0 +1,578 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var repoSync1Yaml = `
+apiVersion: configsync.gke.io/v1beta1
+kind: RepoSync
+metadata:
+  name: repo-sync-1
+  namespace: example
+  uid: "1"
+  resourceVersion: "1"
+  generation: 1
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: https://github.com/config-sync-examples/crontab-crs
+    branch: main
+    dir: configs
+    auth: none
+`
+
+func TestRepoSyncFinalize(t *testing.T) {
+	repoSync1 := yamlToTypedObject(t, repoSync1Yaml).(*v1beta1.RepoSync)
+	repoSync1.SetFinalizers([]string{
+		metadata.ReconcilerFinalizer,
+	})
+
+	asserter := testutil.NewAsserter(
+		cmpopts.EquateErrors(),
+		cmpopts.IgnoreFields(metav1.Time{}, "Time"),
+	)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name                       string
+		rsync                      client.Object
+		setup                      func() error
+		destroyErrs                status.MultiError
+		expectedRsyncBeforeDestroy client.Object
+		expectedError              error
+		expectedStopped            bool
+		expectedRsyncAfterFinalize client.Object
+	}{
+		{
+			name:  "happy path",
+			rsync: repoSync1.DeepCopy(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				obj.SetResourceVersion("2")
+				obj.Status.Conditions = []v1beta1.RepoSyncCondition{
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+				}
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to remove ReconcilerFinalizing condition
+				// +1 to remove Finalizer
+				// TODO: optimize by combining consecutive updates
+				obj.SetResourceVersion("4")
+				// Finalizer has been removed
+				obj.SetFinalizers(nil)
+				// ReconcilerFinalizing condition added and then removed
+				return obj
+			}(),
+		},
+		{
+			name:  "destroy failure",
+			rsync: repoSync1.DeepCopy(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				obj.SetResourceVersion("2")
+				obj.Status.Conditions = []v1beta1.RepoSyncCondition{
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+				}
+				return obj
+			}(),
+			destroyErrs: status.APIServerError(fmt.Errorf("destroy error"), "example message"),
+			expectedError: errors.Wrap(
+				status.APIServerError(fmt.Errorf("destroy error"), "example message"),
+				"deleting managed objects"),
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to set ReconcilerFinalizerFailure condition
+				obj.SetResourceVersion("3")
+				// Finalizer NOT removed
+				// ReconcilerFinalizing condition added and NOT removed
+				// ReconcilerFinalizerFailure condition added
+				obj.Status.Conditions = []v1beta1.RepoSyncCondition{
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+		},
+		{
+			name: "destroy recovery",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to set ReconcilerFinalizerFailure condition
+				obj.SetResourceVersion("3")
+				// Finalizer NOT removed
+				// ReconcilerFinalizing condition added and NOT removed
+				// ReconcilerFinalizerFailure condition added
+				obj.Status.Conditions = []v1beta1.RepoSyncCondition{
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// No changes - continue deleting
+				// TODO: Should finalizer re-entry be vissible to the user by toggling a condition?
+				obj.SetResourceVersion("3")
+				obj.Status.Conditions = []v1beta1.RepoSyncCondition{
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+			destroyErrs:     nil,
+			expectedError:   nil,
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to remove ReconcilerFinalizing condition
+				// +1 to remove ReconcilerFinalizerFailure condition
+				// +1 to remove Finalizer
+				// TODO: optimize by combining consecutive updates
+				obj.SetResourceVersion("6")
+				// Finalizer has been removed
+				obj.SetFinalizers(nil)
+				// ReconcilerFinalizing condition removed
+				// ReconcilerFinalizerFailure condition removed
+				return obj
+			}(),
+		},
+		{
+			name:  "rsync not found",
+			rsync: repoSync1.DeepCopy(),
+			setup: func() error {
+				// delete RepoSync to cause update error
+				return fakeClient.Delete(context.Background(), repoSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				errors.Wrapf(
+					status.APIServerError(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+							"example/repo-sync-1"),
+						"failed to update object status",
+						repoSync1.DeepCopy()),
+					"failed to set ReconcilerFinalizing condition"),
+				"setting Finalizing condition"),
+			expectedStopped:            true,
+			expectedRsyncAfterFinalize: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			stopped := false
+			continueCh := make(chan struct{})
+			stopFunc := func() {
+				defer close(continueCh)
+				stopped = true
+			}
+			destroyFunc := func(context.Context) status.MultiError {
+				// Lookup the current RepoSync
+				key := client.ObjectKeyFromObject(repoSync1)
+				rsync := &v1beta1.RepoSync{}
+				err := fakeClient.Get(context.Background(), key, rsync)
+				require.NoError(t, err)
+				asserter.Equal(t, tc.expectedRsyncBeforeDestroy, rsync)
+				// Return errors, if any
+				return tc.destroyErrs
+			}
+			fakeDestroyer := newFakeDestroyer(tc.destroyErrs, destroyFunc)
+			finalizer := &RepoSyncFinalizer{
+				Destroyer:          fakeDestroyer,
+				Client:             fakeClient,
+				StopControllers:    stopFunc,
+				ControllersStopped: continueCh,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			err := finalizer.Finalize(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedStopped, stopped)
+			var expectedObjs []client.Object
+			if tc.expectedRsyncAfterFinalize != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsyncAfterFinalize)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}
+
+func TestRepoSyncAddFinalizer(t *testing.T) {
+	repoSync1 := yamlToTypedObject(t, repoSync1Yaml).(*v1beta1.RepoSync)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name            string
+		rsync           client.Object
+		setup           func() error
+		expectedError   error
+		expectedUpdated bool
+		expectedRsync   client.Object
+	}{
+		{
+			name:            "add finalizer",
+			rsync:           repoSync1.DeepCopy(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "add finalizer again",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: false,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// No change
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "add finalizer to list",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name:  "rsync not found",
+			rsync: repoSync1.DeepCopy(),
+			setup: func() error {
+				// delete RepoSync to cause update error
+				return fakeClient.Delete(context.Background(), repoSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				status.APIServerError(
+					apierrors.NewNotFound(
+						schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+						"example/repo-sync-1"),
+					"failed to update object",
+					repoSync1.DeepCopy()),
+				"failed to add finalizer"),
+			expectedUpdated: false,
+			expectedRsync:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			finalizer := &RepoSyncFinalizer{
+				Client: fakeClient,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			updated, err := finalizer.AddFinalizer(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedUpdated, updated)
+			var expectedObjs []client.Object
+			if tc.expectedRsync != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsync)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}
+
+func TestRepoSyncRemoveFinalizer(t *testing.T) {
+	repoSync1 := yamlToTypedObject(t, repoSync1Yaml).(*v1beta1.RepoSync)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name            string
+		rsync           client.Object
+		setup           func() error
+		expectedError   error
+		expectedUpdated bool
+		expectedRsync   client.Object
+	}{
+		{
+			name: "remove finalizer",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to remove Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+		},
+		{
+			name: "remove finalizer again",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to remove Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: false,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// No change
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+		},
+		{
+			name: "remove finalizer from list",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "rsync not found",
+			rsync: func() client.Object {
+				obj := repoSync1.DeepCopy()
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			setup: func() error {
+				// delete RepoSync to cause update error
+				return fakeClient.Delete(context.Background(), repoSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				status.APIServerError(
+					apierrors.NewNotFound(
+						schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+						"example/repo-sync-1"),
+					"failed to update object",
+					repoSync1.DeepCopy()),
+				"failed to remove finalizer"),
+			expectedUpdated: false,
+			expectedRsync:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			finalizer := &RepoSyncFinalizer{
+				Client: fakeClient,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			updated, err := finalizer.RemoveFinalizer(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedUpdated, updated)
+			var expectedObjs []client.Object
+			if tc.expectedRsync != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsync)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}

--- a/pkg/reconciler/finalizer/rootsync_finalizer.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer.go
@@ -1,0 +1,220 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/rootsync"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/mutate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RootSyncFinalizer handles finalizing RootSync objects, using the Destroyer
+// to destroy all managed user objects previously applied from source.
+// Impliments the Finalizer interface.
+type RootSyncFinalizer struct {
+	Destroyer applier.Destroyer
+	Client    client.Client
+
+	// StopControllers will be called by the Finalize() method to stop the Parser and Remediator.
+	StopControllers context.CancelFunc
+
+	// ControllersStopped will be closed by the caller when the parser and
+	// remediator have fully stopped. This unblocks Finalize() to destroy
+	// managed resource objects.
+	ControllersStopped <-chan struct{}
+}
+
+// Finalize performs the following actions on the syncObj (RootSync):
+// - Stop other controllers
+// - Wait for other controllers to stop
+// - Sets the Finalizing condition
+// - Uses the Destroyer to delete managed objects
+// - Removes the Finalizing condition
+// - Removes the Finalizer (unblocking deletion)
+//
+// The specified syncObj must be of type `*v1beta1.RootSync`.
+func (f *RootSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object) error {
+	rs, ok := syncObj.(*v1beta1.RootSync)
+	if !ok {
+		return errors.Errorf("invalid syncObj type: expected *v1beta1.RootSync, but got %T", syncObj)
+	}
+
+	// Stop the parser & remediator
+	klog.Info("Finalizer scheduled: Parser & Remediator stopping")
+	f.StopControllers()
+
+	// Wait for parser & remediator to stop
+	<-f.ControllersStopped
+	klog.Info("Finalizer executing: Parser & Remediator stopped")
+
+	if _, err := f.setFinalizingCondition(ctx, rs); err != nil {
+		return errors.Wrap(err, "setting Finalizing condition")
+	}
+
+	if err := f.deleteManagedObjects(ctx, rs); err != nil {
+		return errors.Wrap(err, "deleting managed objects")
+	}
+	klog.Infof("Deletion of managed objects successful")
+
+	// TODO: optimize by combining these updates into a single update
+	if _, err := f.removeFinalizingCondition(ctx, rs); err != nil {
+		return errors.Wrap(err, "removing Finalizing condition")
+	}
+	if _, err := f.RemoveFinalizer(ctx, rs); err != nil {
+		return errors.Wrap(err, "removing finalizer")
+	}
+	return nil
+}
+
+// AddFinalizer adds the `configsync.gke.io/reconciler` finalizer to the
+// specified object, and updates the server.
+//
+// The specified syncObj must be of type `*v1beta1.RootSync`.
+func (f *RootSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
+	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+		if !addFinalizer(syncObj) {
+			// Already added. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to add finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer injection successful")
+	} else {
+		klog.V(5).Info("Finalizer injection skipped: already exists")
+	}
+	return updated, nil
+}
+
+// RemoveFinalizer removes the `configsync.gke.io/reconciler` finalizer from the
+// specified object, and updates the server.
+//
+// The specified syncObj must be of type `*v1beta1.RootSync`.
+func (f *RootSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
+	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+		if !removeFinalizer(syncObj) {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove finalizer")
+	}
+	if updated {
+		klog.Info("Finalizer removal successful")
+	} else {
+		klog.V(5).Info("Finalizer removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// setFinalizingCondition sets the ReconcilerFinalizing condition on the
+// specified object.
+func (f *RootSyncFinalizer) setFinalizingCondition(ctx context.Context, syncObj *v1beta1.RootSync) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if !rootsync.SetReconcilerFinalizing(syncObj, "ResourcesDeleting", "Deleting managed resource objects") {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition update successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizing condition update skipped: already set")
+	}
+	return updated, nil
+}
+
+// removeFinalizingCondition removes the ReconcilerFinalizing condition from the
+// specified object.
+func (f *RootSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncObj *v1beta1.RootSync) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if !rootsync.RemoveCondition(syncObj, v1beta1.RootSyncReconcilerFinalizing) {
+			// Already removed. No change necessary.
+			return &mutate.NoUpdateError{}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to remove ReconcilerFinalizing condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizing condition removal successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizing condition removal skipped: already removed")
+	}
+	return updated, nil
+}
+
+// deleteManagedObjects uses the destroyer to delete managed objects and then
+// updates the ReconcilerFinalizerFailure condition on the specified object.
+func (f *RootSyncFinalizer) deleteManagedObjects(ctx context.Context, syncObj *v1beta1.RootSync) error {
+	destroyErrs := f.Destroyer.Destroy(ctx)
+	// Update the FinalizerFailure condition whether the destroy succeeded or failed
+	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
+		updateErr = errors.Wrap(updateErr, "updating FinalizerFailure condition")
+		if destroyErrs != nil {
+			return status.Append(destroyErrs, updateErr)
+		}
+		return updateErr
+	}
+	if destroyErrs != nil {
+		return destroyErrs
+	}
+	return nil
+}
+
+// updateFailureCondition sets or removes the ReconcilerFinalizerFailure
+// condition on the specified object, depending if errors were specified or not.
+func (f *RootSyncFinalizer) updateFailureCondition(ctx context.Context, syncObj *v1beta1.RootSync, destroyErrs status.MultiError) (bool, error) {
+	updated, err := mutate.Status(ctx, f.Client, syncObj, func() error {
+		if destroyErrs != nil {
+			if !rootsync.SetReconcilerFinalizerFailure(syncObj, destroyErrs) {
+				// Already removed. No change necessary.
+				return &mutate.NoUpdateError{}
+			}
+		} else {
+			if !rootsync.RemoveCondition(syncObj, v1beta1.RootSyncReconcilerFinalizerFailure) {
+				// Already updated. No change necessary.
+				return &mutate.NoUpdateError{}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizerFailure condition")
+	}
+	if updated {
+		klog.Info("ReconcilerFinalizerFailure condition update successful")
+	} else {
+		klog.V(5).Info("ReconcilerFinalizerFailure condition update skipped: already set")
+	}
+	return updated, nil
+}

--- a/pkg/reconciler/finalizer/rootsync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer_test.go
@@ -1,0 +1,629 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// decoder uses core.Scheme to parse YAML/JSON into typed objects
+var scheme = core.Scheme
+var decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+var rootSync1Yaml = `
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+  uid: "1"
+  resourceVersion: "1"
+  generation: 1
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: https://github.com/config-sync-examples/crontab-crs
+    branch: main
+    dir: configs
+    auth: none
+`
+
+func TestRootSyncFinalize(t *testing.T) {
+	rootSync1 := yamlToTypedObject(t, rootSync1Yaml).(*v1beta1.RootSync)
+	rootSync1.SetFinalizers([]string{
+		metadata.ReconcilerFinalizer,
+	})
+
+	asserter := testutil.NewAsserter(
+		cmpopts.EquateErrors(),
+		cmpopts.IgnoreFields(metav1.Time{}, "Time"),
+	)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name                       string
+		rsync                      client.Object
+		setup                      func() error
+		destroyErrs                status.MultiError
+		expectedRsyncBeforeDestroy client.Object
+		expectedError              error
+		expectedStopped            bool
+		expectedRsyncAfterFinalize client.Object
+	}{
+		{
+			name:  "happy path",
+			rsync: rootSync1.DeepCopy(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				obj.SetResourceVersion("2")
+				obj.Status.Conditions = []v1beta1.RootSyncCondition{
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+				}
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to remove ReconcilerFinalizing condition
+				// +1 to remove Finalizer
+				// TODO: optimize by combining consecutive updates
+				obj.SetResourceVersion("4")
+				// Finalizer has been removed
+				obj.SetFinalizers(nil)
+				// ReconcilerFinalizing condition added and then removed
+				return obj
+			}(),
+		},
+		{
+			name:  "destroy failure",
+			rsync: rootSync1.DeepCopy(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				obj.SetResourceVersion("2")
+				obj.Status.Conditions = []v1beta1.RootSyncCondition{
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+				}
+				return obj
+			}(),
+			destroyErrs: status.APIServerError(fmt.Errorf("destroy error"), "example message"),
+			expectedError: errors.Wrap(
+				status.APIServerError(fmt.Errorf("destroy error"), "example message"),
+				"deleting managed objects"),
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to set ReconcilerFinalizerFailure condition
+				obj.SetResourceVersion("3")
+				// Finalizer NOT removed
+				// ReconcilerFinalizing condition added and NOT removed
+				// ReconcilerFinalizerFailure condition added
+				obj.Status.Conditions = []v1beta1.RootSyncCondition{
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+		},
+		{
+			name: "destroy recovery",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to set ReconcilerFinalizing condition
+				// +1 to set ReconcilerFinalizerFailure condition
+				obj.SetResourceVersion("3")
+				// Finalizer NOT removed
+				// ReconcilerFinalizing condition added and NOT removed
+				// ReconcilerFinalizerFailure condition added
+				obj.Status.Conditions = []v1beta1.RootSyncCondition{
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+			expectedRsyncBeforeDestroy: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// No changes - continue deleting
+				// TODO: Should finalizer re-entry be vissible to the user by toggling a condition?
+				obj.SetResourceVersion("3")
+				obj.Status.Conditions = []v1beta1.RootSyncCondition{
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ResourcesDeleting",
+						Message: "Deleting managed resource objects",
+					},
+					{
+						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2002",
+								ErrorMessage: "KNV2002: example message: APIServer error: destroy error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2002",
+							},
+						},
+					},
+				}
+				return obj
+			}(),
+			destroyErrs:     nil,
+			expectedError:   nil,
+			expectedStopped: true,
+			expectedRsyncAfterFinalize: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to remove ReconcilerFinalizing condition
+				// +1 to remove ReconcilerFinalizerFailure condition
+				// +1 to remove Finalizer
+				// TODO: optimize by combining consecutive updates
+				obj.SetResourceVersion("6")
+				// Finalizer has been removed
+				obj.SetFinalizers(nil)
+				// ReconcilerFinalizing condition removed
+				// ReconcilerFinalizerFailure condition removed
+				return obj
+			}(),
+		},
+		{
+			name:  "rsync not found",
+			rsync: rootSync1.DeepCopy(),
+			setup: func() error {
+				// delete RootSync to cause update error
+				return fakeClient.Delete(context.Background(), rootSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				errors.Wrapf(
+					status.APIServerError(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+							"config-management-system/root-sync"),
+						"failed to update object status",
+						rootSync1.DeepCopy()),
+					"failed to set ReconcilerFinalizing condition"),
+				"setting Finalizing condition"),
+			expectedStopped:            true,
+			expectedRsyncAfterFinalize: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			stopped := false
+			continueCh := make(chan struct{})
+			stopFunc := func() {
+				defer close(continueCh)
+				stopped = true
+			}
+			destroyFunc := func(context.Context) status.MultiError {
+				// Lookup the current RootSync
+				key := client.ObjectKeyFromObject(rootSync1)
+				rsync := &v1beta1.RootSync{}
+				err := fakeClient.Get(context.Background(), key, rsync)
+				require.NoError(t, err)
+				asserter.Equal(t, tc.expectedRsyncBeforeDestroy, rsync)
+				// Return errors, if any
+				return tc.destroyErrs
+			}
+			fakeDestroyer := newFakeDestroyer(tc.destroyErrs, destroyFunc)
+			finalizer := &RootSyncFinalizer{
+				Destroyer:          fakeDestroyer,
+				Client:             fakeClient,
+				StopControllers:    stopFunc,
+				ControllersStopped: continueCh,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			err := finalizer.Finalize(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedStopped, stopped)
+			var expectedObjs []client.Object
+			if tc.expectedRsyncAfterFinalize != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsyncAfterFinalize)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}
+
+func TestRootSyncAddFinalizer(t *testing.T) {
+	rootSync1 := yamlToTypedObject(t, rootSync1Yaml).(*v1beta1.RootSync)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name            string
+		rsync           client.Object
+		setup           func() error
+		expectedError   error
+		expectedUpdated bool
+		expectedRsync   client.Object
+	}{
+		{
+			name:            "add finalizer",
+			rsync:           rootSync1.DeepCopy(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "add finalizer again",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: false,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// No change
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "add finalizer to list",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+		},
+		{
+			name:  "rsync not found",
+			rsync: rootSync1.DeepCopy(),
+			setup: func() error {
+				// delete RootSync to cause update error
+				return fakeClient.Delete(context.Background(), rootSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				status.APIServerError(
+					apierrors.NewNotFound(
+						schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+						"config-management-system/root-sync"),
+					"failed to update object",
+					rootSync1.DeepCopy()),
+				"failed to add finalizer"),
+			expectedUpdated: false,
+			expectedRsync:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			finalizer := &RootSyncFinalizer{
+				Client: fakeClient,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			updated, err := finalizer.AddFinalizer(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedUpdated, updated)
+			var expectedObjs []client.Object
+			if tc.expectedRsync != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsync)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}
+
+func TestRootSyncRemoveFinalizer(t *testing.T) {
+	rootSync1 := yamlToTypedObject(t, rootSync1Yaml).(*v1beta1.RootSync)
+
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name            string
+		rsync           client.Object
+		setup           func() error
+		expectedError   error
+		expectedUpdated bool
+		expectedRsync   client.Object
+	}{
+		{
+			name: "remove finalizer",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to remove Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+		},
+		{
+			name: "remove finalizer again",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to remove Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: false,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// No change
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers(nil)
+				return obj
+			}(),
+		},
+		{
+			name: "remove finalizer from list",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				obj.SetResourceVersion("2")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			expectedError:   nil,
+			expectedUpdated: true,
+			expectedRsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				// +1 to add Finalizer
+				obj.SetResourceVersion("3")
+				obj.SetFinalizers([]string{
+					"some-other-finalizer",
+				})
+				return obj
+			}(),
+		},
+		{
+			name: "rsync not found",
+			rsync: func() client.Object {
+				obj := rootSync1.DeepCopy()
+				obj.SetFinalizers([]string{
+					metadata.ReconcilerFinalizer,
+				})
+				return obj
+			}(),
+			setup: func() error {
+				// delete RootSync to cause update error
+				return fakeClient.Delete(context.Background(), rootSync1.DeepCopy())
+			},
+			expectedError: errors.Wrapf(
+				status.APIServerError(
+					apierrors.NewNotFound(
+						schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+						"config-management-system/root-sync"),
+					"failed to update object",
+					rootSync1.DeepCopy()),
+				"failed to remove finalizer"),
+			expectedUpdated: false,
+			expectedRsync:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient = fake.NewClient(t, scheme, tc.rsync)
+			ctx := context.Background()
+
+			finalizer := &RootSyncFinalizer{
+				Client: fakeClient,
+			}
+
+			if tc.setup != nil {
+				err := tc.setup()
+				require.NoError(t, err)
+			}
+
+			updated, err := finalizer.RemoveFinalizer(ctx, tc.rsync)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+
+			assert.Equal(t, tc.expectedUpdated, updated)
+			var expectedObjs []client.Object
+			if tc.expectedRsync != nil {
+				expectedObjs = append(expectedObjs, tc.expectedRsync)
+			}
+			fakeClient.Check(t, expectedObjs...)
+		})
+	}
+}
+
+func yamlToTypedObject(t *testing.T, yml string) client.Object {
+	uObj := &unstructured.Unstructured{}
+	_, _, err := decoder.Decode([]byte(yml), nil, uObj)
+	if err != nil {
+		t.Fatalf("error decoding yaml: %v", err)
+	}
+	rObj, err := kinds.ToTypedObject(uObj, scheme)
+	if err != nil {
+		t.Fatalf("error converting object: %v", err)
+	}
+	cObj, ok := rObj.(client.Object)
+	if !ok {
+		t.Fatalf("error casting object (%T): %v", rObj, err)
+	}
+	return cObj
+}
+
+type fakeDestroyer struct {
+	errs        status.MultiError
+	destroyFunc func(context.Context) status.MultiError
+}
+
+var _ applier.Destroyer = &fakeDestroyer{}
+
+func newFakeDestroyer(errs status.MultiError, destroyFunc func(context.Context) status.MultiError) *fakeDestroyer {
+	return &fakeDestroyer{
+		errs:        errs,
+		destroyFunc: destroyFunc,
+	}
+}
+
+func (d *fakeDestroyer) Destroy(ctx context.Context) status.MultiError {
+	if d.destroyFunc != nil {
+		return d.destroyFunc(ctx)
+	}
+	return d.errs
+}
+
+func (d *fakeDestroyer) Errors() status.MultiError {
+	return d.errs
+}

--- a/pkg/reconciler/finalizer/update.go
+++ b/pkg/reconciler/finalizer/update.go
@@ -1,0 +1,132 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
+	"kpt.dev/configsync/pkg/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// NoUpdateError is an error that when retrned from a `MutateFn` tells
+// `updateObjectWithRetry` and `updateObjectStatus` not to perform the update,
+// usually because the change has already be made.
+type NoUpdateError struct{}
+
+// Error returns the error message
+func (nue *NoUpdateError) Error() string {
+	return "no update required"
+}
+
+// updateObjectWithRetry attempts to update an object.
+// - If the update errors due to an API status error, the update will be retried,
+//   quickly (no backoff).
+// - If the update errors due to a ResourceVersion conflict, the update will be
+//   retried against the latest version.
+// - If the update errors due to a UID conflict, an error will be returned.
+// - If the MutateFn returns a *NoUpdateError, the update will be skipped.
+// TODO: Replace with server-side-apply, if possible.
+func updateObjectWithRetry(ctx context.Context, c client.Client, obj *unstructured.Unstructured, mutate controllerutil.MutateFn) (bool, error) {
+	// UID must be set already, so we can error if it changes.
+	uid := obj.GetUID()
+	if uid == "" {
+		return false, errors.Errorf("failed to update object: metadata.uid is empty: %s", objSummary(obj))
+	}
+	objKey := client.ObjectKeyFromObject(obj)
+	// Wrapped status errors are retriable. All others are terminal.
+	retriable := func(err error) bool {
+		if _, ok := err.(status.Error); ok {
+			return true
+		}
+		return false
+	}
+	retryErr := retry.OnError(retry.DefaultRetry, retriable, func() error {
+		if err := mutate(); err != nil {
+			return err
+		}
+		if updateErr := c.Update(ctx, obj); updateErr != nil {
+			// If the update fails due to ResourceVersion conflict, get the latest
+			// version of the object, remove the finalizer, and retry.
+			if apierrors.IsConflict(updateErr) {
+				getErr := c.Get(ctx, objKey, obj)
+				if getErr != nil {
+					// Return the GET error & retry
+					return status.APIServerError(getErr,
+						fmt.Sprintf("failed to get latest version of object: %s", objSummary(obj)))
+				}
+				if obj.GetUID() != uid {
+					// Stop retrying
+					return errors.Errorf("failed to update object: metadata.uid has changed: %s", objSummary(obj))
+				}
+				// Retry with the updated object
+			}
+			// Return the UPDATE error & retry
+			return status.APIServerError(updateErr,
+				fmt.Sprintf("failed to update object: %s", objSummary(obj)))
+		}
+		return nil
+	})
+	if retryErr != nil {
+		if _, ok := retryErr.(*NoUpdateError); ok {
+			// No change necessary.
+			return false, nil
+		}
+		return false, retryErr
+	}
+	return true, nil
+}
+
+// updateObjectStatus attempts to update an object's status, once.
+// TODO: Replace with server-side-apply, if possible.
+func updateObjectStatus(ctx context.Context, c client.Client, obj *unstructured.Unstructured, mutate controllerutil.MutateFn) (bool, error) {
+	// UID must be set already, so we can error if it changes.
+	uid := obj.GetUID()
+	if uid == "" {
+		return false, errors.Errorf("failed to update object: metadata.uid is empty: %s", objSummary(obj))
+	}
+	objKey := client.ObjectKeyFromObject(obj)
+
+	if getErr := c.Get(ctx, objKey, obj); getErr != nil {
+		// Return the GET error
+		return false, status.APIServerError(getErr,
+			fmt.Sprintf("failed to get latest version of object: %s", objSummary(obj)))
+	}
+	if obj.GetUID() != uid {
+		// Object replaced
+		return false, errors.Errorf("failed to update object status: the UID has changed: %s", objSummary(obj))
+	}
+
+	if err := mutate(); err != nil {
+		if _, ok := err.(*NoUpdateError); ok {
+			// No change necessary.
+			return false, nil
+		}
+		return false, err
+	}
+
+	if updateErr := c.Status().Update(ctx, obj); updateErr != nil {
+		// Return the UPDATE error
+		return false, status.APIServerError(updateErr,
+			fmt.Sprintf("failed to update object status: %s", objSummary(obj)))
+	}
+	return true, nil
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -15,9 +15,13 @@
 package reconciler
 
 import (
+	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/client/restconfig"
@@ -27,11 +31,13 @@ import (
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/importer/reader"
 	"kpt.dev/configsync/pkg/parse"
+	"kpt.dev/configsync/pkg/reconciler/finalizer"
 	"kpt.dev/configsync/pkg/remediator"
 	"kpt.dev/configsync/pkg/remediator/watch"
 	syncerclient "kpt.dev/configsync/pkg/syncer/client"
 	"kpt.dev/configsync/pkg/syncer/metrics"
 	"kpt.dev/configsync/pkg/syncer/reconcile"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -171,7 +177,7 @@ func Run(opts Options) {
 	if err != nil {
 		klog.Fatalf("Error creating clients: %v", err)
 	}
-	var a applier.Applier
+	var a applier.Dormammu
 	if opts.ReconcilerScope == declared.RootReconciler {
 		a, err = applier.NewRootApplier(clientSet, opts.SyncName, reconcileTimeout)
 	} else {
@@ -187,12 +193,12 @@ func Run(opts Options) {
 	// Get a separate config for the remediator to talk to the apiserver since
 	// we want a longer REST config timeout for the remediator to avoid restarting
 	// idle watches too frequently.
-	cfgForRemediator, err := restconfig.NewRestConfig(watch.RESTConfigTimeout)
+	cfgForWatch, err := restconfig.NewRestConfig(watch.RESTConfigTimeout)
 	if err != nil {
 		klog.Fatalf("Error creating rest config for the remediator: %v", err)
 	}
 
-	rem, err := remediator.New(opts.ReconcilerScope, opts.SyncName, cfgForRemediator, baseApplier, decls, opts.NumWorkers)
+	rem, err := remediator.New(opts.ReconcilerScope, opts.SyncName, cfgForWatch, baseApplier, decls, opts.NumWorkers)
 	if err != nil {
 		klog.Fatalf("Instantiating Remediator: %v", err)
 	}
@@ -224,20 +230,103 @@ func Run(opts Options) {
 		}
 	}
 
-	ctx := signals.SetupSignalHandler()
+	// Start listening to signals
+	signalCtx := signals.SetupSignalHandler()
 
-	// Start the Remediator (non-blocking).
-	doneChanForRemediator := rem.Start(ctx)
+	// Create the ControllerManager
+	ctrl.SetLogger(klogr.New())
+	mgrOptions := ctrl.Options{
+		Scheme: core.Scheme,
+		MapperProvider: func(c *rest.Config) (meta.RESTMapper, error) {
+			return mapper, nil
+		},
+		BaseContext: func() context.Context {
+			return signalCtx
+		},
+	}
+	// For Namespaced Reconcilers, set the default namespace to watch.
+	// Otherwise, all namespaced informers will watch at the cluster-scope.
+	// This prevents Namespaced Reconcilers from needing cluster-scoped read
+	// permissions.
+	if opts.ReconcilerScope != declared.RootReconciler {
+		mgrOptions.Namespace = string(opts.ReconcilerScope)
+	}
+	mgr, err := ctrl.NewManager(cfgForWatch, mgrOptions)
+	if err != nil {
+		klog.Fatalf("Instantiating Controller Manager: %v", err)
+	}
 
-	// Start the Parser (blocking).
-	// This will not return until:
-	// - the Context is cancelled, or
-	// - its Done channel is closed.
-	parse.Run(ctx, parser)
+	// This cancelFunc will be used by the Finalizer to stop all the other
+	// controllers (Parser & Remediator).
+	ctx, stopControllers := context.WithCancel(signalCtx)
+	// This channel will be closed when all the other controllers have exited,
+	// signalling for the finalizer to continue.
+	continueChanForFinalizer := make(chan struct{})
+
+	// Create the Finalizer
+	f := &finalizer.Finalizer{
+		Destroyer: a,
+		// The caching client built by the controller-manager doesn't update
+		// the GET cache on UPDATE/PATCH. So we need to use a non-caching client
+		// for the finalizer, which does GET/LIST after UPDATE/PATCH.
+		Client:             cl, // non-caching client
+		StopControllers:    stopControllers,
+		ControllersStopped: continueChanForFinalizer,
+	}
+	finalizerController := &finalizer.Controller{
+		SyncScope: opts.ReconcilerScope,
+		SyncName:  opts.SyncName,
+		Client:    mgr.GetClient(), // caching client
+		Scheme:    mgr.GetScheme(),
+		Mapper:    mgr.GetRESTMapper(),
+		Finalizer: f,
+	}
+
+	// Register the Finalizer Controller
+	if err := finalizerController.SetupWithManager(mgr); err != nil {
+		klog.Fatalf("Instantiating Finalizer: %v", err)
+	}
+
+	klog.Info("Starting ControllerManager")
+	// TODO: Once everything is using the controller-manager, move mgr.Start to the top level.
+	doneChanForManager := make(chan struct{})
+	go func() {
+		defer func() {
+			// If the manager returned, there was either an error or a term/kill
+			// signal. So stop the other controllers, if not already stopped.
+			stopControllers()
+			close(doneChanForManager) // Signal thread completion
+		}()
+		err := mgr.Start(signalCtx) // blocks on signalCtx.Done()
+		if err != nil {
+			klog.Errorf("Starting ControllerManager: %v", err)
+			// klog.Fatalf calls os.Exit, which doesn't trigger defer funcs.
+			// So we're using klog.Error instead, for now.
+			// TODO: Once this is top-level, just call klog.Fatalf
+		}
+	}()
+
+	klog.Info("Starting Remediator")
+	// TODO: Convert the Remediator to use the controller-manager framework.
+	doneChanForRemediator := rem.Start(ctx) // non-blocking
+
+	klog.Info("Starting Parser")
+	// TODO: Convert the Parser to use the controller-manager framework.
+	parse.Run(ctx, parser) // blocks until ctx.Done()
 	klog.Info("Parser exited")
 
 	// Wait for Remediator to exit
 	<-doneChanForRemediator
 	klog.Info("Remediator exited")
+
+	// Unblock the Finalizer to destroy managed resources, if needed.
+	close(continueChanForFinalizer)
+	// Wait for ControllerManager to exit
+	<-doneChanForManager
+	klog.Info("Finalizer exited")
+
+	// Wait for exit signal, if not already received.
+	// This avoids unnecessary restarts after the finalizer has completed.
+	<-signalCtx.Done()
 	klog.Info("All controllers exited")
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -264,15 +264,13 @@ func Run(opts Options) {
 	continueChanForFinalizer := make(chan struct{})
 
 	// Create the Finalizer
-	f := &finalizer.Finalizer{
-		Destroyer: a,
-		// The caching client built by the controller-manager doesn't update
-		// the GET cache on UPDATE/PATCH. So we need to use a non-caching client
-		// for the finalizer, which does GET/LIST after UPDATE/PATCH.
-		Client:             cl, // non-caching client
-		StopControllers:    stopControllers,
-		ControllersStopped: continueChanForFinalizer,
-	}
+	// The caching client built by the controller-manager doesn't update
+	// the GET cache on UPDATE/PATCH. So we need to use the non-caching client
+	// for the finalizer, which does GET/LIST after UPDATE/PATCH.
+	f := finalizer.New(opts.ReconcilerScope, a, cl, // non-caching client
+		stopControllers, continueChanForFinalizer)
+
+	// Create the Finalizer Controller
 	finalizerController := &finalizer.Controller{
 		SyncScope: opts.ReconcilerScope,
 		SyncName:  opts.SyncName,

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -126,6 +126,14 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, status.APIServerError(err, "failed to get RepoSync")
 	}
 
+	if !rs.DeletionTimestamp.IsZero() {
+		// Deletion requested.
+		// Cleanup is handled above, after the RepoSync is NotFound.
+		log.V(3).Info("Deletion timestamp detected",
+			logFieldObject, rsRef.String(),
+			logFieldKind, r.syncKind)
+	}
+
 	// The caching client sometimes returns an old R*Sync, because the watch
 	// hasn't received the update event yet. If so, error and retry.
 	// This is an optimization to avoid unnecessary API calls.

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -123,6 +123,14 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, status.APIServerError(err, "failed to get RootSync")
 	}
 
+	if !rs.DeletionTimestamp.IsZero() {
+		// Deletion requested.
+		// Cleanup is handled above, after the RootSync is NotFound.
+		log.V(3).Info("Deletion timestamp detected",
+			logFieldObject, rsRef.String(),
+			logFieldKind, r.syncKind)
+	}
+
 	// The caching client sometimes returns an old R*Sync, because the watch
 	// hasn't received the update event yet. If so, error and retry.
 	// This is an optimization to avoid unnecessary API calls.

--- a/pkg/reposync/conditions.go
+++ b/pkg/reposync/conditions.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/status"
 )
 
 // Local alias to enable unit test mocking.
@@ -91,7 +92,7 @@ var singleErrorSummary = &v1beta1.ErrorSummary{
 func SetReconciling(rs *v1beta1.RepoSync, reason, message string) (updated, transitioned bool) {
 	updated, transitioned = setCondition(rs, v1beta1.RepoSyncReconciling, metav1.ConditionTrue, reason, message, "", nil, &v1beta1.ErrorSummary{}, now())
 	if transitioned {
-		removeCondition(rs, v1beta1.RepoSyncSyncing)
+		RemoveCondition(rs, v1beta1.RepoSyncSyncing)
 	}
 	return updated, transitioned
 }
@@ -103,7 +104,7 @@ func SetReconciling(rs *v1beta1.RepoSync, reason, message string) (updated, tran
 func SetStalled(rs *v1beta1.RepoSync, reason string, err error) (updated, transitioned bool) {
 	updated, transitioned = setCondition(rs, v1beta1.RepoSyncStalled, metav1.ConditionTrue, reason, err.Error(), "", nil, singleErrorSummary, now())
 	if transitioned {
-		removeCondition(rs, v1beta1.RepoSyncSyncing)
+		RemoveCondition(rs, v1beta1.RepoSyncSyncing)
 	}
 	return updated, transitioned
 }
@@ -119,6 +120,51 @@ func SetSyncing(rs *v1beta1.RepoSync, status bool, reason, message, commit strin
 		conditionStatus = metav1.ConditionFalse
 	}
 	return setCondition(rs, v1beta1.RepoSyncSyncing, conditionStatus, reason, message, commit, errorSources, errorSummary, timestamp)
+}
+
+// SetReconcilerFinalizing sets the ReconcilerFinalizing condition to True.
+// Use RemoveCondition to remove this condition. It should never be set to False.
+func SetReconcilerFinalizing(rs *v1beta1.RepoSync, reason, message string) (updated bool) {
+	updated, _ = setCondition(rs, v1beta1.RepoSyncReconcilerFinalizing, metav1.ConditionTrue, reason, message, "", nil, nil, now())
+	return updated
+}
+
+// SetReconcilerFinalizerFailure sets the ReconcilerFinalizerFailure condition.
+// If there are errors, the status is True, otherwise False.
+// Use RemoveCondition to remove this condition when the finalizer is done.
+func SetReconcilerFinalizerFailure(rs *v1beta1.RepoSync, errs status.MultiError) (updated bool) {
+	var conditionStatus metav1.ConditionStatus
+	var reason, message string
+	var summary *v1beta1.ErrorSummary
+	if errs != nil {
+		conditionStatus = metav1.ConditionTrue
+		reason = "DestroyFailure"
+		message = errs.Error()
+		summary = summarizeFinalizerErrors(errs)
+	} else {
+		conditionStatus = metav1.ConditionFalse
+		reason = "DestroySuccess"
+		message = "Successfully deleted managed resource objects"
+		summary = nil
+	}
+	updated, _ = setCondition(rs, v1beta1.RepoSyncReconcilerFinalizerFailure,
+		conditionStatus, reason, message, "", nil, summary, now())
+	return updated
+}
+
+// summarizeErrors summarizes the errors from `sourceStatus` and `syncStatus`,
+// and returns an ErrorSource slice and an ErrorSummary.
+func summarizeFinalizerErrors(errs status.MultiError) *v1beta1.ErrorSummary {
+	if errs == nil {
+		return nil
+	}
+	// TODO: handle error truncation (requires new status.finalizer fields)
+	count := len(errs.Errors())
+	return &v1beta1.ErrorSummary{
+		TotalCount:                count,
+		Truncated:                 false,
+		ErrorCountAfterTruncation: count,
+	}
 }
 
 // setCondition adds or updates the specified condition with a True status.
@@ -166,8 +212,8 @@ func GetCondition(conditions []v1beta1.RepoSyncCondition, condType v1beta1.RepoS
 	return nil
 }
 
-// removeCondition removes the RepoSync condition with the provided type.
-func removeCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType) (updated bool) {
+// RemoveCondition removes the RepoSync condition with the provided type.
+func RemoveCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType) (updated bool) {
 	rs.Status.Conditions, updated = filterOutCondition(rs.Status.Conditions, condType)
 	return updated
 }

--- a/pkg/reposync/conditions.go
+++ b/pkg/reposync/conditions.go
@@ -90,7 +90,7 @@ var singleErrorSummary = &v1beta1.ErrorSummary{
 // (status change).
 // Removes the Syncing condition if the Reconciling condition transitioned.
 func SetReconciling(rs *v1beta1.RepoSync, reason, message string) (updated, transitioned bool) {
-	updated, transitioned = setCondition(rs, v1beta1.RepoSyncReconciling, metav1.ConditionTrue, reason, message, "", nil, &v1beta1.ErrorSummary{}, now())
+	updated, transitioned = setCondition(rs, v1beta1.RepoSyncReconciling, metav1.ConditionTrue, reason, message, "", nil, nil, &v1beta1.ErrorSummary{}, now())
 	if transitioned {
 		RemoveCondition(rs, v1beta1.RepoSyncSyncing)
 	}
@@ -102,7 +102,7 @@ func SetReconciling(rs *v1beta1.RepoSync, reason, message string) (updated, tran
 // (status change).
 // Removes the Syncing condition if the Stalled condition transitioned.
 func SetStalled(rs *v1beta1.RepoSync, reason string, err error) (updated, transitioned bool) {
-	updated, transitioned = setCondition(rs, v1beta1.RepoSyncStalled, metav1.ConditionTrue, reason, err.Error(), "", nil, singleErrorSummary, now())
+	updated, transitioned = setCondition(rs, v1beta1.RepoSyncStalled, metav1.ConditionTrue, reason, err.Error(), "", nil, nil, singleErrorSummary, now())
 	if transitioned {
 		RemoveCondition(rs, v1beta1.RepoSyncSyncing)
 	}
@@ -119,13 +119,13 @@ func SetSyncing(rs *v1beta1.RepoSync, status bool, reason, message, commit strin
 	} else {
 		conditionStatus = metav1.ConditionFalse
 	}
-	return setCondition(rs, v1beta1.RepoSyncSyncing, conditionStatus, reason, message, commit, errorSources, errorSummary, timestamp)
+	return setCondition(rs, v1beta1.RepoSyncSyncing, conditionStatus, reason, message, commit, nil, errorSources, errorSummary, timestamp)
 }
 
 // SetReconcilerFinalizing sets the ReconcilerFinalizing condition to True.
 // Use RemoveCondition to remove this condition. It should never be set to False.
 func SetReconcilerFinalizing(rs *v1beta1.RepoSync, reason, message string) (updated bool) {
-	updated, _ = setCondition(rs, v1beta1.RepoSyncReconcilerFinalizing, metav1.ConditionTrue, reason, message, "", nil, nil, now())
+	updated, _ = setCondition(rs, v1beta1.RepoSyncReconcilerFinalizing, metav1.ConditionTrue, reason, message, "", nil, nil, nil, now())
 	return updated
 }
 
@@ -135,42 +135,30 @@ func SetReconcilerFinalizing(rs *v1beta1.RepoSync, reason, message string) (upda
 func SetReconcilerFinalizerFailure(rs *v1beta1.RepoSync, errs status.MultiError) (updated bool) {
 	var conditionStatus metav1.ConditionStatus
 	var reason, message string
-	var summary *v1beta1.ErrorSummary
+	var csErrs []v1beta1.ConfigSyncError
 	if errs != nil {
 		conditionStatus = metav1.ConditionTrue
 		reason = "DestroyFailure"
-		message = errs.Error()
-		summary = summarizeFinalizerErrors(errs)
+		message = "Failed to delete managed resource objects"
+		csErrs = status.ToCSE(errs)
 	} else {
 		conditionStatus = metav1.ConditionFalse
 		reason = "DestroySuccess"
 		message = "Successfully deleted managed resource objects"
-		summary = nil
+		csErrs = nil
 	}
 	updated, _ = setCondition(rs, v1beta1.RepoSyncReconcilerFinalizerFailure,
-		conditionStatus, reason, message, "", nil, summary, now())
+		conditionStatus, reason, message, "", csErrs, nil, nil, now())
 	return updated
-}
-
-// summarizeErrors summarizes the errors from `sourceStatus` and `syncStatus`,
-// and returns an ErrorSource slice and an ErrorSummary.
-func summarizeFinalizerErrors(errs status.MultiError) *v1beta1.ErrorSummary {
-	if errs == nil {
-		return nil
-	}
-	// TODO: handle error truncation (requires new status.finalizer fields)
-	count := len(errs.Errors())
-	return &v1beta1.ErrorSummary{
-		TotalCount:                count,
-		Truncated:                 false,
-		ErrorCountAfterTruncation: count,
-	}
 }
 
 // setCondition adds or updates the specified condition with a True status.
 // Returns whether the condition was updated (any change) or transitioned
 // (status change).
-func setCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType, status metav1.ConditionStatus, reason, message, commit string, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, timestamp metav1.Time) (updated, transitioned bool) {
+//
+// Use Errors OR (ErrorSource & ErrorSummary).
+// Errors should only be used if there isn't another status field to reference.
+func setCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType, status metav1.ConditionStatus, reason, message, commit string, errs []v1beta1.ConfigSyncError, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, timestamp metav1.Time) (updated, transitioned bool) {
 	condition := GetCondition(rs.Status.Conditions, condType)
 	if condition == nil {
 		i := len(rs.Status.Conditions)
@@ -186,6 +174,7 @@ func setCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType, 
 	} else if condition.Reason != reason ||
 		condition.Message != message ||
 		condition.Commit != commit ||
+		!equality.Semantic.DeepEqual(condition.Errors, errs) ||
 		!equality.Semantic.DeepEqual(condition.ErrorSourceRefs, errorSources) ||
 		!equality.Semantic.DeepEqual(condition.ErrorSummary, errorSummary) {
 		updated = true
@@ -195,6 +184,7 @@ func setCondition(rs *v1beta1.RepoSync, condType v1beta1.RepoSyncConditionType, 
 	condition.Reason = reason
 	condition.Message = message
 	condition.Commit = commit
+	condition.Errors = errs
 	condition.ErrorSourceRefs = errorSources
 	condition.ErrorSummary = errorSummary
 	condition.LastUpdateTime = timestamp

--- a/pkg/reposync/conditions_test.go
+++ b/pkg/reposync/conditions_test.go
@@ -650,10 +650,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 					Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
 					Status:  metav1.ConditionTrue,
 					Reason:  "DestroyFailure",
-					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
-					ErrorSummary: &v1beta1.ErrorSummary{
-						TotalCount:                1,
-						ErrorCountAfterTruncation: 1,
+					Message: "Failed to delete managed resource objects",
+					Errors: []v1beta1.ConfigSyncError{
+						{
+							Code:         "2009",
+							ErrorMessage: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+						},
 					},
 					LastUpdateTime:     updatedNow,
 					LastTransitionTime: updatedNow,
@@ -669,10 +671,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
 						Status:  metav1.ConditionTrue,
 						Reason:  "DestroyFailure",
-						Message: "fake error message",
-						ErrorSummary: &v1beta1.ErrorSummary{
-							TotalCount:                1,
-							ErrorCountAfterTruncation: 1,
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2009",
+								ErrorMessage: "KNV2009: fake error message",
+							},
 						},
 						LastUpdateTime:     initialNow,
 						LastTransitionTime: initialNow,
@@ -714,10 +718,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 					Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
 					Status:  metav1.ConditionTrue,
 					Reason:  "DestroyFailure",
-					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
-					ErrorSummary: &v1beta1.ErrorSummary{
-						TotalCount:                1,
-						ErrorCountAfterTruncation: 1,
+					Message: "Failed to delete managed resource objects",
+					Errors: []v1beta1.ConfigSyncError{
+						{
+							Code:         "2009",
+							ErrorMessage: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+						},
 					},
 					LastUpdateTime:     updatedNow,
 					LastTransitionTime: initialNow,

--- a/pkg/rootsync/conditions_test.go
+++ b/pkg/rootsync/conditions_test.go
@@ -649,10 +649,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 					Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
 					Status:  metav1.ConditionTrue,
 					Reason:  "DestroyFailure",
-					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
-					ErrorSummary: &v1beta1.ErrorSummary{
-						TotalCount:                1,
-						ErrorCountAfterTruncation: 1,
+					Message: "Failed to delete managed resource objects",
+					Errors: []v1beta1.ConfigSyncError{
+						{
+							Code:         "2009",
+							ErrorMessage: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+						},
 					},
 					LastUpdateTime:     updatedNow,
 					LastTransitionTime: updatedNow,
@@ -668,10 +670,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
 						Status:  metav1.ConditionTrue,
 						Reason:  "DestroyFailure",
-						Message: "fake error message",
-						ErrorSummary: &v1beta1.ErrorSummary{
-							TotalCount:                1,
-							ErrorCountAfterTruncation: 1,
+						Message: "Failed to delete managed resource objects",
+						Errors: []v1beta1.ConfigSyncError{
+							{
+								Code:         "2009",
+								ErrorMessage: "KNV2009: fake error message",
+							},
 						},
 						LastUpdateTime:     initialNow,
 						LastTransitionTime: initialNow,
@@ -713,10 +717,12 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 					Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
 					Status:  metav1.ConditionTrue,
 					Reason:  "DestroyFailure",
-					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
-					ErrorSummary: &v1beta1.ErrorSummary{
-						TotalCount:                1,
-						ErrorCountAfterTruncation: 1,
+					Message: "Failed to delete managed resource objects",
+					Errors: []v1beta1.ConfigSyncError{
+						{
+							Code:         "2009",
+							ErrorMessage: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+						},
 					},
 					LastUpdateTime:     updatedNow,
 					LastTransitionTime: initialNow,

--- a/pkg/rootsync/conditions_test.go
+++ b/pkg/rootsync/conditions_test.go
@@ -24,7 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -530,6 +532,316 @@ func TestSetSyncing(t *testing.T) {
 			}
 			assert.Equal(t, tc.wantUpdated, updated, "updated")
 			assert.Equal(t, tc.wantTransitioned, transitioned, "transitioned")
+		})
+	}
+}
+
+func TestSetReconcilerFinalizing(t *testing.T) {
+	now = func() metav1.Time {
+		return initialNow
+	}
+	testCases := []struct {
+		name        string
+		rs          *v1beta1.RootSync
+		reason      string
+		message     string
+		want        []v1beta1.RootSyncCondition
+		wantUpdated bool
+	}{
+		{
+			name:    "Set new finalizing condition without error",
+			rs:      fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			reason:  "Finalizing",
+			message: "",
+			want: []v1beta1.RootSyncCondition{
+				// Update and transition
+				{
+					Type:               v1beta1.RootSyncReconcilerFinalizing,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Finalizing",
+					Message:            "",
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "Update to add change message",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:               v1beta1.RootSyncReconcilerFinalizing,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Finalizing",
+						Message:            "",
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			reason:  "Finalizing",
+			message: "Deleting managed objects",
+			want: []v1beta1.RootSyncCondition{
+				// Update but no transition
+				{
+					Type:               v1beta1.RootSyncReconcilerFinalizing,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Finalizing",
+					Message:            "Deleting managed objects",
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: initialNow,
+				},
+			},
+			wantUpdated: true,
+		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated := SetReconcilerFinalizing(tc.rs, tc.reason, tc.message)
+			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
+				t.Error(diff)
+			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
+		})
+	}
+}
+
+func TestSetReconcilerFinalizerFailure(t *testing.T) {
+	deployment1 := fake.DeploymentObject()
+	deployment1ID := core.IDOf(deployment1)
+
+	now = func() metav1.Time {
+		return initialNow
+	}
+	testCases := []struct {
+		name        string
+		rs          *v1beta1.RootSync
+		errs        status.MultiError
+		want        []v1beta1.RootSyncCondition
+		wantUpdated bool
+	}{
+		{
+			name: "Set new finalizer failure condition without error",
+			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			errs: nil,
+			want: []v1beta1.RootSyncCondition{
+				// Update and transition
+				{
+					Type:               v1beta1.RootSyncReconcilerFinalizerFailure,
+					Status:             metav1.ConditionFalse,
+					Reason:             "DestroySuccess",
+					Message:            "Successfully deleted managed resource objects",
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "Set new finalizer failure condition with error",
+			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			errs: applier.DeleteErrorForResource(errors.New("fake error"), deployment1ID),
+			want: []v1beta1.RootSyncCondition{
+				// Update and transition
+				{
+					Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+					Status:  metav1.ConditionTrue,
+					Reason:  "DestroyFailure",
+					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+					ErrorSummary: &v1beta1.ErrorSummary{
+						TotalCount:                1,
+						ErrorCountAfterTruncation: 1,
+					},
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "Update to change status",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "fake error message",
+						ErrorSummary: &v1beta1.ErrorSummary{
+							TotalCount:                1,
+							ErrorCountAfterTruncation: 1,
+						},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			errs: nil,
+			want: []v1beta1.RootSyncCondition{
+				// Update but no transition
+				{
+					Type:               v1beta1.RootSyncReconcilerFinalizerFailure,
+					Status:             metav1.ConditionFalse,
+					Reason:             "DestroySuccess",
+					Message:            "Successfully deleted managed resource objects",
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "Update to change error message",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+						Status:  metav1.ConditionTrue,
+						Reason:  "DestroyFailure",
+						Message: "fake error message",
+						ErrorSummary: &v1beta1.ErrorSummary{
+							TotalCount:                1,
+							ErrorCountAfterTruncation: 1,
+						},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			errs: applier.DeleteErrorForResource(errors.New("fake error"), deployment1ID),
+			want: []v1beta1.RootSyncCondition{
+				// Update but no transition
+				{
+					Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
+					Status:  metav1.ConditionTrue,
+					Reason:  "DestroyFailure",
+					Message: "KNV2009: failed to delete Deployment.apps, /default-name: fake error\n\nFor more information, see https://g.co/cloud/acm-errors#knv2009",
+					ErrorSummary: &v1beta1.ErrorSummary{
+						TotalCount:                1,
+						ErrorCountAfterTruncation: 1,
+					},
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: initialNow,
+				},
+			},
+			wantUpdated: true,
+		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated := SetReconcilerFinalizerFailure(tc.rs, tc.errs)
+			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
+				t.Error(diff)
+			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
+		})
+	}
+}
+
+func TestRemoveCondition(t *testing.T) {
+	now = func() metav1.Time {
+		return initialNow
+	}
+	testCases := []struct {
+		name        string
+		rs          *v1beta1.RootSync
+		condType    v1beta1.RootSyncConditionType
+		want        []v1beta1.RootSyncCondition
+		wantUpdated bool
+	}{
+		{
+			name: "Remove Reconciling condition",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:               v1beta1.RootSyncReconciling,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Reconciling",
+						Message:            "",
+						ErrorSummary:       &v1beta1.ErrorSummary{},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			condType:    v1beta1.RootSyncReconciling,
+			want:        nil,
+			wantUpdated: true,
+		},
+		{
+			name: "Remove Syncing condition when Reconciling",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:               v1beta1.RootSyncSyncing,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Syncing",
+						Message:            "",
+						ErrorSummary:       &v1beta1.ErrorSummary{},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					},
+					v1beta1.RootSyncCondition{
+						Type:               v1beta1.RootSyncReconciling,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Reconciling",
+						Message:            "",
+						ErrorSummary:       &v1beta1.ErrorSummary{},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			condType: v1beta1.RootSyncSyncing,
+			want: []v1beta1.RootSyncCondition{
+				{
+					Type:               v1beta1.RootSyncReconciling,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Reconciling",
+					Message:            "",
+					ErrorSummary:       &v1beta1.ErrorSummary{},
+					LastUpdateTime:     initialNow,
+					LastTransitionTime: initialNow,
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "Remove missing condition",
+			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				withConditions(
+					v1beta1.RootSyncCondition{
+						Type:               v1beta1.RootSyncReconcilerFinalizing,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Finalizing",
+						Message:            "",
+						ErrorSummary:       &v1beta1.ErrorSummary{},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			condType: v1beta1.RootSyncSyncing,
+			want: []v1beta1.RootSyncCondition{
+				// Update but no transition
+				{
+					Type:               v1beta1.RootSyncReconcilerFinalizing,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Finalizing",
+					Message:            "",
+					ErrorSummary:       &v1beta1.ErrorSummary{},
+					LastUpdateTime:     initialNow,
+					LastTransitionTime: initialNow,
+				},
+			},
+			wantUpdated: false,
+		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated := RemoveCondition(tc.rs, tc.condType)
+			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
+				t.Error(diff)
+			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
 		})
 	}
 }

--- a/pkg/util/mutate/mutate.go
+++ b/pkg/util/mutate/mutate.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/util/retry"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,12 +40,26 @@ func (nue *NoUpdateError) Error() string {
 	return "no update required"
 }
 
+// Retriable identifies Kubernetes apiserver errors that are normally transient
+// and safely retriable.
+func Retriable(err error) bool {
+	return apierrors.IsInternalError(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		net.IsConnectionRefused(err)
+}
+
+// RetriableOrConflict identifies Kubernetes apiserver errors that are either
+// retriable or a conflict (retriable with GET + mutation).
+func RetriableOrConflict(err error) bool {
+	return Retriable(err) || apierrors.IsConflict(err)
+}
+
 // WithRetry attempts to update an object until successful or update becomes
 // unnecessary (`NoUpdateError` from the `mutate.Func`). Retries are quick, with
 // no backoff.
 //
-//   - If the update errors due to an API status error, the object will
-//     be re-read from the server, re-mutated, and re-updated.
+//   - If the update errors due to a `Retriable“ API status error, the object
+//     will be re-read from the server, re-mutated, and re-updated.
 //   - If the update errors due to a ResourceVersion conflict, the object will
 //     be re-read from the server, re-mutated, and re-updated.
 //   - If the update errors due to a UID conflict, that means the object has
@@ -54,49 +70,58 @@ func WithRetry(ctx context.Context, c client.Client, obj client.Object, mutate F
 	// UID must be set already, so we can error if it changes.
 	uid := obj.GetUID()
 	if uid == "" {
-		return false, fmt.Errorf("failed to update object: metadata.uid is empty: %s", objSummary(obj))
+		return false, fmt.Errorf("failed to update object: %s: metadata.uid is empty", objSummary(obj))
+	}
+	// Mutate the object from the server
+	if err := mutate(); err != nil {
+		if noUpdateErr := (&NoUpdateError{}); errors.As(err, &noUpdateErr) {
+			// No change necessary.
+			return false, nil
+		}
+		return false, errors.Wrap(err, "failed to mutate object")
 	}
 	objKey := client.ObjectKeyFromObject(obj)
-	// Wrapped status errors are retriable. All others are terminal.
-	retriable := func(err error) bool {
-		if _, ok := err.(status.Error); ok {
-			return true
-		}
-		return false
-	}
-	retryErr := retry.OnError(retry.DefaultRetry, retriable, func() error {
-		if err := mutate(); err != nil {
-			return err
+	retryErr := retry.OnError(retry.DefaultRetry, RetriableOrConflict, func() error {
+		// If ResourceVersion is NOT set, request the latest object from the server.
+		// Otherwise, assume the object was previously retrieved.
+		if obj.GetResourceVersion() == "" {
+			if getErr := c.Get(ctx, objKey, obj); getErr != nil {
+				// Return the GET error & retry
+				return errors.Wrap(getErr, "failed to get latest version of object")
+			}
+			if obj.GetUID() != uid {
+				// Stop retrying
+				return errors.New("metadata.uid has changed: object may have been re-created")
+			}
+			// Mutate the latest object from the server
+			if err := mutate(); err != nil {
+				// Stop retrying
+				return errors.Wrap(err, "failed to mutate object")
+			}
 		}
 		if updateErr := c.Update(ctx, obj); updateErr != nil {
 			// If the update fails due to ResourceVersion conflict, get the latest
 			// version of the object, remove the finalizer, and retry.
 			if apierrors.IsConflict(updateErr) {
-				fmt.Printf("WithRetry update conflict: %v", updateErr)
-				getErr := c.Get(ctx, objKey, obj)
-				if getErr != nil {
-					// Return the GET error & retry
-					return status.APIServerError(getErr,
-						fmt.Sprintf("failed to get latest version of object: %s", objSummary(obj)))
-				}
-				if obj.GetUID() != uid {
-					// Stop retrying
-					return fmt.Errorf("failed to update object: metadata.uid has changed: %s", objSummary(obj))
-				}
-				// Retry with the updated object
+				// Clear ResourceVersion to trigger GET on next retry
+				obj.SetResourceVersion("")
 			}
 			// Return the UPDATE error & retry
-			return status.APIServerError(updateErr,
-				fmt.Sprintf("failed to update object: %s", objSummary(obj)))
+			return updateErr
 		}
+		// Success! Stop retrying.
 		return nil
 	})
 	if retryErr != nil {
-		if _, ok := retryErr.(*NoUpdateError); ok {
+		if noUpdateErr := (&NoUpdateError{}); errors.As(retryErr, &noUpdateErr) {
 			// No change necessary.
 			return false, nil
 		}
-		return false, retryErr
+		if statusErr := apierrors.APIStatus(nil); errors.As(retryErr, &statusErr) {
+			// The error (or an error it wraps) is a known status error from K8s
+			return false, status.APIServerError(retryErr, "failed to update object", obj)
+		}
+		return false, errors.Wrapf(retryErr, "failed to update object: %s", objSummary(obj))
 	}
 	return true, nil
 }
@@ -110,32 +135,38 @@ func Status(ctx context.Context, c client.Client, obj client.Object, mutate Func
 	// UID must be set already, so we can error if it changes.
 	uid := obj.GetUID()
 	if uid == "" {
-		return false, fmt.Errorf("failed to update object: metadata.uid is empty: %s", objSummary(obj))
+		return false, fmt.Errorf("failed to update object: %s: metadata.uid is empty", objSummary(obj))
 	}
-	objKey := client.ObjectKeyFromObject(obj)
-
-	if getErr := c.Get(ctx, objKey, obj); getErr != nil {
-		// Return the GET error
-		return false, status.APIServerError(getErr,
-			fmt.Sprintf("failed to get latest version of object: %s", objSummary(obj)))
-	}
-	if obj.GetUID() != uid {
-		// Object replaced
-		return false, fmt.Errorf("failed to update object status: the UID has changed: %s", objSummary(obj))
-	}
-
-	if err := mutate(); err != nil {
-		if _, ok := err.(*NoUpdateError); ok {
+	// Wrap inner part in a closure to simplify consistent error handling.
+	// Errors from `Status`` and `WithRetry` should look similar, even tho
+	// `Status` only makes one attempt.
+	retryErr := func() error {
+		// If ResourceVersion is NOT set, request the latest object from the server.
+		// Otherwise, assume the object was previously retrieved.
+		if obj.GetResourceVersion() == "" {
+			objKey := client.ObjectKeyFromObject(obj)
+			if getErr := c.Get(ctx, objKey, obj); getErr != nil {
+				return errors.Wrap(getErr, "failed to get latest version of object")
+			}
+			if obj.GetUID() != uid {
+				return errors.New("metadata.uid has changed: object may have been re-created")
+			}
+		}
+		if err := mutate(); err != nil {
+			return errors.Wrap(err, "failed to mutate object")
+		}
+		return c.Status().Update(ctx, obj)
+	}()
+	if retryErr != nil {
+		if noUpdateErr := (&NoUpdateError{}); errors.As(retryErr, &noUpdateErr) {
 			// No change necessary.
 			return false, nil
 		}
-		return false, err
-	}
-
-	if updateErr := c.Status().Update(ctx, obj); updateErr != nil {
-		// Return the UPDATE error
-		return false, status.APIServerError(updateErr,
-			fmt.Sprintf("failed to update object status: %s", objSummary(obj)))
+		if statusErr := apierrors.APIStatus(nil); errors.As(retryErr, &statusErr) {
+			// The error (or an error it wraps) is a known status error from K8s
+			return false, status.APIServerError(retryErr, "failed to update object status", obj)
+		}
+		return false, errors.Wrapf(retryErr, "failed to update object status: %s", objSummary(obj))
 	}
 	return true, nil
 }

--- a/pkg/util/mutate/mutate_test.go
+++ b/pkg/util/mutate/mutate_test.go
@@ -1,0 +1,439 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/pointer"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// decoder uses core.Scheme to parse YAML/JSON into typed objects
+var decoder = serializer.NewCodecFactory(core.Scheme).UniversalDeserializer()
+
+var deployment1Yaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+  namespace: default
+  uid: "1"
+  resourceVersion: "1"
+  generation: 1
+spec:
+  selector:
+    matchLabels:
+      app: hello-world
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      containers:
+      - name: hello
+        image: "gcr.io/google-samples/hello-app:2.0"
+        env:
+        - name: "PORT"
+          value: "50000"
+`
+
+func TestStatus(t *testing.T) {
+	deployment1 := yamlToTypedObject(t, deployment1Yaml)
+
+	var inputObj client.Object
+
+	testCases := []struct {
+		name            string
+		obj             client.Object
+		mutateFunc      Func
+		existingObjs    []client.Object
+		expectedUpdated bool
+		expectedError   error
+		expectedObj     client.Object
+	}{
+		{
+			name: "no change client-side",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				return &NoUpdateError{}
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: false,
+			expectedError:   nil,
+			expectedObj:     deploymentCopy(deployment1), // ResourceVersion & generation unchanged
+		},
+		{
+			name: "status change",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Status.Replicas = 1
+				return nil
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: true,
+			expectedError:   nil,
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				obj.Status.Replicas = 1
+				obj.SetResourceVersion("2")
+				// generation unchanged (no spec changes)
+				return obj
+			}(),
+		},
+		{
+			name: "no change server-side",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Status.Replicas = 1
+				obj.SetResourceVersion("1") // Fake a duplicate request
+				return nil
+			},
+			existingObjs: []client.Object{
+				func() client.Object {
+					obj := deploymentCopy(deployment1)
+					obj.Status.Replicas = 1
+					obj.SetResourceVersion("2") // server object already updated
+					// generation unchanged (no spec changes)
+					return obj
+				}(),
+			},
+			// Expect no update because there was an error
+			expectedUpdated: false,
+			// Expect a conflict, because the ResourceVersion in the request is older than the one on the server
+			expectedError: status.APIServerError(
+				apierrors.NewConflict(
+					schema.GroupResource{Group: "apps", Resource: "Deployment"},
+					"default/hello-world",
+					fmt.Errorf("ResourceVersion conflict: expected \"1\" but found \"2\"")),
+				"failed to update object status: *v1.Deployment default/hello-world"),
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				obj.Status.Replicas = 1
+				obj.SetResourceVersion("2") // unchanged
+				return obj
+			}(),
+		},
+		{
+			name: "ignore spec change",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Spec.Replicas = pointer.Int32(2)
+				return nil
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: true,
+			expectedError:   nil,
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				// spec change not persisted
+				obj.SetResourceVersion("2") // ResourceVersion updated, even tho nothing changed // TODO: does this match apiserver behavior?
+				// generation unchanged (no spec changes)
+				return obj
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// set the input object so tc.mutateFunc can update it
+			inputObj = tc.obj
+
+			scheme := core.Scheme
+			fakeClient := fake.NewClient(t, scheme, tc.existingObjs...)
+			ctx := context.Background()
+			key := client.ObjectKeyFromObject(tc.obj)
+			updated, err := Status(ctx, fakeClient, tc.obj, tc.mutateFunc)
+			if tc.expectedError != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+			assert.Equal(t, tc.expectedUpdated, updated)
+
+			obj := newObjectWithSameType(t, scheme, tc.expectedObj)
+			err = fakeClient.Get(ctx, key, obj)
+			require.NoError(t, err)
+			testutil.AssertEqual(t, tc.expectedObj, obj)
+		})
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	deployment1 := yamlToTypedObject(t, deployment1Yaml)
+
+	var inputObj client.Object
+	var once sync.Once
+	var fakeClient *fake.Client
+
+	testCases := []struct {
+		name            string
+		obj             client.Object
+		mutateFunc      Func
+		existingObjs    []client.Object
+		expectedUpdated bool
+		expectedError   error
+		expectedObj     client.Object
+	}{
+		{
+			name: "no change client-side",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				return &NoUpdateError{}
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: false,
+			expectedError:   nil,
+			expectedObj:     deploymentCopy(deployment1), // ResourceVersion & generation unchanged
+		},
+		{
+			name: "spec change",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Spec.Replicas = pointer.Int32(2)
+				return nil
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: true,
+			expectedError:   nil,
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				obj.Spec.Replicas = pointer.Int32(2)
+				obj.SetResourceVersion("2") // updated
+				obj.SetGeneration(2)        // updated
+				return obj
+			}(),
+		},
+		{
+			name: "no change server-side (retry but eventually give up)",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Spec.Replicas = pointer.Int32(1)
+				obj.SetResourceVersion("1") // Fake a duplicate request
+				return nil
+			},
+			existingObjs: []client.Object{
+				func() client.Object {
+					obj := deploymentCopy(deployment1)
+					obj.Spec.Replicas = pointer.Int32(1)
+					obj.SetResourceVersion("2") // server object already updated
+					obj.SetGeneration(2)        // server spec already updated
+					return obj
+				}(),
+			},
+			// Expect no update because there was an error
+			expectedUpdated: false,
+			// Expect a conflict, because the ResourceVersion in the request is older than the one on the server
+			expectedError: status.APIServerError(
+				apierrors.NewConflict(
+					schema.GroupResource{Group: "apps", Resource: "Deployment"},
+					"default/hello-world",
+					fmt.Errorf("ResourceVersion conflict: expected \"1\" but found \"2\"")),
+				"failed to update object: *v1.Deployment default/hello-world"),
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				obj.Spec.Replicas = pointer.Int32(1)
+				obj.SetResourceVersion("2") // unchanged
+				obj.SetGeneration(2)        // unchanged
+				return obj
+			}(),
+		},
+		{
+			name: "ignore status change",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Status.Replicas = 1
+				return nil
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			expectedUpdated: true,
+			expectedError:   nil,
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				// status change not persisted
+				obj.SetResourceVersion("2") // ResourceVersion updated, even tho nothing changed // TODO: does this match apiserver behavior?
+				// generation unchanged (no spec changes)
+				return obj
+			}(),
+		},
+		{
+			name: "stale version (succeed on retry)",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+				obj.Spec.Replicas = pointer.Int32(2)
+				once.Do(func() {
+					obj.SetResourceVersion("1") // Fake a stale request once
+				})
+				return nil
+			},
+			existingObjs: []client.Object{
+				func() client.Object {
+					obj := deploymentCopy(deployment1)
+					obj.Spec.Replicas = pointer.Int32(1)
+					obj.SetResourceVersion("2") // server object already updated
+					obj.SetGeneration(2)        // server spec already updated
+					return obj
+				}(),
+			},
+			// Expect no update because there was an error
+			expectedUpdated: true,
+			// Expect a conflict, because the ResourceVersion in the request is older than the one on the server
+			expectedError: nil,
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				obj.Spec.Replicas = pointer.Int32(2)
+				obj.SetResourceVersion("3") // changed
+				obj.SetGeneration(3)        // changed
+				return obj
+			}(),
+		},
+		{
+			name: "async re-creation",
+			obj:  deploymentCopy(deployment1),
+			mutateFunc: func() error {
+				obj := inputObj.(*appsv1.Deployment)
+
+				// Fake async delete
+				err := fakeClient.Delete(context.Background(), obj.DeepCopy())
+				if err != nil {
+					return fmt.Errorf("failed to delete object: %w", err)
+				}
+				// Fake async re-create (with different UID)
+				replacementObj := obj.DeepCopy()
+				replacementObj.SetUID("2")
+				err = fakeClient.Create(context.Background(), replacementObj)
+				if err != nil {
+					return fmt.Errorf("failed to create object: %w", err)
+				}
+
+				// Continue mutation
+				obj.Spec.Replicas = pointer.Int32(1)
+				return nil
+			},
+			existingObjs: []client.Object{
+				deploymentCopy(deployment1),
+			},
+			// Expect no update because there was an error
+			expectedUpdated: false,
+			// Expect err, because the UID in the request is older than the one on the server
+			expectedError: errors.New("failed to update object: metadata.uid has changed: *v1.Deployment default/hello-world"),
+			expectedObj: func() client.Object {
+				obj := deploymentCopy(deployment1)
+				// no change persisted
+				obj.SetUID("2")
+				return obj
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// set the input object so tc.mutateFunc can update it
+			inputObj = tc.obj
+			// Reset once to allow one per test
+			once = sync.Once{}
+
+			scheme := core.Scheme
+			fakeClient = fake.NewClient(t, scheme, tc.existingObjs...)
+			ctx := context.Background()
+			key := client.ObjectKeyFromObject(tc.obj)
+			updated, err := WithRetry(ctx, fakeClient, tc.obj, tc.mutateFunc)
+			if tc.expectedError != nil && err != nil {
+				// AssertEqual doesn't work well on APIServerError, because the
+				// Error.Is impl is too lenient. So check the error message and
+				// type, instead.
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+				assert.IsType(t, tc.expectedError, err)
+			} else {
+				testutil.AssertEqual(t, tc.expectedError, err)
+			}
+			assert.Equal(t, tc.expectedUpdated, updated)
+
+			obj := newObjectWithSameType(t, scheme, tc.expectedObj)
+			err = fakeClient.Get(ctx, key, obj)
+			require.NoError(t, err)
+			testutil.AssertEqual(t, tc.expectedObj, obj)
+		})
+	}
+}
+
+func newObjectWithSameType(t *testing.T, scheme *runtime.Scheme, in client.Object) client.Object {
+	var obj client.Object
+	if _, ok := in.(*unstructured.Unstructured); ok {
+		obj = &unstructured.Unstructured{}
+	} else {
+		gvk, err := kinds.Lookup(in, scheme)
+		require.NoError(t, err)
+		rObj, err := scheme.New(gvk)
+		require.NoError(t, err)
+		obj = rObj.(client.Object)
+	}
+	return obj
+}
+
+func yamlToTypedObject(t *testing.T, yml string) client.Object {
+	obj := &appsv1.Deployment{}
+	_, _, err := decoder.Decode([]byte(yml), nil, obj)
+	if err != nil {
+		t.Fatalf("error decoding yaml: %v", err)
+		return nil
+	}
+	return obj
+}
+
+func deploymentCopy(in client.Object) *appsv1.Deployment {
+	return in.(*appsv1.Deployment).DeepCopy()
+}


### PR DESCRIPTION
Add a new reconciler finalizer to optionally destroy user objects that were previously applied (exist in the ResourceGroup inventory spec).

Design (internal): [go/config-sync-deletion-propagation](http://goto.google.com/config-sync-deletion-propagation)

### Goals
- The primary purpose of this feature is to be able to simplify e2e testing, by delegating cleanup of managed objects to the reconciler.
- The secondary purpose of this feature is to prototype a new feature to allow users to delete manage objects easily, which is useful for testing, experimentation, demos, and sometimes migration.

### Annotations
- To enable, set the RootSync/RepoSync annotation: `configsync.gke.io/deletion-propagation-policy: Foreground`
- To disable, delete the annotation or use: `configsync.gke.io/deletion-propagation-policy: Orphan`

### Finalizers
- When the  `configsync.gke.io/deletion-propagation-policy: Foreground` annotation is detected, the reconciler will add the `configsync.gke.io/reconciler` finalizer to the RootSync/RepoSync. The finalizer blocks deletion and triggers the reconciler to execute the kpt destroyer when the deletionTimestamp is detected. The destroyer will delete all resources managed by that reconciler.

### Conditions
- The `ReconcilerFinalizing` condition is used to tell the user that the new finalizer is running or complete. If it hasn't started yet, it won't be added.
- The `ReconcilerFinalizerFailure` condition is used to tell the user that the finalizer has encountered errors. Unlike the `Syncing` condition, the `ReconcilerFinalizerFailure` condition uses the legacy `errors` field to list errors. This was done to avoid adding new API status fields, for now. If we decide to document this feature for customer use, we'll probably want to change how the errors are exposed, to solve the problem of too many errors consuming > 1.5MB (the etcd object size limit). The `Syncing` condition uses truncation for this, which we could adopt here as well. But for now, this is out of scope for MVP.

### Webhook
- The webhook was updated to allow reconcilers to update their own RootSync/RepoSync, so they can manage the finalizer.

### Permissions
- The ClusterRole used to grant permissions to the reconciler has been updated to allow the reconciler to get, list, update, patch, and watch (but not create or delete) the spec of RootSyncs/RepoSyncs, not just the status, so they can manage the finalizer. Unfortunately, finalizers are not a sub-resource, so their permissions cannot be managed independently of the spec or other metadata.

### Why this way?
- The interface for this feature was chosen for its similarity to k8s' built-in deletion propagation, which uses garbage collection (background), a blocking finalizer (foreground), or nothing (orphan) to delete objects owned by the object being deleted.
- We can't use the built-in k8s deletion propagation for deleting user objects, because ownership only works within the same namespace, we want the behavior to be consistent for RootSync & RepoSync, and we didn't want to modify the user objects to mark them as owned (this would make diffing and remediation harder).
- We didn't implement a "background" deletion equivalent, because we don't have a use case for it yet. And for the reconciler to implement background deletion, the reconciler deployment lifecycle would need to be changed. This could be added later, if needed.
- For this MVP, we wanted to avoid modifying the CRD schema until we're sure it works well and are ready to expose it for general availability and the resulting reverse compatibility guarantees. So we used conditions and annotations for the interface. In the future, however, we may replace the annotation with a spec field and may add a status field with error truncation, but these are out of scope for MVP.
