### PR TITLE
Export SLI-related metrics to Google Cloud Monitoring

### DIFF
--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -90,6 +90,10 @@ processors:
         match_type: regexp
         metric_names:
           - reconciler_errors
+          - apply_duration_seconds
+          - reconcile_duration_seconds
+          - rg_reconcile_duration_seconds
+          - last_sync_timestamp
           - pipeline_error_observed
           - declared_resources
           - apply_operations_total

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	depAnnotationGooglecloud = "afd3350628e16f83b8951ceef0e776d2"
+	depAnnotationGooglecloud = "c7420e47ee5c361e221cbe0896d1bea0"
 	depAnnotationCustom      = "7021ec2418429875d452e1cd5455724a"
 )
 


### PR DESCRIPTION
Config Sync SLIs:
https://cloud.google.com/anthos-config-management/docs/how-to/config-sync-slis