### PR TITLE
make default VERSION and IMAGE_TAG the same

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TEST_GEN_YAML_DIR := $(OUTPUT_DIR)/test/yaml
 
 # Use git tags to set version string.
 ifeq ($(origin VERSION), undefined)
-VERSION := $(shell git describe --tags --always --dirty)
+VERSION := $(shell git describe --tags --always --dirty --long)
 endif
 
 # UID of current user


### PR DESCRIPTION
This passes the same options for the default value of VERSION and IMAGE_TAG. This ensures that the version the image is tagged with is the same as the version that the nomos binary is built with. This disparity was leading to a test failure when the HEAD commit has a tag.

This change does not alter the release functionality, since the release flows pass in a value rather than relying on the default.