### PR TITLE
Enhance the `last_sync_timestamp` metric

### DIFF
--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -87,10 +87,6 @@ func RecordParserDuration(ctx context.Context, trigger, source, status string, s
 
 // RecordLastSync produces a measurement for the LastSync view.
 func RecordLastSync(ctx context.Context, status, commit string, timestamp time.Time) {
-	if commit == "" {
-		// TODO: Remove default value when otel-collector supports empty tag values correctly.
-		commit = CommitNone
-	}
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyStatus, status),
 		tag.Upsert(KeyCommit, commit))

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -312,7 +312,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, errs status.Mu
 		klog.Infof("New sync errors for RepoSync %s/%s: %+v",
 			rs.Namespace, rs.Name, csErrs)
 	}
-	if !syncing {
+	if !syncing && rs.Status.Sync.Commit != "" {
 		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -408,7 +408,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, errs status.MultiEr
 		klog.Infof("New sync errors for RootSync %s/%s: %+v",
 			rs.Namespace, rs.Name, csErrs)
 	}
-	if !syncing {
+	if !syncing && rs.Status.Sync.Commit != "" {
 		metrics.RecordLastSync(ctx, metrics.StatusTagValueFromSummary(errorSummary), rs.Status.Sync.Commit, rs.Status.Sync.LastUpdate.Time)
 	}
 


### PR DESCRIPTION
Currently, the metric may be sent with an empty commit, since we support asynchronous status updates.  This PR ensures this metric is only recorded when the `commit` label is not empty.