### PR TITLE
Replace Wait with Watch (continued)

### DIFF
--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -148,11 +148,12 @@ func Clean(nt *NT, failOnError FailOnError) {
 		}
 
 		for _, u := range list {
-			if failOnError {
-				WaitForNotFound(nt, u.GroupVersionKind(), u.GetName(), u.GetNamespace())
-			} else {
-				WaitForNotFound(nt, u.GroupVersionKind(), u.GetName(), u.GetNamespace(),
-					WaitStrategy(WaitFailureStrategyLog))
+			if err := WatchForNotFound(nt, u.GroupVersionKind(), u.GetName(), u.GetNamespace()); err != nil {
+				if failOnError {
+					nt.T.Fatal(err)
+				} else {
+					nt.T.Error(err)
+				}
 			}
 		}
 	}
@@ -289,11 +290,12 @@ func deleteImplicitNamespaces(nt *NT, failOnError FailOnError) {
 				nt.T.Log(err)
 				errDeleting = true
 			}
-			if failOnError {
-				WaitForNotFound(nt, kinds.Namespace(), ns.Name, "")
-			} else {
-				WaitForNotFound(nt, kinds.Namespace(), ns.Name, "",
-					WaitStrategy(WaitFailureStrategyLog))
+			if err := WatchForNotFound(nt, kinds.Namespace(), ns.Name, ""); err != nil {
+				if failOnError {
+					nt.T.Fatal(err)
+				} else {
+					nt.T.Error(err)
+				}
 			}
 		}
 	}

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -518,7 +518,9 @@ func revokeRepoSyncClusterRoleBinding(nt *NT, nn types.NamespacedName) {
 		}
 		nt.T.Fatal(err)
 	}
-	WaitForNotFound(nt, kinds.ClusterRoleBinding(), nn.Name+"-"+nn.Namespace, "")
+	if err := WatchForNotFound(nt, kinds.ClusterRoleBinding(), nn.Name+"-"+nn.Namespace, ""); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func revokeRepoSyncNamespace(nt *NT, ns string) {
@@ -541,7 +543,9 @@ func revokeRepoSyncNamespace(nt *NT, ns string) {
 			nt.T.Fatal(err)
 		}
 	}
-	WaitForNotFound(nt, kinds.Namespace(), ns, "")
+	if err := WatchForNotFound(nt, kinds.Namespace(), ns, ""); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 // setReconcilerDebugMode ensures the Reconciler deployments are run in debug mode.
@@ -1173,8 +1177,12 @@ func deleteRootRepos(nt *NT) {
 		if err := nt.Delete(&rs); err != nil {
 			nt.T.Fatal(err)
 		}
-		WaitForNotFound(nt, kinds.Deployment(), core.RootReconcilerName(rs.Name), rs.Namespace)
-		WaitForNotFound(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace)
+		if err := WatchForNotFound(nt, kinds.Deployment(), core.RootReconcilerName(rs.Name), rs.Namespace); err != nil {
+			nt.T.Fatal(err)
+		}
+		if err := WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace); err != nil {
+			nt.T.Fatal(err)
+		}
 	}
 }
 
@@ -1199,7 +1207,9 @@ func deleteNamespaceRepos(nt *NT) {
 	if err := nt.Delete(rsClusterRole); err != nil && !apierrors.IsNotFound(err) {
 		nt.T.Fatal(err)
 	}
-	WaitForNotFound(nt, kinds.ClusterRole(), rsClusterRole.Name, "")
+	if err := WatchForNotFound(nt, kinds.ClusterRole(), rsClusterRole.Name, ""); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 // SetPolicyDir updates the root-sync object with the provided policyDir.

--- a/e2e/nomostest/wait.go
+++ b/e2e/nomostest/wait.go
@@ -25,7 +25,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
-	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
 // WaitOption is an optional parameter for Wait
@@ -88,26 +87,6 @@ func Wait(t testing.NTB, opName string, timeout time.Duration, condition func() 
 		}
 	}
 	t.Logf("took %v to wait for %s", took, opName)
