### PR TITLE
Add dependencies to e2e CentralizedControl setup

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -629,7 +629,7 @@ func (a *applier) removeFromInventory(rg *live.InventoryResourceGroup, objs []cl
 // disableObject disables the management for a single object by removing the
 // ConfigSync labels and annotations.
 func (a *applier) disableObject(ctx context.Context, obj client.Object) error {
-	meta := objMetaFrom(obj)
+	meta := ObjMetaFromObject(obj)
 	mapping, err := a.clientSet.Mapper.RESTMapping(meta.GroupKind)
 	if err != nil {
 		return err

--- a/pkg/applier/utils.go
+++ b/pkg/applier/utils.go
@@ -60,7 +60,8 @@ func toUnstructured(objs []client.Object) ([]*unstructured.Unstructured, status.
 	return unstructureds, errs
 }
 
-func objMetaFrom(obj client.Object) object.ObjMetadata {
+// ObjMetaFromObject constructs an ObjMetadata representing the Object.
+func ObjMetaFromObject(obj client.Object) object.ObjMetadata {
 	return object.ObjMetadata{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -86,7 +86,7 @@ func TestObjMetaFrom(t *testing.T) {
 			Kind:  "Deployment",
 		},
 	}
-	actual := objMetaFrom(d)
+	actual := ObjMetaFromObject(d)
 	if actual != expected {
 		t.Errorf("expected %v but got %v", expected, actual)
 	}
@@ -94,7 +94,7 @@ func TestObjMetaFrom(t *testing.T) {
 
 func TestIDFrom(t *testing.T) {
 	d := fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
-	meta := objMetaFrom(d)
+	meta := ObjMetaFromObject(d)
 	id := idFrom(meta)
 	if id != core.IDOf(d) {
 		t.Errorf("expected %v but got %v", core.IDOf(d), id)
@@ -111,47 +111,47 @@ func TestRemoveFrom(t *testing.T) {
 		{
 			name: "toRemove is empty",
 			allObjMeta: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				objMetaFrom(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: nil,
 			expected: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				objMetaFrom(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "all toRemove are in the original list",
 			allObjMeta: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				objMetaFrom(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				fake.ServiceObject(core.Name("service"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "some toRemove are not in the original list",
 			allObjMeta: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				objMetaFrom(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				fake.ServiceObject(core.Name("service"), core.Namespace("default")),
 				fake.ConfigMapObject(core.Name("cm"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "toRemove are the same as original objects",
 			allObjMeta: []object.ObjMetadata{
-				objMetaFrom(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				objMetaFrom(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				fake.DeploymentObject(core.Name("deploy"), core.Namespace("default")),


### PR DESCRIPTION
- Make RepoSync depend on the [Cluster]RoleBinding & ClusterRole that grant the reconciler permissions. This ensures the reconciler has correct permissions until fully exited.
- No need to do the same for RootSync, because the RootSync permissions are not managed by setupCentralizedControl.