### PR TITLE
Add Config Sync resource related attributes to GCM

### DIFF
--- a/cmd/hydration-controller/main.go
+++ b/cmd/hydration-controller/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	// Register the OC Agent exporter
-	oce, err := kmetrics.RegisterOCAgentExporter()
+	oce, err := kmetrics.RegisterOCAgentExporter(reconcilermanager.HydrationController)
 	if err != nil {
 		klog.Fatalf("Failed to register the OC Agent exporter: %v", err)
 	}

--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 
 	// Register the OC Agent exporter
-	oce, err := metrics.RegisterOCAgentExporter()
+	oce, err := metrics.RegisterOCAgentExporter(reconcilermanager.ManagerName)
 	if err != nil {
 		setupLog.Error(err, "failed to register the OC Agent exporter")
 		os.Exit(1)

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	// Register the OC Agent exporter
-	oce, err := ocmetrics.RegisterOCAgentExporter()
+	oce, err := ocmetrics.RegisterOCAgentExporter(reconcilermanager.Reconciler)
 	if err != nil {
 		klog.Fatalf("Failed to register the OC Agent exporter: %v", err)
 	}

--- a/manifests/otel-agent-cm.yaml
+++ b/manifests/otel-agent-cm.yaml
@@ -32,6 +32,19 @@ data:
         tls:
           insecure: true
     processors:
+      # Attributes processor adds custom configsync metric labels to applicable
+      # metrics to identify the sync object used to configure this deployment
+      attributes:
+        actions:
+          - key: configsync.sync.kind
+            action: upsert
+            value: $CONFIGSYNC_SYNC_KIND
+          - key: configsync.sync.name
+            action: upsert
+            value: $CONFIGSYNC_SYNC_NAME
+          - key: configsync.sync.namespace
+            action: upsert
+            value: $CONFIGSYNC_SYNC_NAMESPACE
       batch:
       # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
       # the GCE metadata service, if available.
@@ -44,5 +57,5 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch, resourcedetection]
+          processors: [batch, resourcedetection, attributes]
           exporters: [opencensus]

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -175,9 +175,6 @@ data:
            - /otelcol-contrib
            args:
            - "--config=/conf/otel-agent-config.yaml"
-           # TODO: Remove this feature gate when opentelemetry semantic conventions are used
-           # in the collector code.
-           - "--feature-gates=-exporter.googlecloud.OTLPDirect"
            resources:
              limits:
                cpu: 1
@@ -266,10 +263,7 @@ data:
                k8s.pod.uid=$(KUBE_POD_UID),\
                k8s.pod.ip=$(KUBE_POD_IP),\
                k8s.node.name=$(KUBE_NODE_NAME),\
-               k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME),\
-               configsync.sync.kind=$(CONFIGSYNC_SYNC_KIND),\
-               configsync.sync.name=$(CONFIGSYNC_SYNC_NAME),\
-               configsync.sync.namespace=$(CONFIGSYNC_SYNC_NAMESPACE)"
+               k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)"
          volumes:
          - name: repo
            emptyDir: {}

--- a/pkg/kmetrics/register.go
+++ b/pkg/kmetrics/register.go
@@ -15,12 +15,22 @@
 package kmetrics
 
 import (
+	"os"
+
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
 )
 
 // RegisterOCAgentExporter creates the OC Agent metrics exporter.
-func RegisterOCAgentExporter() (*ocagent.Exporter, error) {
+func RegisterOCAgentExporter(containerName string) (*ocagent.Exporter, error) {
+	// Add the k8s.container.name resource label so that the google cloud monitoring
+	// and monarch metrics exporters will use the k8s_container resource type
+	err := os.Setenv(
+		"OC_RESOURCE_LABELS",
+		"k8s.container.name=\""+containerName+"\"")
+	if err != nil {
+		return nil, err
+	}
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 	)

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -51,6 +51,22 @@ exporters:
       # The metric streaming data is not affected
       # https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/529
       skip_create_descriptor: true
+      # resource_filters looks for metric resource attributes by prefix and converts
+      # them into custom metric labels, so they become visible and can be accessed
+      # under the GroupBy dropdown list in Cloud Monitoring
+      resource_filters:
+        - prefix: "cloud.account.id"
+        - prefix: "cloud.availability.zone"
+        - prefix: "cloud.platform"
+        - prefix: "cloud.provider"
+        - prefix: "k8s.pod.ip"
+        - prefix: "k8s.pod.namespace"
+        - prefix: "k8s.pod.uid"
+        - prefix: "k8s.container.name"
+        - prefix: "host.id"
+        - prefix: "host.name"
+        - prefix: "k8s.deployment.name"
+        - prefix: "k8s.node.name"
     retry_on_failure:
       enabled: false
     sending_queue:
@@ -138,6 +154,15 @@ processors:
           # included by the 'regex include' filter above and is not included in
           # our Monarch metric definitions
           - kcc_resource_count_total
+  # Remove custom configsync metric labels that are not registered with Monarch
+  attributes/kubernetes:
+    actions:
+      - key: configsync.sync.kind
+        action: delete
+      - key: configsync.sync.name
+        action: delete
+      - key: configsync.sync.namespace
+        action: delete
   metricstransform/kubernetes:
     transforms:
       - include: declared_resources
@@ -191,6 +216,6 @@ service:
       exporters: [prometheus]
     metrics/kubernetes:
       receivers: [opencensus]
-      processors: [batch, filter/kubernetes, metricstransform/kubernetes, resourcedetection]
+      processors: [batch, filter/kubernetes, attributes/kubernetes, metricstransform/kubernetes, resourcedetection]
       exporters: [googlecloud/kubernetes]`
 )

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -15,12 +15,22 @@
 package metrics
 
 import (
+	"os"
+
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
 )
 
 // RegisterOCAgentExporter creates the OC Agent metrics exporter.
-func RegisterOCAgentExporter() (*ocagent.Exporter, error) {
+func RegisterOCAgentExporter(containerName string) (*ocagent.Exporter, error) {
+	// Add the k8s.container.name resource label so that the google cloud monitoring
+	// and monarch metrics exporters will use the k8s_container resource type
+	err := os.Setenv(
+		"OC_RESOURCE_LABELS",
+		"k8s.container.name=\""+containerName+"\"")
+	if err != nil {
+		return nil, err
+	}
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 	)

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -46,7 +46,7 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "48a5b088ea2af4e9bc259230f88cafd3"
+	depAnnotationGooglecloud = "d32e8c1367859b810b6694ff3ba2b6a1"
 	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.


### PR DESCRIPTION
This change converts the non-k8s-pod typed resource attributes added in [this PR](https://github.com/GoogleContainerTools/kpt-config-sync/pull/114) that are related to Config Sync resources into metric labels.

The resource_filter in googlecloud exporter converts the cloud / k8s /
host related attributes directly into metrics labels in GCM.

Configsync.sync attributes are added with resource processor as metric
labels.

Adding metrics labels at reconciler level requires the shared Otel Collector
to remove them from all metrics before exporting to internal(Monarch) pipeline.

Labels are viewable in `groupby` drop down list and can be selected to
aggregate metrics.http://screen/ZtkKWoEx6bxnyiZ

This change also adds k8s.container.name to Config Sync metrics and Kustomize
wrapper metrics in Hydration Controller. This will make metrics to be mapped
to K8sContainer resource type. Change is compatible with current Monarch configuration.

Prometheus pipeline remain functioning http://screen/4tS9qSfoaFLSvAA

Context: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/534