### PR TITLE
Resolve the fight between reconciler manager and Autopilot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,13 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.5.0
+	github.com/spyzhov/ajson v0.4.2
 	github.com/stretchr/testify v1.7.1
 	go.opencensus.io v0.23.0
 	go.uber.org/multierr v1.6.0
 	golang.org/x/net v0.0.0-20220708220712-1185a9018129
 	golang.org/x/oauth2 v0.0.0-20220718184931-c8730f7fcb92
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.24.0
 	k8s.io/apiextensions-apiserver v0.24.0
 	k8s.io/apimachinery v0.24.0
@@ -114,7 +116,6 @@ require (
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spyzhov/ajson v0.4.2 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20210901212718-87f333178d59 // indirect
@@ -133,7 +134,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/component-base v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -67,8 +67,6 @@ data:
            volumeMounts:
            - name: repo
              mountPath: /repo
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
            securityContext:
              allowPrivilegeEscalation: false
@@ -110,8 +108,6 @@ data:
              capabilities:
                drop:
                - NET_RAW
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
          - name: git-sync
            image: gcr.io/config-management-release/git-sync:v3.6.1-gke.2__linux_amd64
@@ -122,8 +118,6 @@ data:
            - name: git-creds
              mountPath: /etc/git-secret
              readOnly: true
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
            securityContext:
              allowPrivilegeEscalation: false
@@ -142,8 +136,6 @@ data:
            volumeMounts:
            - name: repo
              mountPath: /repo
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
            securityContext:
              allowPrivilegeEscalation: false
@@ -165,8 +157,6 @@ data:
            - name: helm-creds
              mountPath: /etc/helm-secret
              readOnly: true
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
            securityContext:
              allowPrivilegeEscalation: false
@@ -214,21 +204,11 @@ data:
                path: /
                port: 13133 # Health Check extension default port.
                scheme: HTTP
-             timeoutSeconds: 1
-             periodSeconds: 10
-             successThreshold: 1
-             failureThreshold: 3
            readinessProbe:
              httpGet:
                path: /
                port: 13133 # Health Check extension default port.
                scheme: HTTP
-             timeoutSeconds: 1
-             periodSeconds: 10
-             successThreshold: 1
-             failureThreshold: 3
-           terminationMessagePath: "/dev/termination-log"
-           terminationMessagePolicy: File
            imagePullPolicy: IfNotPresent
            # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
            # is used by the otel-agent to populate resource attributes when
@@ -290,10 +270,6 @@ data:
                configsync.sync.kind=$(CONFIGSYNC_SYNC_KIND),\
                configsync.sync.name=$(CONFIGSYNC_SYNC_NAME),\
                configsync.sync.namespace=$(CONFIGSYNC_SYNC_NAMESPACE)"
-         restartPolicy: Always
-         terminationGracePeriodSeconds: 30
-         dnsPolicy: ClusterFirst
-         schedulerName: default-scheduler
          volumes:
          - name: repo
            emptyDir: {}
@@ -317,5 +293,3 @@ data:
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault
-     revisionHistoryLimit: 10
-     progressDeadlineSeconds: 600

--- a/pkg/kinds/resources.go
+++ b/pkg/kinds/resources.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinds
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// DeploymentResource returns the canonical Deployment GroupVersionResource.
+func DeploymentResource() schema.GroupVersionResource {
+	return appsv1.SchemeGroupVersion.WithResource("deployments")
+}

--- a/pkg/reconcilermanager/controllers/jsonpath.go
+++ b/pkg/reconcilermanager/controllers/jsonpath.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spyzhov/ajson"
+	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
+)
+
+// deleteFields evaluates the JSONPath expression to delete fields from the input map.
+func deleteFields(obj map[string]interface{}, expression string) error {
+	// format input object as json for input into jsonpath library
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal input to json: %w", err)
+	}
+	// parse json into an ajson node
+	root, err := ajson.Unmarshal(jsonBytes)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal input json: %w", err)
+	}
+
+	// find nodes that match the expression
+	nodes, err := root.JSONPath(expression)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate jsonpath expression (%s): %w", expression, err)
+	}
+
+	if len(nodes) == 0 {
+		// zero nodes found, none updated
+		return nil
+	}
+	// get value of all matching nodes
+	for _, node := range nodes {
+		if err = node.Delete(); err != nil {
+			klog.Warningf("failed to delete a node: %v", err)
+		}
+	}
+
+	jsonBytes, err = ajson.Marshal(root)
+	if err != nil {
+		return fmt.Errorf("failed to marshal jsonpath result to json: %w", err)
+	}
+	// parse json back into the input map
+	err = yaml.Unmarshal(jsonBytes, &obj)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal jsonpath delete result: %w", err)
+	}
+	return nil
+}

