### PR TITLE
Only update condition timestamps on change

### DIFF
--- a/pkg/reposync/conditions_test.go
+++ b/pkg/reposync/conditions_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -31,7 +32,8 @@ import (
 const testNs = "test"
 const fakeConditionMessage = "Testing"
 
-var testNow = metav1.Date(1, time.February, 3, 4, 5, 6, 7, time.Local)
+var initialNow = metav1.Date(1, time.February, 3, 4, 5, 6, 0, time.Local)
+var updatedNow = metav1.Date(1, time.February, 3, 4, 5, 7, 0, time.Local)
 
 func withConditions(conds ...v1beta1.RepoSyncCondition) core.MetaMutator {
 	return func(o client.Object) {
@@ -40,14 +42,14 @@ func withConditions(conds ...v1beta1.RepoSyncCondition) core.MetaMutator {
 	}
 }
 
-func fakeCondition(condType v1beta1.RepoSyncConditionType, status metav1.ConditionStatus, strs ...string) v1beta1.RepoSyncCondition {
+func fakeCondition(condType v1beta1.RepoSyncConditionType, status metav1.ConditionStatus, lastTransitionTime, lastUpdateTime metav1.Time, strs ...string) v1beta1.RepoSyncCondition {
 	rsc := v1beta1.RepoSyncCondition{
 		Type:               condType,
 		Status:             status,
 		Reason:             "Test",
 		Message:            fakeConditionMessage,
-		LastUpdateTime:     testNow,
-		LastTransitionTime: testNow,
+		LastUpdateTime:     lastUpdateTime,
+		LastTransitionTime: lastTransitionTime,
 	}
 	if condType == v1beta1.RepoSyncReconciling && status == metav1.ConditionTrue {
 		rsc.ErrorSummary = &v1beta1.ErrorSummary{}
@@ -71,19 +73,24 @@ func TestIsReconciling(t *testing.T) {
 		want bool
 	}{
 		{
-			"Missing condition is false",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			false,
+			name: "Missing condition is false",
+			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			want: false,
 		},
 		{
-			"False condition is false",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse))),
-			false,
+			name: "False condition is false",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
+			want: false,
 		},
 		{
-			"True condition is true",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			true,
+			name: "True condition is true",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			want: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -103,19 +110,24 @@ func TestIsStalled(t *testing.T) {
 		want bool
 	}{
 		{
-			"Missing condition is false",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			false,
+			name: "Missing condition is false",
+			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			want: false,
 		},
 		{
-			"False condition is false",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			false,
+			name: "False condition is false",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			want: false,
 		},
 		{
-			"True condition is true",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue))),
-			true,
+			name: "True condition is true",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
+			want: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -135,19 +147,24 @@ func TestReconcilingMessage(t *testing.T) {
 		want string
 	}{
 		{
-			"Missing condition is empty",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			"",
+			name: "Missing condition is empty",
+			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			want: "",
 		},
 		{
-			"False condition is empty",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse))),
-			"",
+			name: "False condition is empty",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
+			want: "",
 		},
 		{
-			"True condition is its message",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			fakeConditionMessage,
+			name: "True condition is its message",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			want: fakeConditionMessage,
 		},
 	}
 	for _, tc := range testCases {
@@ -167,19 +184,24 @@ func TestStalledMessage(t *testing.T) {
 		want string
 	}{
 		{
-			"Missing condition is empty",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			"",
+			name: "Missing condition is empty",
+			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			want: "",
 		},
 		{
-			"False condition is empty",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			"",
+			name: "False condition is empty",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			want: "",
 		},
 		{
-			"True condition is its message",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue))),
-			fakeConditionMessage,
+			name: "True condition is its message",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
+			want: fakeConditionMessage,
 		},
 	}
 	for _, tc := range testCases {
@@ -194,7 +216,7 @@ func TestStalledMessage(t *testing.T) {
 
 func TestClearCondition(t *testing.T) {
 	now = func() metav1.Time {
-		return testNow
+		return initialNow
 	}
 	testCases := []struct {
 		name    string
@@ -203,29 +225,42 @@ func TestClearCondition(t *testing.T) {
 		want    []v1beta1.RepoSyncCondition
 	}{
 		{
-			"Clear existing true condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue))),
-			v1beta1.RepoSyncStalled,
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue),
-				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, "", ""),
+			name: "Clear existing true condition",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
+			toClear: v1beta1.RepoSyncStalled,
+			want: []v1beta1.RepoSyncCondition{
+				// No update or transition
+				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+				// Update and transition
+				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, updatedNow, updatedNow, "", ""),
 			},
 		},
 		{
-			"Ignore existing false condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			v1beta1.RepoSyncStalled,
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue),
-				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse),
+			name: "Ignore existing false condition",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			toClear: v1beta1.RepoSyncStalled,
+			want: []v1beta1.RepoSyncCondition{
+				// No update or transition
+				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+				// No update or transition
+				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow),
 			},
 		},
 		{
-			"Handle empty conditions",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			v1beta1.RepoSyncStalled,
-			nil,
+			name:    "Handle empty conditions",
+			rs:      fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			toClear: v1beta1.RepoSyncStalled,
+			want:    nil,
 		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -239,79 +274,263 @@ func TestClearCondition(t *testing.T) {
 
 func TestSetReconciling(t *testing.T) {
 	now = func() metav1.Time {
-		return testNow
+		return initialNow
 	}
 	testCases := []struct {
-		name    string
-		rs      *v1beta1.RepoSync
-		reason  string
-		message string
-		want    []v1beta1.RepoSyncCondition
+		name             string
+		rs               *v1beta1.RepoSync
+		reason           string
+		message          string
+		want             []v1beta1.RepoSyncCondition
+		wantUpdated      bool
+		wantTransitioned bool
 	}{
 		{
-			"Set new reconciling condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			"Test1",
-			"This is test 1",
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, "Test1", "This is test 1"),
+			name: "Set new reconciling condition",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow))),
+			reason:  "Test1",
+			message: "This is test 1",
+			want: []v1beta1.RepoSyncCondition{
+				// Update but no transition
+				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, updatedNow, "Test1", "This is test 1"),
 			},
