### PR TITLE
ci: consolidate gke cluster args

### DIFF
--- a/build/test-e2e-go/e2e.sh
+++ b/build/test-e2e-go/e2e.sh
@@ -19,34 +19,6 @@
 
 set -eo pipefail
 
-DIR=$(dirname "${BASH_SOURCE[0]}")
-
-if [ $KUBERNETES_ENV == "GKE" ]; then
-  echo "GKE environment"
-
-  # Installs gcloud as an auth helper for kubectl with the credentials that
-  # were set with the service account activation above.
-  # Needs cloud.containers.get permission.
-  # shellcheck disable=SC2154
-  if [[ -z ${GCP_ZONE} ]] && [[ -z ${GCP_REGION} ]]; then
-    echo "neither GCP_ZONE nor GCP_REGION is set."
-    exit 1
-  elif [[ -n ${GCP_ZONE} ]] && [[ -n ${GCP_REGION} ]]; then
-    echo "At most one of GCP_ZONE | GCP_REGION may be specified."
-    exit 1
-  elif [[ -n ${GCP_ZONE} ]]; then
-    gcloud --quiet container clusters get-credentials "${GCP_CLUSTER}" --zone="${GCP_ZONE}" --project="${GCP_PROJECT}"
-  else
-    gcloud --quiet container clusters get-credentials "${GCP_CLUSTER}" --region="${GCP_REGION}" --project="${GCP_PROJECT}"
-  fi
-
-elif [ $KUBERNETES_ENV == "KIND" ]; then
-  echo "kind environment"
-else
-  echo "Unexpected Kubernetes environment, '$KUBERNETES_ENV'"
-  exit 1
-fi
-
 set +e
 
 echo "Starting e2e tests"

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,10 +104,14 @@ current context in your kubeconfig.
 ```shell
 # Ensure gcloud context is set to correct project
 gcloud config set project <PROJECT_ID>
-# Ensure kubectl context is set to correct cluster
-kubectl config set-context <CONTEXT>
 # Build images/manifests and push images
 make config-sync-manifest
+# Set env vars for GKE cluster
+export GCP_PROJECT=<PROJECT_ID>
+export GCP_CLUSTER=<CLUSTER_NAME>
+# One of GCP_REGION and GCP_ZONE must be set (but not both)
+export GCP_REGION=<REGION>
+export GCP_ZONE=<ZONE>
 # Run the tests with image prefix/tag from previous step and desired test regex
 go test ./e2e/... --e2e --debug --test.v --share-test-env=true --test.parallel=1 --test-cluster=gke --test.run (test name regexp)
 ```

--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -73,10 +73,6 @@ var TestCluster = flag.String("test-cluster", Kind,
 		"If --test-cluster=%s, create a Kind cluster. Otherwise use the GKE context specified in %s.",
 		GKE, Kind, Kind, Kubeconfig))
 
