### PR TITLE
Fake client fixes

### DIFF
--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -366,6 +366,9 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideReconcilerCPUAndGitSyncMemResources,
 	}
@@ -387,7 +390,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerResourcesMutator(overrideReconcilerCPUAndGitSyncMemResources),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -400,6 +403,9 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -418,7 +424,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -492,6 +498,9 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideReconcilerAndGitSyncResources,
 	}
@@ -513,7 +522,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerResourcesMutator(overrideReconcilerAndGitSyncResources),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -542,6 +551,9 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideReconcilerResources,
 	}
@@ -563,7 +575,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerResourcesMutator(overrideReconcilerResources),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -584,6 +596,9 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideGitSyncResources,
 	}
@@ -605,7 +620,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerResourcesMutator(overrideGitSyncResources),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -617,6 +632,9 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -635,7 +653,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("5"),
+		setUID("1"), setResourceVersion("5"), setGeneration(5),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -711,7 +729,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -798,6 +816,9 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// Set rs.Spec.NoSSLVerify to false
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.NoSSLVerify = false
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -822,6 +843,9 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Set rs.Spec.NoSSLVerify to true
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.NoSSLVerify = true
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -841,7 +865,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(updatedRepoDeployment)] = updatedRepoDeployment
 
@@ -928,6 +952,9 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// Set rs.Spec.NoSSLVerify to false
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.NoSSLVerify = false
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -1030,6 +1057,9 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 	t.Log("Deployment successfully created")
 
 	// Unset rs.Spec.CACertSecretRef
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.CACertSecretRef = &v1beta1.SecretReference{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
@@ -1045,6 +1075,9 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 	t.Log("No need to update Deployment")
 
 	// Set rs.Spec.CACertSecretRef
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.CACertSecretRef.Name = caCertSecret
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
@@ -1063,7 +1096,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		envVarMutator(gitSyncName, nsSecretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, nsSecretName, GitSecretConfigKeyToken),
 		containerEnvMutator(repoContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(updatedRepoDeployment)] = updatedRepoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1072,6 +1105,9 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Unset rs.Spec.CACertSecretRef
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.CACertSecretRef.Name = ""
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
@@ -1144,7 +1180,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1157,6 +1193,9 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	t.Log("Deployment successfully created")
 
 	// Test overriding the git sync depth to a positive value
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	var depth int64 = 5
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1173,7 +1212,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = updatedRepoDeployment
 
@@ -1186,6 +1225,9 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test overriding the git sync depth to 0
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	depth = 0
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1202,7 +1244,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = updatedRepoDeployment
 
@@ -1215,6 +1257,9 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Set rs.Spec.Override.GitSyncDepth to nil.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SafeOverride().GitSyncDepth = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1235,6 +1280,9 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1305,7 +1353,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1318,6 +1366,9 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	t.Log("Deployment successfully created")
 
 	// Test overriding the reconcile timeout to 50s
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1334,7 +1385,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = updatedRepoDeployment
 
@@ -1347,6 +1398,9 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Set rs.Spec.Override.ReconcileTimeout to nil.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1367,6 +1421,9 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1445,6 +1502,9 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	t.Log("Deployment successfully created")
 
 	// Test overriding the api server timeout to 50s
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().APIServerTimeout = &reconcileTimeout
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1471,6 +1531,9 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Set rs.Spec.Override.APIServerTimeout to nil.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SafeOverride().APIServerTimeout = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1488,6 +1551,9 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
@@ -1536,7 +1602,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
 		core.Labels(label),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -1545,7 +1611,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1565,6 +1631,9 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	t.Log("Resources successfully created")
 
 	// Test updating RepoSync resources with SSH auth type.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: reposyncSSHKey}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1581,7 +1650,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1593,6 +1662,9 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test updating RepoSync resources with None auth type.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1609,7 +1681,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneGitContainers()),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -1648,7 +1720,7 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1764,7 +1836,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		nsReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Labels(label1),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts := map[core.ID]*corev1.ServiceAccount{core.IDOf(serviceAccount1): serviceAccount1}
 
@@ -1772,7 +1844,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		RepoSyncPermissionsName(),
 		nsReconcilerName,
 		core.Namespace(rs1.Namespace),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	roleBinding1.Subjects = addSubjectByName(roleBinding1.Subjects, nsReconcilerName)
 	wantRoleBindings := map[core.ID]*rbacv1.RoleBinding{core.IDOf(roleBinding1): roleBinding1}
@@ -1783,7 +1855,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv1),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment1): repoDeployment1}
 
