### PR TITLE
Improve thread-safety of sync status updates

### DIFF
--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -80,11 +80,13 @@ type Parser interface {
 	parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError)
 	setSourceStatus(ctx context.Context, newStatus sourceStatus) error
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
-	SetSyncStatus(ctx context.Context, errs status.MultiError) error
+	SetSyncStatus(ctx context.Context, newStatus syncStatus) error
 	options() *opts
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.
 	SyncErrors() status.MultiError
+	// Syncing returns true if the updater is running.
+	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 }


### PR DESCRIPTION
- Wrap applier errors in their own mutex
- Move applier.Syncing() to Parser.Syncing() with updater.Updating() doing the heavy lifting. The Syncing condition status should reflect the whole updater, not just the applier.
- Rename applier.Interface -> KptApplier to make room for adding KptDestroyer in the future.
- Rename KptApplier.sync -> applyInner to make room for adding destroyInner in the future.
- Refactor state.syncStatus and Parser.SetSyncStatus to use a new syncStatus struct, which is like the sourceStatus struct but with an added sync bool. This should also be less confusing, because state.syncStatus no longer uses a sourceStatus struct as its value.
- Add a new setSyncStatusErrors func to use in prependRootSyncRemediatorStatus, to avoid needing to to re-construct the initial syncStatus when prepending errors. (Note: This cross-rsync update changes the `.status.sync.errs` and `.status.sync.lastUpdate` without updating the Syncing condition or `reconciler_errors` metric, which means they will continue to be out of sync when there's a conflict. But this is not a new problem.)
