### PR TITLE
Postprocess the junit report by appending a testcases.Failure

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -39,6 +39,14 @@ build-cli: pull-buildenv buildenv-dirs
 		--version $(VERSION) \
 		$(PLATFORMS)
 
+# NOTE: this rule depends on OUTPUT_DIR because buildenv needs those dirs to
+# exist in order to work.
+build-junit-report-cli: pull-buildenv buildenv-dirs
+	@echo "+++ Compiling junit-report binaries for linux_amd64"
+	@echo "+++ Compiling with VERSION: $(VERSION)"
+	@mkdir -p $(addprefix $(OUTPUT_DIR)/go/bin/,linux_amd64)
+	@docker run $(DOCKER_RUN_ARGS) ./scripts/build-junitreport-cli.sh linux_amd64 $(VERSION)
+
 # Build Config Sync docker images
 .PHONY: build-images
 build-images: license

--- a/build/test-e2e-go/e2e.sh
+++ b/build/test-e2e-go/e2e.sh
@@ -31,6 +31,9 @@ echo "Tests took $(( end_time - start_time )) seconds"
 if [ -d "/logs/artifacts" ]; then
   echo "Creating junit xml report"
   cat test_results.txt | go-junit-report --subtest-mode=exclude-parents > /logs/artifacts/junit_report.xml
+  if [ "$exit_code" -eq 0 ]; then
+    junit-report reset-failure --path=/logs/artifacts/junit_report.xml
+  fi
 fi
 
 exit $exit_code

--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -65,3 +65,6 @@ COPY . .
 
 # Make sure the nomos command is available for tests.
 RUN go install kpt.dev/configsync/cmd/nomos
+
+# Make sure the junit-report command is available for tests.
+RUN go install kpt.dev/configsync/cmd/junit-report

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -66,3 +66,6 @@ COPY . .
 
 # Make sure the nomos command is available for tests.
 RUN go install kpt.dev/configsync/cmd/nomos
+
+# Make sure the junit-report command is available for tests.
+RUN go install kpt.dev/configsync/cmd/junit-report

--- a/cmd/junit-report/main.go
+++ b/cmd/junit-report/main.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/cmd/junit-report/resetfailure"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:   "junit-report",
+		Short: "Postprocess the junit report",
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(resetfailure.Cmd)
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/junit-report/resetfailure/reset_failure.go
+++ b/cmd/junit-report/resetfailure/reset_failure.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resetfailure
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/jstemmer/go-junit-report/v2/junit"
+	"github.com/spf13/cobra"
+)
+
+var reportFile string
+
+func init() {
+	Cmd.Flags().StringVar(&reportFile, "path", "",
+		"The file path to the junit report")
+}
+
+// Cmd is the Cobra object representing the junit-report reset-failure command
+var Cmd = &cobra.Command{
+	Use:     "reset-failure",
+	Short:   "Add an empty Failure entry to the junit report",
+	Long:    `Add an empty Failure entry to the junit report`,
+	Example: `junit-report reset-failure --path /logs/artifacts/junit_report.xml`,
+	Args:    cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return ResetFailure(reportFile)
+	},
+}
+
+// ResetFailure adds a Failure entry to the report.
+func ResetFailure(path string) error {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	testSuites := &junit.Testsuites{}
+	if err = xml.Unmarshal(bytes, testSuites); err != nil {
+		return err
+	}
+
+	failureTestSuite := junit.Testsuite{
+		Name: "kpt.dev/configsync/e2e/testcases",
+		ID:   len(testSuites.Suites),
+		Time: "0",
+		Testcases: []junit.Testcase{
+			{
+				Name:      "Failure",
+				Classname: "kpt.dev/configsync/e2e/testcases",
+				Time:      "0",
+			},
+		},
+	}
+
+	testSuites.AddSuite(failureTestSuite)
+	return updateReport(testSuites, path)
+}
+
+func updateReport(t *junit.Testsuites, path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	return writeXML(t, f)
+}
+
+// copied from https://github.com/jstemmer/go-junit-report/blob/075629ad5f2934f016fa8fe79deb821f98bd8b44/junit/junit.go#L41
+// TODO: remove the duplicate when a new go-junit-report release is available.
+func writeXML(t *junit.Testsuites, w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}

--- a/cmd/junit-report/resetfailure/reset_failure_test.go
+++ b/cmd/junit-report/resetfailure/reset_failure_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resetfailure
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	source   = "../../../e2e/testdata/junit-report.xml"
+	expected = "../../../e2e/testdata/junit-report-updated.xml"
+)
+
+func TestResetFailure(t *testing.T) {
+	tmpFile, err := os.CreateTemp(os.TempDir(), "junit-report-test-*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err = os.RemoveAll(tmpFile.Name()); err != nil {
+			t.Error(err)
+		}
+	})
+
+	report, err := os.OpenFile(source, os.O_RDONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = io.Copy(tmpFile, report); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = ResetFailure(tmpFile.Name()); err != nil {
+		t.Fatalf("expected no error, but got %v", err)
+	}
+
+	updatedContent, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedContent, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(updatedContent, expectedContent); diff != "" {
+		t.Fatalf("expected no diff, got %s", diff)
+	}
+}

