### PR TITLE
Simplify status reporting of sync errors

### DIFF
--- a/pkg/applier/kpt_applier.go
+++ b/pkg/applier/kpt_applier.go
@@ -525,7 +525,9 @@ func (a *Applier) sync(ctx context.Context, objs []client.Object) (map[schema.Gr
 // Errors implements Interface.
 // Errors returns the errors encountered during apply.
 func (a *Applier) Errors() status.MultiError {
-	return a.errs
+	// TODO: Make read/write of a.errs thread-safe
+	// Return a copy
+	return status.Append(nil, a.errs)
 }
 
 // Syncing implements Interface.

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -162,7 +162,7 @@ func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus so
 
 	currentRS := rs.DeepCopy()
 
-	setSourceStatus(&rs.Status.Source, p, newStatus, denominator)
+	setSourceStatusFields(&rs.Status.Source, p, newStatus, denominator)
 
 	continueSyncing := (rs.Status.Source.ErrorSummary.TotalCount == 0)
 	var errorSource []v1beta1.ErrorSource
@@ -224,7 +224,7 @@ func (p *namespace) setRenderingStatusWithRetires(ctx context.Context, newStatus
 
 	currentRS := rs.DeepCopy()
 
-	setRenderingStatus(&rs.Status.Rendering, p, newStatus, denominator)
+	setRenderingStatusFields(&rs.Status.Rendering, p, newStatus, denominator)
 
 	continueSyncing := (rs.Status.Rendering.ErrorSummary.TotalCount == 0)
 	var errorSource []v1beta1.ErrorSource
@@ -287,7 +287,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 	// syncing indicates whether the applier is syncing.
 	syncing := p.applier.Syncing()
 
-	setSyncStatus(&rs.Status.Status, status.ToCSE(errs), denominator)
+	setSyncStatusFields(&rs.Status.Status, status.ToCSE(errs), denominator)
 
 	errorSources, errorSummary := summarizeErrors(rs.Status.Source, rs.Status.Sync)
 	if syncing {
@@ -332,14 +332,11 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 	return nil
 }
 
-// ApplierErrors implements the Parser interface
-func (p *namespace) ApplierErrors() status.MultiError {
-	return p.applier.Errors()
-}
-
-// RemediatorConflictErrors implements the Parser interface
-func (p *namespace) RemediatorConflictErrors() []status.ManagementConflictError {
-	return p.remediator.ConflictErrors()
+// SyncErrors returns all the sync errors, including remediator errors,
+// validation errors, applier errors, and watch update errors.
+// SyncErrors implements the Parser interface
+func (p *namespace) SyncErrors() status.MultiError {
+	return p.updater.Errors()
 }
 
 // K8sClient implements the Parser interface

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -82,10 +82,9 @@ type Parser interface {
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
 	SetSyncStatus(ctx context.Context, errs status.MultiError) error
 	options() *opts
-	// ApplierErrors returns the errors surfaced by the applier.
-	ApplierErrors() status.MultiError
-	// RemediatorConflictErrors returns the conflict errors detected by the remediator.
-	RemediatorConflictErrors() []status.ManagementConflictError
+	// SyncErrors returns all the sync errors, including remediator errors,
+	// validation errors, applier errors, and watch update errors.
+	SyncErrors() status.MultiError
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 }

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -128,7 +128,11 @@ func (r *Remediator) ManagementConflict() bool {
 
 // ConflictErrors implements Interface.
 func (r *Remediator) ConflictErrors() []status.ManagementConflictError {
-	return r.conflictErrs
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	// Return a copy
+	return append([]status.ManagementConflictError(nil), r.conflictErrs...)
 }
 
 func (r *Remediator) addConflictError(e status.ManagementConflictError) {


### PR DESCRIPTION
- Add a new setSyncStatus that handles:
  - Updating the cached sync status in `state`
  - Checking the cached sync status to avoid unnecessary updates
  - Calling SetSyncStatus with the new sync errors
  - Calling reportRootSyncConflicts to update remote RootSyncs, if
    they are causing conflicts with the current RSync.
- Rename UpdateConflictManagerStatus -> reportRootSyncConflicts
- Rename parse.setXStatus -> setXStatusFields to allow the name
  setSyncStatus to be used by the wrapper that handles state
- Call the new parse.setSyncStatus to make all the updates
  consistent, instead of calling parser.SetSyncStatus directly.
- Rename updateSyncStatus -> updateSyncStatusPeriodically to
  indicate it handles retrying until cancelled.
- Rename Parser.ApplierErrors() -> SyncErrors() and have it
  delegate to the new updater.Errors(), which centralizes
  aggregation of the following errors that are all reported as
  sync errors:
  - Remediator conflict errors
  - Validation errors from updating the object set
  - Applier errors
  - Watch update errors
- Remove Parser.RemediatorConflictErrors() because it's obsolete
  with the new SyncErrors. The conflict errors are a subset of the
  sync errors and are extracted as-needed in setSyncErrors.
  This extraction probably won't be necessary in the future, as we
  plan to stop reporting errors across RSyncs.
- Enhance TestConflictingDefinitions_RootToRoot to handle catching
  conflict errors in parallel, for speed and consistently.
- Fix linter copylock error