@@ -1831,7 +1903,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName2),
 		gceNodeMutator(""),
 		containerEnvMutator(repoContainerEnv2),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(repoDeployment2)] = repoDeployment2
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1842,7 +1914,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		nsReconcilerName2,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Labels(label2),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount2)] = serviceAccount2
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1853,7 +1925,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		RepoSyncPermissionsName(),
 		nsReconcilerName2,
 		core.Namespace(rs2.Namespace),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	roleBinding2.Subjects = addSubjectByName(roleBinding2.Subjects, nsReconcilerName2)
 	wantRoleBindings[core.IDOf(roleBinding2)] = roleBinding2
@@ -1894,7 +1966,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName3),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(repoContainerEnv3),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(repoDeployment3)] = repoDeployment3
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1906,7 +1978,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Annotation(GCPSAAnnotationKey, rs3.Spec.GCPServiceAccountEmail),
 		core.Labels(label3),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount3)] = serviceAccount3
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1957,7 +2029,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		secretMutator(nsReconcilerName4+"-"+reposyncCookie),
 		envVarMutator("HTTPS_PROXY", nsReconcilerName4+"-"+reposyncCookie, "https_proxy"),
 		containerEnvMutator(repoContainerEnv4),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(repoDeployment4)] = repoDeployment4
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1968,7 +2040,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		nsReconcilerName4,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Labels(label4),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount4)] = serviceAccount4
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -2021,7 +2093,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		envVarMutator(gitSyncName, nsReconcilerName5+"-"+secretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, nsReconcilerName5+"-"+secretName, GitSecretConfigKeyToken),
 		containerEnvMutator(repoContainerEnv5),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(repoDeployment5)] = repoDeployment5
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2031,7 +2103,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		nsReconcilerName5,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Labels(label5),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount5)] = serviceAccount5
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -2047,6 +2119,9 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and ClusterRoleBindings successfully created")
 
 	// Test updating Deployment resources for rs1: my-repo-sync
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs1), rs1); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs1.Spec.Git.Revision = gitUpdatedRevision
 	if err := fakeClient.Update(ctx, rs1); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2065,7 +2140,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv1),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment1)] = repoDeployment1
 
@@ -2078,6 +2153,9 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test updating Deployment resources for rs2: repo-sync
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs2), rs2); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs2.Spec.Git.Revision = gitUpdatedRevision
 	if err := fakeClient.Update(ctx, rs2); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2096,7 +2174,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName2),
 		gceNodeMutator(""),
 		containerEnvMutator(repoContainerEnv2),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment2)] = repoDeployment2
 
@@ -2109,6 +2187,9 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test updating Deployment resources for rs3: my-rs-3
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs3), rs3); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs3.Spec.Git.Revision = gitUpdatedRevision
 	if err := fakeClient.Update(ctx, rs3); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2127,7 +2208,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		setServiceAccountName(nsReconcilerName3),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(repoContainerEnv3),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment3)] = repoDeployment3
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2139,6 +2220,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Resources successfully updated")
 
 	// Test garbage collecting RoleBinding after all RepoSyncs are deleted
+	rs1.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs1); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2164,6 +2246,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.FailNow()
 	}
 
+	rs2.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs2); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2184,6 +2267,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.FailNow()
 	}
 
+	rs3.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs3); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2205,6 +2289,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.FailNow()
 	}
 