--- a/e2e/testdata/junit-report-updated.xml
+++ b/e2e/testdata/junit-report-updated.xml
@@ -1,0 +1,470 @@
+<testsuites tests="179" skipped="138">
+	<testsuite name="kpt.dev/configsync/e2e" tests="0" failures="0" errors="0" id="0" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest" tests="0" failures="0" errors="0" id="1" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/docker" tests="0" failures="0" errors="0" id="2" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/gitproviders" tests="0" failures="0" errors="0" id="3" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/metrics" tests="0" failures="0" errors="0" id="4" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/ntopts" tests="0" failures="0" errors="0" id="5" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/policy" tests="0" failures="0" errors="0" id="6" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/testing" tests="0" failures="0" errors="0" id="7" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/testcases" tests="179" failures="0" errors="0" id="8" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" skipped="138" time="3828.920" timestamp="2022-12-15T15:24:51Z">
+		<testcase name="TestAcmeCorpRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    acme_test.go:46: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectInCMSNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    acme_test.go:180: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAdmission" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    admission_test.go:37: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDisableWebhookConfigurationUpdate" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    admission_test.go:155: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAdoptClientSideAppliedResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    adopt_client_side_applied_test.go:31: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCreateAPIServiceAndEndpointInTheSameCommit" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apiservice_test.go:36: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestImporterAndSyncerResilientToFlakyAPIService" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apiservice_test.go:70: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestApplyScopedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apply_scoped_resource_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceGarbageCollection" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:37: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespacePolicyspaceConversion" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:57: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncDeploymentAndReplicaSet" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:82: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestRolebindingsUpdated" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:130: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceDefaultCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:203: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceGatekeeperSystemCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:209: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceKubeSystemCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:216: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceKubePublicCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:222: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNomosInitVet" classname="kpt.dev/configsync/e2e/testcases" time="0.120"></testcase>
+		<testcase name="TestNomosInitHydrate" classname="kpt.dev/configsync/e2e/testcases" time="0.300"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsHierarchical" classname="kpt.dev/configsync/e2e/testcases" time="2.610"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsDefaultSourceFormat" classname="kpt.dev/configsync/e2e/testcases" time="2.550"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsUnstructured" classname="kpt.dev/configsync/e2e/testcases" time="2.530"></testcase>
+		<testcase name="TestSyncFromNomosHydrateOutputYAMLDir" classname="kpt.dev/configsync/e2e/testcases" time="96.140"></testcase>
+		<testcase name="TestSyncFromNomosHydrateOutputJSONDir" classname="kpt.dev/configsync/e2e/testcases" time="90.910"></testcase>
+		<testcase name="TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorJSONFlat" classname="kpt.dev/configsync/e2e/testcases" time="88.890"></testcase>
+		<testcase name="TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorJSONFlat" classname="kpt.dev/configsync/e2e/testcases" time="68.320"></testcase>
+		<testcase name="TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorYAMLFlat" classname="kpt.dev/configsync/e2e/testcases" time="127.130"></testcase>
+		<testcase name="TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorYAMLFlat" classname="kpt.dev/configsync/e2e/testcases" time="68.420"></testcase>
+		<testcase name="TestNomosHydrateWithUnknownScopedObject" classname="kpt.dev/configsync/e2e/testcases" time="1.990"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/invalid_output_format" classname="kpt.dev/configsync/e2e/testcases" time="0.100"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/must_use_&#39;unstructured&#39;_format_for_DRY_repos" classname="kpt.dev/configsync/e2e/testcases" time="0.090"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_a_DRY_repo_without_kustomization.yaml" classname="kpt.dev/configsync/e2e/testcases" time="0.110"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_deprecated_Group_and_Kind" classname="kpt.dev/configsync/e2e/testcases" time="3.760"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_duplicate_resources" classname="kpt.dev/configsync/e2e/testcases" time="1.290"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_helm_components" classname="kpt.dev/configsync/e2e/testcases" time="1.580"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_kustomize_components" classname="kpt.dev/configsync/e2e/testcases" time="0.480"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_helm_overlay" classname="kpt.dev/configsync/e2e/testcases" time="3.150"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_remote_base" classname="kpt.dev/configsync/e2e/testcases" time="1.160"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_relative_path" classname="kpt.dev/configsync/e2e/testcases" time="0.420"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_WET_repo" classname="kpt.dev/configsync/e2e/testcases" time="0.100"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_a_namespace_repo_should_fail_when_source-format_is_set_to_hierarchy" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_automatically_validate_a_namespace_repo_with_the_unstructured_mode_if_source-format_is_not_set" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_automatically_validate_a_namespace_repo_with_the_unstructured_mode_if_source-format_is_set_to_unstructured" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_validate_a_DRY_namespace_repo" classname="kpt.dev/configsync/e2e/testcases" time="0.190"></testcase>
+		<testcase name="TestCLIBugreportNomosRunningCorrectly" classname="kpt.dev/configsync/e2e/testcases" time="57.790"></testcase>
+		<testcase name="TestRevertClusterRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_resources_test.go:71: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterRoleLifecycle" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_resources_test.go:151: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestTargetingDifferentResourceQuotasToDifferentClusters" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:103: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnObjects" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:165: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:239: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectReactsToChangeInInlineClusterSelector" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:415: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectReactsToChangeInLegacyClusterSelector" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:447: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestImporterIgnoresNonSelectedCustomResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:486: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnNamespaceRepos" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:518: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInlineClusterSelectorFormat" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:565: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorAnnotationConflicts" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:648: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorForCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:672: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestComposition" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    composition_test.go:74: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGCENode" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:60: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestChangeCustomResourceDefinitionSchema" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_schema_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveCustomResourceWithDefinitionV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:115: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveCustomResourceWithDefinitionV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:126: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddAndRemoveCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:182: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddAndRemoveCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:187: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveUnManagedCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:245: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveUnManagedCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:250: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateRemoveClusterScopedCRDV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:340: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateRemoveClusterScopedCRDV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:345: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateNamespaceScopedCRDV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:446: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateNamespaceScopedCRDV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:451: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLargeCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:462: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCRDDeleteBeforeRemoveCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:36: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCRDDeleteBeforeRemoveCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:130: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncUpdateCustomResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:215: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclaredFieldsPod" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    declared_fields_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConstraintTemplateAndConstraintInSameCommit" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    gatekeeper_test.go:53: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPublicHelm" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:53: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmNamespaceRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:127: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmGCENode" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:263: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARTokenAuth" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:291: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateKustomizeComponents" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:50: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateHelmComponents" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:115: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateHelmOverlay" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:199: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateRemoteResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:293: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateResourcesInRelativePath" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:363: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidRootSyncBranchStatus" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:31: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidRepoSyncBranchStatus" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:60: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncFailureAfterSuccessfulSyncs" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:97: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKCCResourcesOnCSR" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    kcc_test.go:38: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestIgnoreKptfiles" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    kptfile_test.go:28: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:39: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:124: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionClusterRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:189: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionSpecialNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:257: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLocalConfig" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    local_config_test.go:33: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLocalConfigWithManagementDisabled" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    local_config_test.go:79: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKubectlCreatesManagedNamespaceResourceMultiRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:61: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKubectlCreatesManagedConfigMapResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:190: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:368: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedResourcesWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:428: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddFieldsIntoManagedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:487: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:540: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestModifyManagedFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:564: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestModifyManagedFieldsWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:620: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:664: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedFieldsWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:718: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultiSyncs_Unstructured_MixedControl" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:77: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_RootToNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:206: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_NamespaceToRoot" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:298: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_RootToRoot" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:397: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_NamespaceToNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:502: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestControllerValidationErrors" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:604: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_CustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:38: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_CustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:172: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_RoleBinding" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:298: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceRepo_Centralized" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:42: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceRepo_Delegated" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:133: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:182: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:215: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteNamespaceReconcilerDeployment" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:351: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclareNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:42: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceLabelAndAnnotationLifecycle" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:77: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceExistsAndDeclared" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:188: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceEnabledAnnotationNotDeclared" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:220: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagementDisabledNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:254: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagementDisabledConfigMap" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:366: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncLabelsAndAnnotationsOnKubeSystem" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:476: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDoNotRemoveManagedByLabelExceptForConfigManagement" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:565: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclareImplicitNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:600: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDontDeleteAllNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:671: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNoSSLVerifyV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="259.910"></testcase>
+		<testcase name="TestNoSSLVerifyV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="262.130"></testcase>
+		<testcase name="TestPublicOCI" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:75: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGCENodeOCI" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:106: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSwitchFromGitToOci" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:286: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOverrideGitSyncDepthV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="297.140"></testcase>
+		<testcase name="TestOverrideGitSyncDepthV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="308.040"></testcase>
+		<testcase name="TestOverrideReconcileTimeout" classname="kpt.dev/configsync/e2e/testcases" time="259.620"></testcase>
+		<testcase name="TestOverrideReconcilerResourcesV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="344.090"></testcase>
+		<testcase name="TestOverrideReconcilerResourcesV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="354.670"></testcase>
+		<testcase name="TestMissingRepoErrorWithHierarchicalFormat" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:29: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPolicyDirUnset" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:37: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidPolicyDir" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:59: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveGeneratedServiceFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:38: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveGeneratedClusterRoleFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:162: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveLastApplied" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:247: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateDeleteLabels" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:295: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateDeleteAnnotations" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:351: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretRefV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:59: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretRefV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:170: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretWatch" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:286: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncingThroughAProxy" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    proxy_test.go:33: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagingReconciler" classname="kpt.dev/configsync/e2e/testcases" time="91.810"></testcase>
+		<testcase name="TestAutopilotReconcilerAdjustment" classname="kpt.dev/configsync/e2e/testcases" time="63.390"></testcase>
+		<testcase name="TestResourceGroupController" classname="kpt.dev/configsync/e2e/testcases" time="111.230"></testcase>
+		<testcase name="TestDeleteRootSyncAndRootSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="76.090"></testcase>
+		<testcase name="TestUpdateRootSyncGitDirectory" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:90: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestUpdateRootSyncGitBranch" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:185: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestForceRevert" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:259: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestRootSyncReconcilingStatus" classname="kpt.dev/configsync/e2e/testcases" time="86.530"></testcase>
+		<testcase name="TestStatusEnabledAndDisabled" classname="kpt.dev/configsync/e2e/testcases" time="109.510"></testcase>
+		<testcase name="TestStressCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:60: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressLargeNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:129: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressFrequentGitCommits" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:164: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressLargeRequest" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:196: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultiDependencies" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:40: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestExternalDependencyError" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:315: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDependencyWithReconciliation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:409: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+	</testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/testcases" tests="0" failures="0" errors="0" id="9" time="0">
+		<testcase name="Failure" classname="kpt.dev/configsync/e2e/testcases" time="0"></testcase>
+	</testsuite>
+</testsuites>

