### PR TITLE
Stream e2e log output

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -40,7 +40,12 @@ test-e2e-go-nobuild:
 .PHONY: test-e2e-kind-multi-repo
 test-e2e-kind-multi-repo: config-sync-manifest-local
 	kind delete clusters --all
-	GCP_PROJECT=$(GCP_PROJECT) ./scripts/e2e-kind.sh --timeout 60m --parallel 15 $(E2E_ARGS)
+	GCP_PROJECT=$(GCP_PROJECT) ./scripts/e2e-kind.sh \
+		--timeout 60m \
+		--test.v -v \
+		--parallel 15 \
+		--p 1 \
+		$(E2E_ARGS)
 
 # This target runs the first group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group1

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -33,11 +33,13 @@ __docker-run-e2e-go-gke: config-sync-manifest __build-e2e-go-container
 		--env GCP_REGION=$(GCP_REGION) \
 		--network=host \
 		nomos-gcloud-image \
-		./build/test-e2e-go/e2e.sh $(E2E_ARGS) \
+		./build/test-e2e-go/e2e.sh \
 			--timeout $(GKE_E2E_TIMEOUT) \
+			--test.v -v \
 			--parallel 1 \
 			--p 1 \
-			--test-cluster=gke
+			--test-cluster=gke \
+			$(E2E_ARGS)
 
 # The CI target that runs the golang e2e test on a GKE cluster in prow with various E2E_ARGS.
 # Examples:


### PR DESCRIPTION
Streaming requires test verbosity and one package at a time, but still allows any number of parallel tests.