+	rs4.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs4); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2224,6 +2309,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.FailNow()
 	}
 
+	rs5.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs5); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2574,7 +2660,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -2607,7 +2693,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		fleetWorkloadIdentityMutator(workloadIdentityPool, gcpSAEmail),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments = map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -2621,6 +2707,9 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	t.Log("Resources successfully created")
 
 	// Test updating RepoSync resources with SSH auth type.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: reposyncSSHKey}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2638,7 +2727,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -2651,6 +2740,9 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test updating RepoSync resources with None auth type.
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2667,7 +2759,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneGitContainers()),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -2704,7 +2796,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 		envVarMutator(helmSyncName, nsReconcilerName+"-"+secretName, "username"),
 		envVarMutator(helmSyncPassword, nsReconcilerName+"-"+secretName, "password"),
 		containerEnvMutator(repoContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -2731,7 +2823,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
 		containerEnvMutator(repoContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2776,7 +2868,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		nsReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Labels(label),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -2785,7 +2877,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -2805,6 +2897,9 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	t.Log("Resources successfully created")
 
 	t.Log("Test updating RepoSync resources with gcenode auth type.")
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Oci.Auth = configsync.AuthGCENode
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2824,7 +2919,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2836,6 +2931,9 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	t.Log("Test updating RepoSync resources with gcpserviceaccount auth type.")
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Oci.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Oci.GCPServiceAccountEmail = gcpSAEmail
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2850,7 +2948,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 
 	wantServiceAccount = fake.ServiceAccountObject(
@@ -2858,7 +2956,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
 		core.Labels(label),
-		core.ResourceVersion("2"),
+		core.UID("1"), core.ResourceVersion("2"), core.Generation(1),
 	)
 	// compare ServiceAccount.
 	wantServiceAccounts[core.IDOf(wantServiceAccount)] = wantServiceAccount
@@ -2899,7 +2997,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		fwiOciMutator(workloadIdentityPool),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 
@@ -2920,6 +3018,9 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideOciSyncResources,
 	}
@@ -2940,7 +3041,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		fwiOciMutator(workloadIdentityPool),
 		containerResourcesMutator(overrideOciSyncResources),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("5"),
+		setUID("1"), setResourceVersion("5"), setGeneration(5),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2967,6 +3068,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Git
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.GitSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2979,6 +3083,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Oci
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -2991,6 +3098,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -3003,6 +3113,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing OCI image
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -3016,6 +3129,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify invalid OCI Auth
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -3029,6 +3145,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm repo
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{}
@@ -3043,6 +3162,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm chart
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -3056,6 +3178,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify invalid Helm Auth
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -3069,6 +3194,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid OCI spec
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
@@ -3091,6 +3219,9 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid Helm spec
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the repo sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -296,7 +296,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		secretMutator(rootsyncSSHKey),
 		containerResourcesMutator(overrideAllContainerResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -326,6 +326,9 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideSelectedResources,
 	}
@@ -342,7 +345,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		secretMutator(rootsyncSSHKey),
 		containerResourcesMutator(overrideSelectedResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -353,9 +356,10 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
-	// Clear rs.Spec.Override
-	rs.Spec.Override = &v1beta1.OverrideSpec{}
-
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
+	rs.Spec.Override = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -368,7 +372,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -400,7 +404,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -437,6 +441,9 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideAllContainerResources,
 	}
@@ -453,7 +460,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		secretMutator(rootsyncSSHKey),
 		containerResourcesMutator(overrideAllContainerResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
@@ -483,6 +490,9 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideReconcilerAndHydrationResources,
 	}
@@ -499,7 +509,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		secretMutator(rootsyncSSHKey),
 		containerResourcesMutator(overrideReconcilerAndHydrationResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -519,6 +529,9 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideGitSyncResources,
 	}
@@ -535,7 +548,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		secretMutator(rootsyncSSHKey),
 		containerResourcesMutator(overrideGitSyncResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -546,9 +559,11 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
-
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -561,7 +576,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("5"),
+		setUID("1"), setResourceVersion("5"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -625,7 +640,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -637,6 +652,9 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	t.Log("Deployment successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.NoSSLVerify to false
 	rs.Spec.NoSSLVerify = false
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -655,6 +673,9 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	t.Log("No need to update Deployment")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.NoSSLVerify to true
 	rs.Spec.NoSSLVerify = true
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -670,7 +691,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -681,6 +702,9 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.NoSSLVerify to false
 	rs.Spec.NoSSLVerify = false
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -729,7 +753,7 @@ func TestRootSyncCreateWithCACertSecret(t *testing.T) {
 		envVarMutator(gitSyncName, secretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, secretName, GitSecretConfigKeyToken),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -764,7 +788,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 		envVarMutator(gitSyncName, secretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, secretName, GitSecretConfigKeyToken),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -773,6 +797,9 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	t.Log("Deployment successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Unset rs.Spec.CACertSecretRef
 	rs.Spec.CACertSecretRef = &v1beta1.SecretReference{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -788,6 +815,9 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	t.Log("No need to update Deployment")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.CACertSecretRef
 	caCertSecret := "foo-secret"
 	rs.Spec.CACertSecretRef.Name = caCertSecret
@@ -807,7 +837,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 		envVarMutator(gitSyncName, secretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, secretName, GitSecretConfigKeyToken),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -815,6 +845,9 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Unset rs.Spec.CACertSecretRef
 	rs.Spec.CACertSecretRef.Name = ""
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -885,7 +918,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -897,6 +930,9 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	t.Log("ServiceAccount, ClusterRoleBinding and Deployment successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test overriding the git sync depth to a positive value
 	var depth int64 = 5
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
@@ -913,7 +949,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
 
@@ -925,6 +961,9 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test overriding the git sync depth to 0
 	depth = 0
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
@@ -941,7 +980,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
 
@@ -953,6 +992,9 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.Override.GitSyncDepth to nil.
 	rs.Spec.SafeOverride().GitSyncDepth = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -973,6 +1015,9 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1042,7 +1087,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1054,6 +1099,9 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	t.Log("ServiceAccount, ClusterRoleBinding and Deployment successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test overriding the reconcile timeout to 50s
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
@@ -1069,7 +1117,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
@@ -1082,6 +1130,9 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.Override.ReconcileTimeout to nil.
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1102,6 +1153,9 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1175,6 +1229,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	t.Log("ServiceAccount, ClusterRoleBinding and Deployment successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test overriding the reconcile timeout to 50s
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
@@ -1200,6 +1257,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Set rs.Spec.Override.ReconcileTimeout to nil.
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1217,6 +1277,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.OverrideSpec{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -1256,11 +1319,11 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
 		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
 		core.Labels(labels),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
 	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
@@ -1269,7 +1332,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1288,6 +1351,9 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	}
 	t.Log("Resources successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating RootSync resources with SSH auth type.
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: rootsyncSSHKey}
@@ -1304,7 +1370,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1315,6 +1381,9 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating RootSync resources with None auth type.
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
@@ -1331,7 +1400,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneGitContainers()),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
@@ -1363,7 +1432,7 @@ func TestRootSyncReconcilerRestart(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1470,17 +1539,17 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs1.Name, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rs1.Name, "1"),
 		}),
 		core.Labels(label1),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts := map[core.ID]*corev1.ServiceAccount{core.IDOf(serviceAccount1): serviceAccount1}
 
 	crb := clusterrolebinding(
 		RootSyncPermissionsName(),
 		rootReconcilerName,
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName)
 	rootContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, rootReconcilerName)
@@ -1540,10 +1609,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName2,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs2.Name, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rs2.Name, "1"),
 		}),
 		core.Labels(label2),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount2)] = serviceAccount2
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1552,6 +1621,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName2)
 	crb.ResourceVersion = "2"
