### PR TITLE
RoleBinding -> ClusterRoleBinding in e2e tests

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -410,10 +410,7 @@ func (nt *NT) DefaultRootSyncObjectCount() int {
 		numObjects++                             // 1 for the ClusterRole, shared by all RepoSyncs
 		numObjects += nt.NumRepoSyncNamespaces() // 1 for each unique RepoSync Namespace
 		numObjects += numRepoSyncs               // 1 for each RepoSync
-		numObjects += numRepoSyncs               // 1 for each RepoSync RoleBinding
-		if isPSPCluster() {
-			numObjects += numRepoSyncs // 1 for each RepoSync ClusterRoleBinding
-		}
+		numObjects += numRepoSyncs               // 1 for each RepoSync ClusterRoleBinding
 	}
 	return numObjects
 }


### PR DESCRIPTION
Using CRB, instead of RB, makes it easier to avoid deadlocks when deleting namespaces containing RepoSyncs with deletion propagation enabled. When using RBs, the RB and RepoSync are deleted at the same time, violating depends-on deletion ordering, because the namespace finalizer doesn't respect or know about dependencies.

Users can still use RoleBindings with RepoSyncs, and we still test that in a couple tests, but we may want to recommend using ClusterRoleBindings once the deletion propagation feature is promoted to a GA feature.