-}
-
-// WaitForNotFound waits for the passed object to be fully deleted.
-// Immediately fails the test if the object is not deleted within the timeout.
-func WaitForNotFound(nt *NT, gvk schema.GroupVersionKind, name, namespace string, opts ...WaitOption) {
-	nt.T.Helper()
-
-	Wait(nt.T, fmt.Sprintf("wait for %q %v to be not found", name, gvk), nt.DefaultWaitTimeout, func() error {
-		u := &unstructured.Unstructured{}
-		u.SetGroupVersionKind(gvk)
-		return nt.ValidateNotFound(name, namespace, u)
-	}, opts...)
-}
-
-// WaitForCurrentStatus waits for the passed object to reconcile.
-func WaitForCurrentStatus(nt *NT, gvk schema.GroupVersionKind, name, namespace string, opts ...WaitOption) {
-	nt.T.Helper()
-	WatchForObject(nt, gvk, name, namespace,
-		[]Predicate{StatusEquals(nt, kstatus.CurrentStatus)},
-		opts...)
 }
 
 // WaitForConfigSyncReady validates if the config sync deployments are ready.

--- a/e2e/nomostest/watch.go
+++ b/e2e/nomostest/watch.go
@@ -19,82 +19,173 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/util/log"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// WatchForObject watches the specified object util all predicates return nil,
-// or the timeout is reached.
-func WatchForObject(nt *NT, gvk schema.GroupVersionKind, name, namespace string, predicates []Predicate, waitOpts ...WaitOption) {
-	nt.T.Helper()
+// WatchOption is an optional parameter for Watch
+type WatchOption func(watch *watchSpec)
 
-	startTime := time.Now()
-
-	wait := waitSpec{
-		timeout:         nt.DefaultWaitTimeout,
-		failureStrategy: WaitFailureStrategyFatal,
-	}
-	for _, opt := range waitOpts {
-		opt(&wait)
-	}
-
-	err := watchForObjectInner(nt, gvk, name, namespace, predicates, wait)
-	if err != nil {
-		took := time.Since(startTime)
-		nt.T.Logf("failed after %v watching for predicates to be satisfied", took)
-		switch wait.failureStrategy {
-		case WaitFailureStrategyFatal:
-			nt.T.Fatal(err)
-		case WaitFailureStrategyError:
-			nt.T.Error(err)
-		}
-		return
-	}
-	took := time.Since(startTime)
-	nt.T.Logf("took %v watching for predicates to be satisfied", took)
+type watchSpec struct {
+	timeout         time.Duration
+	errorOnNotFound bool
 }
 
-func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace string, predicates []Predicate, wait waitSpec) error {
-	nt.T.Helper()
+// WatchTimeout provides the timeout option to Watch.
+func WatchTimeout(timeout time.Duration) WatchOption {
+	return func(watch *watchSpec) {
+		watch.timeout = timeout
+	}
+}
 
-	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
-	rObj, err := nt.WatchClient.Scheme().New(listGVK)
+// watchErrorOnNotFound configures Watch to error if the object is deleted or
+// not found.
+// This is a private option. You probably want to use WatchForNotFound instead.
+func watchErrorOnNotFound() WatchOption {
+	return func(watch *watchSpec) {
+		watch.errorOnNotFound = true
+	}
+}
+
+// WatchObjectNotFoundError is returned by WatchObject when the watched object
+// is deleted or not found, if WatchErrorOnDelete is enabled.
+type WatchObjectNotFoundError struct {
+	GroupVersionKind schema.GroupVersionKind
+	Name             string
+	Namespace        string
+}
+
+func (wde *WatchObjectNotFoundError) Error() string {
+	return fmt.Sprintf("expected %s %s/%s to exist and continue to exist, but it was deleted or not found",
+		wde.GroupVersionKind.Kind, wde.Namespace, wde.Name)
+}
+
+// WatchObject watches the specified object util all predicates return nil,
+// or the timeout is reached. Object does not need to exist yet, as long as the
+// resource type exists.
+func WatchObject(nt *NT, gvk schema.GroupVersionKind, name, namespace string, predicates []Predicate, opts ...WatchOption) error {
+	errPrefix := fmt.Sprintf("WatchObject(%s %s/%s)", gvk.Kind, namespace, name)
+
+	startTime := time.Now()
+	defer func() {
+		took := time.Since(startTime)
+		nt.T.Logf("%s watched for %v", errPrefix, took)
+	}()
+
+	spec := watchSpec{
+		timeout: nt.DefaultWaitTimeout,
+	}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+
+	cObjList, err := newObjectListForObjectKind(gvk, nt.scheme)
 	if err != nil {
 		return err
 	}
-	cObjList, ok := rObj.(client.ObjectList)
-	if !ok {
-		return fmt.Errorf("%w: got %T, want client.Object", ErrWrongType, rObj)
-	}
 
 	var listOpts []client.ListOption
+	listOpts = append(listOpts, client.MatchingFieldsSelector{
+		Selector: fields.OneTermEqualSelector("metadata.name", name),
+	})
 	if namespace != "" {
 		listOpts = append(listOpts, client.InNamespace(namespace))
 	}
 
-	ctx, cancel := context.WithTimeout(nt.Context, wait.timeout)
+	ctx, cancel := context.WithTimeout(nt.Context, spec.timeout)
 	defer cancel()
+
+	// Use LIST with a single-object selector, instead of GET, because we want
+	// the resource version of the LIST response to start the watch with, so we
+	// don't miss any updates.
+
+	// Use the Client, instead of the WatchClient, because it has a shorter timeout.
+	err = nt.Client.List(ctx, cObjList, listOpts...)
+	if err != nil {
+		return err
+	}
+	// The Items field of a ObjectList is a typed array.
+	// So we have to use reflection to get the items out.
+	items, err := meta.ExtractList(cObjList)
+	if err != nil {
+		return errors.Wrapf(err, "%s unable to understand list result %#v",
+			errPrefix, cObjList)
+	}
+	// Iterate through the list to find the desired object, if it exists
+	var prevObj client.Object
+	for _, rObj := range items {
+		cObj, ok := rObj.(client.Object)
+		if !ok {
+			return errors.Wrapf(
+				WrongTypeErr(rObj, client.Object(nil)),
+				"%s unexpected list item type", errPrefix)
+		}
+		if cObj.GetName() != name {
+			// Ignore other objects, if any.
+			// Should never happen, due to name selector.
+			continue
+		}
+		prevObj = cObj
+		break
+	}
+	if prevObj == nil {
+		if spec.errorOnNotFound {
+			return &WatchObjectNotFoundError{
+				GroupVersionKind: gvk,
+				Name:             name,
+				Namespace:        namespace,
+			}
+		}
+		nt.DebugLogf("%s GET Not Found", errPrefix)
+	} else {
+		// Log the initial/current state as a diff to make it easy to compare with update diffs.
+		// Use diff.Diff because it doesn't truncate like cmp.Diff does.
+		// Use log.AsYAMLWithScheme to get the full scheme-consistent YAML with GVK.
+		nt.DebugLogf("%s GET Diff (+ Current):\n%s",
+			errPrefix, log.AsYAMLDiffWithScheme(nil, prevObj, nt.scheme))
+	}
+
+	rv := cObjList.GetResourceVersion()
+
+	// Create a new empty list to use with WATCH
+	cObjList, err = newObjectListForObjectKind(gvk, nt.scheme)
+	if err != nil {
+		return err
+	}
+
+	// Specify ResourceVersion to ensure the Watch starts where the List stopped.
+	cObjList.SetResourceVersion(rv)
+
+	// Use the WatchClient, instead of the Client, because it has a longer timeout.
 	result, err := nt.WatchClient.Watch(ctx, cObjList, listOpts...)
 	defer result.Stop()
 	if err != nil {
 		return err
 	}
 
-	var prevObj client.Object
+	// Save the predicate errors from the last state change and return them
+	// if the watch closes before the predicates all pass.
 	var prevErrs []error
 
 	for event := range result.ResultChan() {
 		rObj := event.Object
 		cObj, ok := rObj.(client.Object)
 		if !ok {
-			return errors.Errorf("expected event object of type client.Object but got %T", rObj)
+			return errors.Errorf("%s expected event object of type client.Object but got %T",
+				errPrefix, rObj)
 		}
 		if cObj.GetName() != name {
 			// Ignore events for other objects, if any.
+			// Should never happen, due to name selector.
 			continue
 		}
 
@@ -102,12 +193,24 @@ func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace st
 		case watch.Bookmark:
 			// do nothing
 		case watch.Deleted:
-			nt.DebugLogf("WatchObject(%s) Diff (- Old, + New)\n%s",
-				event.Type, cmp.Diff(prevObj, nil))
+			nt.DebugLogf("%s %s", errPrefix, event.Type)
 			prevObj = nil
+			if spec.errorOnNotFound {
+				return &WatchObjectNotFoundError{
+					GroupVersionKind: gvk,
+					Name:             name,
+					Namespace:        namespace,
+				}
+			}
 		case watch.Added, watch.Modified:
-			nt.DebugLogf("WatchObject(%s) Diff (- Old, + New)\n%s",
-				event.Type, cmp.Diff(prevObj, cObj))
+			eType := event.Type
+			if eType == watch.Added && prevObj != nil {
+				// Added to cache for the first time, but not to k8s
+				eType = watch.Modified
+			}
+			nt.DebugLogf("%s %s Diff (- Removed, + Added):\n%s",
+				errPrefix, eType,
+				log.AsYAMLDiffWithScheme(prevObj, cObj, nt.scheme))
 			var errs []error
 			for _, predicate := range predicates {
 				if err := predicate(cObj); err != nil {
@@ -121,9 +224,11 @@ func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace st
 			prevErrs = errs
 			prevObj = cObj
 		case watch.Error:
-			return errors.Errorf("watch error: %+v", event)
+			return errors.Errorf("%s received error event: %#v",
+				errPrefix, event)
 		default:
-			return errors.Errorf("unexpected watch event type %q", event.Type)
+			return errors.Errorf("%s received unexpected event: %#v",
+				errPrefix, event)
 		}
 	}
 
@@ -131,5 +236,55 @@ func watchForObjectInner(nt *NT, gvk schema.GroupVersionKind, name, namespace st
 		// watch exited with predicate errors
 		return multierr.Combine(prevErrs...)
 	}
-	return errors.Errorf("watch exited before any add/update events were recieved")
+	return errors.Errorf("%s exited before any add/update events were received",
+		errPrefix)
+}
+
+// WatchForCurrentStatus watches the object until it reconciles (Current).
+func WatchForCurrentStatus(nt *NT, gvk schema.GroupVersionKind, name, namespace string, opts ...WatchOption) error {
+	return WatchObject(nt, gvk, name, namespace,
+		[]Predicate{StatusEquals(nt, kstatus.CurrentStatus)},
+		opts...)
+}
+
+// WatchForNotFound waits for the passed object to be fully deleted or not found.
+// Returns an error if the object is not deleted within the timeout.
+func WatchForNotFound(nt *NT, gvk schema.GroupVersionKind, name, namespace string, opts ...WatchOption) error {
+	opts = append(opts, watchErrorOnNotFound())
+	err := WatchObject(nt, gvk, name, namespace,
+		[]Predicate{objectNotFoundPredicate},
+		opts...)
+	if err == nil {
+		// Should never happen!
+		panic("WatchForNotFound exited without error or timeout")
+	}
+	if nfe := (&WatchObjectNotFoundError{}); errors.As(err, &nfe) {
+		// yay!
+		return nil
+	}
+	return err
+}
+
+// objectNotFound always returns an error.
+// This is a dummy predicate which will cause WatchOject to continue watching
+// until another error or timeout is reached.
+// If you see this error, the timeout was probably reached.
+func objectNotFoundPredicate(o client.Object) error {
+	return errors.Errorf("expected %T object %s to be not found",
+		o, core.ObjectNamespacedName(o))
+}
+
+func newObjectListForObjectKind(gvk schema.GroupVersionKind, scheme *runtime.Scheme) (client.ObjectList, error) {
+	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
+	rObjList, err := scheme.New(listGVK)
+	if err != nil {
+		return nil, err
+	}
+	cObjList, ok := rObjList.(client.ObjectList)
+	if !ok {
+		return nil, errors.Wrapf(
+			WrongTypeErr(rObjList, client.ObjectList(nil)),
+			"list type is invalid: %s", listGVK)
+	}
+	return cObjList, nil
 }

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -113,8 +113,12 @@ func TestPublicHelm(t *testing.T) {
 	// if err := nt.Validate("my-ingress-nginx-controller", configsync.DefaultHelmReleaseNamespace, &appsv1.Deployment{}); err != nil {
 	// 	nt.T.Error(err)
 	// }
-	nomostest.WaitForCurrentStatus(nt, kinds.Deployment(), "my-ingress-nginx-controller", configsync.DefaultHelmReleaseNamespace)
-	nomostest.WaitForNotFound(nt, kinds.Deployment(), "my-ingress-nginx-controller", "ingress-nginx")
+	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), "my-ingress-nginx-controller", configsync.DefaultHelmReleaseNamespace); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nomostest.WatchForNotFound(nt, kinds.Deployment(), "my-ingress-nginx-controller", "ingress-nginx"); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 // TestHelmNamespaceRepo verifies RepoSync does not sync the helm chart with cluster-scoped resources. It also verifies that RepoSync can successfully

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -87,7 +87,9 @@ metadata:
 	}
 
 	// Config Sync should remove `test-ns1`.
