### PR TITLE
run configsync-crds as part of presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,14 +206,14 @@ include Makefile.oss.prow
 include Makefile.reconcilermanager
 -include Makefile.release
 
-all: test deps
+all: test deps configsync-crds
 
 # Cleans all artifacts.
 clean:
 	@echo "+++ Cleaning $(OUTPUT_DIR)"
 	@rm -rf $(OUTPUT_DIR)
 
-test-unit: pull-buildenv buildenv-dirs install-kustomize
+test-unit: pull-buildenv buildenv-dirs "$(BIN_DIR)/kustomize"
 	@echo "+++ Running unit tests in a docker container"
 	@docker run $(DOCKER_RUN_ARGS) ./scripts/test-unit.sh $(NOMOS_GO_PKG)
 
@@ -265,7 +265,11 @@ lint-license: pull-buildenv buildenv-dirs
 	go install github.com/google/addlicense@v1.0.0
 
 "$(GOBIN)/kustomize":
-	go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
+	CGO_ENABLED=0 go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
+
+# install kustomize binary for containerized testing
+"$(BIN_DIR)/kustomize": "$(GOBIN)/kustomize"
+	cp $(GOBIN)/kustomize $(BIN_DIR)/kustomize
 
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"

--- a/Makefile.build
+++ b/Makefile.build
@@ -1,7 +1,6 @@
 # Included by Makefile.
 # Rules related to building nomos and docker images.
 
-KUSTOMIZE := $(BIN_DIR)/kustomize
 HELM := $(BIN_DIR)/helm
 
 ###################################
@@ -20,14 +19,6 @@ build-buildenv: build/buildenv/Dockerfile
 push-buildenv: build-buildenv
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
 	@docker push $(BUILDENV_IMAGE)
-
-.PHONY: install-kustomize
-# install kustomize binary
-install-kustomize:
-	wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz -O /tmp/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
-	tar -zxvf /tmp/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz -C /tmp
-	mv /tmp/kustomize $(KUSTOMIZE)
-	rm /tmp/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
 
 ###################################
 # Docker images

--- a/Makefile.reconcilermanager
+++ b/Makefile.reconcilermanager
@@ -13,7 +13,7 @@ generate: install-controller-gen
 
 .PHONY: configsync-crds
 # Generate configsync CRDs
-configsync-crds: install-controller-gen install-kustomize
+configsync-crds: install-controller-gen "$(GOBIN)/kustomize" "$(GOBIN)/addlicense"
 	$(CONTROLLER_GEN) \
 		crd \
 		paths="./pkg/api/configsync/v1alpha1" \
@@ -21,11 +21,12 @@ configsync-crds: install-controller-gen install-kustomize
 		output:artifacts:config=manifests \
 		&& mv manifests/configsync.gke.io_reposyncs.yaml manifests/patch/reposync-crd.yaml \
 		&& mv manifests/configsync.gke.io_rootsyncs.yaml manifests/patch/rootsync-crd.yaml; \
-  	$(KUSTOMIZE) build ./manifests/patch -o ./manifests;  \
-  	mv ./manifests/*customresourcedefinition_rootsyncs* ./manifests/rootsync-crd.yaml; \
-  	mv ./manifests/*customresourcedefinition_reposyncs* ./manifests/reposync-crd.yaml; \
-  	rm ./manifests/patch/reposync-crd.yaml; \
-  	rm ./manifests/patch/rootsync-crd.yaml; \
+	"$(GOBIN)/kustomize" build ./manifests/patch -o ./manifests;  \
+	mv ./manifests/*customresourcedefinition_rootsyncs* ./manifests/rootsync-crd.yaml; \
+	mv ./manifests/*customresourcedefinition_reposyncs* ./manifests/reposync-crd.yaml; \
+	rm ./manifests/patch/reposync-crd.yaml; \
+	rm ./manifests/patch/rootsync-crd.yaml; \
+	"$(GOBIN)/addlicense" ./manifests; \
 
 .PHONY: install-controller-gen
 # install controller-gen from source


### PR DESCRIPTION
this ensures that the CRD yaml is up to date as part of presubmit checks. also consolidates the kustomize install make targets and runs addlicense after generating crds.