+			wantUpdated:      true,
+			wantTransitioned: false,
 		},
 		{
-			"Update existing reconciling condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			"Test2",
-			"This is test 2",
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, "Test2", "This is test 2"),
-				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse),
+			name: "Update existing reconciling condition",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			reason:  "Test2",
+			message: "This is test 2",
+			want: []v1beta1.RepoSyncCondition{
+				// Update but no transition
+				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, updatedNow, "Test2", "This is test 2"),
+				// No update or transition
+				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow),
 			},
+			wantUpdated:      true,
+			wantTransitioned: false,
 		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			SetReconciling(tc.rs, tc.reason, tc.message)
+			updated, transitioned := SetReconciling(tc.rs, tc.reason, tc.message)
 			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
 				t.Error(diff)
 			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
+			assert.Equal(t, tc.wantTransitioned, transitioned, "transitioned")
 		})
 	}
 }
 
 func TestSetStalled(t *testing.T) {
+	now = func() metav1.Time {
+		return initialNow
+	}
 	testCases := []struct {
-		name   string
-		rs     *v1beta1.RepoSync
-		reason string
-		err    error
-		want   []v1beta1.RepoSyncCondition
+		name             string
+		rs               *v1beta1.RepoSync
+		reason           string
+		err              error
+		want             []v1beta1.RepoSyncCondition
+		wantUpdated      bool
+		wantTransitioned bool
 	}{
 		{
-			"Set new stalled condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
-			"Error1",
-			errors.New("this is error 1"),
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, "Error1", "this is error 1"),
+			name:   "Set new stalled condition",
+			rs:     fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			reason: "Error1",
+			err:    errors.New("this is error 1"),
+			want: []v1beta1.RepoSyncCondition{
+				// Update and transition
+				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, updatedNow, updatedNow, "Error1", "this is error 1"),
 			},
+			wantUpdated:      true,
+			wantTransitioned: true,
 		},
 		{
-			"Update existing stalled condition",
-			fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withConditions(fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue), fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse))),
-			"Error2",
-			errors.New("this is error 2"),
-			[]v1beta1.RepoSyncCondition{
-				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue),
-				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, "Error2", "this is error 2"),
+			name: "Update existing stalled condition",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
+			reason: "Error2",
+			err:    errors.New("this is error 2"),
+			want: []v1beta1.RepoSyncCondition{
+				// No update or transition
+				fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
+				// Update and transition
+				fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, updatedNow, updatedNow, "Error2", "this is error 2"),
 			},
