### PR TITLE
Enhance the `parser_duration_seconds` and `apply_duration_seconds` metrics

### DIFF
--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -19,7 +19,11 @@ import (
 	"go.opencensus.io/tag"
 )
 
+// distributionBounds defines the bounds for a histogram distribution meansuring short durations.
 var distributionBounds = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
+
+// longDistributionBounds defines the bounds for a histogram distribution meansuring long durations.
+var longDistributionBounds = []float64{1, 5, 10, 30, 60, 300, 600, 1200, 1800, 3600, 5400}
 
 var (
 	// APICallDurationView aggregates the APICallDuration metric measurements.
@@ -67,7 +71,7 @@ var (
 		Measure:     ParserDuration,
 		Description: "The latency distribution of the parse-apply-watch loop",
 		TagKeys:     []tag.Key{KeyStatus, KeyTrigger, KeyParserSource},
-		Aggregation: view.Distribution(distributionBounds...),
+		Aggregation: view.Distribution(longDistributionBounds...),
 	}
 
 	// LastSyncTimestampView aggregates the LastSyncTimestamp metric measurements.
@@ -102,7 +106,7 @@ var (
 		Measure:     ApplyDuration,
 		Description: "The latency distribution of applier resource sync events",
 		TagKeys:     []tag.Key{KeyStatus},
-		Aggregation: view.Distribution(distributionBounds...),
+		Aggregation: view.Distribution(longDistributionBounds...),
 	}
 
 	// LastApplyTimestampView aggregates the LastApplyTimestamp metric measurements.


### PR DESCRIPTION
Currently, the bounds for the histogram distribution is `[]float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}`, and all the timeseries whose values are greater than 10 are put into the same bucket, [10, +Infinite]. This PR uses the bounds `[]float64{1, 5, 10, 30, 60, 300, 600, 1200, 1800, 3600, 5400}` to better align with the common use cases.