+	crb.Generation = 2
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1595,11 +1665,11 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName3,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs3.Name, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rs3.Name, "1"),
 		}),
 		core.Annotation(GCPSAAnnotationKey, rs3.Spec.GCPServiceAccountEmail),
 		core.Labels(label3),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount3)] = serviceAccount3
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1608,6 +1678,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName3)
 	crb.ResourceVersion = "3"
+	crb.Generation = 3
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1655,10 +1726,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName4,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs4.Name, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rs4.Name, "1"),
 		}),
 		core.Labels(label4),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount4)] = serviceAccount4
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1667,6 +1738,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName4)
 	crb.ResourceVersion = "4"
+	crb.Generation = 4
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1715,10 +1787,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 		rootReconcilerName5,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs5.Name, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rs5.Name, "1"),
 		}),
 		core.Labels(label5),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	wantServiceAccounts[core.IDOf(serviceAccount5)] = serviceAccount5
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
@@ -1727,6 +1799,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName5)
 	crb.ResourceVersion = "5"
+	crb.Generation = 5
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1735,6 +1808,9 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployments, ServiceAccounts, and ClusterRoleBindings successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs1), rs1); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating Deployment resources for rs1: my-root-sync
 	rs1.Spec.Git.Revision = gitUpdatedRevision
 	if err := fakeClient.Update(ctx, rs1); err != nil {
@@ -1758,7 +1834,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv1),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment1)] = rootDeployment1
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1769,6 +1845,9 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs2), rs2); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating Deployment resources for rs2: root-sync
 	rs2.Spec.Git.Revision = gitUpdatedRevision
 	if err := fakeClient.Update(ctx, rs2); err != nil {
@@ -1791,7 +1870,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName2),
 		gceNodeMutator(""),
 		containerEnvMutator(rootContainerEnv2),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment2)] = rootDeployment2
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1802,6 +1881,9 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs3), rs3); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating  Deployment resources for rs3: my-rs-3
 	rs3.Spec.Git.Revision = gitUpdatedRevision
 	rs3.Spec.Git.Revision = gitUpdatedRevision