--- a/pkg/reconcilermanager/controllers/jsonpath_test.go
+++ b/pkg/reconcilermanager/controllers/jsonpath_test.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/jsonpath"
+	"sigs.k8s.io/yaml"
+)
+
+var o1y = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-namespace
+map:
+  a:
+  - "1"
+  - "2"
+  - "3"
+  b: null
+  c:
+  - x
+  - y
+  - z
+  e: 1
+  f: false
+entries:
+- name: a
+  value: x
+- name: b
+  value: "y"
+- name: c
+  value: z
+`
+
+func TestDeleteFields(t *testing.T) {
+	o1 := yamlToUnstructured(t, o1y)
+
+	testCases := map[string]struct {
+		obj    *unstructured.Unstructured
+		path   string
+		values []interface{}
+		errMsg string
+	}{
+		"string in map": {
+			obj:    o1,
+			path:   "$.metadata.name",
+			values: []interface{}{"pod-name"},
+		},
+		"bool in map": {
+			obj:    o1,
+			path:   "$.map.f",
+			values: []interface{}{false},
+		},
+		"int in map": {
+			obj:    o1,
+			path:   "$.map.e",
+			values: []interface{}{1},
+		},
+		"string in array in map": {
+			obj:    o1,
+			path:   "$.map.c[2]",
+			values: []interface{}{"z"},
+		},
+		"nil in map": {
+			obj:    o1,
+			path:   "$.map.b",
+			values: []interface{}{nil},
+		},
+		"array in map": {
+			obj:    o1,
+			path:   "$.map.a",
+			values: []interface{}{[]interface{}{"1", "2", "3"}},
+		},
+		"field selector": {
+			obj:    o1,
+			path:   `$.entries[?(@.name=="b")].value`,
+			values: []interface{}{"y"},
+		},
+		"multi-field selector": {
+			obj:    o1,
+			path:   `$.entries[?(@.name=="a" || @.name=="c")].value`,
+			values: []interface{}{"x", "z"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			testCtx := []interface{}{"path: %s\nobject:\n%s", tc.path, toYaml(t, tc.obj.Object)}
+			values, err := jsonpath.Get(tc.obj.Object, tc.path)
+			require.NoError(t, err, testCtx...)
+			require.Equal(t, tc.values, values, testCtx...)
+			err = deleteFields(tc.obj.Object, tc.path)
+			require.NoError(t, err, testCtx...)
+			values, err = jsonpath.Get(tc.obj.Object, tc.path)
+			require.NoError(t, err, testCtx...)
+			require.Equal(t, []interface{}{}, values, testCtx...)
+		})
+	}
+}
+
+func toYaml(t *testing.T, in interface{}) string {
+	yamlBytes, err := yaml.Marshal(in)
+	require.NoError(t, err)
+	return string(yamlBytes)
+}
+
+func yamlToUnstructured(t *testing.T, yml string) *unstructured.Unstructured {
+	m := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(yml), &m)
+	if err != nil {
+		t.Fatalf("error parsing yaml: %v", err)
+		return nil
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+func yamlToDeployment(t *testing.T, yml string) *appsv1.Deployment {
+	d := &appsv1.Deployment{}
+	err := yaml.Unmarshal([]byte(yml), d)
+	if err != nil {
+		t.Fatalf("error parsing yaml: %v", err)
+		return nil
+	}
+	return d
+}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -69,11 +70,12 @@ type RepoSyncReconciler struct {
 }
 
 // NewRepoSyncReconciler returns a new RepoSyncReconciler.
-func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
+func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
 	return &RepoSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
 			client:                  client,
+			dynamicClient:           dynamicClient,
 			log:                     log,
 			scheme:                  scheme,
 			reconcilerPollingPeriod: reconcilerPollingPeriod,

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -77,11 +78,12 @@ type RootSyncReconciler struct {
 }
 
 // NewRootSyncReconciler returns a new RootSyncReconciler.
-func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
+func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
 	return &RootSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			clusterName:             clusterName,
 			client:                  client,
+			dynamicClient:           dynamicClient,
 			log:                     log,
 			scheme:                  scheme,
 			reconcilerPollingPeriod: reconcilerPollingPeriod,

--- a/pkg/syncer/syncertest/fake/dynamic_client.go
+++ b/pkg/syncer/syncertest/fake/dynamic_client.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+)
+
+// DynamicClient is a fake dynamic client which contains a map to store unstructured objects
+type DynamicClient struct {
+	*dynamicfake.FakeDynamicClient
+	UnObjects map[core.ID]*unstructured.Unstructured
+}
+
+// NewDynamicClient instantiates a new fake.DynamicClient
+func NewDynamicClient(t *testing.T, scheme *runtime.Scheme) *DynamicClient {
+	t.Helper()
+
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	unObjs := make(map[core.ID]*unstructured.Unstructured)
+
+	fakeClient.PrependReactor("get", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		gk := kinds.Deployment().GroupKind()
+		name := action.(clienttesting.GetAction).GetName()
+		namespace := action.(clienttesting.GetAction).GetNamespace()
+		id := genID(namespace, name, gk)
+		if unObjs[id] != nil {
+			return true, unObjs[id].DeepCopy(), nil
+		}
+		return false, nil, nil
+	})
+	fakeClient.PrependReactor("patch", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchData := action.(clienttesting.PatchAction).GetPatch()
+		var u unstructured.Unstructured
+		gk := kinds.Deployment().GroupKind()
+		name := action.(clienttesting.PatchAction).GetName()
+		namespace := action.(clienttesting.PatchAction).GetNamespace()
+		id := genID(namespace, name, gk)
+		if err := u.UnmarshalJSON(patchData); err != nil {
+			return false, nil, nil
+		}
+		unObjs[id] = &u
+		return true, unObjs[id].DeepCopy(), nil
+	})
+	fakeClient.PrependReactor("delete", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		gk := kinds.Deployment().GroupKind()
+		name := action.(clienttesting.DeleteAction).GetName()
+		namespace := action.(clienttesting.DeleteAction).GetNamespace()
+		id := genID(namespace, name, gk)
+		if unObjs[id] != nil {
+			delete(unObjs, id)
+			return true, nil, nil
+		}
+		return false, nil, nil
+	})
+
+	return &DynamicClient{
+		fakeClient, unObjs,
+	}
+}
+
+func genID(namespace, name string, gk schema.GroupKind) core.ID {
+	return core.ID{
+		GroupKind: gk,
+		ObjectKey: types.NamespacedName{Namespace: namespace, Name: name},
+	}
+}


### PR DESCRIPTION
    Create an allowlist in reconciler manager and add the fields that we
    allow others to modify to the allowlist.
    
    When compare the current reconciler deployment with the declared
    reconciler deployment, ignore the differences of the fields in the
    allowlist.
    
    Use Sever Side Apply to only manage the fields defined in
    reconciler-manager-configmap to prevent the reconciler manager from fighting with other controllers 
    on the fields we do not define
