### PR TITLE
Add RSync -> RoleBinding dependencies in e2e tests

### DIFF
--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -453,6 +453,22 @@ func (g *Repository) Remove(path string) {
 	g.Git("add", absPath)
 }
 
+// Exists returns true if the file or directory exists at the specified path.
+func (g *Repository) Exists(path string) bool {
+	g.T.Helper()
+
+	absPath := filepath.Join(g.Root, path)
+
+	_, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		g.T.Fatal(err)
+	}
+	return true
+}
+
 // CommitAndPush commits any changes to the git repository, and
 // pushes them to the git server.
 // We don't care about differentiating between committing and pushing


### PR DESCRIPTION
- Add Repository.Exists(path) to avoid fatal errors from Delete in a Cleanup block
- Fix TestComposition level-1 RootSync file location, so that it's correctly managed by level-0 and can depend on its RoleBinding
- Add nomostest.SetDependencies to simplify annotation construction
- Add TestMultiSyncs_Unstructured_MixedControl Cleanup to handle deletion ordering of dependencies between managed and unmanaged resources
