### PR TITLE
fixup: dont use buildx for nomos image

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -100,7 +100,7 @@ build-images: license
 		--build-arg VERSION=${VERSION} \
 		.
 	@echo "+++ Building the Nomos image: $(NOMOS_TAG)"
-	@docker buildx build $(DOCKER_BUILD_QUIET) \
+	@docker build $(DOCKER_BUILD_QUIET) \
 		--target $(NOMOS_IMAGE) \
 		-t $(NOMOS_TAG) \
 		-f build/all/Dockerfile \


### PR DESCRIPTION
main switched all of the docker image builds to buildx, which happened after the 1.14 release branch was cut. We are seeing an issue with the build of this image in CI. This is a fixup to the cherry pick to use docker build instead.