@@ -1825,7 +1907,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName3),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(rootContainerEnv3),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment3)] = rootDeployment3
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1837,6 +1919,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	// Test garbage collecting ClusterRoleBinding after all RootSyncs are deleted
+	rs1.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs1); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -1851,6 +1934,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	// Subject for rs1 is removed from ClusterRoleBinding.Subjects
 	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName)
 	crb.ResourceVersion = "6"
+	crb.Generation = 6
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1860,6 +1944,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully deleted")
 
+	rs2.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs2); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -1874,6 +1959,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	// Subject for rs2 is removed from ClusterRoleBinding.Subjects
 	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName2)
 	crb.ResourceVersion = "7"
+	crb.Generation = 7
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1883,6 +1969,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully deleted")
 
+	rs3.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs3); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -1897,6 +1984,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	// Subject for rs3 is removed from ClusterRoleBinding.Subjects
 	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName3)
 	crb.ResourceVersion = "8"
+	crb.Generation = 8
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1906,6 +1994,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully deleted")
 
+	rs4.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs4); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -1920,6 +2009,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	// Subject for rs4 is removed from ClusterRoleBinding.Subjects
 	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName4)
 	crb.ResourceVersion = "9"
+	crb.Generation = 9
 	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
 		t.Error(err)
 	}
@@ -1929,6 +2019,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	t.Log("Deployment successfully deleted")
 
+	rs5.ResourceVersion = "" // Skip ResourceVersion validation
 	if err := fakeClient.Delete(ctx, rs5); err != nil {
 		t.Fatalf("failed to delete the root sync request, got error: %v, want error: nil", err)
 	}
