### PR TITLE
Escape the newline character in the apply/reconcile log

### DIFF
--- a/pkg/applier/status.go
+++ b/pkg/applier/status.go
@@ -57,7 +57,7 @@ func (m ObjectStatusMap) Log(logger infofLogger) {
 	var b strings.Builder
 	for i, status := range actuationStatuses {
 		if i > 0 {
-			b.WriteString(commaNewlineDelimiter)
+			b.WriteString(commaEscapedNewlineDelimiter)
 		}
 		ids := m.Filter(actuation.ActuationStrategyApply, status, -1)
 		count += len(ids)
@@ -66,14 +66,14 @@ func (m ObjectStatusMap) Log(logger infofLogger) {
 	if count == 0 {
 		logger.Infof("Apply Actuations (Total: %d)", count)
 	} else {
-		logger.Infof("Apply Actuations (Total: %d):\n%s", count, b.String())
+		logger.Infof("Apply Actuations (Total: %d):\\n%s", count, b.String())
 	}
 
 	count = 0
 	b.Reset()
 	for i, status := range reconcileStatuses {
 		if i > 0 {
-			b.WriteString(commaNewlineDelimiter)
+			b.WriteString(commaEscapedNewlineDelimiter)
 		}
 		ids := m.Filter(actuation.ActuationStrategyApply, -1, status)
 		count += len(ids)
@@ -82,14 +82,14 @@ func (m ObjectStatusMap) Log(logger infofLogger) {
 	if count == 0 {
 		logger.Infof("Apply Reconciles (Total: %d)", count)
 	} else {
-		logger.Infof("Apply Reconciles (Total: %d):\n%s", count, b.String())
+		logger.Infof("Apply Reconciles (Total: %d):\\n%s", count, b.String())
 	}
 
 	count = 0
 	b.Reset()
 	for i, status := range actuationStatuses {
 		if i > 0 {
-			b.WriteString(commaNewlineDelimiter)
+			b.WriteString(commaEscapedNewlineDelimiter)
 		}
 		ids := m.Filter(actuation.ActuationStrategyDelete, status, -1)
 		count += len(ids)
@@ -98,14 +98,14 @@ func (m ObjectStatusMap) Log(logger infofLogger) {
 	if count == 0 {
 		logger.Infof("Delete Actuations (Total: %d)", count)
 	} else {
-		logger.Infof("Delete Actuations (Total: %d):\n%s", count, b.String())
+		logger.Infof("Delete Actuations (Total: %d):\\n%s", count, b.String())
 	}
 
 	count = 0
 	b.Reset()
 	for i, status := range reconcileStatuses {
 		if i > 0 {
-			b.WriteString(commaNewlineDelimiter)
+			b.WriteString(commaEscapedNewlineDelimiter)
 		}
 		ids := m.Filter(actuation.ActuationStrategyDelete, -1, status)
 		count += len(ids)
@@ -114,7 +114,7 @@ func (m ObjectStatusMap) Log(logger infofLogger) {
 	if count == 0 {
 		logger.Infof("Delete Reconciles (Total: %d)", count)
 	} else {
-		logger.Infof("Delete Reconciles (Total: %d):\n%s", count, b.String())
+		logger.Infof("Delete Reconciles (Total: %d):\\n%s", count, b.String())
 	}
 }
 

--- a/pkg/applier/status_test.go
+++ b/pkg/applier/status_test.go
@@ -179,23 +179,23 @@ func TestObjectStatusMapLog(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"Apply Actuations (Total: 1):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (1): [apps/namespaces/test-namespace/Deployment/random-name],\n" +
+				"Apply Actuations (Total: 1):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (1): [apps/namespaces/test-namespace/Deployment/random-name],\\n" +
 					"Failed (0)",
-				"Apply Reconciles (Total: 1):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (0),\n" +
-					"Failed (1): [apps/namespaces/test-namespace/Deployment/random-name],\n" +
+				"Apply Reconciles (Total: 1):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (0),\\n" +
+					"Failed (1): [apps/namespaces/test-namespace/Deployment/random-name],\\n" +
 					"Timeout (0)",
-				"Delete Actuations (Total: 1):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\n" +
+				"Delete Actuations (Total: 1):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\\n" +
 					"Failed (0)",
-				"Delete Reconciles (Total: 1):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\n" +
-					"Failed (0),\n" +
+				"Delete Reconciles (Total: 1):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\\n" +
+					"Failed (0),\\n" +
 					"Timeout (0)",
 			},
 		},
@@ -216,14 +216,14 @@ func TestObjectStatusMapLog(t *testing.T) {
 			expected: []string{
 				"Apply Actuations (Total: 0)",
 				"Apply Reconciles (Total: 0)",
-				"Delete Actuations (Total: 2):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (2): [apps/namespaces/test-namespace/Deployment/random-name, configsync.test/namespaces/test-namespace/Test/random-name],\n" +
+				"Delete Actuations (Total: 2):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (2): [apps/namespaces/test-namespace/Deployment/random-name, configsync.test/namespaces/test-namespace/Test/random-name],\\n" +
 					"Failed (0)",
-				"Delete Reconciles (Total: 2):\n" +
-					"Skipped (0),\n" +
-					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\n" +
-					"Failed (1): [apps/namespaces/test-namespace/Deployment/random-name],\n" +
+				"Delete Reconciles (Total: 2):\\n" +
+					"Skipped (0),\\n" +
+					"Succeeded (1): [configsync.test/namespaces/test-namespace/Test/random-name],\\n" +
+					"Failed (1): [apps/namespaces/test-namespace/Deployment/random-name],\\n" +
 					"Timeout (0)",
 			},
 		},

--- a/pkg/applier/utils.go
+++ b/pkg/applier/utils.go
@@ -166,10 +166,8 @@ func stringsFromRefs(refs ...mutation.ResourceReference) []string {
 }
 
 const (
-	// Uncomment if needed for building depends-on annotations (deadcode)
-	// commaDelimiter        = ","
-	commaSpaceDelimiter   = ", "
-	commaNewlineDelimiter = ",\n"
+	commaSpaceDelimiter          = ", "
+	commaEscapedNewlineDelimiter = ",\\n"
 )
 
 // joinIDs joins the object IDs (GKNN) using ResourceReference string format
@@ -180,7 +178,7 @@ const (
 // by commas.
 //
 // This can be used to build depends-on annotations when commaDelimiter is used,
-// or for log messages with commaSpaceDelimiter or commaNewlineDelimiter.
+// or for log messages with commaSpaceDelimiter or commaEscapedNewlineDelimiter.
 func joinIDs(delimiter string, ids ...core.ID) string {
 	if len(ids) == 0 {
 		return ""


### PR DESCRIPTION
The applier logs each status with a new line, which makes it an Error log in cloud logging: http://screen/sk9CAhpH7e4YqxA.

This commit escapes the newline character, so it will be a single line in cloud logging. It can also be easily converted to multiple lines.