### PR TITLE
fix: copy acm-psp from correct directory

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -330,7 +330,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
 
 	@ # Additional optional OSS manifests
 	@ rsync \
-		.output/manifests/acm-psp.yaml $(OSS_MANIFEST_STAGING_DIR)/acm-psp.yaml
+		manifests/acm-psp.yaml $(OSS_MANIFEST_STAGING_DIR)/acm-psp.yaml
 	@ cat "manifests/templates/admission-webhook.yaml" \
 		| sed -e "s|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|g" \
 		> $(OSS_MANIFEST_STAGING_DIR)/admission-webhook.yaml


### PR DESCRIPTION
the .output/manifests directory is leftover from the legacy manifest make targets. the new manifest make targets do not create this directory, so we should copy directly from the committed manifest.