@@ -2077,7 +2168,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -2109,7 +2200,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		fleetWorkloadIdentityMutator(workloadIdentityPool, gcpSAEmail),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments = map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -2122,6 +2213,9 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 	}
 	t.Log("Resources successfully created")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating RootSync resources with SSH auth type.
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: rootsyncSSHKey}
@@ -2138,7 +2232,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2149,6 +2243,9 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 	}
 	t.Log("Deployment successfully updated")
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	// Test updating RootSync resources with None auth type.
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
@@ -2165,7 +2262,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneGitContainers()),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
@@ -2203,7 +2300,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 		envVarMutator(helmSyncName, secretName, HelmSecretKeyUsername),
 		envVarMutator(helmSyncPassword, secretName, HelmSecretKeyPassword),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -2230,7 +2327,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2266,10 +2363,10 @@ func TestRootSyncWithOCI(t *testing.T) {
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
 		}),
 		core.Labels(labels),
-		core.ResourceVersion("1"),
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
 	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
@@ -2278,6 +2375,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(rootContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -2297,6 +2395,9 @@ func TestRootSyncWithOCI(t *testing.T) {
 	t.Log("Resources successfully created")
 
 	t.Log("Test updating RootSync resources with gcenode auth type.")
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Oci.Auth = configsync.AuthGCENode
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -2315,7 +2416,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2327,6 +2428,9 @@ func TestRootSyncWithOCI(t *testing.T) {
 	t.Log("Deployment successfully updated")
 
 	t.Log("Test updating RootSync resources with gcpserviceaccount auth type.")
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Oci.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Oci.GCPServiceAccountEmail = gcpSAEmail
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2340,11 +2444,11 @@ func TestRootSyncWithOCI(t *testing.T) {
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
 		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, ""),
+			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
 		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
 		core.Labels(labels),
-		core.ResourceVersion("2"),
+		core.UID("1"), core.ResourceVersion("2"), core.Generation(1),
 	)
 	// compare ServiceAccount.
 	wantServiceAccounts[core.IDOf(wantServiceAccount)] = wantServiceAccount
@@ -2356,7 +2460,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneOciContainers()),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("3"),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
@@ -2390,7 +2494,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		fwiOciMutator(workloadIdentityPool),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("4"),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
@@ -2411,6 +2515,9 @@ func TestRootSyncWithOCI(t *testing.T) {
 		},
 	}
 
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.Override = &v1beta1.OverrideSpec{
 		Resources: overrideOciSyncResources,
 	}
@@ -2430,7 +2537,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		fwiOciMutator(workloadIdentityPool),
 		containerResourcesMutator(overrideOciSyncResources),
 		containerEnvMutator(rootContainerEnvs),
-		setResourceVersion("5"),
+		setUID("1"), setResourceVersion("5"), setGeneration(4),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2460,6 +2567,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Git
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.GitSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -2472,6 +2582,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Oci
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -2484,6 +2597,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -2496,6 +2612,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing OCI image
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2509,6 +2628,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify invalid OCI Auth
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2522,6 +2644,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm repo
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{}
 	rs.Spec.Oci = nil
