### PR TITLE
Fix vulnerability found in the git-sync image

### DIFF
--- a/manifests/templates/git-importer.yaml
+++ b/manifests/templates/git-importer.yaml
@@ -99,7 +99,7 @@ spec:
             cpu: "150m"
             memory: "100Mi"
       - name: git-sync
-        image: gcr.io/config-management-release/git-sync:v3.6.1-gke.1__linux_amd64
+        image: gcr.io/config-management-release/git-sync:v3.6.1-gke.2__linux_amd64
         # Do not put "rev-" in the root arg or you will break our parsing of commit hashes. See
         # pkg/policyimporter/git/git.go to see where we depend on that magic string from git-sync.
         args: ["--root=/repo/root", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json", "--v=5"]

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -114,7 +114,7 @@ data:
            terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.1-gke.1__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v3.6.1-gke.2__linux_amd64
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json", "--v=5"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
High: CVE-2022-43680 for expat/2.2.10-2+deb11u4 (debian) CVSS Score: 7.5
Fixed in 2.2.10-2+deb11u5

b/256594156