### PR TITLE
Add e2e and unit test coverage to make sure a root|ns-reconciler Deployment is not updated unnecessarily

### DIFF
--- a/e2e/nomostest/predicates.go
+++ b/e2e/nomostest/predicates.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -209,16 +210,16 @@ func HasCorrectResourceRequestsLimits(containerName string, cpuRequest, cpuLimit
 		}
 		for _, container := range dep.Spec.Template.Spec.Containers {
 			if containerName == container.Name {
-				if container.Resources.Requests[corev1.ResourceCPU] != cpuRequest {
+				if !equality.Semantic.DeepEqual(container.Resources.Requests[corev1.ResourceCPU], cpuRequest) {
 					return errors.Errorf("The CPU request of the %q container should be %v, got %v", container.Name, cpuRequest, container.Resources.Requests[corev1.ResourceCPU])
 				}
-				if container.Resources.Limits[corev1.ResourceCPU] != cpuLimit {
+				if !equality.Semantic.DeepEqual(container.Resources.Limits[corev1.ResourceCPU], cpuLimit) {
 					return errors.Errorf("The CPU limit of the %q container should be %v, got %v", container.Name, cpuLimit, container.Resources.Limits[corev1.ResourceCPU])
 				}
-				if container.Resources.Requests[corev1.ResourceMemory] != memoryRequest {
+				if !equality.Semantic.DeepEqual(container.Resources.Requests[corev1.ResourceMemory], memoryRequest) {
 					return errors.Errorf("The memory request of the %q container should be %v, got %v", container.Name, memoryRequest, container.Resources.Requests[corev1.ResourceMemory])
 				}
-				if container.Resources.Limits[corev1.ResourceMemory] != memoryLimit {
+				if !equality.Semantic.DeepEqual(container.Resources.Limits[corev1.ResourceMemory], memoryLimit) {
 					return errors.Errorf("The memory limit of the %q container should be %v, got %v", container.Name, memoryLimit, container.Resources.Limits[corev1.ResourceMemory])
 				}
 

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -437,7 +437,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		{
 			ContainerName: reconcilermanager.HydrationController,
 			CPURequest:    resource.MustParse("500m"),
-			CPULimit:      resource.MustParse("1"),
+			CPULimit:      resource.MustParse("1000m"),
 			MemoryRequest: resource.MustParse("500Mi"),
 			MemoryLimit:   resource.MustParse("1Gi"),
 		},

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -265,7 +265,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		{
 			ContainerName: reconcilermanager.HydrationController,
 			CPURequest:    resource.MustParse("500m"),
-			CPULimit:      resource.MustParse("1"),
+			CPULimit:      resource.MustParse("1000m"),
 			MemoryRequest: resource.MustParse("500Mi"),
 			MemoryLimit:   resource.MustParse("1Gi"),
 		},


### PR DESCRIPTION
The quantity of CPU resources can be specified in multiple formats: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/. For example, '1' and '1000m' are semantically equal to each other.

There is a bug in ACM 1.11.0 - ACM 1.13.1, which causes a root|ns-reconciler Deployment to be updated constantly if the CPU resource request/limit are in the format of '1000m' instead of '1'. The issue is fixed in
https://github.com/GoogleContainerTools/kpt-config-sync/pull/78.

This PR add e2e and unit test coverage for this.

This PR is the second attempt to fix this, the first attempt (https://github.com/GoogleContainerTools/kpt-config-sync/pull/289) was reverted because it broken GKE CI jobs which runs e2e tests on a shared environment. The first attempt assumes the generation of a root|ns reconciler deployment is 1 at the start of a e2e test. This PR removes this assumption.