-	nomostest.WaitForNotFound(nt, kinds.Namespace(), "test-ns1", "")
+	if err := nomostest.WatchForNotFound(nt, kinds.Namespace(), "test-ns1", ""); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	/* A new test */
 	ns = []byte(`
@@ -223,7 +225,9 @@ data:
 	}
 
 	// Config Sync should remove `test-ns`.
-	nomostest.WaitForNotFound(nt, kinds.ConfigMap(), "test-cm1", "bookstore")
+	if err := nomostest.WatchForNotFound(nt, kinds.ConfigMap(), "test-cm1", "bookstore"); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	/* A new test */
 	cm = []byte(`

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -723,10 +724,10 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].RemoveSafetyNamespace()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("undeclare all Namespaces")
 
-	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
-		[]nomostest.Predicate{
+	require.NoError(nt.T,
+		nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []nomostest.Predicate{
 			nomostest.RootSyncHasSyncError(nt, status.EmptySourceErrorCode, ""),
-		})
+		}))
 
 	// Wait 10 seconds before checking the namespaces.
 	// Checking the namespaces immediately may not catch the case where

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -43,10 +44,10 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 		[]byte(`{"spec": {"override": {"reconcileTimeout": "30s"}}}`))); err != nil {
 		nt.T.Fatal(err)
 	}