+			wantUpdated:      true,
+			wantTransitioned: true,
+		},
+	}
+	now = func() metav1.Time {
+		return updatedNow
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated, transitioned := SetStalled(tc.rs, tc.reason, tc.err)
+			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
+				t.Error(diff)
+			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
+			assert.Equal(t, tc.wantTransitioned, transitioned, "transitioned")
+		})
+	}
+}
+
+func TestSetSyncing(t *testing.T) {
+	testCases := []struct {
+		name             string
+		rs               *v1beta1.RepoSync
+		status           bool
+		reason           string
+		message          string
+		commit           string
+		errorSources     []v1beta1.ErrorSource
+		errorSummary     *v1beta1.ErrorSummary
+		timestamp        metav1.Time
+		want             []v1beta1.RepoSyncCondition
+		wantUpdated      bool
+		wantTransitioned bool
+	}{
+		{
+			name:         "Set new syncing condition without error",
+			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			status:       true,
+			reason:       "Syncing",
+			message:      "",
+			commit:       "commit-1",
+			errorSources: nil,
+			errorSummary: &v1beta1.ErrorSummary{},
+			timestamp:    updatedNow,
+			want: []v1beta1.RepoSyncCondition{
+				// Update and transition
+				{
+					Type:               v1beta1.RepoSyncSyncing,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Syncing",
+					Message:            "",
+					Commit:             "commit-1",
+					ErrorSourceRefs:    nil,
+					ErrorSummary:       &v1beta1.ErrorSummary{},
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated:      true,
+			wantTransitioned: true,
+		},
+		{
+			name: "Update to add syncing error",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					v1beta1.RepoSyncCondition{
+						Type:               v1beta1.RepoSyncSyncing,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Syncing",
+						Message:            "",
+						Commit:             "commit-1",
+						ErrorSourceRefs:    nil,
+						ErrorSummary:       &v1beta1.ErrorSummary{},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			status:  true,
+			reason:  "Error1",
+			message: "this is error 1",
+			commit:  "commit-1",
+			errorSources: []v1beta1.ErrorSource{
+				"status.sync.errors",
+			},
+			errorSummary: &v1beta1.ErrorSummary{
+				TotalCount: 1,
+			},
+			timestamp: updatedNow,
+			want: []v1beta1.RepoSyncCondition{
+				// Update but no transition
+				{
+					Type:    v1beta1.RepoSyncSyncing,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Error1",
+					Message: "this is error 1",
+					Commit:  "commit-1",
+					ErrorSourceRefs: []v1beta1.ErrorSource{
+						"status.sync.errors",
+					},
+					ErrorSummary: &v1beta1.ErrorSummary{
+						TotalCount: 1,
+					},
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: initialNow,
+				},
+			},
+			wantUpdated:      true,
+			wantTransitioned: false,
+		},
+		{
+			name: "Transition to completed",
+			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+				withConditions(
+					v1beta1.RepoSyncCondition{
+						Type:    v1beta1.RepoSyncSyncing,
+						Status:  metav1.ConditionTrue,
+						Reason:  "Error1",
+						Message: "this is error 1",
+						Commit:  "commit-1",
+						ErrorSourceRefs: []v1beta1.ErrorSource{
+							"status.sync.errors",
+						},
+						ErrorSummary: &v1beta1.ErrorSummary{
+							TotalCount: 1,
+						},
+						LastUpdateTime:     initialNow,
+						LastTransitionTime: initialNow,
+					})),
+			status:       false,
+			reason:       "Synced",
+			message:      "Sync Completed",
+			commit:       "commit-2",
+			errorSources: nil,
+			errorSummary: &v1beta1.ErrorSummary{},
+			timestamp:    updatedNow,
+			want: []v1beta1.RepoSyncCondition{
+				// Update and transition
+				{
+					Type:               v1beta1.RepoSyncSyncing,
+					Status:             metav1.ConditionFalse,
+					Reason:             "Synced",
+					Message:            "Sync Completed",
+					Commit:             "commit-2",
+					ErrorSourceRefs:    nil,
+					ErrorSummary:       &v1beta1.ErrorSummary{},
+					LastUpdateTime:     updatedNow,
+					LastTransitionTime: updatedNow,
+				},
+			},
+			wantUpdated:      true,
+			wantTransitioned: true,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			SetStalled(tc.rs, tc.reason, tc.err)
+			updated, transitioned := SetSyncing(tc.rs, tc.status, tc.reason, tc.message, tc.commit, tc.errorSources, tc.errorSummary, tc.timestamp)
 			if diff := cmp.Diff(tc.want, tc.rs.Status.Conditions); diff != "" {
 				t.Error(diff)
 			}
+			assert.Equal(t, tc.wantUpdated, updated, "updated")
+			assert.Equal(t, tc.wantTransitioned, transitioned, "transitioned")
 		})
 	}
 }
@@ -323,57 +542,57 @@ func TestConditionHasNoErrors(t *testing.T) {
 		want bool
 	}{
 		{
-			"Errors is nil, ErrorSummary is nil",
-			v1beta1.RepoSyncCondition{},
-			true,
+			name: "Errors is nil, ErrorSummary is nil",
+			cond: v1beta1.RepoSyncCondition{},
+			want: true,
 		},
 		{
-			"Errors is not nil but empty, ErrorSummary is nil",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is not nil but empty, ErrorSummary is nil",
+			cond: v1beta1.RepoSyncCondition{
 				Errors: []v1beta1.ConfigSyncError{},
 			},
-			true,
+			want: true,
 		},
 		{
-			"Errors is not nil and not empty, ErrorSummary is nil",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is not nil and not empty, ErrorSummary is nil",
+			cond: v1beta1.RepoSyncCondition{
 				Errors: []v1beta1.ConfigSyncError{
 					{Code: "1061", ErrorMessage: "rendering-error-message"},
 				},
 			},
-			false,
+			want: false,
 		},
 		{
-			"Errors is nil, ErrorSummary is not nil but empty",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is nil, ErrorSummary is not nil but empty",
+			cond: v1beta1.RepoSyncCondition{
 				ErrorSummary: &v1beta1.ErrorSummary{},
 			},
-			true,
+			want: true,
 		},
 		{
-			"Errors is nil, ErrorSummary is not nil and not empty",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is nil, ErrorSummary is not nil and not empty",
+			cond: v1beta1.RepoSyncCondition{
 				ErrorSummary: &v1beta1.ErrorSummary{TotalCount: 1},
 			},
-			false,
+			want: false,
 		},
 		{
-			"Errors is not nil but empty, ErrorSummary is not nil but empty",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is not nil but empty, ErrorSummary is not nil but empty",
+			cond: v1beta1.RepoSyncCondition{
 				Errors:       []v1beta1.ConfigSyncError{},
 				ErrorSummary: &v1beta1.ErrorSummary{},
 			},
-			true,
+			want: true,
 		},
 		{
-			"Errors is not nil and not empty, ErrorSummary is not nil and not empty",
-			v1beta1.RepoSyncCondition{
+			name: "Errors is not nil and not empty, ErrorSummary is not nil and not empty",
+			cond: v1beta1.RepoSyncCondition{
 				Errors: []v1beta1.ConfigSyncError{
 					{Code: "1061", ErrorMessage: "rendering-error-message"},
 				},
 				ErrorSummary: &v1beta1.ErrorSummary{TotalCount: 1},
 			},
-			false,
+			want: false,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/rootsync/conditions.go
+++ b/pkg/rootsync/conditions.go
@@ -15,6 +15,7 @@
 package rootsync
 
 import (
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 )
@@ -84,36 +85,46 @@ var singleErrorSummary = &v1beta1.ErrorSummary{
 }
 
 // SetReconciling sets the Reconciling condition to True.
-func SetReconciling(rs *v1beta1.RootSync, reason, message string) {
-	if setCondition(rs, v1beta1.RootSyncReconciling, metav1.ConditionTrue, reason, message, "", nil, &v1beta1.ErrorSummary{}, now()) {
-		// Only remove the Syncing condition when the Reconciling condition status is updated from false to true.
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+// Removes the Syncing condition if the Reconciling condition transitioned.
+func SetReconciling(rs *v1beta1.RootSync, reason, message string) (updated, transitioned bool) {
+	updated, transitioned = setCondition(rs, v1beta1.RootSyncReconciling, metav1.ConditionTrue, reason, message, "", nil, &v1beta1.ErrorSummary{}, now())
+	if transitioned {
 		removeCondition(rs, v1beta1.RootSyncSyncing)
 	}
+	return updated, transitioned
 }
 
 // SetStalled sets the Stalled condition to True.
-func SetStalled(rs *v1beta1.RootSync, reason string, err error) {
-	if setCondition(rs, v1beta1.RootSyncStalled, metav1.ConditionTrue, reason, err.Error(), "", nil, singleErrorSummary, now()) {
-		// Only remove the Syncing condition when the Stalled condition status is updated from false to true.
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+// Removes the Syncing condition if the Stalled condition transitioned.
+func SetStalled(rs *v1beta1.RootSync, reason string, err error) (updated, transitioned bool) {
+	updated, transitioned = setCondition(rs, v1beta1.RootSyncStalled, metav1.ConditionTrue, reason, err.Error(), "", nil, singleErrorSummary, now())
+	if transitioned {
 		removeCondition(rs, v1beta1.RootSyncSyncing)
 	}
+	return updated, transitioned
 }
 
 // SetSyncing sets the Syncing condition.
-func SetSyncing(rs *v1beta1.RootSync, status bool, reason, message, commit string, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, lastUpdate metav1.Time) {
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+func SetSyncing(rs *v1beta1.RootSync, status bool, reason, message, commit string, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, timestamp metav1.Time) (updated, transitioned bool) {
 	var conditionStatus metav1.ConditionStatus
 	if status {
 		conditionStatus = metav1.ConditionTrue
 	} else {
 		conditionStatus = metav1.ConditionFalse
 	}
-	setCondition(rs, v1beta1.RootSyncSyncing, conditionStatus, reason, message, commit, errorSources, errorSummary, lastUpdate)
+	return setCondition(rs, v1beta1.RootSyncSyncing, conditionStatus, reason, message, commit, errorSources, errorSummary, timestamp)
 }
 
-// setCondition adds or updates the specified condition.
-// It returns a boolean indicating if the condition status is transited.
-func setCondition(rs *v1beta1.RootSync, condType v1beta1.RootSyncConditionType, status metav1.ConditionStatus, reason, message, commit string, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, lastUpdate metav1.Time) bool {
-	conditionTransited := false
+// setCondition adds or updates the specified condition with a True status.
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+func setCondition(rs *v1beta1.RootSync, condType v1beta1.RootSyncConditionType, status metav1.ConditionStatus, reason, message, commit string, errorSources []v1beta1.ErrorSource, errorSummary *v1beta1.ErrorSummary, timestamp metav1.Time) (updated, transitioned bool) {
 	condition := GetCondition(rs.Status.Conditions, condType)
 	if condition == nil {
 		i := len(rs.Status.Conditions)
@@ -123,16 +134,26 @@ func setCondition(rs *v1beta1.RootSync, condType v1beta1.RootSyncConditionType, 
 
 	if condition.Status != status {
 		condition.Status = status
-		condition.LastTransitionTime = lastUpdate
-		conditionTransited = true
+		condition.LastTransitionTime = timestamp
+		transitioned = true
+		updated = true
+	} else if condition.Reason != reason ||
+		condition.Message != message ||
+		condition.Commit != commit ||
+		!equality.Semantic.DeepEqual(condition.ErrorSourceRefs, errorSources) ||
+		!equality.Semantic.DeepEqual(condition.ErrorSummary, errorSummary) {
+		updated = true
+	} else {
+		return updated, transitioned
 	}
 	condition.Reason = reason
 	condition.Message = message
 	condition.Commit = commit
 	condition.ErrorSourceRefs = errorSources
 	condition.ErrorSummary = errorSummary
-	condition.LastUpdateTime = lastUpdate
-	return conditionTransited
+	condition.LastUpdateTime = timestamp
+
+	return updated, transitioned
 }
 
 // GetCondition returns the condition with the provided type.
@@ -146,20 +167,23 @@ func GetCondition(conditions []v1beta1.RootSyncCondition, condType v1beta1.RootS
 }
 
 // removeCondition removes the RootSync condition with the provided type.
-func removeCondition(rs *v1beta1.RootSync, condType v1beta1.RootSyncConditionType) {
-	rs.Status.Conditions = filterOutCondition(rs.Status.Conditions, condType)
+func removeCondition(rs *v1beta1.RootSync, condType v1beta1.RootSyncConditionType) (updated bool) {
+	rs.Status.Conditions, updated = filterOutCondition(rs.Status.Conditions, condType)
+	return updated
 }
 
 // filterOutCondition returns a new slice of RootSync conditions without conditions with the provided type.
-func filterOutCondition(conditions []v1beta1.RootSyncCondition, condType v1beta1.RootSyncConditionType) []v1beta1.RootSyncCondition {
+func filterOutCondition(conditions []v1beta1.RootSyncCondition, condType v1beta1.RootSyncConditionType) ([]v1beta1.RootSyncCondition, bool) {
 	var newConditions []v1beta1.RootSyncCondition
+	updated := false
 	for _, c := range conditions {
 		if c.Type == condType {
+			updated = true
 			continue
 		}
 		newConditions = append(newConditions, c)
 	}
-	return newConditions
+	return newConditions, updated
 }
 
 // ConditionHasNoErrors returns true when `cond` has no errors, and returns false when `cond` has errors.


### PR DESCRIPTION
- LastTransitionTime should only change if the Status changes.
- LastUpdateTime should only change if one of the condition field values changes.
- This should prevent unnecessary updates. Tho hopefully this behavior is redundant, due to the existing cmp.Equal check using IgnoreTimestampUpdates.
- Ideally this should alow us to stop using cmp.Equal in the future and consistently use semantic.DeepEqual instead.
