### PR TITLE
Enhance the `apply_operations` metric

### DIFF
--- a/pkg/applier/clientset.go
+++ b/pkg/applier/clientset.go
@@ -111,6 +111,7 @@ func (cs *clientSet) handleDisabledObjects(ctx context.Context, rg *live.Invento
 	var errs status.MultiError
 	for _, obj := range objs {
 		err := cs.disableObject(ctx, obj)
+		handleMetrics(ctx, "unmanage", err, obj.GetObjectKind().GroupVersionKind())
 		if err != nil {
 			klog.Warningf("failed to disable object %v", core.IDOf(obj))
 			errs = status.Append(errs, Error(err))

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -105,10 +105,11 @@ func RecordDeclaredResources(ctx context.Context, numResources int) {
 }
 
 // RecordApplyOperation produces a measurement for the ApplyOperations view.
-func RecordApplyOperation(ctx context.Context, operation, status string, gvk schema.GroupVersionKind) {
+func RecordApplyOperation(ctx context.Context, controller, operation, status string, gvk schema.GroupVersionKind) {
 	tagCtx, _ := tag.New(ctx,
 		//tag.Upsert(KeyName, GetResourceLabels()),
 		tag.Upsert(KeyOperation, operation),
+		tag.Upsert(KeyController, controller),
 		//tag.Upsert(KeyType, gvk.Kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := ApplyOperations.M(1)

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -31,6 +31,9 @@ var (
 	// KeyOperation groups metrics by their operation. Possible values: create, patch, update, delete.
 	KeyOperation, _ = tag.NewKey("operation")
 
+	// KeyController groups metrics by their controller. Possible values: applier, remediator.
+	KeyController, _ = tag.NewKey("controller")
+
 	// KeyComponent groups metrics by their component. Possible values: parsing, source, sync, rendering, readiness(from Resource Group Controller).
 	KeyComponent, _ = tag.NewKey("component")
 
@@ -94,6 +97,10 @@ const (
 	// CommitNone is the string value for the commit key indicating that no
 	// commit has been synced.
 	CommitNone = "NONE"
+	// ApplierController is the string value for the applier controller in the multi-repo mode
+	ApplierController = "applier"
+	// RemediatorController is the string value for the remediator controller in the multi-repo mode
+	RemediatorController = "remediator"
 )
 
 // StatusTagKey returns a string representation of the error, if it exists, otherwise success.

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -92,7 +92,7 @@ var (
 		Name:        ApplyOperations.Name() + "_total",
 		Measure:     ApplyOperations,
 		Description: "The total number of operations that have been performed to sync resources to source of truth",
-		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
+		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyStatus},
 		Aggregation: view.Count(),
 	}
 

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -112,7 +112,7 @@ func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Objec
 			return err
 		}
 		klog.V(3).Infof("The remediator is about to unmanage object %v", core.GKNN(actual))
-		_, err = r.applier.RemoveNomosMeta(ctx, actual)
+		_, err = r.applier.RemoveNomosMeta(ctx, actual, metrics.RemediatorController)
 		return err
 	default:
 		// e.g. differ.DeleteNsConfig, which shouldn't be possible to get to any way.

--- a/pkg/syncer/syncertest/fake/applier.go
+++ b/pkg/syncer/syncertest/fake/applier.go
@@ -58,7 +58,7 @@ func (a *Applier) Update(ctx context.Context, intendedState, _ *unstructured.Uns
 }
 
 // RemoveNomosMeta implements reconcile.Applier.
-func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured) (bool, status.Error) {
+func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured, controller string) (bool, status.Error) {
 	updated := metadata.RemoveConfigSyncMetadata(intent)
 	if !updated {
 		return false, nil


### PR DESCRIPTION
    * add a new label named `controller` to track whether the operation
      is from the applier or the remediator
    * record this metric when an ApplyFailed/PruneFailed event is
      observed on the event channel returned from the cli-utils library.