-	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
-		[]nomostest.Predicate{
+	require.NoError(nt.T,
+		nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []nomostest.Predicate{
 			nomostest.RootSyncHasObservedGenerationNoLessThan(rootSync.Generation),
-		})
+		}))
 	nt.WaitForRepoSyncs()
 	// Pre-provision a low priority workload to force the cluster to scale up.
 	// Later, when the real workload is being scheduled, if there's no more resources available
@@ -57,10 +58,10 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 		nt.T.Cleanup(func() {
 			nt.MustKubectl("delete", "-f", "../testdata/low-priority-pause-deployment.yaml", "--ignore-not-found")
 		})
-		nomostest.WatchForObject(nt, kinds.Deployment(), "pause-deployment", "default",
-			[]nomostest.Predicate{
+		require.NoError(nt.T,
+			nomostest.WatchObject(nt, kinds.Deployment(), "pause-deployment", "default", []nomostest.Predicate{
 				nomostest.StatusEquals(nt, kstatus.CurrentStatus),
-			})
+			}))
 	}
 
 	namespaceName := "timeout-1"
@@ -106,10 +107,10 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 		[]byte(`{"spec": {"override": {"reconcileTimeout": "5m"}}}`))); err != nil {
 		nt.T.Fatal(err)
 	}
