### PR TITLE
Add log.AsYAML and log.AsYAMLDiff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-containerregistry v0.11.0
 	github.com/google/uuid v1.3.0
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
+	github.com/kylelemons/godebug v1.1.0
 	github.com/open-policy-agent/cert-controller v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kulti/thelper v0.4.0/go.mod h1:vMu2Cizjy/grP+jmsvOFDx1kYP6+PD1lqg4Yu5exl2U=
 github.com/kunwardeep/paralleltest v1.0.3/go.mod h1:vLydzomDFpk7yu5UX02RmP0H8QfRPOV/oFhWN85Mjb4=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/ldez/gomoddirectives v0.2.2/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=

--- a/pkg/util/log/stringer.go
+++ b/pkg/util/log/stringer.go
@@ -17,7 +17,14 @@ package log
 import (
 	"fmt"
 
+	"github.com/kylelemons/godebug/diff"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	jserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/json"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/yaml"
 )
 
 type jsonStringer struct {
@@ -31,11 +38,103 @@ func AsJSON(o interface{}) fmt.Stringer {
 	return &jsonStringer{O: o}
 }
 
-// Returns the object as json, or the error string if marshalling fails.
+// String returns the object as json, or the error string if marshalling fails.
 func (ojs *jsonStringer) String() string {
 	bytes, err := json.Marshal(ojs.O)
 	if err != nil {
 		return err.Error()
 	}
 	return string(bytes)
+}
+
+type yamlStringer struct {
+	O      interface{}
+	Scheme *runtime.Scheme
+}
+
+// AsYAML returns a new stringer object that delays marshaling until the
+// String method is called. For logging at higher verbosity levels, to
+// avoid formatting when the output isn't going to be used.
+// The primary use is for logging Kubernetes objects, but should also work
+// with other types, like Go structs.
+func AsYAML(o interface{}) fmt.Stringer {
+	return &yamlStringer{O: o}
+}
+
+// AsYAMLWithScheme is similar to AsYAML, except it allows specifying which
+// scheme to use to encode the object, instead of defaulting to the global
+// `core.Scheme`.
+func AsYAMLWithScheme(obj runtime.Object, scheme *runtime.Scheme) fmt.Stringer {
+	return &yamlStringer{O: obj, Scheme: scheme}
+}
+
+// String returns the object as yaml, or the error string if marshalling fails.
+func (oys *yamlStringer) String() string {
+	// Use scheme-aware serialization, if possible.
+	// This adds type fields and orders consistently.
+	if rObj, ok := oys.O.(runtime.Object); ok {
+		scheme := oys.Scheme
+		// Default to the global scheme, if unspecified
+		if scheme == nil {
+			scheme = core.Scheme
+		}
+		// Make best effort to ensure GVK is set
+		_, isUnstructured := rObj.(*unstructured.Unstructured)
+		if !isUnstructured && rObj.GetObjectKind().GroupVersionKind().Empty() {
+			gvk, err := kinds.Lookup(rObj, scheme)
+			// do nothing if lookup errors
+			if err == nil {
+				// copy the object to avoid side effects
+				rObj = rObj.DeepCopyObject()
+				rObj.GetObjectKind().SetGroupVersionKind(gvk)
+			}
+		}
+		// Encode
+		yamlSerializer := jserializer.NewYAMLSerializer(jserializer.DefaultMetaFactory, scheme, scheme)
+		bytes, err := runtime.Encode(yamlSerializer, rObj)
+		if err != nil {
+			return err.Error()
+		}
+		return string(bytes)
+	}
+	// Default to general yaml serializer
+	bytes, err := yaml.Marshal(oys.O)
+	if err != nil {
+		return err.Error()
+	}
+	return string(bytes)
+}
+
+type yamlDiffStringer struct {
+	Old, New interface{}
+	Scheme   *runtime.Scheme
+}
+
+// AsYAMLDiff returns a new stringer object that delays marshaling and diffing
+// until the String method is called. For logging at higher verbosity levels, to
+// avoid formatting when the output isn't going to be used.
+// The primary use is for comparing two Kubernetes objects, but should also work
+// with other types, like Go structs.
+// Does not do any object type or version conversion.
+func AsYAMLDiff(old, new interface{}) fmt.Stringer {
+	return &yamlDiffStringer{Old: old, New: new}
+}
+
+// AsYAMLDiffWithScheme is similar to AsYAMLDiff, except it allows specifying
+// which scheme to use to encode the objects, instead of defaulting to the
+// global `core.Scheme`.
+func AsYAMLDiffWithScheme(old, new runtime.Object, scheme *runtime.Scheme) fmt.Stringer {
+	return &yamlDiffStringer{Old: old, New: new, Scheme: scheme}
+}
+
+// String returns a diff (- Removed, + Added) of the objects as yaml, or the
+// error string if marshalling fails.
+// Uses diff.Diff to print full yaml, instead of cmp.Diff which truncates.
+func (yds *yamlDiffStringer) String() string {
+	if yds.Scheme != nil {
+		return diff.Diff(
+			AsYAMLWithScheme(yds.Old.(runtime.Object), yds.Scheme).String(),
+			AsYAMLWithScheme(yds.New.(runtime.Object), yds.Scheme).String())
+	}
+	return diff.Diff(AsYAML(yds.Old).String(), AsYAML(yds.New).String())
 }

--- a/pkg/util/log/stringer_test.go
+++ b/pkg/util/log/stringer_test.go
@@ -1,0 +1,280 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/core"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAsYAML(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          interface{}
+		expectedOutput string
+	}{
+		{
+			name: "typed Namespace",
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+			},
+			expectedOutput: `apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: example
+spec: {}
+status: {}
+`,
+		},
+		{
+			name: "unstructured namespace",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "example",
+					},
+				},
+			},
+			expectedOutput: `apiVersion: v1
+kind: Namespace
+metadata:
+  name: example
+`,
+		},
+		{
+			name: "unstructured object missing kind",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name": "example",
+					},
+				},
+			},
+			expectedOutput: `apiVersion: v1
+metadata:
+  name: example
+`,
+		},
+		{
+			name: "core.ID (non-object compound struct)",
+			input: core.ID{
+				GroupKind: schema.GroupKind{
+					Group: "",
+					Kind:  "Namespace",
+				},
+				ObjectKey: client.ObjectKey{
+					Name:      "example",
+					Namespace: "",
+				},
+			},
+			expectedOutput: `Group: ""
+Kind: Namespace
+Name: example
+Namespace: ""
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := AsYAML(tc.input).String()
+			testutil.AssertEqual(t, tc.expectedOutput, out)
+		})
+	}
+}
+
+func TestAsYAMLDiff(t *testing.T) {
+	testCases := []struct {
+		name           string
+		old, new       interface{}
+		expectedOutput string
+	}{
+		{
+			name: "typed Namespace no diff",
+			old: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+			},
+			new: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+			},
+			expectedOutput: ``, // empty-string means no diff
+		},
+		{
+			name: "typed Namespace with diff",
+			old: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+					Labels: map[string]string{
+						"key1": "value1",
+					},
+				},
+			},
+			new: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+					Labels: map[string]string{
+						"key2": "value2",
+					},
+				},
+			},
+			expectedOutput: ` apiVersion: v1
+ kind: Namespace
+ metadata:
+   creationTimestamp: null
+   labels:
+-    key1: value1
++    key2: value2
+   name: example
+ spec: {}
+ status: {}
+ `,
+		},
+		{
+			name: "unstructured namespace with no diff",
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "example",
+					},
+				},
+			},
+			new: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "example",
+					},
+				},
+			},
+			expectedOutput: ``, // empty-string means no diff
+		},
+		{
+			name: "unstructured namespace with diff",
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "example",
+						"labels": map[string]string{
+							"key1": "value1",
+						},
+					},
+				},
+			},
+			new: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "example",
+						"labels": map[string]string{
+							"key2": "value2",
+						},
+					},
+				},
+			},
+			expectedOutput: ` apiVersion: v1
+ kind: Namespace
+ metadata:
+   labels:
+-    key1: value1
++    key2: value2
+   name: example
+ `,
+		},
+		{
+			name: "core.ID (non-object compound struct) with no diff",
+			old: core.ID{
+				GroupKind: schema.GroupKind{
+					Group: "",
+					Kind:  "Namespace",
+				},
+				ObjectKey: client.ObjectKey{
+					Name:      "example",
+					Namespace: "",
+				},
+			},
+			new: core.ID{
+				GroupKind: schema.GroupKind{
+					Group: "",
+					Kind:  "Namespace",
+				},
+				ObjectKey: client.ObjectKey{
+					Name:      "example",
+					Namespace: "",
+				},
+			},
+			expectedOutput: ``,
+		},
+		{
+			name: "core.ID (non-object compound struct) with diff",
+			old: core.ID{
+				GroupKind: schema.GroupKind{
+					Group: "",
+					Kind:  "Namespace",
+				},
+				ObjectKey: client.ObjectKey{
+					Name:      "example",
+					Namespace: "",
+				},
+			},
+			new: core.ID{
+				GroupKind: schema.GroupKind{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+				ObjectKey: client.ObjectKey{
+					Name:      "example",
+					Namespace: "",
+				},
+			},
+			expectedOutput: `-Group: ""
+-Kind: Namespace
++Group: apps
++Kind: Deployment
+ Name: example
+ Namespace: ""
+ `,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := AsYAMLDiff(tc.old, tc.new).String()
+			testutil.AssertEqual(t, tc.expectedOutput, out)
+		})
+	}
+}

--- a/vendor/github.com/kylelemons/godebug/LICENSE
+++ b/vendor/github.com/kylelemons/godebug/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kylelemons/godebug/diff/diff.go
+++ b/vendor/github.com/kylelemons/godebug/diff/diff.go
@@ -1,0 +1,186 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diff implements a linewise diff algorithm.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Chunk represents a piece of the diff.  A chunk will not have both added and
+// deleted lines.  Equal lines are always after any added or deleted lines.
+// A Chunk may or may not have any lines in it, especially for the first or last
+// chunk in a computation.
+type Chunk struct {
+	Added   []string
+	Deleted []string
+	Equal   []string
+}
+
+func (c *Chunk) empty() bool {
+	return len(c.Added) == 0 && len(c.Deleted) == 0 && len(c.Equal) == 0
+}
+
+// Diff returns a string containing a line-by-line unified diff of the linewise
+// changes required to make A into B.  Each line is prefixed with '+', '-', or
+// ' ' to indicate if it should be added, removed, or is correct respectively.
+func Diff(A, B string) string {
+	aLines := strings.Split(A, "\n")
+	bLines := strings.Split(B, "\n")
+
+	chunks := DiffChunks(aLines, bLines)
+
+	buf := new(bytes.Buffer)
+	for _, c := range chunks {
+		for _, line := range c.Added {
+			fmt.Fprintf(buf, "+%s\n", line)
+		}
+		for _, line := range c.Deleted {
+			fmt.Fprintf(buf, "-%s\n", line)
+		}
+		for _, line := range c.Equal {
+			fmt.Fprintf(buf, " %s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// DiffChunks uses an O(D(N+M)) shortest-edit-script algorithm
+// to compute the edits required from A to B and returns the
+// edit chunks.
+func DiffChunks(a, b []string) []Chunk {
+	// algorithm: http://www.xmailserver.org/diff2.pdf
+
+	// We'll need these quantities a lot.
+	alen, blen := len(a), len(b) // M, N
+
+	// At most, it will require len(a) deletions and len(b) additions
+	// to transform a into b.
+	maxPath := alen + blen // MAX
+	if maxPath == 0 {
+		// degenerate case: two empty lists are the same
+		return nil
+	}
+
+	// Store the endpoint of the path for diagonals.
+	// We store only the a index, because the b index on any diagonal
+	// (which we know during the loop below) is aidx-diag.
+	// endpoint[maxPath] represents the 0 diagonal.
+	//
+	// Stated differently:
+	// endpoint[d] contains the aidx of a furthest reaching path in diagonal d
+	endpoint := make([]int, 2*maxPath+1) // V
+
+	saved := make([][]int, 0, 8) // Vs
+	save := func() {
+		dup := make([]int, len(endpoint))
+		copy(dup, endpoint)
+		saved = append(saved, dup)
+	}
+
+	var editDistance int // D
+dLoop:
+	for editDistance = 0; editDistance <= maxPath; editDistance++ {
+		// The 0 diag(onal) represents equality of a and b.  Each diagonal to
+		// the left is numbered one lower, to the right is one higher, from
+		// -alen to +blen.  Negative diagonals favor differences from a,
+		// positive diagonals favor differences from b.  The edit distance to a
+		// diagonal d cannot be shorter than d itself.
+		//
+		// The iterations of this loop cover either odds or evens, but not both,
+		// If odd indices are inputs, even indices are outputs and vice versa.
+		for diag := -editDistance; diag <= editDistance; diag += 2 { // k
+			var aidx int // x
+			switch {
+			case diag == -editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath-editDistance+1] + 0
+			case diag == editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath+editDistance-1] + 1
+			case endpoint[maxPath+diag+1] > endpoint[maxPath+diag-1]:
+				// diagonal d+1 was farther along, so use that
+				aidx = endpoint[maxPath+diag+1] + 0
+			default:
+				// diagonal d-1 was farther (or the same), so use that
+				aidx = endpoint[maxPath+diag-1] + 1
+			}
+			// On diagonal d, we can compute bidx from aidx.
+			bidx := aidx - diag // y
+			// See how far we can go on this diagonal before we find a difference.
+			for aidx < alen && bidx < blen && a[aidx] == b[bidx] {
+				aidx++
+				bidx++
+			}
+			// Store the end of the current edit chain.
+			endpoint[maxPath+diag] = aidx
+			// If we've found the end of both inputs, we're done!
+			if aidx >= alen && bidx >= blen {
+				save() // save the final path
+				break dLoop
+			}
+		}
+		save() // save the current path
+	}
+	if editDistance == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, editDistance+1)
+
+	x, y := alen, blen
+	for d := editDistance; d > 0; d-- {
+		endpoint := saved[d]
+		diag := x - y
+		insert := diag == -d || (diag != d && endpoint[maxPath+diag-1] < endpoint[maxPath+diag+1])
+
+		x1 := endpoint[maxPath+diag]
+		var x0, xM, kk int
+		if insert {
+			kk = diag + 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0
+		} else {
+			kk = diag - 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0 + 1
+		}
+		y0 := x0 - kk
+
+		var c Chunk
+		if insert {
+			c.Added = b[y0:][:1]
+		} else {
+			c.Deleted = a[x0:][:1]
+		}
+		if xM < x1 {
+			c.Equal = a[xM:][:x1-xM]
+		}
+
+		x, y = x0, y0
+		chunks[d] = c
+	}
+	if x > 0 {
+		chunks[0].Equal = a[:x]
+	}
+	if chunks[0].empty() {
+		chunks = chunks[1:]
+	}
+	if len(chunks) == 0 {
+		return nil
+	}
+	return chunks
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,6 +254,9 @@ github.com/klauspost/compress/internal/cpuinfo
 github.com/klauspost/compress/internal/snapref
 github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
+# github.com/kylelemons/godebug v1.1.0
+## explicit; go 1.11
+github.com/kylelemons/godebug/diff
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter


### PR DESCRIPTION
- Use the Stringer pattern (like the existing log.AsJSON) to avoid expensive diffing and serializing of objects, for logging with configurable verbosity.
- Use github.com/kylelemons/godebug/diff for diffing, because it doesn't truncate the way cmp.Diff does.
- Use the (configurable) scheme to lookup object GKV from its type and encode YAML, if possible. Fallback to yaml.Marshal for other Go types.