### PR TITLE
Update git-sync version to 3.6.2 to clear vulnerabilities

### DIFF
--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -110,7 +110,7 @@ data:
                - NET_RAW
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.1-gke.2__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v3.6.2-gke.1__linux_amd64
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json", "--v=5"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
Bumped from https://github.com/kubernetes/git-sync/issues/644