### PR TITLE
Modify the Delete method in fake client

### DIFF
--- a/pkg/syncer/syncertest/fake/client.go
+++ b/pkg/syncer/syncertest/fake/client.go
@@ -380,10 +380,8 @@ func (c *Client) Delete(_ context.Context, obj client.Object, opts ...client.Del
 		return newConflictingResourceVersion(id, obj.GetResourceVersion(), cachedObj.GetResourceVersion())
 	}
 
-	// Copy latest values back to input object
-	obj.SetUID(cachedObj.GetUID())
-	obj.SetResourceVersion(cachedObj.GetResourceVersion())
-	obj.SetGeneration(cachedObj.GetGeneration())
+	// Delete method in real typed client(https://github.com/kubernetes-sigs/controller-runtime/blob/v0.14.1/pkg/client/typed_client.go#L84)
+	// does not copy the latest values back to input object which is different from other methods.
 
 	klog.V(5).Infof("Deleting %T %s (Generation: %v, ResourceVersion: %q): %s",
 		cachedObj, client.ObjectKeyFromObject(cachedObj),


### PR DESCRIPTION
To align with the real typed client, remove the logic to copy latest values back to input object from the Delete method.