### PR TITLE
Move periodic status updates into the parser

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -168,6 +168,7 @@ func main() {
 		ResyncPeriod:            *resyncPeriod,
 		PollingPeriod:           *pollingPeriod,
 		RetryPeriod:             configsync.DefaultReconcilerRetryPeriod,
+		StatusUpdatePeriod:      configsync.DefaultReconcilerSyncStatusUpdatePeriod,
 		SourceRoot:              absSourceDir,
 		RepoRoot:                absRepoRoot,
 		HydratedRoot:            *hydratedRootDir,

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -70,6 +70,11 @@ const (
 	// TODO: replace with retry-backoff strategy
 	DefaultReconcilerRetryPeriod = time.Second
 
+	// DefaultReconcilerSyncStatusUpdatePeriod is the time delay between async
+	// status updates by the reconciler. These updates report new management
+	// conflict errors from the remediator, if there are any.
+	DefaultReconcilerSyncStatusUpdatePeriod = 5 * time.Second
+
 	// DefaultReconcileTimeout is the default wait timeout used by the applier
 	// when waiting for reconciliation after actuation.
 	// For Apply, it waits for Current status.

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -41,7 +41,7 @@ import (
 )
 
 // NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
-func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope declared.Scope, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
+func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope declared.Scope, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod, statusUpdatePeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
 	converter, err := declared.NewValueConverter(dc)
 	if err != nil {
 		return nil, err
@@ -49,15 +49,16 @@ func NewNamespaceRunner(clusterName, syncName, reconcilerName string, scope decl
 
 	return &namespace{
 		opts: opts{
-			clusterName:    clusterName,
-			client:         c,
-			syncName:       syncName,
-			reconcilerName: reconcilerName,
-			pollingPeriod:  pollingPeriod,
-			resyncPeriod:   resyncPeriod,
-			retryPeriod:    retryPeriod,
-			files:          files{FileSource: fs},
-			parser:         filesystem.NewParser(fileReader),
+			clusterName:        clusterName,
+			client:             c,
+			syncName:           syncName,
+			reconcilerName:     reconcilerName,
+			pollingPeriod:      pollingPeriod,
+			resyncPeriod:       resyncPeriod,
+			retryPeriod:        retryPeriod,
+			statusUpdatePeriod: statusUpdatePeriod,
+			files:              files{FileSource: fs},
+			parser:             filesystem.NewParser(fileReader),
 			updater: updater{
 				scope:      scope,
 				resources:  resources,

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -56,6 +56,10 @@ type opts struct {
 	// retryPeriod is how long the parser waits between retries, after an error.
 	retryPeriod time.Duration
 
+	// statusUpdatePeriod is how long the parser waits between updates of the
+	// sync status, to account for management conflict errors from the remediator.
+	statusUpdatePeriod time.Duration
+
 	// discoveryInterface is how the parser learns what types are currently
 	// available on the cluster.
 	discoveryInterface discovery.ServerResourcer
@@ -63,9 +67,6 @@ type opts struct {
 	// converter uses the discoveryInterface to encode the declared fields of
 	// objects in Git.
 	converter *declared.ValueConverter
-
-	// reconciling indicates whether the reconciler is reconciling a change.
-	reconciling bool
 
 	// mux prevents status update conflicts.
 	mux *sync.Mutex
@@ -81,10 +82,6 @@ type Parser interface {
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
 	SetSyncStatus(ctx context.Context, errs status.MultiError) error
 	options() *opts
-	// SetReconciling sets the field indicating whether the reconciler is reconciling a change.
-	SetReconciling(value bool)
-	// Reconciling returns whether the reconciler is reconciling a change.
-	Reconciling() bool
 	// ApplierErrors returns the errors surfaced by the applier.
 	ApplierErrors() status.MultiError
 	// RemediatorConflictErrors returns the conflict errors detected by the remediator.
@@ -99,12 +96,4 @@ func (o *opts) k8sClient() client.Client {
 
 func (o *opts) discoveryClient() discovery.ServerResourcer {
 	return o.discoveryInterface
-}
-
-func (o *opts) SetReconciling(value bool) {
-	o.reconciling = value
-}
-
-func (o *opts) Reconciling() bool {
-	return o.reconciling
 }

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -51,22 +51,23 @@ import (
 )
 
 // NewRootRunner creates a new runnable parser for parsing a Root repository.
-func NewRootRunner(clusterName, syncName, reconcilerName string, format filesystem.SourceFormat, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
+func NewRootRunner(clusterName, syncName, reconcilerName string, format filesystem.SourceFormat, fileReader reader.Reader, c client.Client, pollingPeriod, resyncPeriod, retryPeriod, statusUpdatePeriod time.Duration, fs FileSource, dc discovery.DiscoveryInterface, resources *declared.Resources, app applier.Interface, rem remediator.Interface) (Parser, error) {
 	converter, err := declared.NewValueConverter(dc)
 	if err != nil {
 		return nil, err
 	}
 
 	opts := opts{
-		clusterName:    clusterName,
-		syncName:       syncName,
-		reconcilerName: reconcilerName,
-		client:         c,
-		pollingPeriod:  pollingPeriod,
-		resyncPeriod:   resyncPeriod,
-		retryPeriod:    retryPeriod,
-		files:          files{FileSource: fs},
-		parser:         filesystem.NewParser(fileReader),
+		clusterName:        clusterName,
+		syncName:           syncName,
+		reconcilerName:     reconcilerName,
+		client:             c,
+		pollingPeriod:      pollingPeriod,
+		resyncPeriod:       resyncPeriod,
+		retryPeriod:        retryPeriod,
+		statusUpdatePeriod: statusUpdatePeriod,
+		files:              files{FileSource: fs},
+		parser:             filesystem.NewParser(fileReader),
 		updater: updater{
 			scope:      declared.RootReconciler,
 			resources:  resources,


### PR DESCRIPTION
- This avoids needing to synchronize two goroutines. Instead, the
  periodic status updater will only run between parse.run calls.
- Disable sync status updates when a newer commit is being processed.