### PR TITLE
Update go-junt-report version and config

### DIFF
--- a/build/test-e2e-go/e2e.sh
+++ b/build/test-e2e-go/e2e.sh
@@ -30,7 +30,7 @@ echo "Tests took $(( end_time - start_time )) seconds"
 
 if [ -d "/logs/artifacts" ]; then
   echo "Creating junit xml report"
-  cat test_results.txt | go-junit-report > /logs/artifacts/junit_report.xml
+  cat test_results.txt | go-junit-report --subtest-mode=exclude-parents > /logs/artifacts/junit_report.xml
 fi
 
 exit $exit_code

--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=gcloud-install /usr/bin/kubectl /opt/gcloud/google-cloud-sdk/bin/kub
 ENV PATH /opt/gcloud/google-cloud-sdk/bin:$PATH
 
 # Get go-junit-report
-RUN go install github.com/jstemmer/go-junit-report@v1.0.0
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
 
 # Steps after here can't be cached since they touch the local filesystem.
 

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -57,7 +57,7 @@ RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomiz
   rm /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
 
 # Get go-junit-report.
-RUN go install github.com/jstemmer/go-junit-report@v1.0.0
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
 
 # Steps after here can't be cached since they touch the local filesystem.
 


### PR DESCRIPTION
go-junit-report v2.0.0 added support for -subtest-mode flag to exclude or ignore results of subtest parent tests:
https://g3doc.corp.google.com/third_party/golang/github_com/jstemmer/go_junit_report/v/v2/README.md#changelog.