-	nomostest.WatchForObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
-		[]nomostest.Predicate{
+	require.NoError(nt.T,
+		nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []nomostest.Predicate{
 			nomostest.RootSyncHasObservedGenerationNoLessThan(rootSync.Generation),
-		})
+		}))
 	nt.WaitForRepoSyncs()
 
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/pod-1.yaml")

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/e2e/nomostest"
@@ -330,10 +331,10 @@ func TestCACertSecretWatch(t *testing.T) {
 	// Modify the secret in c-m-s namespace
 	nt.MustMergePatch(cmsSecret, secretDataPatch("foo", "bar"))
 	// Check that watch triggered resync of the c-m-s secret
-	nomostest.WatchForObject(nt, kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem,
-		[]nomostest.Predicate{
+	require.NoError(nt.T,
+		nomostest.WatchObject(nt, kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem, []nomostest.Predicate{
 			nomostest.SecretMissingKey("foo"),
-		})
+		}))
 	// Modify the secret in RepoSync namespace
 	rsSecret := &corev1.Secret{}
 	err = nt.Validate(caCertSecret, backendNamespace, rsSecret)
@@ -342,10 +343,10 @@ func TestCACertSecretWatch(t *testing.T) {
 	}
 	nt.MustMergePatch(rsSecret, secretDataPatch("baz", "bat"))
 	// Check that the watch triggered upsert to c-m-s secret
-	nomostest.WatchForObject(nt, kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem,
-		[]nomostest.Predicate{
+	require.NoError(nt.T,
+		nomostest.WatchObject(nt, kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem, []nomostest.Predicate{
 			nomostest.SecretHasKey("baz", "bat"),
-		})
+		}))
 	// Unset caCertSecret for repoSyncBackend and use SSH
 	repoSyncSSHURL := nt.GitProvider.SyncURL(nt.NonRootRepos[nn].RemoteRepoName)
 	repoSyncBackend.Spec.Git.Repo = repoSyncSSHURL

--- a/pkg/util/log/stringer.go
+++ b/pkg/util/log/stringer.go
@@ -132,9 +132,13 @@ func AsYAMLDiffWithScheme(old, new runtime.Object, scheme *runtime.Scheme) fmt.S
 // Uses diff.Diff to print full yaml, instead of cmp.Diff which truncates.
 func (yds *yamlDiffStringer) String() string {
 	if yds.Scheme != nil {
+		// Must be either runtime.Object or nil.
+		// Don't panic trying to cast nil interface{} to runtime.Object.
+		old, _ := yds.Old.(runtime.Object)
+		new, _ := yds.New.(runtime.Object)
 		return diff.Diff(
-			AsYAMLWithScheme(yds.Old.(runtime.Object), yds.Scheme).String(),
-			AsYAMLWithScheme(yds.New.(runtime.Object), yds.Scheme).String())
+			AsYAMLWithScheme(old, yds.Scheme).String(),
+			AsYAMLWithScheme(new, yds.Scheme).String())
 	}
 	return diff.Diff(AsYAML(yds.Old).String(), AsYAML(yds.New).String())
 }

--- a/pkg/util/log/stringer_test.go
+++ b/pkg/util/log/stringer_test.go
@@ -269,6 +269,24 @@ func TestAsYAMLDiff(t *testing.T) {
  Namespace: ""
  `,
 		},
+		{
+			name: "nil vs typed",
+			old:  nil,
+			new: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+			},
+			expectedOutput: `-null
++apiVersion: v1
++kind: Namespace
++metadata:
++  creationTimestamp: null
++  name: example
++spec: {}
++status: {}
+ `,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- Rename WatchForObject to WatchObject
- Update WatchObject to List before Watch, to get the current state,
  instead of needing to wait for the next change.
- Update Watch funcs to return an error, instead of calling Error or
  Fatal. This makes it possible to use in parallel and in Clean/Reset
  where test failure is undesirable.
- Update Watch to use log.AsYAMLDiff, for non-truncating diffs that are
  only computed if debug is enabled.
- Replace WaitForNotFound with WatchForNotFound. This makes it faster
  and easier to debug (diffs logged for each state change)
- Update log.AsYAMLDiff to work with nil objects

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/362