--- a/e2e/testdata/junit-report.xml
+++ b/e2e/testdata/junit-report.xml
@@ -1,0 +1,468 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="179" skipped="138">
+	<testsuite name="kpt.dev/configsync/e2e" tests="0" failures="0" errors="0" id="0" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest" tests="0" failures="0" errors="0" id="1" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/docker" tests="0" failures="0" errors="0" id="2" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/gitproviders" tests="0" failures="0" errors="0" id="3" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/metrics" tests="0" failures="0" errors="0" id="4" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/ntopts" tests="0" failures="0" errors="0" id="5" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/policy" tests="0" failures="0" errors="0" id="6" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/nomostest/testing" tests="0" failures="0" errors="0" id="7" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" time="0.000" timestamp="2022-12-15T15:24:51Z"></testsuite>
+	<testsuite name="kpt.dev/configsync/e2e/testcases" tests="179" failures="0" errors="0" id="8" hostname="b60fa88d-7c82-11ed-a95d-4a3f9da110ce" skipped="138" time="3828.920" timestamp="2022-12-15T15:24:51Z">
+		<testcase name="TestAcmeCorpRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    acme_test.go:46: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectInCMSNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    acme_test.go:180: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAdmission" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    admission_test.go:37: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDisableWebhookConfigurationUpdate" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    admission_test.go:155: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAdoptClientSideAppliedResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    adopt_client_side_applied_test.go:31: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCreateAPIServiceAndEndpointInTheSameCommit" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apiservice_test.go:36: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestImporterAndSyncerResilientToFlakyAPIService" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apiservice_test.go:70: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestApplyScopedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    apply_scoped_resource_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceGarbageCollection" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:37: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespacePolicyspaceConversion" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:57: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncDeploymentAndReplicaSet" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:82: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestRolebindingsUpdated" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:130: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceDefaultCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:203: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceGatekeeperSystemCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:209: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceKubeSystemCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:216: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceKubePublicCanBeManaged" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    basic_test.go:222: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNomosInitVet" classname="kpt.dev/configsync/e2e/testcases" time="0.120"></testcase>
+		<testcase name="TestNomosInitHydrate" classname="kpt.dev/configsync/e2e/testcases" time="0.300"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsHierarchical" classname="kpt.dev/configsync/e2e/testcases" time="2.610"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsDefaultSourceFormat" classname="kpt.dev/configsync/e2e/testcases" time="2.550"></testcase>
+		<testcase name="TestNomosHydrateWithClusterSelectorsUnstructured" classname="kpt.dev/configsync/e2e/testcases" time="2.530"></testcase>
+		<testcase name="TestSyncFromNomosHydrateOutputYAMLDir" classname="kpt.dev/configsync/e2e/testcases" time="96.140"></testcase>
+		<testcase name="TestSyncFromNomosHydrateOutputJSONDir" classname="kpt.dev/configsync/e2e/testcases" time="90.910"></testcase>
+		<testcase name="TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorJSONFlat" classname="kpt.dev/configsync/e2e/testcases" time="88.890"></testcase>
+		<testcase name="TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorJSONFlat" classname="kpt.dev/configsync/e2e/testcases" time="68.320"></testcase>
+		<testcase name="TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorYAMLFlat" classname="kpt.dev/configsync/e2e/testcases" time="127.130"></testcase>
+		<testcase name="TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorYAMLFlat" classname="kpt.dev/configsync/e2e/testcases" time="68.420"></testcase>
+		<testcase name="TestNomosHydrateWithUnknownScopedObject" classname="kpt.dev/configsync/e2e/testcases" time="1.990"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/invalid_output_format" classname="kpt.dev/configsync/e2e/testcases" time="0.100"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/must_use_&#39;unstructured&#39;_format_for_DRY_repos" classname="kpt.dev/configsync/e2e/testcases" time="0.090"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_a_DRY_repo_without_kustomization.yaml" classname="kpt.dev/configsync/e2e/testcases" time="0.110"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_deprecated_Group_and_Kind" classname="kpt.dev/configsync/e2e/testcases" time="3.760"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_error:_duplicate_resources" classname="kpt.dev/configsync/e2e/testcases" time="1.290"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_helm_components" classname="kpt.dev/configsync/e2e/testcases" time="1.580"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_kustomize_components" classname="kpt.dev/configsync/e2e/testcases" time="0.480"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_helm_overlay" classname="kpt.dev/configsync/e2e/testcases" time="3.150"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_remote_base" classname="kpt.dev/configsync/e2e/testcases" time="1.160"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_DRY_repo_with_relative_path" classname="kpt.dev/configsync/e2e/testcases" time="0.420"></testcase>
+		<testcase name="TestNomosHydrateAndVetDryRepos/hydrate_a_WET_repo" classname="kpt.dev/configsync/e2e/testcases" time="0.100"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_a_namespace_repo_should_fail_when_source-format_is_set_to_hierarchy" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_automatically_validate_a_namespace_repo_with_the_unstructured_mode_if_source-format_is_not_set" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_automatically_validate_a_namespace_repo_with_the_unstructured_mode_if_source-format_is_set_to_unstructured" classname="kpt.dev/configsync/e2e/testcases" time="0.050"></testcase>
+		<testcase name="TestNomosVetNamespaceRepo/nomos_vet_should_validate_a_DRY_namespace_repo" classname="kpt.dev/configsync/e2e/testcases" time="0.190"></testcase>
+		<testcase name="TestCLIBugreportNomosRunningCorrectly" classname="kpt.dev/configsync/e2e/testcases" time="57.790"></testcase>
+		<testcase name="TestRevertClusterRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_resources_test.go:71: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterRoleLifecycle" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_resources_test.go:151: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestTargetingDifferentResourceQuotasToDifferentClusters" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:103: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnObjects" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:165: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:239: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectReactsToChangeInInlineClusterSelector" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:415: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestObjectReactsToChangeInLegacyClusterSelector" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:447: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestImporterIgnoresNonSelectedCustomResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:486: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorOnNamespaceRepos" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:518: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInlineClusterSelectorFormat" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:565: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorAnnotationConflicts" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:648: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestClusterSelectorForCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    cluster_selectors_test.go:672: Skip the test because the feature "cluster-selector" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestComposition" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    composition_test.go:74: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGCENode" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:60: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestChangeCustomResourceDefinitionSchema" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_schema_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveCustomResourceWithDefinitionV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:115: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveCustomResourceWithDefinitionV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:126: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddAndRemoveCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:182: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddAndRemoveCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:187: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveUnManagedCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:245: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMustRemoveUnManagedCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:250: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateRemoveClusterScopedCRDV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:340: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateRemoveClusterScopedCRDV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:345: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateNamespaceScopedCRDV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:446: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateNamespaceScopedCRDV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:451: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLargeCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resource_definitions_test.go:462: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCRDDeleteBeforeRemoveCustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:36: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCRDDeleteBeforeRemoveCustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:130: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncUpdateCustomResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    custom_resources_test.go:215: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclaredFieldsPod" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    declared_fields_test.go:31: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConstraintTemplateAndConstraintInSameCommit" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    gatekeeper_test.go:53: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPublicHelm" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:53: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmNamespaceRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:127: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmGCENode" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:263: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHelmARTokenAuth" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    helm_sync_test.go:291: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateKustomizeComponents" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:50: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateHelmComponents" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:115: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateHelmOverlay" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:199: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateRemoteResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:293: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestHydrateResourcesInRelativePath" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    hydration_test.go:363: Skip the test because the feature "hydration" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidRootSyncBranchStatus" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:31: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidRepoSyncBranchStatus" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:60: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncFailureAfterSuccessfulSyncs" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    invalid_git_branch_test.go:97: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKCCResourcesOnCSR" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    kcc_test.go:38: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestIgnoreKptfiles" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    kptfile_test.go:28: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:39: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:124: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionClusterRole" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:189: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreventDeletionSpecialNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    lifecycle_directives_test.go:257: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLocalConfig" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    local_config_test.go:33: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestLocalConfigWithManagementDisabled" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    local_config_test.go:79: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKubectlCreatesManagedNamespaceResourceMultiRepo" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:61: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestKubectlCreatesManagedConfigMapResource" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:190: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:368: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedResourcesWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:428: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddFieldsIntoManagedResources" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:487: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:540: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestModifyManagedFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:564: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestModifyManagedFieldsWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:620: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:664: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteManagedFieldsWithIgnoreMutationAnnotation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    managed_resources_test.go:718: Skip the test because the feature "drift-control" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultiSyncs_Unstructured_MixedControl" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:77: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_RootToNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:206: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_NamespaceToRoot" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:298: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_RootToRoot" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:397: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestConflictingDefinitions_NamespaceToNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:502: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestControllerValidationErrors" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multi_sync_test.go:604: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_CustomResourceV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:38: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_CustomResourceV1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:172: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultipleVersions_RoleBinding" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    multiversion_test.go:298: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceRepo_Centralized" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:42: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceRepo_Delegated" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:133: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:182: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:215: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeleteNamespaceReconcilerDeployment" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespace_repo_test.go:351: Skip the test because the feature "multi-repos" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclareNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:42: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceLabelAndAnnotationLifecycle" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:77: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceExistsAndDeclared" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:188: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNamespaceEnabledAnnotationNotDeclared" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:220: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagementDisabledNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:254: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagementDisabledConfigMap" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:366: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncLabelsAndAnnotationsOnKubeSystem" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:476: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDoNotRemoveManagedByLabelExceptForConfigManagement" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:565: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDeclareImplicitNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:600: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDontDeleteAllNamespaces" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    namespaces_test.go:671: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestNoSSLVerifyV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="259.910"></testcase>
+		<testcase name="TestNoSSLVerifyV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="262.130"></testcase>
+		<testcase name="TestPublicOCI" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:75: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestGCENodeOCI" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:106: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRGKEWorkloadIdentity" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRFleetWISameProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIARFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOCIGCRFleetWIDifferentProject" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    csr_auth_test.go:229: Skip the test because the feature "workload-identity" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSwitchFromGitToOci" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    oci_sync_test.go:286: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestOverrideGitSyncDepthV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="297.140"></testcase>
+		<testcase name="TestOverrideGitSyncDepthV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="308.040"></testcase>
+		<testcase name="TestOverrideReconcileTimeout" classname="kpt.dev/configsync/e2e/testcases" time="259.620"></testcase>
+		<testcase name="TestOverrideReconcilerResourcesV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="344.090"></testcase>
+		<testcase name="TestOverrideReconcilerResourcesV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="354.670"></testcase>
+		<testcase name="TestMissingRepoErrorWithHierarchicalFormat" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:29: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPolicyDirUnset" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:37: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestInvalidPolicyDir" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    policy_dir_test.go:59: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveGeneratedServiceFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:38: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveGeneratedClusterRoleFields" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:162: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestPreserveLastApplied" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:247: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateDeleteLabels" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:295: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestAddUpdateDeleteAnnotations" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    preserve_fields_test.go:351: Skip the test because the feature "reconciliation-2" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretRefV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:59: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretRefV1Beta1" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:170: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestCACertSecretWatch" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    private_cert_secret_test.go:286: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestSyncingThroughAProxy" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    proxy_test.go:33: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestManagingReconciler" classname="kpt.dev/configsync/e2e/testcases" time="91.810"></testcase>
+		<testcase name="TestAutopilotReconcilerAdjustment" classname="kpt.dev/configsync/e2e/testcases" time="63.390"></testcase>
+		<testcase name="TestResourceGroupController" classname="kpt.dev/configsync/e2e/testcases" time="111.230"></testcase>
+		<testcase name="TestDeleteRootSyncAndRootSyncV1Alpha1" classname="kpt.dev/configsync/e2e/testcases" time="76.090"></testcase>
+		<testcase name="TestUpdateRootSyncGitDirectory" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:90: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestUpdateRootSyncGitBranch" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:185: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestForceRevert" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    root_sync_test.go:259: Skip the test because the feature "sync-source" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestRootSyncReconcilingStatus" classname="kpt.dev/configsync/e2e/testcases" time="86.530"></testcase>
+		<testcase name="TestStatusEnabledAndDisabled" classname="kpt.dev/configsync/e2e/testcases" time="109.510"></testcase>
+		<testcase name="TestStressCRD" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:60: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressLargeNamespace" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:129: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressFrequentGitCommits" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:164: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestStressLargeRequest" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    stress_test.go:196: Skip the test because the feature "reconciliation-1" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestMultiDependencies" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:40: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestExternalDependencyError" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:315: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+		<testcase name="TestDependencyWithReconciliation" classname="kpt.dev/configsync/e2e/testcases" time="0.000">
+			<skipped message="Skipped"><![CDATA[    sync_ordering_test.go:409: Skip the test because the feature "lifecycle" is not included in the test-features flag "acm-controller,nomos-cli,override-api"]]></skipped>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-containerregistry v0.11.0
 	github.com/google/uuid v1.3.0
