### PR TITLE
we are now on 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ fmt-go: pull-buildenv buildenv-dirs
 	@docker run $(DOCKER_RUN_ARGS) goimports -w $(NOMOS_CODE_DIRS)
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.19
 
 vendor:
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ fmt-go: pull-buildenv buildenv-dirs
 	@docker run $(DOCKER_RUN_ARGS) goimports -w $(NOMOS_CODE_DIRS)
 
 tidy:
-	go mod tidy
+	go mod tidy -compat=1.17
 
 vendor:
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ REGISTRY ?= gcr.io/$(GCR_PREFIX)
 OLD_REGISTRY ?= $(REGISTRY)
 
 # Docker image used for build and test. This image does not support CGO.
-BUILDENV_IMAGE ?= gcr.io/stolos-dev/buildenv:v0.2.11
+BUILDENV_IMAGE ?= gcr.io/stolos-dev/buildenv:v0.2.12
 
 # All Nomos K8S deployments.
 ALL_K8S_DEPLOYMENTS := git-importer monitor

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ fmt-go: pull-buildenv buildenv-dirs
 	@docker run $(DOCKER_RUN_ARGS) goimports -w $(NOMOS_CODE_DIRS)
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy
 
 vendor:
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ fmt-go: pull-buildenv buildenv-dirs
 	@docker run $(DOCKER_RUN_ARGS) goimports -w $(NOMOS_CODE_DIRS)
 
 tidy:
-	go mod tidy -compat=1.19
+	go mod tidy
 
 vendor:
 	go mod vendor

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build all nomos go binaries
-FROM golang:1.17 as bins
+FROM golang:1.19 as bins
 
 WORKDIR /workspace
 

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -27,7 +27,7 @@
 # when the go1.17 image is released in it.
 # Note that we shouldn't use the -alpine image here
 # since it is not allowed due to busybox for licensing.
-ARG GOLANG_CONTAINER=golang:1.17.7-buster
+ARG GOLANG_CONTAINER=golang:1.19.2-buster
 
 # Environment to build the helper binaries from.
 FROM ${GOLANG_CONTAINER} AS tools-base

--- a/build/e2e-tests/Dockerfile
+++ b/build/e2e-tests/Dockerfile
@@ -35,7 +35,7 @@
 # When adding helper binaries, ensure to build from a specific commit ID, rather
 # than a tag or a branch, so that rebuilds are reproducible. See examples below
 # on how.
-FROM golang:1.17.7-alpine AS build-base
+FROM golang:1.19.2-alpine AS build-base
 RUN apk add bash coreutils git gcc g++ libc-dev unzip
 
 ENV GO111MODULE=on

--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -17,7 +17,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:369.0.0-slim as gcloud-install
 RUN apt-get install -y kubectl
 
 # Build e2e image
-FROM golang:1.17.7-alpine
+FROM golang:1.19.2-alpine
 
 WORKDIR /repo
 

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.7-alpine
+FROM golang:1.19.2-alpine
 
 WORKDIR /repo
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kpt.dev/configsync
 
-go 1.17
+go 1.19
 
 require (
 	cloud.google.com/go/trace v1.1.0


### PR DESCRIPTION
Why not get the performance improvements from Go for free? 

20% bump from 1.17 to 1.18 at least.

This doesn't impact the final Docker image distribution because ultimately Go produces a compiled binary.

@sdowell - this might impact the internal build images though.