### PR TITLE
Several enhancements to metrics

### DIFF
--- a/pkg/applier/clientset.go
+++ b/pkg/applier/clientset.go
@@ -111,6 +111,7 @@ func (cs *clientSet) handleDisabledObjects(ctx context.Context, rg *live.Invento
 	var errs status.MultiError
 	for _, obj := range objs {
 		err := cs.disableObject(ctx, obj)
+		handleMetrics(ctx, "unmanage", err, obj.GetObjectKind().GroupVersionKind())
 		if err != nil {
 			klog.Warningf("failed to disable object %v", core.IDOf(obj))
 			errs = status.Append(errs, Error(err))

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/status"
 )
 
 func record(ctx context.Context, ms ...stats.Measurement) {
@@ -48,13 +49,20 @@ func RecordAPICallDuration(ctx context.Context, operation, status string, gvk sc
 
 // RecordReconcilerErrors produces a measurement for the ReconcilerErrors view.
 func RecordReconcilerErrors(ctx context.Context, component string, errs []v1beta1.ConfigSyncError) {
-	class := ""
-	tagCtx, _ := tag.New(ctx,
-		tag.Upsert(KeyComponent, component),
-		tag.Upsert(KeyErrorClass, class),
-	)
-	measurement := ReconcilerErrors.M(int64(len(errs)))
-	record(tagCtx, measurement)
+	errorCountByClass := status.CountErrorByClass(errs)
+	var supportedErrorClasses = []string{"1xxx", "2xxx", "9xxx"}
+	for _, errorclass := range supportedErrorClasses {
+		var errorCount int64
+		if v, ok := errorCountByClass[errorclass]; ok {
+			errorCount = v
+		}
+		tagCtx, _ := tag.New(ctx,
+			tag.Upsert(KeyComponent, component),
+			tag.Upsert(KeyErrorClass, errorclass),
+		)
+		measurement := ReconcilerErrors.M(errorCount)
+		record(tagCtx, measurement)
+	}
 }
 
 // RecordPipelineError produces a measurement for the PipelineError view
@@ -87,10 +95,6 @@ func RecordParserDuration(ctx context.Context, trigger, source, status string, s
 
 // RecordLastSync produces a measurement for the LastSync view.
 func RecordLastSync(ctx context.Context, status, commit string, timestamp time.Time) {
-	if commit == "" {
-		// TODO: Remove default value when otel-collector supports empty tag values correctly.
-		commit = CommitNone
-	}
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyStatus, status),
 		tag.Upsert(KeyCommit, commit))
@@ -105,10 +109,11 @@ func RecordDeclaredResources(ctx context.Context, numResources int) {
 }
 
 // RecordApplyOperation produces a measurement for the ApplyOperations view.
-func RecordApplyOperation(ctx context.Context, operation, status string, gvk schema.GroupVersionKind) {
+func RecordApplyOperation(ctx context.Context, controller, operation, status string, gvk schema.GroupVersionKind) {
 	tagCtx, _ := tag.New(ctx,
 		//tag.Upsert(KeyName, GetResourceLabels()),
 		tag.Upsert(KeyOperation, operation),
+		tag.Upsert(KeyController, controller),
 		//tag.Upsert(KeyType, gvk.Kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := ApplyOperations.M(1)

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -31,7 +31,10 @@ var (
 	// KeyOperation groups metrics by their operation. Possible values: create, patch, update, delete.
 	KeyOperation, _ = tag.NewKey("operation")
 
-	// KeyComponent groups metrics by their component. Possible values: parsing, source, sync, rendering, readiness(from Resource Group Controller).
+	// KeyController groups metrics by their controller. Possible values: applier, remediator, syncer.
+	KeyController, _ = tag.NewKey("controller")
+
+	// KeyComponent groups metrics by their component. Possible values: source, sync, rendering, readiness(from Resource Group Controller).
 	KeyComponent, _ = tag.NewKey("component")
 
 	// KeyErrorClass groups metrics by their error code.
@@ -94,6 +97,10 @@ const (
 	// CommitNone is the string value for the commit key indicating that no
 	// commit has been synced.
 	CommitNone = "NONE"
+	// ApplierController is the string value for the applier controller in the multi-repo mode
+	ApplierController = "applier"
+	// RemediatorController is the string value for the remediator controller in the multi-repo mode
+	RemediatorController = "remediator"
 )
 
 // StatusTagKey returns a string representation of the error, if it exists, otherwise success.

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -19,7 +19,11 @@ import (
 	"go.opencensus.io/tag"
 )
 
+// distributionBounds defines the bounds for a histogram distribution meansuring short durations.
 var distributionBounds = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
+
+// longDistributionBounds defines the bounds for a histogram distribution meansuring long durations.
+var longDistributionBounds = []float64{1, 5, 10, 30, 60, 300, 600, 1200, 1800, 3600, 5400}
 
 var (
 	// APICallDurationView aggregates the APICallDuration metric measurements.
@@ -67,7 +71,7 @@ var (
 		Measure:     ParserDuration,
 		Description: "The latency distribution of the parse-apply-watch loop",
 		TagKeys:     []tag.Key{KeyStatus, KeyTrigger, KeyParserSource},
-		Aggregation: view.Distribution(distributionBounds...),
+		Aggregation: view.Distribution(longDistributionBounds...),
 	}
 
 	// LastSyncTimestampView aggregates the LastSyncTimestamp metric measurements.
@@ -92,7 +96,7 @@ var (
 		Name:        ApplyOperations.Name() + "_total",
 		Measure:     ApplyOperations,
 		Description: "The total number of operations that have been performed to sync resources to source of truth",
-		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
+		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyStatus},
 		Aggregation: view.Count(),
 	}
 
@@ -102,7 +106,7 @@ var (
 		Measure:     ApplyDuration,
 		Description: "The latency distribution of applier resource sync events",
 		TagKeys:     []tag.Key{KeyStatus},
-		Aggregation: view.Distribution(distributionBounds...),
+		Aggregation: view.Distribution(longDistributionBounds...),
 	}
 
 	// LastApplyTimestampView aggregates the LastApplyTimestamp metric measurements.

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -121,8 +121,6 @@ func (p *namespace) parseSource(ctx context.Context, state sourceState) ([]ast.F
 
 	objs, err = validate.Unstructured(objs, options)
 
-	metrics.RecordReconcilerErrors(ctx, "parsing", status.NonBlockingErrors(err))
-
 	if status.HasBlockingErrors(err) {
 		return nil, err
 	}
@@ -319,7 +317,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 		klog.Infof("New sync errors for RepoSync %s/%s: %+v",
 			rs.Namespace, rs.Name, csErrs)
 	}
-	if !syncing {
+	if !syncing && rs.Status.Sync.Commit != "" {
 		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -139,8 +139,6 @@ func (p *root) parseSource(ctx context.Context, state sourceState) ([]ast.FileOb
 		objs, err = validate.Hierarchical(objs, options)
 	}
 
-	metrics.RecordReconcilerErrors(ctx, "parsing", status.NonBlockingErrors(err))
-
 	if status.HasBlockingErrors(err) {
 		return nil, err
 	}
@@ -415,7 +413,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, errs status.MultiEr
 		klog.Infof("New sync errors for RootSync %s/%s: %+v",
 			rs.Namespace, rs.Name, csErrs)
 	}
-	if !syncing {
+	if !syncing && rs.Status.Sync.Commit != "" {
 		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -763,7 +763,9 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 				status.SourceError.Sprintf("source error").Build(),
 			},
 			wantMetrics: []*view.Row{
-				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
 			},
 		},
 		{
@@ -773,7 +775,9 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 				status.InternalError("internal error"),
 			},
 			wantMetrics: []*view.Row{
-				{Data: &view.LastValueData{Value: 2}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
 			},
 		},
 	}
@@ -820,9 +824,12 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 				applier.Error(errors.New("sync error")),
 			},
 			wantMetrics: []*view.Row{
-				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "parsing"}}},
-				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}}},
-				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
 			},
 		},
 		{
@@ -832,9 +839,12 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 				status.InternalError("internal error"),
 			},
 			wantMetrics: []*view.Row{
-				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "parsing"}}},
-				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}}},
-				{Data: &view.LastValueData{Value: 2}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
+				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "2xxx"}}},
+				{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "sync"}, {Key: metrics.KeyErrorClass, Value: "9xxx"}}},
 			},
 		},
 	}

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -112,7 +112,7 @@ func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Objec
 			return err
 		}
 		klog.V(3).Infof("The remediator is about to unmanage object %v", core.GKNN(actual))
