### PR TITLE
Fix Otel Collector resource mapping

### DIFF
--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -135,9 +135,6 @@ spec:
         - /otelcol-contrib
         args:
         - "--config=/conf/otel-collector-config.yaml"
-        # TODO: Remove this feature gate when opentelemetry semantic conventions are used
-        # in the collector code.
-        - "--feature-gates=-exporter.googlecloud.OTLPDirect"
         resources:
           limits:
             cpu: 1

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	depAnnotationGooglecloud = "6ba29d7cac4cdd7b23c0e1a6f355d0f5"
+	depAnnotationGooglecloud = "0e2c217290c9e809236c09007e961fe2"
 	depAnnotationCustom      = "9182661d55e260a55da649363c03c187"
 )
 


### PR DESCRIPTION
Config Sync updated Otel Collector image in v1.12.2 and started having
[incompatibilities](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/breaking-changes.md) in resource label format. The issue was mitigated in 1.13.1 by reverting Otel Collector to legacy mode.

This change

- uses `resourcedetection` processor to correclty map resource labels from OpenCensus to OpenTelemetry
- modified the `googlecloud` exporter to remove `instrumentation_source` and `insrtumentation_version` labels when exporting to Cloud Monarch
- disables metricDescriptor creation in Monarch pipeline so it won't conflict with internal definitions