+	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	github.com/open-policy-agent/cert-controller v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
+github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/scripts/build-junitreport-cli.sh
+++ b/scripts/build-junitreport-cli.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euox pipefail
+
+GOPATH="${GOPATH:-$(go env GOPATH)}"
+
+PLATFORM=$1
+VERSION=$2
+
+if [[ -z "${VERSION}" ]]; then
+    echo "VERSION must be set"
+    exit 1
+fi
+
+# Example: "linux_amd64" -> ["linux" "amd64"]
+IFS='_' read -r -a platform_split <<< "${PLATFORM}"
+GOOS="${platform_split[0]}"
+GOARCH="${platform_split[1]}"
+
+echo "Building junit-report for ${PLATFORM}"
+env GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED="0" go install \
+    -installsuffix "static" \
+    -ldflags "-X kpt.dev/configsync/pkg/version.VERSION=${VERSION}" \
+    ./cmd/junit-report
+
+# When go builds for native architecture, it puts output in $GOPATH/bin
+# but when cross compiling, it puts it in the $GOPATH/bin/$GOOS_$GOARCH dir
+if [ -f "${GOPATH}/bin/junit-report" ]; then
+  mv "${GOPATH}/bin/junit-report" "${GOPATH}/bin/${PLATFORM}/junit-report"
+fi

