### PR TITLE
use NS reconciler cluster role in e2e tests

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -64,6 +64,9 @@ const (
 
 	// e2e/raw-nomos/manifests/multi-repo-configmaps.yaml
 	multiConfigMapsName = "multi-repo-configmaps.yaml"
+
+	// clusterRoleName imitates a user-created (Cluster)Role for NS reconcilers.
+	clusterRoleName = "c2-e2e"
 )
 
 var (
@@ -78,9 +81,6 @@ var (
 
 	multiConfigMaps = filepath.Join(baseDir, "e2e", "raw-nomos", Manifests, multiConfigMapsName)
 
-	// clusterRoleName is the ClusterRole used by Namespace Reconciler.
-	clusterRoleName = fmt.Sprintf("%s:%s", configsync.GroupName, core.NsReconcilerPrefix)
-
 	templates = []string{
 		"admission-webhook.yaml",
 		"otel-collector.yaml",
@@ -94,6 +94,7 @@ var (
 		webhookconfig.ShortName:                      true,
 		"admission-webhook-cert":                     true,
 		"configsync.gke.io:admission-webhook":        true,
+		"configsync.gke.io:ns-reconciler":            true,
 		"admission-webhook.configsync.gke.io":        true,
 		"configsync.gke.io:reconciler-manager":       true,
 		reconcilermanager.ManagerName:                true,
@@ -546,6 +547,7 @@ func waitForReconciler(nt *NT, name string) error {
 // RepoSyncClusterRole returns clusterrole with permissions to manage resources in the cluster.
 func RepoSyncClusterRole() *rbacv1.ClusterRole {
 	cr := fake.ClusterRoleObject(core.Name(clusterRoleName))
+	// TODO: make this more granular by test options
 	cr.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{rbacv1.APIGroupAll},

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -144,10 +144,11 @@ func TestComposition(t *testing.T) {
 		}
 	})
 
-	nt.T.Logf("Adding Namespace & RoleBinding for RepoSync: %s", lvl2NN.Name)
-	lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("ns-%s.yaml", testNs)), fake.NamespaceObject(lvl2NN.Namespace))
-	lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("rb-%s.yaml", testNs)), nomostest.RepoSyncRoleBinding(lvl2NN))
-	lvl0Repo.CommitAndPush(fmt.Sprintf("Adding Namespace & RoleBinding for RepoSync: %s", lvl2NN))
+	nt.T.Logf("Adding Namespace & RoleBindings for RepoSyncs")
+	lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("ns-%s.yaml", testNs)), fake.NamespaceObject(testNs))
+	lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("rb-%s-%s.yaml", testNs, lvl2NN.Name)), nomostest.RepoSyncRoleBinding(lvl2NN))
+	lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("rb-%s-%s.yaml", testNs, lvl3NN.Name)), nomostest.RepoSyncRoleBinding(lvl3NN))
+	lvl0Repo.CommitAndPush("Adding Namespace & RoleBindings for RepoSyncs")
 
 	nt.T.Log("Waiting for R*Syncs to be synced...")
 	waitForSync(nt, rootSha1Fn, lvl0Sync)

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -92,6 +93,14 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	nn3Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn3, filesystem.SourceFormatUnstructured)
 	nn4Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn4, filesystem.SourceFormatUnstructured)
 	nn5Repo := nomostest.NewRepository(nt, nomostest.NamespaceRepo, nn5, filesystem.SourceFormatUnstructured)
+
+	nt.T.Logf("Adding Namespace & RoleBindings for RepoSyncs")
+	nt.RootRepos[configsync.RootSyncName].Add(filepath.Join("acme/cluster", fmt.Sprintf("ns-%s.yaml", testNs)), fake.NamespaceObject(testNs))
+	nt.RootRepos[configsync.RootSyncName].Add(filepath.Join("acme/cluster", fmt.Sprintf("rb-%s-%s.yaml", testNs, nn2.Name)), nomostest.RepoSyncRoleBinding(nn2))
+	nt.RootRepos[configsync.RootSyncName].Add(filepath.Join("acme/cluster", fmt.Sprintf("rb-%s-%s.yaml", testNs, nn3.Name)), nomostest.RepoSyncRoleBinding(nn3))
+	nt.RootRepos[configsync.RootSyncName].Add(filepath.Join("acme/cluster", fmt.Sprintf("rb-%s-%s.yaml", testNs, nn4.Name)), nomostest.RepoSyncRoleBinding(nn4))
+	nt.RootRepos[configsync.RootSyncName].Add(filepath.Join("acme/cluster", fmt.Sprintf("rb-%s-%s.yaml", testNs, nn5.Name)), nomostest.RepoSyncRoleBinding(nn5))
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Namespace & RoleBindings for RepoSyncs")
 
 	nt.T.Logf("Add RootSync %s to the repository of RootSync %s", rr2, configsync.RootSyncName)
 	nt.RootRepos[rr2] = rr2Repo

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -289,12 +289,17 @@ func TestSwitchFromGitToOci(t *testing.T) {
 	rsGitYAMLFile := "../testdata/reconciler-manager/reposync-sample.yaml"
 	// file path to the RepoSync config in the root repository.
 	repoResourcePath := "acme/reposync-bookinfo.yaml"
+	rsNN := types.NamespacedName{
+		Name:      configsync.RepoSyncName,
+		Namespace: namespace,
+	}
 
 	// Verify the central controlled configuration: switch from Git to OCI
 	// Backward compatibility check. Previously managed RepoSync objects without sourceType should still work.
 	nt.T.Log("Add the RepoSync object to the Root Repo")
 	nt.RootRepos[configsync.RootSyncName].Copy(rsGitYAMLFile, repoResourcePath)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/cr.yaml", nomostest.RepoSyncClusterRole())
+	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/crb.yaml", nomostest.RepoSyncRoleBinding(rsNN))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("configure RepoSync in the root repository")
 	// nt.WaitForRepoSyncs only waits for the root repo being synced because the reposync is not tracked by nt.
 	nt.WaitForRepoSyncs()


### PR DESCRIPTION
The e2e tests were creating their own version of the ns reconciler cluster role with namespace admin permissions.

This updates the test scaffolding to more closely reflect real scenarios where the CS installation comes with a ClusterRole for the NS reconcilers and the user adds additional roles/bindings.