-		_, err = r.applier.RemoveNomosMeta(ctx, actual)
+		_, err = r.applier.RemoveNomosMeta(ctx, actual, metrics.RemediatorController)
 		return err
 	default:
 		// e.g. differ.DeleteNsConfig, which shouldn't be possible to get to any way.

--- a/pkg/status/error.go
+++ b/pkg/status/error.go
@@ -247,3 +247,24 @@ func cseFromResourceError(err ResourceError) v1beta1.ConfigSyncError {
 	}
 	return cse
 }
+
+// CountErrorByClass counts the errors by errorclass.
+// The errorclass is a string derived from the error code. For example, the errorclass
+// of a ConfigSyncErrow with the error code of "1323" is "1xxx".
+func CountErrorByClass(errs []v1beta1.ConfigSyncError) map[string]int64 {
+	var result = make(map[string]int64)
+	for _, err := range errs {
+		// `err.Code` should not be empty
+		if err.Code == "" {
+			continue
+		}
+
+		errorclass := fmt.Sprintf("%sxxx", string(err.Code[0]))
+		if _, ok := result[errorclass]; !ok {
+			result[errorclass] = 1
+		} else {
+			result[errorclass]++
+		}
+	}
+	return result
+}

--- a/pkg/syncer/syncertest/fake/applier.go
+++ b/pkg/syncer/syncertest/fake/applier.go
@@ -58,7 +58,7 @@ func (a *Applier) Update(ctx context.Context, intendedState, _ *unstructured.Uns
 }
 
 // RemoveNomosMeta implements reconcile.Applier.
