### PR TITLE
Clean up REST client construction

### DIFF
--- a/cmd/nomos/parse/parse.go
+++ b/cmd/nomos/parse/parse.go
@@ -42,7 +42,7 @@ func GetSyncedCRDs(ctx context.Context, skipAPIServer bool, apiServerTimeout tim
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	config, err := restconfig.MonoRepoRestClient(apiServerTimeout)
+	config, err := restconfig.NewRestConfig(apiServerTimeout)
 	if err != nil {
 		return nil, getSyncedCRDsError(err, "failed to create rest config")
 	}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -149,8 +149,10 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		ClusterName:             opts.Name,
 		TmpDir:                  opts.TmpDir,
 		Config:                  opts.RESTConfig,
+		WatchConfig:             opts.WatchConfig,
 		repoSyncPermissions:     opts.RepoSyncPermissions,
 		Client:                  sharedNt.Client,
+		WatchClient:             sharedNt.WatchClient,
 		IsGKEAutopilot:          sharedNt.IsGKEAutopilot,
 		DefaultWaitTimeout:      sharedNt.DefaultWaitTimeout,
 		DefaultReconcileTimeout: sharedNt.DefaultReconcileTimeout,
@@ -239,7 +241,6 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	t.Helper()
 
 	scheme := newScheme(t)
-	c := connect(t, opts.RESTConfig, scheme)
 	ctx := context.Background()
 
 	webhookDisabled := false
@@ -249,8 +250,8 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		ClusterName:             opts.Name,
 		TmpDir:                  opts.TmpDir,
 		Config:                  opts.RESTConfig,
+		WatchConfig:             opts.WatchConfig,
 		repoSyncPermissions:     opts.RepoSyncPermissions,
-		Client:                  c,
 		DefaultReconcileTimeout: 1 * time.Minute,
 		kubeconfigPath:          opts.KubeconfigPath,
 		ReconcilerPollingPeriod: 50 * time.Millisecond,
@@ -263,6 +264,9 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		RemoteRepositories:      make(map[types.NamespacedName]*Repository),
 		WebhookDisabled:         &webhookDisabled,
 	}
