### PR TITLE
add log/metric writing roles to compute account

### DIFF
--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -52,6 +52,8 @@ resource "google_project_iam_member" "gce-default-sa-iam" {
     "roles/source.reader",
     "roles/artifactregistry.reader",
     "roles/storage.objectViewer",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
   ])
 
   role    = each.value


### PR DESCRIPTION
this enables the compute account to write cloud logs and cloud monitoring metrics