-func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured) (bool, status.Error) {
+func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured, controller string) (bool, status.Error) {
 	updated := metadata.RemoveConfigSyncMetadata(intent)
 	if !updated {
 		return false, nil


### PR DESCRIPTION
   Several enhancements to metrics
    
    1) Enhance the `reconciler_errors` metric
       * stop using the `parsing` `component` label value to be consistent
         with R*Syncs status APIs
       * support the `errorclass` label correctly. Currently, this label is
         always set to an empty string. With this PR, the value of the
         errorclass label can be “1xxx”, “2xxx”, “9xxx”. For every
         component, three time series will be recorded, one for each
         errorclass.
    2) Enhance the `apply_operations` metric
        * add a new label named `controller` to track whether the operation
          is from the applier or the remediator
        * record this metric when an ApplyFailed/PruneFailed event is
          observed on the event channel returned from the cli-utils library.
    3) Enhance the `last_sync_timestamp` metric
        * only send this metric when the `commit` label is not empty.
          Currently, the metric may be sent with an empty commit, since we
          support asynchronous status updates.
    4) Enahnce the `parser_duration_seconds` metric
        * Currently, the bounds for the histogram distribution is
          []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}, and
          all the timeseries whose values are greater than 10 are put into
          the same bucket, [10, +Infinite]. This PR uses the bounds
          []float64{1, 5, 10, 30, 60, 300, 600, 1200, 1800} to better align
          with the common use cases.
    5) Enhance the `apply_duration_seconds` metric
        * Currently, the bounds for the histogram distribution is
          []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}, and
          all the timeseries whose values are greater than 10 are put into
          the same bucket, [10, +Infinite]. This PR uses the bounds
          []float64{1, 5, 10, 30, 60, 300, 600, 1200, 1800} to better align
          with the common use cases.