-// KubeConfig specifies the file path to the kubeconfig file.
-var KubeConfig = flag.String(Kubeconfig, "",
-	"The file path to the kubeconfig file. If not set, use the default context.")
-
 // ShareTestEnv indicates whether to share the test env for all test cases.
 // If it is true, we only install nomos once before all tests and tear it down until all tests complete.
 var ShareTestEnv = flag.Bool("share-test-env", false,

--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -15,6 +15,7 @@
 package nomostest
 
 import (
+	"path/filepath"
 	"strings"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -95,6 +96,8 @@ func newScheme(t testing.NTB) *runtime.Scheme {
 // If --test-cluster=kind, it creates a Kind cluster.
 // If --test-cluster=kubeconfig, it uses the context specified in kubeconfig.
 func RestConfig(t testing.NTB, opts *ntopts.New) {
+	opts.KubeconfigPath = filepath.Join(opts.TmpDir, ntopts.Kubeconfig)
+	t.Logf("kubeconfig will be created at %s", opts.KubeconfigPath)
 	switch strings.ToLower(*e2e.TestCluster) {
 	case e2e.Kind:
 		ntopts.Kind(t, *e2e.KubernetesVersion)(opts)

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -96,6 +96,21 @@ func newOptStruct(testName, tmpDir string, t nomostesting.NTB, ntOptions ...ntop
 		t.Skip("Test skipped for non-local GitProvider types")
 	}
 
+	if *e2e.TestCluster == e2e.GKE { // required env vars for GKE
+		if nomostesting.GCPProjectIDFromEnv == "" {
+			t.Fatal("Environment variable GCP_PROJECT is required for GKE clusters")
+		}
+		if nomostesting.GCPClusterFromEnv == "" {
+			t.Fatal("Environment variable GCP_CLUSTER is required for GKE clusters")
+		}
+		if nomostesting.GCPRegionFromEnv == "" && nomostesting.GCPZoneFromEnv == "" {
+			t.Fatal("One of GCP_REGION or GCP_ZONE is required for GKE clusters")
+		}
+		if nomostesting.GCPRegionFromEnv != "" && nomostesting.GCPZoneFromEnv != "" {
+			t.Fatal("At most one of GCP_ZONE or GCP_REGION may be specified")
+		}
+	}
+
 	if optsStruct.RESTConfig == nil {
 		RestConfig(t, optsStruct)
 		// Increase the QPS for the clients used by the e2e tests.

--- a/e2e/nomostest/ntopts/gke.go
+++ b/e2e/nomostest/ntopts/gke.go
@@ -15,13 +15,11 @@
 package ntopts
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"time"
 
-	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 )
 
@@ -30,46 +28,40 @@ func GKECluster(t testing.NTB, apiServerTimeout time.Duration) Opt {
 	return func(opt *New) {
 		t.Helper()
 
-		kubeconfig := *e2e.KubeConfig
-		if len(kubeconfig) == 0 {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				t.Fatal(err)
-			}
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-		if err := os.Setenv(Kubeconfig, kubeconfig); err != nil {
-			t.Fatalf("unexpected error %v", err)
-		}
-		opt.KubeconfigPath = kubeconfig
-
-		forceAuthRefresh(t)
+		getGKECredentials(t, opt.KubeconfigPath)
 	}
 }
 
-// forceAuthRefresh forces gcloud to refresh the access_token to avoid using an expired one in the middle of a test.
-func forceAuthRefresh(t testing.NTB) {
-	out, err := exec.Command("kubectl", "config", "current-context").CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to get current config: %v\nstdout/stderr:\n%s", err, string(out))
-	}
-	context := strings.TrimSpace(string(out))
-	gkeArgs := strings.Split(context, "_")
-	if len(gkeArgs) < 4 {
-		t.Fatalf("unknown GKE context format: %s", context)
-	}
-	gkeProject := gkeArgs[1]
-	gkeZone := gkeArgs[2]
-	gkeCluster := gkeArgs[3]
+func withKubeConfig(cmd *exec.Cmd, kubeconfig string) *exec.Cmd {
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	return cmd
+}
 
-	out, err = exec.Command("gcloud", "container", "clusters", "get-credentials",
-		gkeCluster, "--zone", gkeZone, "--project", gkeProject).CombinedOutput()
-	if err != nil {
+// getGKECredentials fetches GKE credentials at the specified kubeconfig path.
+func getGKECredentials(t testing.NTB, kubeconfig string) {
+	args := []string{
+		"container", "clusters", "get-credentials",
+		testing.GCPClusterFromEnv, "--project", testing.GCPProjectIDFromEnv,
+	}
+	if testing.GCPZoneFromEnv != "" {
+		args = append(args, "--zone", testing.GCPZoneFromEnv)
+	}
+	if testing.GCPRegionFromEnv != "" {
+		args = append(args, "--region", testing.GCPRegionFromEnv)
+	}
+	cmd := withKubeConfig( // gcloud container clusters get-credentials <args>
+		exec.Command("gcloud", args...),
+		kubeconfig,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to get credentials: %v\nstdout/stderr:\n%s", err, string(out))
 	}
-
-	out, err = exec.Command("gcloud", "config", "config-helper", "--force-auth-refresh").CombinedOutput()
-	if err != nil {
+	cmd = withKubeConfig( // gcloud config config-helper --force-auth-refresh
+		exec.Command("gcloud", "config", "config-helper", "--force-auth-refresh"),
+		kubeconfig,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to refresh access_token: %v\nstdout/stderr:\n%s", err, string(out))
 	}
 }

--- a/e2e/nomostest/ntopts/kind.go
+++ b/e2e/nomostest/ntopts/kind.go
@@ -61,7 +61,7 @@ const (
 func Kind(t testing.NTB, version string) Opt {
 	v := asKindVersion(t, version)
 	return func(opt *New) {
-		opt.KubeconfigPath = newKind(t, opt.Name, opt.TmpDir, v)
+		newKind(t, opt.Name, opt.TmpDir, opt.KubeconfigPath, v)
 	}
 }
 
@@ -101,9 +101,8 @@ func asKindVersion(t testing.NTB, version string) KindVersion {
 // newKind creates a new Kind cluster for use in testing with the specified name.
 //
 // Automatically registers the cluster to be deleted at the end of the test.
-func newKind(t testing.NTB, name, tmpDir string, version KindVersion) string {
+func newKind(t testing.NTB, name, tmpDir, kcfgPath string, version KindVersion) {
 	p := cluster.NewProvider()
-	kcfgPath := filepath.Join(tmpDir, Kubeconfig)
 
 	start := time.Now()
 	t.Logf("started creating cluster %s at %s", name, start.Format(time.RFC3339))
@@ -151,8 +150,6 @@ kind delete cluster --name=%s`, name)
 		t.Fatalf("creating Kind cluster: %v", err)
 	}
 	t.Logf("finished creating cluster at %s", finish.Format(time.RFC3339))
-
-	return kcfgPath
 }
 
 func createKindCluster(p *cluster.Provider, name, kcfgPath string, version KindVersion) error {

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -88,15 +88,6 @@ func RequireGKE(t testing.NTB) Opt {
 	if *e2e.TestCluster != e2e.GKE {
 		t.Skip("The --test-cluster flag must be set to `gke` to run this test.")
 	}
-	if testing.GCPProjectIDFromEnv == "" {
-		t.Fatal("Environment variable 'GCP_PROJECT' is required for this test case")
-	}
-	if testing.GCPClusterFromEnv == "" {
-		t.Fatal("Environment variable 'GCP_CLUSTER' is required for this test case")
-	}
-	if testing.GCPRegionFromEnv == "" && testing.GCPZoneFromEnv == "" {
-		t.Fatal("Environment variable 'GCP_REGION' or 'GCP_ZONE' is required for this test case")
-	}
 	return func(opt *New) {}
 }
 


### PR DESCRIPTION
There was a combination of a required kubeconfig and env vars that needed to be set to run tests on GKE. This change consolidates the setup to only require the env vars to be set. This simplifies some of the scaffolding and interface for running GKE tests.