### PR TITLE
Switch to docker buildx for faster builds

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -14,7 +14,7 @@ pull-buildenv:
 
 build-buildenv: build/buildenv/Dockerfile
 	@echo "+++ Creating the docker container for $(BUILDENV_IMAGE)"
-	@docker build $(DOCKER_BUILD_QUIET) build/buildenv -t $(BUILDENV_IMAGE)
+	@docker buildx build $(DOCKER_BUILD_QUIET) build/buildenv -t $(BUILDENV_IMAGE)
 
 push-buildenv: build-buildenv
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
@@ -43,49 +43,49 @@ build-cli: pull-buildenv buildenv-dirs
 .PHONY: build-images
 build-images: license
 	@echo "+++ Building the Reconciler image: $(RECONCILER_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_IMAGE) \
 		-t $(RECONCILER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Reconciler Manager image: $(RECONCILER_MANAGER_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_MANAGER_IMAGE) \
 		-t $(RECONCILER_MANAGER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Admission Webhook image: $(ADMISSION_WEBHOOK_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(ADMISSION_WEBHOOK_IMAGE) \
 		-t $(ADMISSION_WEBHOOK_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Hydration Controller image: $(HYDRATION_CONTROLLER_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(HYDRATION_CONTROLLER_IMAGE) \
 		-t $(HYDRATION_CONTROLLER_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Hydration Controller image with shell: $(HYDRATION_CONTROLLER_WITH_SHELL_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(HYDRATION_CONTROLLER_WITH_SHELL_IMAGE) \
 		-t $(HYDRATION_CONTROLLER_WITH_SHELL_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the OCI-sync image: $(OCI_SYNC_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(OCI_SYNC_IMAGE) \
 		-t $(OCI_SYNC_TAG) \
 		-f build/all/Dockerfile \
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Helm-sync image: $(HELM_SYNC_TAG)"
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(HELM_SYNC_IMAGE) \
 		-t $(HELM_SYNC_TAG) \
 		-f build/all/Dockerfile \
@@ -245,7 +245,7 @@ build-git-server:
 	@rm -rf $(GIT_SERVER_DOCKER)
 	@git clone https://github.com/jkarlosb/git-server-docker.git $(GIT_SERVER_DOCKER)
 	@cd $(GIT_SERVER_DOCKER) && git checkout $(GIT_SERVER_RELEASE)
-	@docker build $(DOCKER_BUILD_QUIET) \
+	@docker buildx build $(DOCKER_BUILD_QUIET) \
 			$(GIT_SERVER_DOCKER) \
 			-t gcr.io/stolos-dev/git-server:$(GIT_SERVER_RELEASE)
 	@gcloud $(GCLOUD_QUIET) auth configure-docker
@@ -258,7 +258,7 @@ E2E_TEST_IMAGE_HTTP_GIT_SERVER := gcr.io/stolos-dev/http-git-server:$(E2E_TEST_I
 # Builds the container used by e2e tests to test git over HTTPS.
 build-http-git-server:
 	@echo "+++ Building the http-git-server image"
-	docker build \
+	docker buildx build \
 		-t $(E2E_TEST_IMAGE_HTTP_GIT_SERVER) \
 		test/docker/http-git-server/
 	@docker push $(E2E_TEST_IMAGE_HTTP_GIT_SERVER)

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -3,7 +3,7 @@
 # Build a test docker container with gcloud and kubectl installed.
 __build-e2e-go-container:
 	@echo "+++ Building build/test-e2e-go/gke/Dockerfile nomos-gcloud-image"
-	@docker build . \
+	@docker buildx build . \
 	 	--network host \
 		-f build/test-e2e-go/gke/Dockerfile \
 		-t nomos-gcloud-image

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -26,7 +26,7 @@ E2E_TEST_IMAGE_OSS_PROW_TAG := kubekins-e2e-$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS)-
 E2E_TEST_IMAGE_OSS_PROW := gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:$(E2E_TEST_IMAGE_OSS_PROW_TAG)
 image-oss-prow: build/prow/kubekins-kind/Dockerfile
 	@echo "+++ Building the image for the oss-prow presubmit run"
-	docker build \
+	docker buildx build \
 		-t $(E2E_TEST_IMAGE_OSS_PROW) \
 		--build-arg KUBEKINS_REGISTRY=$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS_REGISTRY) \
 		--build-arg KUBEKINS=$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS) \

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -15,7 +15,7 @@
 
 
 echo "+++ Building build/test-e2e-go/kind/Dockerfile prow-image"
-docker build . -f build/test-e2e-go/kind/Dockerfile -t prow-image
+docker buildx build . -f build/test-e2e-go/kind/Dockerfile -t prow-image
 # The .sock volume allows you to connect to the Docker daemon of the host.
 # Part of the docker-in-docker pattern.
 


### PR DESCRIPTION
- buildx is demonstratably faster than the current build behavior, and is even faster than just seperating out the multi-stage builds into thier own Dockerfiles.