### PR TITLE
Cleanup time duration options

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -41,11 +41,13 @@ var (
 	clusterName = flag.String("cluster-name", os.Getenv(reconcilermanager.ClusterNameKey),
 		"Cluster name to use for Cluster selection")
 
-	reconcilerPollingPeriod = flag.Duration("reconciler-polling-period", controllers.PollingPeriod(reconcilermanager.ReconcilerPollingPeriod, configsync.DefaultReconcilerPollingPeriod),
-		"How often the reconciler should poll the filesystem for updates to the source or rendered configs.")
+	reconcilerPollingPeriod = flag.Duration("reconciler-polling-period",
+		controllers.PollingPeriod(reconcilermanager.ReconcilerPollingPeriod, configsync.DefaultReconcilerPollingPeriod),
+		"Period of time between checking the filesystem for source updates to sync.")
 
-	hydrationPollingPeriod = flag.Duration("hydration-polling-period", controllers.PollingPeriod(reconcilermanager.HydrationPollingPeriod, configsync.DefaultHydrationPollingPeriod),
-		"How often the hydration-controller should poll the filesystem for rendering the DRY configs.")
+	hydrationPollingPeriod = flag.Duration("hydration-polling-period",
+		controllers.PollingPeriod(reconcilermanager.HydrationPollingPeriod, configsync.DefaultHydrationPollingPeriod),
+		"Period of time between checking the filesystem for source updates to render.")
 
 	setupLog = ctrl.Log.WithName("setup")
 )

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -43,18 +43,37 @@ const (
 )
 
 const (
-	// DefaultPeriodSecs is the default value in seconds between consecutive syncs.
-	DefaultPeriodSecs = 15
-
-	// DefaultReconcilerPollingPeriod defines how often the reconciler should poll
-	// the filesystem for updates to the source or rendered configs.
-	DefaultReconcilerPollingPeriod = 5 * time.Second
-
-	// DefaultHydrationPollingPeriod defines how often the hydration controller
-	// should poll the filesystem for rendering the DRY configs.
+	// DefaultHydrationPollingPeriod is the time delay between polling the
+	// filesystem for source updates to render.
 	DefaultHydrationPollingPeriod = 5 * time.Second
 
-	// DefaultReconcileTimeout defines the timeout of kpt applier reconcile/prune task
+	// DefaultHydrationRetryPeriod is the time delay between attempts to
+	// re-render config after an error.
+	// TODO: replace with retry-backoff strategy
+	DefaultHydrationRetryPeriod = 30 * time.Minute
+
+	// DefaultReconcilerPollingPeriodSeconds is time delay between polling the
+	// filesystem for source updates to sync, in seconds.
+	DefaultReconcilerPollingPeriodSeconds = 15
+
+	// DefaultReconcilerPollingPeriod is the time delay between polling the
+	// filesystem for source updates to sync.
+	DefaultReconcilerPollingPeriod = DefaultReconcilerPollingPeriodSeconds * time.Second
+
+	// DefaultReconcilerResyncPeriod is the time delay between forced re-syncs
+	// from source (even without a new commit).
+	DefaultReconcilerResyncPeriod = time.Hour
+
+	// DefaultReconcilerRetryPeriod is the time delay between polling the
+	// filesystem for source updates to sync, when the previous attempt errored.
+	// Note: This retry period is also used for watch updates.
+	// TODO: replace with retry-backoff strategy
+	DefaultReconcilerRetryPeriod = time.Second
+
+	// DefaultReconcileTimeout is the default wait timeout used by the applier
+	// when waiting for reconciliation after actuation.
+	// For Apply, it waits for Current status.
+	// For Delete, it waits for NotFound status.
 	DefaultReconcileTimeout = 5 * time.Minute
 
 	// DefaultHelmReleaseNamespace is the default namespace for a Helm Release which does not have a namespace specified

--- a/pkg/api/configsync/v1alpha1/getters.go
+++ b/pkg/api/configsync/v1alpha1/getters.go
@@ -22,7 +22,7 @@ import (
 // GetPeriodSecs returns the sync period defaulting to 15 if empty.
 func GetPeriodSecs(g *Git) float64 {
 	if g.Period.Duration == 0 {
-		return configsync.DefaultPeriodSecs
+		return configsync.DefaultReconcilerPollingPeriodSeconds
 	}
 	return g.Period.Duration.Seconds()
 }

--- a/pkg/api/configsync/v1beta1/getters.go
+++ b/pkg/api/configsync/v1beta1/getters.go
@@ -23,7 +23,7 @@ import (
 // GetPeriodSecs returns the sync period defaulting to 15 if empty.
 func GetPeriodSecs(period metav1.Duration) float64 {
 	if period.Duration == 0 {
-		return configsync.DefaultPeriodSecs
+		return configsync.DefaultReconcilerPollingPeriodSeconds
 	}
 	return period.Duration.Seconds()
 }

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -41,7 +41,7 @@ import (
 )
 
 // NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
-func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope declared.Scope, fileReader reader.Reader, c client.Client, pollingFrequency time.Duration, resyncPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
+func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope declared.Scope, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
 	converter, err := declared.NewValueConverter(dc)
 	if err != nil {
 		return nil, err
@@ -49,14 +49,15 @@ func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope decl
 
 	return &namespace{
 		opts: opts{
-			clusterName:      clusterName,
-			client:           c,
-			syncName:         syncName,
-			reconcilerName:   reconcilerName,
-			pollingFrequency: pollingFrequency,
-			resyncPeriod:     resyncPeriod,
-			files:            files{FileSource: fs},
-			parser:           filesystem.NewParser(fileReader),
+			clusterName:    clusterName,
+			client:         c,
+			syncName:       syncName,
+			reconcilerName: reconcilerName,
+			pollingPeriod:  pollingPeriod,
+			resyncPeriod:   resyncPeriod,
+			retryPeriod:    retryPeriod,
+			files:          files{FileSource: fs},
+			parser:         filesystem.NewParser(fileReader),
 			updater: updater{
 				scope:      scope,
 				resources:  resources,

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -34,23 +34,27 @@ type opts struct {
 	// clusterName is the name of the cluster we're syncing configuration to.
 	clusterName string
 
-	// client knows how to read objects from a Kubernetes cluster and update status.
+	// client knows how to read objects from a Kubernetes cluster and update
+	// status.
 	client client.Client
 
-	// reconcilerName is the name of the reconciler resources, such as service account, service, deployment and etc.
+	// reconcilerName is the name of the reconciler resources, such as service
+	// account, service, deployment and etc.
 	reconcilerName string
 
 	// syncName is the name of the RootSync or RepoSync object.
 	syncName string
 
-	// pollingFrequency is how often to re-import configuration from the filesystem.
-	//
-	// For tests, use zero as it will poll continuously.
-	pollingFrequency time.Duration
+	// pollingPeriod is the period of time between checking the filesystem for
+	// source updates to sync.
+	pollingPeriod time.Duration
 
-	// ResyncPeriod is the period of time between forced re-sync from source (even
-	// without a new commit).
+	// ResyncPeriod is the period of time between forced re-sync from source
+	// (even without a new commit).
 	resyncPeriod time.Duration
+
+	// retryPeriod is how long the parser waits between retries, after an error.
+	retryPeriod time.Duration
 
 	// discoveryInterface is how the parser learns what types are currently
 	// available on the cluster.

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -51,21 +51,22 @@ import (
 )
 
 // NewRootRunner creates a new runnable parser for parsing a Root repository.
-func NewRootRunner(clusterName, syncName, reconcilerName string, format filesystem.SourceFormat, fileReader reader.Reader, c client.Client, pollingFrequency time.Duration, resyncPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
+func NewRootRunner(clusterName, syncName, reconcilerName string, format filesystem.SourceFormat, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
 	converter, err := declared.NewValueConverter(dc)
 	if err != nil {
 		return nil, err
 	}
 
 	opts := opts{
-		clusterName:      clusterName,
-		syncName:         syncName,
-		reconcilerName:   reconcilerName,
-		client:           c,
-		pollingFrequency: pollingFrequency,
-		resyncPeriod:     resyncPeriod,
-		files:            files{FileSource: fs},
-		parser:           filesystem.NewParser(fileReader),
+		clusterName:    clusterName,
+		syncName:       syncName,
+		reconcilerName: reconcilerName,
+		client:         c,
+		pollingPeriod:  pollingPeriod,
+		resyncPeriod:   resyncPeriod,
+		retryPeriod:    retryPeriod,
+		files:          files{FileSource: fs},
+		parser:         filesystem.NewParser(fileReader),
 		updater: updater{
 			scope:      declared.RootReconciler,
 			resources:  resources,

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -64,9 +64,12 @@ type Options struct {
 	// ResyncPeriod is the period of time between forced re-sync from source (even
 	// without a new commit).
 	ResyncPeriod time.Duration
-	// FilesystemPollingFrequency is how often to check the local source repository for
-	// changes.
-	FilesystemPollingFrequency time.Duration
+	// PollingPeriod is the period of time between checking the filesystem for
+	// source updates to sync.
+	PollingPeriod time.Duration
+	// RetryPeriod is the period of time between checking the filesystem for
+	// source updates to sync, after an error.
+	RetryPeriod time.Duration
 	// SourceRoot is the absolute path to the source repository.
 	// Usually contains a symlink that must be resolved every time before parsing.
 	SourceRoot cmpath.Absolute
@@ -203,13 +206,13 @@ func Run(opts Options) {
 	}
 	if opts.ReconcilerScope == declared.RootReconciler {
 		parser, err = parse.NewRootRunner(opts.ClusterName, opts.SyncName, opts.ReconcilerName, opts.SourceFormat, &reader.File{}, cl,
-			opts.FilesystemPollingFrequency, opts.ResyncPeriod, fs, discoveryClient, decls, a, rem)
+			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, fs, discoveryClient, decls, a, rem)
 		if err != nil {
 			klog.Fatalf("Instantiating Root Repository Parser: %v", err)
 		}
 	} else {
 		parser, err = parse.NewNamespaceRunner(opts.ClusterName, opts.SyncName, opts.ReconcilerName, opts.ReconcilerScope, &reader.File{}, cl,
-			opts.FilesystemPollingFrequency, opts.ResyncPeriod, fs, discoveryClient, decls, a, rem)
+			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, fs, discoveryClient, decls, a, rem)
 		if err != nil {
 			klog.Fatalf("Instantiating Namespace Repository Parser: %v", err)
 		}


### PR DESCRIPTION
- Use the -Period suffix consistently. Technically, most of these should be "Delay", because they're a timer between attempts and not the duration of the event itself, but we're already using "period" for most of them. So this at least makes them all consistent without requiring rename of any external facing env vars or command flags.
- Standardize the many duplicate descriptions for duration options, at each layer of the stack.
- Add missing constants to replace hard-coded durations.
- Reafactor existing duration constants to make the names consistent.