--- a/scripts/lint-license-headers.sh
+++ b/scripts/lint-license-headers.sh
@@ -20,4 +20,7 @@ if [ "${GOBIN:-"unset"}" == "unset" ]; then
   exit 1
 fi
 
-"${GOBIN}/addlicense" -check -ignore=vendor/** -ignore=e2e/testdata/helm-charts/** -ignore=.output/** . 2>&1 | sed '/ skipping: / d'
+"${GOBIN}/addlicense" -check -ignore=vendor/** \
+  -ignore=e2e/testdata/helm-charts/** \
+  -ignore=.output/** \
+  -ignore=e2e/testdata/*.xml . 2>&1 | sed '/ skipping: / d'

--- a/vendor/github.com/jstemmer/go-junit-report/v2/LICENSE
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Joel Stemmer
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
@@ -1,0 +1,126 @@
+// Package gtr defines a standard test report format and provides convenience
+// methods to create and convert reports.
+package gtr
+
+import (
+	"strings"
+	"time"
+)
+
+// Result is the result of a test.
+type Result int
+
+const (
+	Unknown Result = iota
+	Pass
+	Fail
+	Skip
+)
+
+func (r Result) String() string {
+	switch r {
+	case Unknown:
+		return "UNKNOWN"
+	case Pass:
+		return "PASS"
+	case Fail:
+		return "FAIL"
+	case Skip:
+		return "SKIP"
+	default:
+		panic("invalid Result")
+	}
+}
+
+// Report contains the build and test results of a collection of packages.
+type Report struct {
+	Packages []Package
+}
+
+// IsSuccessful returns true if none of the packages in this report have build
+// or runtime errors and all tests passed without failures or were skipped.
+func (r *Report) IsSuccessful() bool {
+	for _, pkg := range r.Packages {
+		if pkg.BuildError.Name != "" || pkg.RunError.Name != "" {
+			return false
+		}
+		for _, t := range pkg.Tests {
+			if t.Result != Pass && t.Result != Skip {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Package contains build and test results for a single package.
+type Package struct {
+	Name       string
+	Timestamp  time.Time
+	Duration   time.Duration
+	Coverage   float64
+	Output     []string
+	Properties map[string]string
+
+	Tests []Test
+
+	BuildError Error
+	RunError   Error
+}
+
+// SetProperty stores a key/value property in the current package. If a
+// property with the given key already exists, its old value will be
+// overwritten with the given value.
+func (p *Package) SetProperty(key, value string) {
+	if p.Properties == nil {
+		p.Properties = make(map[string]string)
+	}
+	p.Properties[key] = value
+}
+
+// Test contains the results of a single test.
+type Test struct {
+	ID       int
+	Name     string
+	Duration time.Duration
+	Result   Result
+	Level    int
+	Output   []string
+	Data     map[string]interface{}
+}
+
+// NewTest creates a new Test with the given id and name.
+func NewTest(id int, name string) Test {
+	return Test{ID: id, Name: name, Data: make(map[string]interface{})}
+}
+
+// Error contains details of a build or runtime error.
+type Error struct {
+	ID       int
+	Name     string
+	Duration time.Duration
+	Cause    string
+	Output   []string
+}
+
+// TrimPrefixSpaces trims the leading whitespace of the given line using the
+// indentation level of the test. Printing logs in a Go test is typically
+// prepended by blocks of 4 spaces to align it with the rest of the test
+// output. TrimPrefixSpaces intends to only trim the whitespace added by the Go
+// test command, without inadvertently trimming whitespace added by the test
+// author.
+func TrimPrefixSpaces(line string, indent int) string {
+	// We only want to trim the whitespace prefix if it was part of the test
+	// output. Test output is usually prefixed by a series of 4-space indents,
+	// so we'll check for that to decide whether this output was likely to be
+	// from a test.
+	prefixLen := strings.IndexFunc(line, func(r rune) bool { return r != ' ' })
+	if prefixLen%4 == 0 {
+		// Use the subtest level to trim a consistenly sized prefix from the
+		// output lines.
+		for i := 0; i <= indent; i++ {
+			line = strings.TrimPrefix(line, "    ")
+		}
+	}
+	return strings.TrimPrefix(line, "\t")
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
@@ -1,0 +1,239 @@
+// Package junit defines a JUnit XML report and includes convenience methods
+// for working with these reports.
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+)
+
+// Testsuites is a collection of JUnit testsuites.
+type Testsuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	Name     string `xml:"name,attr,omitempty"`
+	Time     string `xml:"time,attr,omitempty"` // total duration in seconds
+	Tests    int    `xml:"tests,attr,omitempty"`
+	Errors   int    `xml:"errors,attr,omitempty"`
+	Failures int    `xml:"failures,attr,omitempty"`
+	Skipped  int    `xml:"skipped,attr,omitempty"`
+	Disabled int    `xml:"disabled,attr,omitempty"`
+
+	Suites []Testsuite `xml:"testsuite,omitempty"`
+}
+
+// AddSuite adds a Testsuite and updates this testssuites' totals.
+func (t *Testsuites) AddSuite(ts Testsuite) {
+	t.Suites = append(t.Suites, ts)
+	t.Tests += ts.Tests
+	t.Errors += ts.Errors
+	t.Failures += ts.Failures
+	t.Skipped += ts.Skipped
+	t.Disabled += ts.Disabled
+}
+
+// Testsuite is a single JUnit testsuite containing testcases.
+type Testsuite struct {
+	// required attributes
+	Name     string `xml:"name,attr"`
+	Tests    int    `xml:"tests,attr"`
+	Failures int    `xml:"failures,attr"`
+	Errors   int    `xml:"errors,attr"`
+	ID       int    `xml:"id,attr"`
+
+	// optional attributes
+	Disabled  int    `xml:"disabled,attr,omitempty"`
+	Hostname  string `xml:"hostname,attr,omitempty"`
+	Package   string `xml:"package,attr,omitempty"`
+	Skipped   int    `xml:"skipped,attr,omitempty"`
+	Time      string `xml:"time,attr"`                // duration in seconds
+	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
+
+	Properties *[]Property `xml:"properties>property,omitempty"`
+	Testcases  []Testcase  `xml:"testcase,omitempty"`
+	SystemOut  *Output     `xml:"system-out,omitempty"`
+	SystemErr  *Output     `xml:"system-err,omitempty"`
+}
+
+// AddProperty adds a property with the given name and value to this Testsuite.
+func (t *Testsuite) AddProperty(name, value string) {
+	prop := Property{Name: name, Value: value}
+	if t.Properties == nil {
+		t.Properties = &[]Property{prop}
+		return
+	}
+	props := append(*t.Properties, prop)
+	t.Properties = &props
+}
+
+// AddTestcase adds Testcase tc to this Testsuite.
+func (t *Testsuite) AddTestcase(tc Testcase) {
+	t.Testcases = append(t.Testcases, tc)
+	t.Tests += 1
+
+	if tc.Error != nil {
+		t.Errors += 1
+	}
+
+	if tc.Failure != nil {
+		t.Failures += 1
+	}
+
+	if tc.Skipped != nil {
+		t.Skipped += 1
+	}
+}
+
+// SetTimestamp sets the timestamp in this Testsuite.
+func (ts *Testsuite) SetTimestamp(t time.Time) {
+	ts.Timestamp = t.Format(time.RFC3339)
+}
+
+// Testcase represents a single test with its results.
+type Testcase struct {
+	// required attributes
+	Name      string `xml:"name,attr"`
+	Classname string `xml:"classname,attr"`
+
+	// optional attributes
+	Time   string `xml:"time,attr,omitempty"` // duration in seconds
+	Status string `xml:"status,attr,omitempty"`
+
+	Skipped   *Result `xml:"skipped,omitempty"`
+	Error     *Result `xml:"error,omitempty"`
+	Failure   *Result `xml:"failure,omitempty"`
+	SystemOut *Output `xml:"system-out,omitempty"`
+	SystemErr *Output `xml:"system-err,omitempty"`
+}
+
+// Property represents a key/value pair.
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// Result represents the result of a single test.
+type Result struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Data    string `xml:",cdata"`
+}
+
+// Output represents output written to stdout or sderr.
+type Output struct {
+	Data string `xml:",cdata"`
+}
+
+// CreateFromReport creates a JUnit representation of the given gtr.Report.
+func CreateFromReport(report gtr.Report, hostname string) Testsuites {
+	var suites Testsuites
+	for _, pkg := range report.Packages {
+		var duration time.Duration
+		suite := Testsuite{
+			Name:     pkg.Name,
+			Hostname: hostname,
+			ID:       len(suites.Suites),
+		}
+
+		if !pkg.Timestamp.IsZero() {
+			suite.SetTimestamp(pkg.Timestamp)
+		}
+
+		for k, v := range pkg.Properties {
+			suite.AddProperty(k, v)
+		}
+
+		if len(pkg.Output) > 0 {
+			suite.SystemOut = &Output{Data: formatOutput(pkg.Output, 0)}
+		}
+
+		if pkg.Coverage > 0 {
+			suite.AddProperty("coverage.statements.pct", fmt.Sprintf("%.2f", pkg.Coverage))
+		}
+
+		for _, test := range pkg.Tests {
+			duration += test.Duration
+			suite.AddTestcase(createTestcaseForTest(pkg.Name, test))
+		}
+
+		// JUnit doesn't have a good way of dealing with build or runtime
+		// errors that happen before a test has started, so we create a single
+		// failing test that contains the build error details.
+		if pkg.BuildError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.BuildError.Name,
+				Name:      pkg.BuildError.Cause,
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Build error",
+					Data:    strings.Join(pkg.BuildError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if pkg.RunError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.RunError.Name,
+				Name:      "Failure",
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Runtime error",
+					Data:    strings.Join(pkg.RunError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if (pkg.Duration) == 0 {
+			suite.Time = formatDuration(duration)
+		} else {
+			suite.Time = formatDuration(pkg.Duration)
+		}
+		suites.AddSuite(suite)
+	}
+	return suites
+}
+
+func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
+	tc := Testcase{
+		Classname: pkgName,
+		Name:      test.Name,
+		Time:      formatDuration(test.Duration),
+	}
+
+	if test.Result == gtr.Fail {
+		tc.Failure = &Result{
+			Message: "Failed",
+			Data:    formatOutput(test.Output, test.Level),
+		}
+	} else if test.Result == gtr.Skip {
+		tc.Skipped = &Result{
+			Message: "Skipped",
+			Data:    formatOutput(test.Output, test.Level),
+		}
+	} else if test.Result == gtr.Unknown {
+		tc.Error = &Result{
+			Message: "No test result found",
+			Data:    formatOutput(test.Output, test.Level),
+		}
+	} else if len(test.Output) > 0 {
+		tc.SystemOut = &Output{Data: formatOutput(test.Output, test.Level)}
+	}
+	return tc
+}
+
+// formatDuration returns the JUnit string representation of the given
+// duration.
+func formatDuration(d time.Duration) string {
+	return fmt.Sprintf("%.3f", d.Seconds())
+}
+
+// formatOutput combines the lines from the given output into a single string.
+func formatOutput(output []string, indent int) string {
+	return strings.Join(output, "\n")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,10 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
+# github.com/jstemmer/go-junit-report/v2 v2.0.0
+## explicit; go 1.13
+github.com/jstemmer/go-junit-report/v2/gtr
+github.com/jstemmer/go-junit-report/v2/junit
 # github.com/klauspost/compress v1.15.8
 ## explicit; go 1.16
 github.com/klauspost/compress


### PR DESCRIPTION
The testgrid failed to autocloase the bug because the testcases.Failure entry wasn't removed from a successful run.

This commit postprocesses the junit report to ensure the bug can be autoclosed immediately.