@@ -2536,6 +2661,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify missing Helm chart
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2549,6 +2677,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify invalid Helm Auth
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
 	if err := fakeClient.Update(ctx, rs); err != nil {
@@ -2562,6 +2693,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid OCI spec
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
@@ -2584,6 +2718,9 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid Helm spec
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+		t.Fatalf("failed to get the root sync: %v", err)
+	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil
@@ -2810,6 +2947,18 @@ func rootSyncDeployment(reconcilerName string, muts ...depMutator) *appsv1.Deplo
 func setResourceVersion(rv string) depMutator {
 	return func(dep *appsv1.Deployment) {
 		dep.ResourceVersion = rv
+	}
+}
+
+func setUID(uid types.UID) depMutator {
+	return func(dep *appsv1.Deployment) {
+		dep.UID = uid
+	}
+}
+
+func setGeneration(gen int64) depMutator {
+	return func(dep *appsv1.Deployment) {
+		dep.Generation = gen
 	}
 }
 

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -117,7 +117,9 @@ func TestUpsertAuthSecret(t *testing.T) {
 			client:   fakeClient(t, secret(t, gitSecretName, keyData, sshAuth, gitSource, core.Namespace(reposyncNs))),
 			wantKey:  types.NamespacedName{Namespace: nsReconcilerKey.Namespace, Name: ReconcilerResourceName(nsReconcilerName, gitSecretName)},
 			wantSecret: secret(t, ReconcilerResourceName(nsReconcilerName, gitSecretName), keyData, sshAuth, gitSource,
-				core.Namespace(nsReconcilerKey.Namespace), core.ResourceVersion("1")),
+				core.Namespace(nsReconcilerKey.Namespace),
+				core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+			),
 		},
 		{
 			name:     "Secret updated for git source",
@@ -128,7 +130,9 @@ func TestUpsertAuthSecret(t *testing.T) {
 			),
 			wantKey: types.NamespacedName{Namespace: nsReconcilerKey.Namespace, Name: ReconcilerResourceName(nsReconcilerName, gitSecretName)},
 			wantSecret: secret(t, ReconcilerResourceName(nsReconcilerName, gitSecretName), updatedKeyData, sshAuth, gitSource,
-				core.Namespace(nsReconcilerKey.Namespace), core.ResourceVersion("2")),
+				core.Namespace(nsReconcilerKey.Namespace),
+				core.UID("1"), core.ResourceVersion("2"), core.Generation(2),
+			),
 		},
 		{
 			name:      "Secret not found for git source",
@@ -151,7 +155,9 @@ func TestUpsertAuthSecret(t *testing.T) {
 			client:   fakeClient(t, secret(t, helmSecretName, tokenData, tokenAuth, helmSource, core.Namespace(reposyncNs))),
 			wantKey:  types.NamespacedName{Namespace: nsReconcilerKey.Namespace, Name: ReconcilerResourceName(nsReconcilerName, helmSecretName)},
 			wantSecret: secret(t, ReconcilerResourceName(nsReconcilerName, helmSecretName), tokenData, tokenAuth, helmSource,
-				core.Namespace(nsReconcilerKey.Namespace), core.ResourceVersion("1")),
+				core.Namespace(nsReconcilerKey.Namespace),
+				core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+			),
 		},
 		{
 			name:     "Secret updated for helm source",
@@ -162,7 +168,9 @@ func TestUpsertAuthSecret(t *testing.T) {
 			),
 			wantKey: types.NamespacedName{Namespace: nsReconcilerKey.Namespace, Name: ReconcilerResourceName(nsReconcilerName, helmSecretName)},
 			wantSecret: secret(t, ReconcilerResourceName(nsReconcilerName, helmSecretName), updatedKeyData, tokenAuth, helmSource,
-				core.Namespace(nsReconcilerKey.Namespace), core.ResourceVersion("2")),
+				core.Namespace(nsReconcilerKey.Namespace),
+				core.UID("1"), core.ResourceVersion("2"), core.Generation(2),
+			),
 		},
 		{
 			name:      "Secret not found for helm source",

--- a/pkg/reconcilermanager/controllers/validate_secret_test.go
+++ b/pkg/reconcilermanager/controllers/validate_secret_test.go
@@ -40,7 +40,8 @@ func TestValidateSecretExist(t *testing.T) {
 			secretReference: "ssh-key",
 			wantSecret: secretObj(t, "ssh-key", configsync.AuthSSH, v1beta1.GitSource,
 				core.Namespace("bookinfo"),
-				core.ResourceVersion("1")),
+				core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+			),
 		},
 
 		{


### PR DESCRIPTION
- Fix ID lookup to work for typed objects without GVK set. Use the scheme to look up the GVK by struct type.
- Add support for auto-incrementing Generation when the spec changes (technically any change that isn't status or metadata, not just the spec field)
- Fix status update to log the diff correctly
- Fix Update to copy UID, ResourceVersion, and Generation changes back to the input object.
- Make fake.Client.Check ignore Timestamps, so conditions can be easily compared.
- Fix Update to error if the specified UID or ResourceVersion is no longer current.
- Update impacted test expectations.
