### PR TITLE
Fix over-agressive role binding subject deletion

### DIFF
--- a/pkg/reconcilermanager/controllers/permissions.go
+++ b/pkg/reconcilermanager/controllers/permissions.go
@@ -14,7 +14,11 @@
 
 package controllers
 
-import rbacv1 "k8s.io/api/rbac/v1"
+import (
+	"sort"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
 
 // rolereference returns an intialized Role with apigroup, kind and name.
 func rolereference(name, kind string) rbacv1.RoleRef {
@@ -25,11 +29,71 @@ func rolereference(name, kind string) rbacv1.RoleRef {
 	}
 }
 
-// subject returns and initialized Subject with kind, name and namespace.
-func subject(name, namespace, kind string) rbacv1.Subject {
+// newSubject returns and initialized Subject with kind, name and namespace.
+func newSubject(name, namespace, kind string) rbacv1.Subject {
 	return rbacv1.Subject{
 		Kind:      kind,
 		Name:      name,
 		Namespace: namespace,
 	}
+}
+
+// findSubjectIndex returns the index of the expected subject in the list, or -1.
+func findSubjectIndex(list []rbacv1.Subject, expected rbacv1.Subject) int {
+	for i, found := range list {
+		if found == expected {
+			return i
+		}
+	}
+	return -1
+}
+
+// addSubject adds a subject to the subject list.
+// Subjects are sorted, if modified.
+func addSubject(subjects []rbacv1.Subject, subject rbacv1.Subject) []rbacv1.Subject {
+	if i := findSubjectIndex(subjects, subject); i < 0 {
+		subjects = sortSubjects(append(subjects, subject)...)
+	}
+	return subjects
+}
+
+// removeSubject removes the subject from the subject list.
+// Subjects are not re-sorted, but will remain sorted if sorted on insert, by
+// addSubject.
+func removeSubject(subjects []rbacv1.Subject, subject rbacv1.Subject) []rbacv1.Subject {
+	if i := findSubjectIndex(subjects, subject); i >= 0 {
+		if i == 0 {
+			// remove first subject
+			subjects = subjects[i+1:]
+		} else if i == len(subjects)-1 {
+			// remove last subject
+			subjects = subjects[:i]
+		} else {
+			// remove middle subject
+			subjects = append(subjects[:i], subjects[i+1:]...)
+		}
+	}
+	return subjects
+}
+
+// sortSubjects returns the subjects as a new sorted list
+func sortSubjects(subjects ...rbacv1.Subject) []rbacv1.Subject {
+	if len(subjects) > 1 {
+		sort.Slice(subjects, func(i, j int) bool {
+			if subjects[i].APIGroup != subjects[j].APIGroup {
+				return subjects[i].APIGroup < subjects[j].APIGroup
+			}
+			if subjects[i].Kind != subjects[j].Kind {
+				return subjects[i].Kind < subjects[j].Kind
+			}
+			if subjects[i].Namespace != subjects[j].Namespace {
+				return subjects[i].Namespace < subjects[j].Namespace
+			}
+			if subjects[i].Name != subjects[j].Name {
+				return subjects[i].Name < subjects[j].Name
+			}
+			return false
+		})
+	}
+	return subjects
 }

--- a/pkg/reconcilermanager/controllers/permissions_test.go
+++ b/pkg/reconcilermanager/controllers/permissions_test.go
@@ -1,0 +1,440 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+var (
+	subject1 = rbacv1.Subject{
+		APIGroup:  "rbac/v1",
+		Kind:      "ServiceAccount",
+		Name:      "reconciler-1",
+		Namespace: "namespace-1",
+	}
+	subject2 = rbacv1.Subject{
+		APIGroup:  "rbac/v1",
+		Kind:      "ServiceAccount",
+		Name:      "reconciler-2",
+		Namespace: "namespace-1",
+	}
+	subject3 = rbacv1.Subject{
+		APIGroup:  "rbac/v1",
+		Kind:      "ServiceAccount",
+		Name:      "reconciler-1",
+		Namespace: "namespace-2",
+	}
+	subject4 = rbacv1.Subject{
+		APIGroup:  "rbac/v1",
+		Kind:      "ServiceAccount",
+		Name:      "reconciler-2",
+		Namespace: "namespace-2",
+	}
+)
+
+func TestFindSubjectIndex(t *testing.T) {
+	testCases := []struct {
+		name          string
+		list          []rbacv1.Subject
+		entry         rbacv1.Subject
+		expectedIndex int
+	}{
+		{
+			name:          "size 0, no match",
+			list:          []rbacv1.Subject{},
+			entry:         subject1,
+			expectedIndex: -1,
+		},
+		{
+			name: "size 1, no match",
+			list: []rbacv1.Subject{
+				subject1,
+			},
+			entry:         subject2,
+			expectedIndex: -1,
+		},
+		{
+			name: "size 2, no match",
+			list: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			entry:         subject3,
+			expectedIndex: -1,
+		},
+		{
+			name: "size 1, match",
+			list: []rbacv1.Subject{
+				subject1,
+			},
+			entry:         subject1,
+			expectedIndex: 0,
+		},
+		{
+			name: "size 2, match",
+			list: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			entry:         subject2,
+			expectedIndex: 1,
+		},
+		{
+			name: "size 3, match",
+			list: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			entry:         subject2,
+			expectedIndex: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			index := findSubjectIndex(tc.list, tc.entry)
+			require.Equal(t, tc.expectedIndex, index)
+		})
+	}
+}
+
+func TestSortSubjects(t *testing.T) {
+	testCases := []struct {
+		name             string
+		subjects         []rbacv1.Subject
+		expectedSubjects []rbacv1.Subject
+	}{
+		{
+			name:             "nil",
+			subjects:         nil,
+			expectedSubjects: nil,
+		},
+		{
+			name:             "size 0",
+			subjects:         []rbacv1.Subject{},
+			expectedSubjects: []rbacv1.Subject{},
+		},
+		{
+			name: "size 1",
+			subjects: []rbacv1.Subject{
+				subject1,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+			},
+		},
+		{
+			name: "size 2, no change",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+		{
+			name: "size 2, changed",
+			subjects: []rbacv1.Subject{
+				subject2,
+				subject1,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+		{
+			name: "size 3, no change",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, swap 1 & 2",
+			subjects: []rbacv1.Subject{
+				subject2,
+				subject1,
+				subject3,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, swap 1 & 3",
+			subjects: []rbacv1.Subject{
+				subject3,
+				subject2,
+				subject1,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, swap 2 & 3",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject3,
+				subject2,
+			},
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subjects := sortSubjects(tc.subjects...)
+			testutil.AssertEqual(t, tc.expectedSubjects, subjects)
+		})
+	}
+}
+
+func TestAddSubject(t *testing.T) {
+	testCases := []struct {
+		name             string
+		subjects         []rbacv1.Subject
+		subject          rbacv1.Subject
+		expectedSubjects []rbacv1.Subject
+	}{
+		{
+			name:     "size 0, append",
+			subjects: []rbacv1.Subject{},
+			subject:  subject1,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+			},
+		},
+		{
+			name: "size 1, append",
+			subjects: []rbacv1.Subject{
+				subject1,
+			},
+			subject: subject2,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+		{
+			name: "size 1, prepend",
+			subjects: []rbacv1.Subject{
+				subject2,
+			},
+			subject: subject1,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+		{
+			name: "size 2, append",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			subject: subject3,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 2, prepend",
+			subjects: []rbacv1.Subject{
+				subject2,
+				subject3,
+			},
+			subject: subject1,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 2, insert",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject3,
+			},
+			subject: subject2,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subjects := addSubject(tc.subjects, tc.subject)
+			testutil.AssertEqual(t, tc.expectedSubjects, subjects)
+		})
+	}
+}
+
+func TestRemoveSubject(t *testing.T) {
+	testCases := []struct {
+		name             string
+		subjects         []rbacv1.Subject
+		subject          rbacv1.Subject
+		expectedSubjects []rbacv1.Subject
+	}{
+		{
+			name:             "size 0",
+			subjects:         []rbacv1.Subject{},
+			subject:          subject1,
+			expectedSubjects: []rbacv1.Subject{},
+		},
+		{
+			name: "size 1, not found",
+			subjects: []rbacv1.Subject{
+				subject1,
+			},
+			subject: subject2,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+			},
+		},
+		{
+			name: "size 1, found",
+			subjects: []rbacv1.Subject{
+				subject1,
+			},
+			subject:          subject1,
+			expectedSubjects: []rbacv1.Subject{},
+		},
+		{
+			name: "size 2, not found",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			subject: subject3,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+		{
+			name: "size 2, first",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			subject: subject1,
+			expectedSubjects: []rbacv1.Subject{
+				subject2,
+			},
+		},
+		{
+			name: "size 2, last",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+			subject: subject2,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+			},
+		},
+		{
+			name: "size 3, not found",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			subject: subject4,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, first",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			subject: subject1,
+			expectedSubjects: []rbacv1.Subject{
+				subject2,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, second",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			subject: subject2,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject3,
+			},
+		},
+		{
+			name: "size 3, third",
+			subjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+				subject3,
+			},
+			subject: subject3,
+			expectedSubjects: []rbacv1.Subject{
+				subject1,
+				subject2,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subjects := removeSubject(tc.subjects, tc.subject)
+			testutil.AssertEqual(t, tc.expectedSubjects, subjects)
+		})
+	}
+}

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,6 +112,10 @@ type reconcilerBase struct {
 	// if it's the latest or not. So this is just an optimization, not a guarantee.
 	// https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
 	lastReconciledResourceVersions map[types.NamespacedName]string
+}
+
+func (r *reconcilerBase) serviceAccountSubject(reconcilerRef types.NamespacedName) rbacv1.Subject {
+	return newSubject(reconcilerRef.Name, reconcilerRef.Namespace, kinds.ServiceAccount().Kind)
 }
 
 func (r *reconcilerBase) upsertServiceAccount(

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1482,7 +1482,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName,
 		core.ResourceVersion("1"),
 	)
-	crb.Subjects = addSubject(crb.Subjects, rootReconcilerName)
+	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName)
 	rootContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, rootReconcilerName)
 	rootDeployment1 := rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