+
+	// init the Client & WatchClient
+	nt.RenewClient()
 
 	if opts.SkipConfigSyncInstall {
 		return nt

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -68,11 +68,22 @@ type NT struct {
 	// Config specifies how to create a new connection to the cluster.
 	Config *rest.Config
 
+	// WatchConfig specifies how to create a new connection to the cluster for
+	// watches.
+	WatchConfig *rest.Config
+
 	// Client is the underlying client used to talk to the Kubernetes cluster.
 	//
 	// Most tests shouldn't need to talk directly to this, unless simulating
 	// direct interactions with the API Server.
-	Client client.WithWatch
+	Client client.Client
+
+	// WatchClient is the underlying client used to talk to the Kubernetes
+	// cluster, when performing watches.
+	//
+	// Most tests shouldn't need to talk directly to this, unless simulating
+	// direct interactions with the API Server.
+	WatchClient client.WithWatch
 
 	// IsGKEAutopilot indicates if the test cluster is a GKE Autopilot cluster.
 	IsGKEAutopilot bool
@@ -452,6 +463,7 @@ func (nt *NT) RenewClient() {
 	nt.T.Helper()
 
 	nt.Client = connect(nt.T, nt.Config, nt.scheme)
+	nt.WatchClient = connect(nt.T, nt.WatchConfig, nt.scheme)
 }
 
 // Kubectl is a convenience method for calling kubectl against the

--- a/e2e/nomostest/ntopts/gke.go
+++ b/e2e/nomostest/ntopts/gke.go
@@ -23,7 +23,6 @@ import (
 
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/testing"
-	"kpt.dev/configsync/pkg/client/restconfig"
 )
 
 // GKECluster tells the test to use the GKE cluster pointed to by the config flags.
@@ -45,11 +44,6 @@ func GKECluster(t testing.NTB, apiServerTimeout time.Duration) Opt {
 		opt.KubeconfigPath = kubeconfig
 
 		forceAuthRefresh(t)
-		restConfig, err := restconfig.NewRestConfig(apiServerTimeout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		opt.RESTConfig = restConfig
 	}
 }
 

--- a/e2e/nomostest/ntopts/kind.go
+++ b/e2e/nomostest/ntopts/kind.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"k8s.io/client-go/tools/clientcmd"
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/docker"
 	"kpt.dev/configsync/e2e/nomostest/testing"
@@ -62,13 +61,7 @@ const (
 func Kind(t testing.NTB, version string) Opt {
 	v := asKindVersion(t, version)
 	return func(opt *New) {
-		var err error
 		opt.KubeconfigPath = newKind(t, opt.Name, opt.TmpDir, v)
-		// We don't need to specify masterUrl since we have a Kubeconfig.
-		opt.RESTConfig, err = clientcmd.BuildConfigFromFlags("", opt.KubeconfigPath)
-		if err != nil {
-			t.Fatalf("building rest.Config: %v", err)
-		}
 	}
 }
 

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -45,6 +45,10 @@ type New struct {
 	// RESTConfig is the config for creating a Client connection to a K8s cluster.
 	RESTConfig *rest.Config
 
+	// WatchConfig is the config for creating a Client connection to a K8s
+	// cluster for watches.
+	WatchConfig *rest.Config
+
 	// KubeconfigPath is the path to the kubeconfig file
 	KubeconfigPath string
 
@@ -107,6 +111,13 @@ func WithInitialCommit(initialCommit Commit) func(opt *New) {
 func WithRestConfig(restConfig *rest.Config) Opt {
 	return func(opt *New) {
 		opt.RESTConfig = restConfig
+	}
+}
+
+// WithWatchConfig uses the provided rest.Config for watches
+func WithWatchConfig(watchConfig *rest.Config) Opt {
+	return func(opt *New) {
+		opt.WatchConfig = watchConfig
 	}
 }
 

--- a/e2e/nomostest/watch.go
+++ b/e2e/nomostest/watch.go
@@ -62,7 +62,7 @@ func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace st
 	nt.T.Helper()
 
 	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
-	rObj, err := nt.Client.Scheme().New(listGVK)
+	rObj, err := nt.WatchClient.Scheme().New(listGVK)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace st
 
 	ctx, cancel := context.WithTimeout(nt.Context, wait.timeout)
 	defer cancel()
-	result, err := nt.Client.Watch(ctx, cObjList, listOpts...)
+	result, err := nt.WatchClient.Watch(ctx, cObjList, listOpts...)
 	defer result.Stop()
 	if err != nil {
 		return err

--- a/pkg/client/restconfig/config.go
+++ b/pkg/client/restconfig/config.go
@@ -55,16 +55,6 @@ func newConfigPath() (string, error) {
 	return path, nil
 }
 
-// newConfigFromPath creates a rest.Config from a configuration file at the
-// supplied path.
-func newConfigFromPath(path string) (*rest.Config, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", path)
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
 // newRawConfigWithRules returns a clientcmdapi.Config from a configuration file whose path is
 // provided by newConfigPath, and the clientcmd.ClientConfigLoadingRules associated with it
 func newRawConfigWithRules() (*clientcmdapi.Config, *clientcmd.ClientConfigLoadingRules, error) {
@@ -128,22 +118,4 @@ func AllKubectlConfigs(timeout time.Duration) (map[string]*rest.Config, error) {
 		cfgErrs = fmt.Errorf("failed to build configs:\n%s", strings.Join(badConfigs, "\n"))
 	}
 	return configs, cfgErrs
-}
-
-// newKubectlConfig creates a config for whichever context is active in kubectl.
-func newKubectlConfig() (*rest.Config, error) {
-	path, err := newConfigPath()
-	if err != nil {
-		return nil, errors.Wrapf(err, "while getting config path")
-	}
-	config, err := newConfigFromPath(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while loading from %v", path)
-	}
-	return config, nil
-}
-
-// newLocalClusterConfig creates a config for connecting to the local cluster API server.
-func newLocalClusterConfig() (*rest.Config, error) {
-	return rest.InClusterConfig()
 }


### PR DESCRIPTION
- Split out NewFromConfigFile & NewFromInClusterConfig for direct use
- Add a new WatchConfig and WatchCLient to the e2e test config. **This fixes a bug where the WatchForObject calls would timeout in 5s on GKE.**
- Use NewRestConfig in e2e for both GKE and Kind. **This uses UpdateQPS in the e2e tests for faster API calls.**
- Remove the unused MonoRepo client config (slower QPS)