@@ -1550,7 +1550,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubject(crb.Subjects, rootReconcilerName2)
+	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName2)
 	crb.ResourceVersion = "2"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1606,7 +1606,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubject(crb.Subjects, rootReconcilerName3)
+	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName3)
 	crb.ResourceVersion = "3"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1665,7 +1665,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubject(crb.Subjects, rootReconcilerName4)
+	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName4)
 	crb.ResourceVersion = "4"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1725,7 +1725,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubject(crb.Subjects, rootReconcilerName5)
+	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName5)
 	crb.ResourceVersion = "5"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1849,7 +1849,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// Subject for rs1 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubject(crb.Subjects, rootReconcilerName)
+	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName)
 	crb.ResourceVersion = "6"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1872,7 +1872,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// Subject for rs2 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubject(crb.Subjects, rootReconcilerName2)
+	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName2)
 	crb.ResourceVersion = "7"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1895,7 +1895,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// Subject for rs3 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubject(crb.Subjects, rootReconcilerName3)
+	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName3)
 	crb.ResourceVersion = "8"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
@@ -1918,7 +1918,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// Subject for rs4 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubject(crb.Subjects, rootReconcilerName4)
+	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName4)
 	crb.ResourceVersion = "9"
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)


### PR DESCRIPTION
- The old code for subject deletion used a List of RSyncs to decide what all the subjects should be in the [Cluster]RoleBinding for the reconciler ServiceAccount. This aggresively removes subjects when their RSync is deleted. However, this caused the upsert to remove subjects when it only needed to add subjects, which can cause reconcilers to be de-authorized before they're deleted.
- This change splits the update code into add and remove code. So the subject will only ever be removed if the RSync is already NotFound, and only by the Reconcile loop specific to that RSync.
- This should unblock the Finalizer to delete managed resources even if the deletion timestamp is already set on the RSync (which is the only time the finalizer runs anyway).
