### PR TITLE
Use deletion propagation for e2e test cleanup

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -536,43 +536,6 @@ func setupRepoSyncRoleBinding(nt *NT, nn types.NamespacedName) error {
 	return nt.Validate(nn.Name, nn.Namespace, &rbacv1.RoleBinding{})
 }
 
-func revokeRepoSyncClusterRoleBinding(nt *NT, nn types.NamespacedName) {
-	if err := nt.Delete(repoSyncClusterRoleBinding(nn)); err != nil {
-		if apierrors.IsNotFound(err) {
-			return
-		}
-		nt.T.Fatal(err)
-	}
-	if err := WatchForNotFound(nt, kinds.ClusterRoleBinding(), nn.Name+"-"+nn.Namespace, ""); err != nil {
-		nt.T.Fatal(err)
-	}
-}
-
-func revokeRepoSyncNamespace(nt *NT, ns string) {
-	// TODO: Ideally we can delete the namespace directly and check if it is terminated.
-	// Due to b/184680603, we have to check if the namespace is in a terminating state to avoid the error:
-	//   Operation cannot be fulfilled on namespaces "bookstore": The system is ensuring all content is removed from this namespace.
-	//   Upon completion, this namespace will automatically be purged by the system.
-	namespace := &corev1.Namespace{}
-	if err := nt.Get(ns, "", namespace); err != nil {
-		if apierrors.IsNotFound(err) {
-			return
-		}
-		nt.T.Fatal(err)
-	}
-	if namespace.Status.Phase != corev1.NamespaceTerminating {
-		if err := nt.Delete(fake.NamespaceObject(ns)); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			nt.T.Fatal(err)
-		}
-	}
-	if err := WatchForNotFound(nt, kinds.Namespace(), ns, ""); err != nil {
-		nt.T.Fatal(err)
-	}
-}
-
 // setReconcilerDebugMode ensures the Reconciler deployments are run in debug mode.
 func setReconcilerDebugMode(obj client.Object) error {
 	if !IsReconcilerManagerConfigMap(obj) {
@@ -731,6 +694,9 @@ func RootSyncObjectV1Alpha1(name, repoURL string, sourceFormat filesystem.Source
 			Name: controllers.GitCredentialVolume,
 		},
 	}
+	// Enable automatic deletion of managed objects by default.
+	// This helps ensure that test artifacts are cleaned up.
+	EnableDeletionPropagation(rs)
 	return rs
 }
 
@@ -764,6 +730,9 @@ func RootSyncObjectV1Beta1(name, repoURL string, sourceFormat filesystem.SourceF
 			Name: controllers.GitCredentialVolume,
 		},
 	}
+	// Enable automatic deletion of managed objects by default.
+	// This helps ensure that test artifacts are cleaned up.
+	EnableDeletionPropagation(rs)
 	return rs
 }
 
@@ -818,6 +787,9 @@ func RepoSyncObjectV1Alpha1(nn types.NamespacedName, repoURL string) *v1alpha1.R
 			Name: "ssh-key",
 		},
 	}
+	// Enable automatic deletion of managed objects by default.
+	// This helps ensure that test artifacts are cleaned up.
+	EnableDeletionPropagation(rs)
 	return rs
 }
 
@@ -833,6 +805,13 @@ func RepoSyncObjectV1Alpha1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1a
 	rs := RepoSyncObjectV1Alpha1(nn, repoURL)
 	if nt.DefaultReconcileTimeout != 0 {
 		rs.Spec.SafeOverride().ReconcileTimeout = toMetav1Duration(nt.DefaultReconcileTimeout)
+	}
+	// Enable automatic deletion of managed objects by default.
+	// This helps ensure that test artifacts are cleaned up.
+	EnableDeletionPropagation(rs)
+	// Add dependencies to ensure managed objects can be deleted.
+	if err := SetRepoSyncDependencies(nt, rs); err != nil {
+		nt.T.Fatal(err)
 	}
 	return rs
 }
@@ -852,6 +831,9 @@ func RepoSyncObjectV1Beta1(nn types.NamespacedName, repoURL string, sourceFormat
 			Name: "ssh-key",
 		},
 	}
+	// Enable automatic deletion of managed objects by default.
+	// This helps ensure that test artifacts are cleaned up.
+	EnableDeletionPropagation(rs)
 	return rs
 }
 
@@ -868,6 +850,10 @@ func RepoSyncObjectV1Beta1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1be
 	if nt.DefaultReconcileTimeout != 0 {
 		rs.Spec.SafeOverride().ReconcileTimeout = toMetav1Duration(nt.DefaultReconcileTimeout)
 	}
+	// Add dependencies to ensure managed objects can be deleted.
+	if err := SetRepoSyncDependencies(nt, rs); err != nil {
+		nt.T.Fatal(err)
+	}
 	return rs
 }
 
@@ -883,6 +869,10 @@ func RepoSyncObjectV1Beta1FromOtherRootRepo(nt *NT, nn types.NamespacedName, rep
 	rs := RepoSyncObjectV1Beta1(nn, repoURL, sourceFormat)
 	if nt.DefaultReconcileTimeout != 0 {
 		rs.Spec.SafeOverride().ReconcileTimeout = toMetav1Duration(nt.DefaultReconcileTimeout)
+	}
+	// Add dependencies to ensure managed objects can be deleted.
+	if err := SetRepoSyncDependencies(nt, rs); err != nil {
+		nt.T.Fatal(err)
 	}
 	return rs
 }
@@ -927,7 +917,6 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 		rsNamespaces[ns] = struct{}{}
 		nt.RootRepos[configsync.RootSyncName].Add(StructuredNSPath(ns, ns), fake.NamespaceObject(ns))
 		rb := RepoSyncRoleBinding(nn)
-		dependencies := []client.Object{cr, rb}
 		nt.RootRepos[configsync.RootSyncName].Add(StructuredNSPath(ns, fmt.Sprintf("rb-%s", nn.Name)), rb)
 		if isPSPCluster() {
 			// Add a ClusterRoleBinding so that the pods can be created
@@ -937,16 +926,10 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 			// TODO: Remove the psp related change when Kubernetes 1.25 is
 			// available on GKE.
 			crb := repoSyncClusterRoleBinding(nn)
-			dependencies = append(dependencies, crb)
 			nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/cluster/crb-%s-%s.yaml", ns, nn.Name), crb)
 		}
 
 		rs := RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
-		// [Cluster]RoleBinding & ClusterRole must be deleted after the RepoSync,
-		// so the reconciler has the right permissions until it's fully exited.
-		if err := SetDependencies(rs, dependencies...); err != nil {
-			nt.T.Fatal(err)
-		}
 		if opts.MultiRepo.ReconcileTimeout != nil {
 			rs.Spec.SafeOverride().ReconcileTimeout = toMetav1Duration(*opts.MultiRepo.ReconcileTimeout)
 		}
@@ -1002,6 +985,38 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
+}
+
+// SetRepoSyncDependencies sets the depends-on annotation on the RepoSync for
+// other objects managed by CentralControl (`setupCentralizedControl`).
+//
+// RootSync dependencies aren't managed by another RootSync, and
+// DelegatedControl doesn't apply with ConfigSync, so depends-on won't have
+// any effect in those scenerios.
+//
+// Takes an Object because it supports both v1alpha1 and v1beta1 RepoSyncs.
+func SetRepoSyncDependencies(nt *NT, rs client.Object) error {
+	if nt.Control != ntopts.CentralControl {
+		return nil
+	}
+	gvk, err := kinds.Lookup(rs, nt.scheme)
+	if err != nil {
+		return err
+	}
+	if gvk.Kind != "RepoSync" {
+		return fmt.Errorf("expected RepoSync, but got %s", gvk.Kind)
+	}
+
+	rsNN := client.ObjectKeyFromObject(rs)
+	dependencies := []client.Object{
+		nt.RepoSyncClusterRole(),
+		RepoSyncRoleBinding(rsNN),
+	}
+	if isPSPCluster() {
+		crb := repoSyncClusterRoleBinding(rsNN)
+		dependencies = append(dependencies, crb)
+	}
+	return SetDependencies(rs, dependencies...)
 }
 
 // SetDependencies sets the specified objects as dependencies of the first object.
@@ -1089,156 +1104,6 @@ func DeletePodByLabel(nt *NT, label, value string, waitForChildren bool) {
 		}
 		return NewPodReady(nt, label, value, "", oldPods.Items, nil)
 	}, WaitTimeout(nt.DefaultWaitTimeout))
-}
-
-// resetRepository re-initializes an existing remote repository or creates a new remote repository.
-func resetRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *Repository {
-	if repo, found := nt.RemoteRepositories[nn]; found {
-		repo.ReInit(nt, sourceFormat)
-		return repo
-	}
-	repo := NewRepository(nt, repoType, nn, sourceFormat)
-	return repo
-}
-
-func resetRootRepo(nt *NT, rsName string, sourceFormat filesystem.SourceFormat) {
-	rs := fake.RootSyncObjectV1Beta1(rsName)
-	if err := nt.Get(rs.Name, rs.Namespace, rs); err != nil && !apierrors.IsNotFound(err) {
-		nt.T.Fatal(err)
-	} else {
-		nt.RootRepos[rsName] = resetRepository(nt, RootRepo, RootSyncNN(rsName), sourceFormat)
-		if err == nil {
-			nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceFormat": "%s", "git": {"dir": "%s"}}}`, sourceFormat, AcmeDir))
-		} else {
-			rs.Spec.SourceFormat = string(sourceFormat)
-			rs.Spec.Git = &v1beta1.Git{
-				Repo:      nt.GitProvider.SyncURL(nt.RootRepos[rsName].RemoteRepoName),
-				Branch:    MainBranch,
-				Dir:       AcmeDir,
-				Auth:      "ssh",
-				SecretRef: &v1beta1.SecretReference{Name: controllers.GitCredentialVolume},
-			}
-			if err = nt.Create(rs); err != nil {
-				nt.T.Fatal(err)
-			}
-		}
-	}
-}
-
-// resetRootRepos resets all RootSync objects to the initial commit to delete
-// managed testing resources.
-//
-// The spec.sourceFormat is reset to the specified format, to ensure the
-// remaining objects are deleted without erroring from format mismatch.
-//
-// The spec.git.dir is reset to "acme", which is created by
-// NewRepository and Repository.ReInit and must still exist.
-//
-// TODO: reset everything else, including the branch
-func resetRootRepos(nt *NT, sourceFormat filesystem.SourceFormat) {
-	// Reset the default root repo first so that other managed RootSyncs can be re-created and initialized.
-	rootRepo := nt.RootRepos[configsync.RootSyncName]
-	// Update the sourceFormat as the test case might use a different sourceFormat
-	// than the one that is created initially.
-	rootRepo.Format = sourceFormat
-	resetRootRepo(nt, configsync.RootSyncName, sourceFormat)
-	nt.WaitForSync(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
-		nt.DefaultWaitTimeout, DefaultRootSha1Fn, RootSyncHasStatusSyncCommit, nil)
-
-	for name := range nt.RootRepos {
-		if name != configsync.RootSyncName {
-			resetRootRepo(nt, name, nt.RootRepos[name].Format)
-			nt.WaitForSync(kinds.RootSyncV1Beta1(), name, configsync.ControllerNamespace,
-				nt.DefaultWaitTimeout, DefaultRootSha1Fn, RootSyncHasStatusSyncCommit, nil)
-			// Now the repo is back to the initial commit, we can delete the safety check Namespace & ClusterRole
-			nt.RootRepos[name].RemoveSafetyNamespace()
-			nt.RootRepos[name].RemoveSafetyClusterRole()
-			nt.RootRepos[name].CommitAndPush("delete the safety check Namespace & ClusterRole")
-			nt.WaitForSync(kinds.RootSyncV1Beta1(), name, configsync.ControllerNamespace,
-				nt.DefaultWaitTimeout, DefaultRootSha1Fn, RootSyncHasStatusSyncCommit, nil)
-		}
-	}
-}
-
-// resetNamespaceRepos sets the namespace repo to the initial state. That should delete all resources in the namespace.
-func resetNamespaceRepos(nt *NT) {
-	namespaceRepos := &v1beta1.RepoSyncList{}
-	if err := nt.List(namespaceRepos); err != nil {
-		nt.T.Fatal(err)
-	}
-	for _, nr := range namespaceRepos.Items {
-		// reset the namespace repo only when it is in 'nt.NonRootRepos' (created by test).
-		// This prevents from resetting an existing namespace repo from a remote git provider.
-		nn := RepoSyncNN(nr.Namespace, nr.Name)
-		if _, found := nt.NonRootRepos[nn]; found {
-			nt.NonRootRepos[nn] = resetRepository(nt, NamespaceRepo, nn, filesystem.SourceFormatUnstructured)
-			rs := &v1beta1.RepoSync{}
-			if err := nt.Get(nn.Name, nn.Namespace, rs); err != nil {
-				if apierrors.IsNotFound(err) {
-					// The RepoSync might be declared in other namespace repos and get pruned in the reset process.
-					// If that happens, re-create the object to clean up the managed testing resources.
-					rs := RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
-					if err := nt.Create(rs); err != nil {
-						nt.T.Fatal(err)
-					}
-				} else {
-					nt.T.Fatal(err)
-				}
-			}
-			nt.WaitForSync(kinds.RepoSyncV1Beta1(), nr.Name, nr.Namespace,
-				nt.DefaultWaitTimeout, DefaultRepoSha1Fn, RepoSyncHasStatusSyncCommit, nil)
-		}
-	}
-}
-
-// deleteRootRepos deletes RootSync objects except for the default one (root-sync).
-// It also deletes the safety check namespace managed by the root repo.
-func deleteRootRepos(nt *NT) {
-	rootSyncs := &v1beta1.RootSyncList{}
-	if err := nt.List(rootSyncs); err != nil {
-		nt.T.Fatal(err)
-	}
-	for _, rs := range rootSyncs.Items {
-		// Keep the default RootSync object
-		if rs.Name == configsync.RootSyncName {
-			continue
-		}
-		if err := nt.Delete(&rs); err != nil {
-			nt.T.Fatal(err)
-		}
-		if err := WatchForNotFound(nt, kinds.Deployment(), core.RootReconcilerName(rs.Name), rs.Namespace); err != nil {
-			nt.T.Fatal(err)
-		}
-		if err := WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace); err != nil {
-			nt.T.Fatal(err)
-		}
-	}
-}
-
-// deleteNamespaceRepos deletes the repo-sync and the namespace.
-func deleteNamespaceRepos(nt *NT) {
-	repoSyncs := &v1beta1.RepoSyncList{}
-	if err := nt.List(repoSyncs); err != nil {
-		nt.T.Fatal(err)
-	}
-
-	for _, rs := range repoSyncs.Items {
-		// revokeRepoSyncNamespace will delete the namespace of RepoSync, which
-		// auto-deletes the resources, including RepoSync, Deployment, RoleBinding, Secret, and etc.
-		revokeRepoSyncNamespace(nt, rs.Namespace)
-		nn := RepoSyncNN(rs.Namespace, rs.Name)
-		if isPSPCluster() {
-			revokeRepoSyncClusterRoleBinding(nt, nn)
-		}
-	}
-
-	rsClusterRole := nt.RepoSyncClusterRole()
-	if err := nt.Delete(rsClusterRole); err != nil && !apierrors.IsNotFound(err) {
-		nt.T.Fatal(err)
-	}
-	if err := WatchForNotFound(nt, kinds.ClusterRole(), rsClusterRole.Name, ""); err != nil {
-		nt.T.Fatal(err)
-	}
 }
 
 // SetPolicyDir updates the root-sync object with the provided policyDir.

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -591,13 +591,15 @@ func (nt *NT) PodLogs(namespace, deployment, container string, previousPodLog bo
 
 // printTestLogs prints test logs and pods information for debugging.
 func (nt *NT) printTestLogs() {
-	// Print the logs for the current container instances.
+	nt.T.Log("[CLEANUP] Printing test logs for current container instances")
 	nt.testLogs(false)
-	// print the logs for the previous container instances if they exist.
+	nt.T.Log("[CLEANUP] Printing test logs for previous container instances")
 	nt.testLogs(true)
+	nt.T.Log("[CLEANUP] Printing test logs for running pods")
 	for _, ns := range CSNamespaces {
 		nt.testPods(ns)
 	}
+	nt.T.Log("[CLEANUP] Describing not-ready pods")
 	for _, ns := range CSNamespaces {
 		nt.describeNotRunningTestPods(ns)
 	}

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -1,0 +1,513 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e/nomostest/taskgroup"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/syncer/differ"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reset performs multi-repo test reset:
+// - Delete unmanaged RootSyncs & RepoSyncs (with deletion propagation)
+// - Validate managed RepoSyncs & RootSyncs are deleted
+// - Delete all test namespaces not containing config-sync itself
+// - Clear Repository-to-RSync assignments
+//
+// This should cleanly delete or reset all registered RSyncs.
+// Any managed RSyncs must have deletion propagation enabled by the test that
+// created them, otherwise their managed resources will not be deleted when the
+// RSync is deleted.
+// Any unregistered Repos must be reset by individual test Cleanup.
+func Reset(nt *NT) error {
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		nt.T.Logf("[RESET] Test environment reset took %v", elapsed)
+	}()
+
+	// Delete all existing RootSyncs with the test label.
+	// Enable deletion propagation first, to clean up managed resources.
+	rootSyncList, err := listRootSyncs(nt)
+	if err != nil {
+		return err
+	}
+	if err := ResetRootSyncs(nt, rootSyncList.Items); err != nil {
+		return err
+	}
+
+	// Delete all existing RepoSyncs with the test label.
+	// Enable deletion propagation first, to clean up managed resources.
+	repoSyncList, err := listRepoSyncs(nt)
+	if err != nil {
+		return err
+	}
+	if err := ResetRepoSyncs(nt, repoSyncList.Items); err != nil {
+		return err
+	}
+
+	// Delete all Namespaces with the test label (except shared).
+	nsList, err := listNamespaces(nt)
+	if err != nil {
+		return err
+	}
+	// Error if any protected namespace was modified by a test (test label added)
+	// and not reverted by the test.
+	protectedNamespaces, nsListItems := filterNamespaces(nsList.Items,
+		protectedNamespaceList()...)
+	if len(protectedNamespaces) > 0 {
+		return errors.Errorf("protected namespace(s) modified by test: %+v",
+			protectedNamespaces)
+	}
+	// Skip deleting namespaces that contain test infra or Config Sync itself.
+	_, nsListItems = filterNamespaces(nsListItems,
+		configsync.ControllerNamespace,
+		configmanagement.RGControllerNamespace,
+		metrics.MonitoringNamespace,
+		testGitNamespace)
+	if err := ResetNamespaces(nt, nsListItems); err != nil {
+		return err
+	}
+
+	// NOTE: These git repos are not actually being deleted here, just
+	// unassigned to a specific RSync. All remote repos are cached in
+	// nt.RemoteRepositories and then reassigned in `resetRepository`.
+	// Repos are actually deleted by `Clean` in environment setup and teardown.
+	nt.NonRootRepos = make(map[types.NamespacedName]*Repository)
+	nt.RootRepos = make(map[string]*Repository)
+
+	return nil
+}
+
+func protectedNamespaceList() []string {
+	list := make([]string, 0, len(differ.SpecialNamespaces))
+	for ns := range differ.SpecialNamespaces {
+		list = append(list, ns)
+	}
+	return list
+}
+
+type resetRecord struct {
+	Objects          map[types.NamespacedName]struct{}
+	ManagedObjects   map[types.NamespacedName]struct{}
+	ObjectNamespaces map[string]struct{}
+}
+
+func newResetRecord() *resetRecord {
+	return &resetRecord{
+		Objects:          make(map[types.NamespacedName]struct{}),
+		ManagedObjects:   make(map[types.NamespacedName]struct{}),
+		ObjectNamespaces: make(map[string]struct{}),
+	}
+}
+
+// ResetRootSyncs cleans up one or more RootSyncs and all their managed objects.
+// Use this for cleaning up RootSyncs in tests that use delegated control.
+func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
+	if len(rsList) == 0 {
+		return nil
+	}
+
+	nt.T.Logf("[RESET] Deleting RootSyncs (%d)", len(rsList))
+
+	record := newResetRecord()
+
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		record.Objects[rsNN] = struct{}{}
+		record.ObjectNamespaces[rsNN.Namespace] = struct{}{}
+
+		if manager, found := rs.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[rsNN] = struct{}{}
+			nt.T.Logf("[RESET] RootSync %s managed by %q", rsNN, manager)
+			if !IsDeletionPropagationEnabled(rs) {
+				// If you go this error, make sure your test cleanup ensures
+				// that the managed RootSync has deletion propagation enabled.
+				return errors.Errorf("RootSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+			}
+			continue
+		}
+
+		// Enable deletion propagation, if not enabled
+		if EnableDeletionPropagation(rs) {
+			nt.T.Logf("[RESET] Enabling deletion propagation on RootSync %s", rsNN)
+			if err := nt.Update(rs); err != nil {
+				return err
+			}
+			if err := WatchObject(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace, []Predicate{
+				HasFinalizer(metadata.ReconcilerFinalizer),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Print reconciler logs in case of failure.
+		// This ensures the logs are printed, even if the reconciler is deleted.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go TailReconcilerLogs(ctx, nt, RootReconcilerObjectKey(rsNN.Name))
+
+		// DeletePropagationBackground is required when deleting RSyncs with
+		// dependencies that have owners references. Otherwise the reconciler
+		// and dependenencies will be garbage collected before the finalizer
+		// can delete the managed resources.
+		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+		nt.T.Logf("[RESET] Deleting RootSync %s", rsNN)
+		if err := nt.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return err
+		}
+	}
+	tg := taskgroup.New()
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		nt.T.Logf("[RESET] Waiting for deletion of RootSync %s ...", rsNN)
+		tg.Go(func() error {
+			return WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace)
+		})
+	}
+	return tg.Wait()
+}
+
+// ResetRepoSyncs cleans up one or more RepoSyncs and all their managed objects.
+// Use this for cleaning up RepoSyncs in tests that use delegated control.
+//
+// To ensure the reconcile finalizer has permission to delete managed resources,
+// ClusterRole and RoleBindings will be created and then later deleted.
+// This also cleans up any CRs, RBs, and CRBs left behind by delegated control.
+func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
+	if len(rsList) == 0 {
+		// Clean up after `setupDelegatedControl`
+		return deleteRepoSyncClusterRole(nt)
+	}
+
+	nt.T.Logf("[RESET] Deleting RepoSyncs (%d)", len(rsList))
+
+	record := newResetRecord()
+
+	// Apply ClusterRole with the permissions specified by this test.
+	rsCR := nt.RepoSyncClusterRole()
+	if err := nt.Apply(rsCR); err != nil {
+		return err
+	}
+
+	for _, item := range rsList {
+		rs := &item
+		rsNN := client.ObjectKeyFromObject(rs)
+		record.Objects[rsNN] = struct{}{}
+		record.ObjectNamespaces[rsNN.Namespace] = struct{}{}
+
+		// If managed, skip direct deletion
+		if manager, found := rs.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[rsNN] = struct{}{}
+			nt.T.Logf("[RESET] RepoSync %s managed by %q", rsNN, manager)
+			if !IsDeletionPropagationEnabled(rs) {
+				// If you go this error, make sure your test cleanup ensures
+				// that the managed RepoSync has deletion propagation enabled.
+				return errors.Errorf("RepoSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+			}
+			continue
+		}
+
+		// Enable deletion propagation, if not enabled
+		if EnableDeletionPropagation(rs) {
+			nt.T.Logf("[RESET] Enabling deletion propagation on RepoSync %s", rsNN)
+			if err := nt.Update(rs); err != nil {
+				return err
+			}
+			if err := WatchObject(nt, kinds.RepoSyncV1Beta1(), rs.Name, rs.Namespace, []Predicate{
+				HasFinalizer(metadata.ReconcilerFinalizer),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Grant the reconcile the permissions specified by this test.
+		rsCRB := RepoSyncRoleBinding(rsNN)
+		if err := nt.Apply(rsCRB); err != nil {
+			return err
+		}
+
+		// Print reconciler logs in case of failure.
+		// This ensures the logs are printed, even if the reconciler is deleted.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go TailReconcilerLogs(ctx, nt, NsReconcilerObjectKey(rsNN.Namespace, rsNN.Name))
+
+		// DeletePropagationBackground is required when deleting RSyncs with
+		// dependencies that have owners references. Otherwise the reconciler
+		// and dependenencies will be garbage collected before the finalizer
+		// can delete the managed resources.
+		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
+		nt.T.Logf("[RESET] Deleting RepoSync %s", rsNN)
+		if err := nt.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return err
+		}
+	}
+	tg := taskgroup.New()
+	for _, item := range rsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		nt.T.Logf("[RESET] Waiting for deletion of RepoSync %s ...", nn)
+		tg.Go(func() error {
+			return WatchForNotFound(nt, kinds.RepoSyncV1Beta1(), obj.Name, obj.Namespace)
+		})
+	}
+	if err := tg.Wait(); err != nil {
+		return err
+	}
+
+	// Delete any RoleBindings left behind.
+	// For central control, the parent RSync _should_ handle deleting the RB,
+	// but for delegated control and other edge cases clean them up regardless.
+	nt.T.Log("[RESET] Deleting test RoleBindings")
+	var rbs []client.Object
+	for rsNN := range record.Objects {
+		rbs = append(rbs, RepoSyncRoleBinding(rsNN))
+	}
+	// Skip deleting managed RoleBindings
+	rbs, err := findUnmanaged(nt, rbs...)
+	if err != nil {
+		return err
+	}
+	if err := batchDeleteAndWait(nt, rbs...); err != nil {
+		return err
+	}
+
+	// Delete any ClusterRoleBindings left behind.
+	// CRBs are usually only applied if PSP was enabled, but clean them up regardless.
+	nt.T.Log("[RESET] Deleting test ClusterRoleBindings")
+	var crbs []client.Object
+	for rsNN := range record.Objects {
+		crbs = append(crbs, repoSyncClusterRoleBinding(rsNN))
+	}
+	// Skip deleting managed ClusterRoleBindings
+	crbs, err = findUnmanaged(nt, crbs...)
+	if err != nil {
+		return err
+	}
+	if err := batchDeleteAndWait(nt, crbs...); err != nil {
+		return err
+	}
+
+	return deleteRepoSyncClusterRole(nt)
+}
+
+// ResetNamespaces cleans up one or more Namespaces and all their namespaced objects.
+// Use this for cleaning up Namespaces in tests that use delegated control.
+func ResetNamespaces(nt *NT, nsList []corev1.Namespace) error {
+	if len(nsList) == 0 {
+		return nil
+	}
+
+	nt.T.Logf("[RESET] Deleting Namespaces (%d)", len(nsList))
+
+	record := newResetRecord()
+
+	for _, item := range nsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		record.Objects[nn] = struct{}{}
+		record.ObjectNamespaces[nn.Namespace] = struct{}{}
+
+		// If managed, skip direct deletion
+		if manager, found := obj.GetAnnotations()[string(metadata.ResourceManagerKey)]; found {
+			record.ManagedObjects[nn] = struct{}{}
+			nt.T.Logf("[RESET] Namespace %s managed by %q", nn, manager)
+			continue
+		}
+
+		nt.T.Logf("[RESET] Deleting Namespace %s", nn)
+		if err := nt.Delete(obj, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			return err
+		}
+	}
+	for _, item := range nsList {
+		obj := &item
+		nn := client.ObjectKeyFromObject(obj)
+		nt.T.Logf("[RESET] Waiting for deletion of Namespace %s ...", nn)
+		if err := WatchForNotFound(nt, kinds.Namespace(), obj.Name, obj.Namespace); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteRepoSyncClusterRole deletes the ClusterRole used by RepoSync
+// reconcilers, if it exists.
+func deleteRepoSyncClusterRole(nt *NT) error {
+	nt.T.Log("[RESET] Deleting RepoSync ClusterRole")
+	return batchDeleteAndWait(nt, nt.RepoSyncClusterRole())
+}
+
+func findUnmanaged(nt *NT, objs ...client.Object) ([]client.Object, error) {
+	var unmanaged []client.Object
+	for _, obj := range objs {
+		if err := nt.Get(obj.GetName(), obj.GetNamespace(), obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+		} else if _, found := obj.GetAnnotations()[string(metadata.ResourceManagerKey)]; !found {
+			unmanaged = append(unmanaged, obj)
+		} // else managed
+	}
+	return unmanaged, nil
+}
+
+func batchDeleteAndWait(nt *NT, objs ...client.Object) error {
+	for _, obj := range objs {
+		if err := nt.Delete(obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	tg := taskgroup.New()
+	for _, obj := range objs {
+		gvk, err := kinds.Lookup(obj, nt.scheme)
+		if err != nil {
+			return err
+		}
+		tg.Go(func() error {
+			return WatchForNotFound(nt, gvk, obj.GetName(), obj.GetNamespace())
+		})
+	}
+	return tg.Wait()
+}
+
+func listRootSyncs(nt *NT, opts ...client.ListOption) (*v1beta1.RootSyncList, error) {
+	rsList := &v1beta1.RootSyncList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(rsList, opts...); err != nil {
+		return rsList, err
+	}
+	return rsList, nil
+}
+
+func listRepoSyncs(nt *NT, opts ...client.ListOption) (*v1beta1.RepoSyncList, error) {
+	rsList := &v1beta1.RepoSyncList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(rsList, opts...); err != nil {
+		return rsList, err
+	}
+	return rsList, nil
+}
+
+func listNamespaces(nt *NT, opts ...client.ListOption) (*corev1.NamespaceList, error) {
+	nsList := &corev1.NamespaceList{}
+	opts = append(opts, withLabelListOption(TestLabel, TestLabelValue))
+	if err := nt.List(nsList, opts...); err != nil {
+		return nsList, err
+	}
+	return nsList, nil
+}
+
+func withLabelListOption(key, value string) client.MatchingLabelsSelector {
+	labelSelector := labels.Set{key: value}.AsSelector()
+	return client.MatchingLabelsSelector{Selector: labelSelector}
+}
+
+func filterNamespaces(nsList []corev1.Namespace, excludes ...string) (found []corev1.Namespace, remaining []corev1.Namespace) {
+	for _, ns := range nsList {
+		if stringSliceContains(excludes, ns.Name) {
+			found = append(found, ns)
+		} else {
+			remaining = append(remaining, ns)
+		}
+	}
+	return found, remaining
+}
+
+func stringSliceContains(list []string, value string) bool {
+	for _, elem := range list {
+		if elem == value {
+			return true
+		}
+	}
+	return false
+}
+
+// resetRepository creates or re-initializes a remote repository.
+func resetRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *Repository {
+	if repo, found := nt.RemoteRepositories[nn]; found {
+		repo.ReInit(nt, sourceFormat)
+		return repo
+	}
+	return NewRepository(nt, repoType, nn, sourceFormat)
+}
+
+// TailReconcilerLogs starts tailing a reconciler's logs.
+// The logs are stored in memory until either the context is cancelled or the
+// kubectl command exits (usually because the container exited).
+// This allows capturing logs even if the reconciler is deleted before the
+// test ends.
+// The logs will only be printed if the test has failed when the command exits.
+// Run in an goroutine to capture logs in the background while deleting RSyncs.
+func TailReconcilerLogs(ctx context.Context, nt *NT, reconcilerNN types.NamespacedName) {
+	out, err := nt.KubectlContext(ctx, "logs",
+		fmt.Sprintf("deployment/%s", reconcilerNN.Name),
+		"-n", reconcilerNN.Namespace,
+		"-c", reconcilermanager.Reconciler,
+		"-f")
+	// Expect the logs to tail until the context is cancelled, or exit early if
+	// the reconciler container exited.
+	if err != nil && err.Error() != "signal: killed" {
+		// We're only using this for debugging, so don't trigger test failure.
+		nt.T.Logf("Failed to tail logs from reconciler %s: %v", reconcilerNN, err)
+	}
+	// Only print the logs if the test has failed
+	if nt.T.Failed() {
+		nt.T.Logf("Reconciler deployment logs (%s):\n%s", reconcilerNN, string(out))
+	}
+}
+
+// RootReconcilerObjectKey returns an ObjectKey for interracting with the
+// RootReconciler for the specified RootSync.
+func RootReconcilerObjectKey(syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.RootReconcilerName(syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}
+
+// NsReconcilerObjectKey returns an ObjectKey for interracting with the
+// NsReconciler for the specified RepoSync.
+func NsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      core.NsReconcilerName(namespace, syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -50,18 +50,12 @@ var privateARHelmRegistry = fmt.Sprintf("oci://us-docker.pkg.dev/%s/config-sync-
 // It tests Config Sync can pull from public Helm repo without any authentication.
 func TestPublicHelm(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace and multiple inline values")
 	rootSyncFilePath := "../testdata/root-sync-helm-chart-cr.yaml"
 	nt.T.Logf("Apply the RootSync object defined in %s", rootSyncFilePath)
 	nt.MustKubectl("apply", "-f", rootSyncFilePath)
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion("wordpress:15.2.35")),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "wordpress"}))
 	var expectedCPURequest string
@@ -137,12 +131,6 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	}}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from a public Helm Chart with cluster-scoped type")
-	// Change the RepoSync to sync from the original git source to make test works in the shared test environment.
-	nt.T.Cleanup(func() {
-		rs.Spec.SourceType = string(v1beta1.GitSource)
-		nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs)
-		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from the original git repository")
-	})
 	nt.WaitForRepoSyncSourceError(repoSyncNN.Namespace, repoSyncNN.Name, nonhierarchical.BadScopeErrCode, "must be Namespace-scoped type")
 	nt.T.Log("Fetch password from Secret Manager")
 	key, err := gitproviders.FetchCloudSecret("config-sync-ci-ar-key")
@@ -262,17 +250,10 @@ func TestHelmGCENode(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest)
 
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
-
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "%s", "auth": "gcenode", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns"}, "git": null}}`,
 		v1beta1.HelmSource, privateARHelmRegistry, privateHelmChart, privateHelmChartVersion))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion(privateHelmChart+":"+privateHelmChartVersion)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: privateHelmChart}))
@@ -292,7 +273,6 @@ func TestHelmARTokenAuth(t *testing.T) {
 		ntopts.Unstructured,
 		ntopts.RequireGKE(t),
 	)
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Fetch password from Secret Manager")
@@ -311,11 +291,6 @@ func TestHelmARTokenAuth(t *testing.T) {
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns", "secretRef": {"name" : "foo"}}}}`,
 		v1beta1.HelmSource, privateARHelmRegistry, privateHelmChart, privateHelmChartVersion))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(helmChartVersion(privateHelmChart+":"+privateHelmChartVersion)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: privateHelmChart}))
 	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{}); err != nil {

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -36,7 +36,6 @@ import (
 // are removed successfully.
 func TestKCCResourcesOnCSR(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.KccTest, ntopts.RequireGKE(t))
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("sync to the kcc resources from a CSR repo")
@@ -82,9 +81,6 @@ func TestKCCResourcesOnCSR(t *testing.T) {
 	validateKCCResourceNotFound(nt, gvkPubSubSubscription, "test-cs-read", "foo")
 	validateKCCResourceNotFound(nt, gvkServiceAccount, "pubsub-app", "foo")
 	validateKCCResourceNotFound(nt, gvkPolicyMember, "policy-member-binding", "foo")
-
-	// Change the rs back so that it works in the shared test environment.
-	defer nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}, "sourceFormat": "hierarchy"}}`, origRepoURL))
 }
 
 func validateKCCResourceReady(nt *nomostest.NT, gvk schema.GroupVersionKind, name, namespace string) {

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -88,11 +88,9 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	// RepoSyncs, which could block deletion if their finalizer hangs.
 	// This also replaces depends-on deletion ordering (RoleBinding -> RepoSync),
 	// which can't be used by unmanaged syncs or objects in different repos.
-	// Stop the webhook to allow deletion of managed resources.
 	nt.T.Cleanup(func() {
-		nt.T.Log("[CLEANUP] Stopping webhook")
-		nomostest.StopWebhook(nt)
 		nt.T.Log("[CLEANUP] Deleting test RepoSyncs")
+		var rsList []v1beta1.RepoSync
 		rsNNs := []types.NamespacedName{nn1, nn2, nn4}
 		for _, rsNN := range rsNNs {
 			rs := &v1beta1.RepoSync{}
@@ -102,12 +100,11 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 					nt.T.Error(err)
 				}
 			} else {
-				if err := nt.Delete(rs); err != nil {
-					if !apierrors.IsNotFound(err) {
-						nt.T.Error(err)
-					}
-				}
+				rsList = append(rsList, *rs)
 			}
+		}
+		if err := nomostest.ResetRepoSyncs(nt, rsList); err != nil {
+			nt.T.Error(err)
 		}
 	})
 

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -76,17 +76,11 @@ func TestPublicOCI(t *testing.T) {
 		publicARImage = fmt.Sprintf("us-docker.pkg.dev/%s/config-sync-test-public/kustomize-components", publicProject)
 	}
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a public OCI image in AR")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"image": "%s", "auth": "none"}, "git": null}}`,
 		v1beta1.OciSource, publicARImage))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(imageDigestFunc(publicARImage)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "."}))
 	validateAllTenants(nt, string(declared.RootReconciler), "base", "tenant-a", "tenant-b", "tenant-c")
@@ -109,18 +103,12 @@ func TestGCENodeOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest)
 
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 	tenant := "tenant-a"
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from an OCI image in Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"dir": "%s", "image": "%s", "auth": "gcenode"}, "git": null}}`,
 		v1beta1.OciSource, tenant, privateARImage))
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(imageDigestFunc(privateARImage)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: tenant}))
 	validateAllTenants(nt, string(declared.RootReconciler), "../base", tenant)
@@ -477,14 +465,8 @@ func isSourceType(sourceType v1beta1.SourceType) nomostest.Predicate {
 // The test uses the current credentials (gcloud auth) when running on the GKE clusters to push new images.
 func TestDigestUpdate(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured, ntopts.RequireGKE(t))
-	origRepoURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	nt.T.Cleanup(func() {
-		// Change the rs back so that it works in the shared test environment.
-		nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": null, "git": {"dir": "acme", "branch": "main", "repo": "%s", "auth": "ssh","gcpServiceAccountEmail": "", "secretRef": {"name": "git-creds"}}}}`,
-			v1beta1.GitSource, origRepoURL))
-	})
 
 	nt.T.Log("Test oci-sync pulling the latest image from AR when digest changes")
 	testDigestUpdate(nt, "us-docker.pkg.dev/${GCP_PROJECT}/config-sync-test-public/digest-update")

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -38,7 +38,6 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -87,7 +86,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Disabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -95,7 +94,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyOrphan) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyOrphan) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -173,7 +172,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -181,7 +180,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -276,8 +275,8 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
-	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -285,7 +284,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -299,7 +298,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 
 	nt.T.Log("Enabling RepoSync deletion propagation")
 	repoSync := rootRepo.Get(repoSyncPath)
-	if setDeletionPropagationPolicy(repoSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(repoSync, metadata.DeletionPropagationPolicyForeground) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Enabling RepoSync deletion propagation")
 	}
@@ -396,8 +395,8 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	// Start here to catch both the finalizer injection and deletion behavior.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tailReconcilerLogs(ctx, nt, rootReconcilerObjectKey(rootSyncNN.Name))
-	go tailReconcilerLogs(ctx, nt, nsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
+	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
 	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
@@ -405,7 +404,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if setDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
+	if nomostest.SetDeletionPropagationPolicy(rootSync, metadata.DeletionPropagationPolicyForeground) {
 		err = nt.Update(rootSync)
 		if err != nil {
 			nt.T.Fatal(err)
@@ -419,7 +418,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 
 	nt.T.Log("Disabling RepoSync deletion propagation")
 	repoSync := rootRepo.Get(repoSyncPath)
-	if removeDeletionPropagationPolicy(repoSync) {
+	if nomostest.RemoveDeletionPropagationPolicy(repoSync) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Disabling RepoSync deletion propagation")
 		nt.WaitForRepoSyncs()
@@ -466,31 +465,6 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 			return errs
 		},
 	)
-}
-
-// tailReconcilerLogs starts tailing a reconciler's logs.
-// The logs are stored in memory until either the context is cancelled or the
-// kubectl command exits (usually because the container exited).
-// This allows capturing logs even if the reconciler is deleted before the
-// test ends.
-// The logs will only be printed if the test has failed when the command exits.
-// Run in an goroutine to capture logs in the background while deleting RSyncs.
-func tailReconcilerLogs(ctx context.Context, nt *nomostest.NT, reconcilerNN types.NamespacedName) {
-	out, err := nt.KubectlContext(ctx, "logs",
-		fmt.Sprintf("deployment/%s", reconcilerNN.Name),
-		"-n", reconcilerNN.Namespace,
-		"-c", reconcilermanager.Reconciler,
-		"-f")
-	// Expect the logs to tail until the context is cancelled, or exit early if
-	// the reconciler container exited.
-	if err != nil && err.Error() != "signal: killed" {
-		// We're only using this for debugging, so don't trigger test failure.
-		nt.T.Logf("Failed to tail logs from reconciler %s: %v", reconcilerNN, err)
-	}
-	// Only print the logs if the test has failed
-	if nt.T.Failed() {
-		nt.T.Logf("Reconciler deployment logs (%s):\n%s", reconcilerNN, string(out))
-	}
 }
 
 func cleanupSingleLevel(nt *nomostest.NT,
@@ -540,7 +514,7 @@ func cleanupSyncsAndObjects(nt *nomostest.NT, syncObjs []client.Object, objs []c
 	nomostest.StopWebhook(nt)
 
 	// For the purposes of these finalizer tests, we assume the finalizer may
-	// not work correctly. So we delete the deletion propegation annotation,
+	// not work correctly. So we delete the deletion propagation annotation,
 	// the syncs, and all the managed objects.
 	for _, syncObj := range syncObjs {
 		if err := deleteSyncWithOrphanPolicy(nt, syncObj); err != nil {
@@ -611,7 +585,7 @@ func deleteSyncWithOrphanPolicy(nt *nomostest.NT, obj client.Object) error {
 	}
 
 	nt.T.Log("Removing deletion propagation annotation")
-	if removeDeletionPropagationPolicy(obj) {
+	if nomostest.RemoveDeletionPropagationPolicy(obj) {
 		err = nt.Update(obj)
 		if err != nil {
 			return err
@@ -645,49 +619,6 @@ func deleteObject(nt *nomostest.NT, obj client.Object) error {
 		return err
 	}
 	return nil
-}
-
-// rootReconcilerObjectKey returns an ObjectKey for interacting with the
-// RootReconciler for the specified RootSync.
-func rootReconcilerObjectKey(syncName string) client.ObjectKey {
-	return client.ObjectKey{
-		Name:      core.RootReconcilerName(syncName),
-		Namespace: configsync.ControllerNamespace,
-	}
-}
-
-// nsReconcilerObjectKey returns an ObjectKey for interacting with the
-// NsReconciler for the specified RepoSync.
-func nsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
-	return client.ObjectKey{
-		Name:      core.NsReconcilerName(namespace, syncName),
-		Namespace: configsync.ControllerNamespace,
-	}
-}
-
-func setDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
-	annotations := obj.GetAnnotations()
-	if len(annotations) == 0 {
-		annotations = make(map[string]string, 1)
-	} else if val, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; found && val == string(policy) {
-		return false
-	}
-	annotations[metadata.DeletionPropagationPolicyAnnotationKey] = string(policy)
-	obj.SetAnnotations(annotations)
-	return true
-}
-
-func removeDeletionPropagationPolicy(obj client.Object) bool {
-	annotations := obj.GetAnnotations()
-	if len(annotations) == 0 {
-		return false
-	}
-	if _, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; !found {
-		return false
-	}
-	delete(annotations, metadata.DeletionPropagationPolicyAnnotationKey)
-	obj.SetAnnotations(annotations)
-	return true
 }
 
 func loadDeployment(nt *nomostest.NT, path string) *appsv1.Deployment {

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -31,6 +31,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/testing/fake"
@@ -53,11 +54,9 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 		nt.T.Fatalf("deleting RootSync: %v", err)
 	}
 
-	_, err = nomostest.Retry(5*time.Second, func() error {
-		return nt.ValidateNotFound(configsync.RootSyncName, v1.NSConfigManagementSystem, fake.RootSyncObjectV1Beta1(configsync.RootSyncName))
-	})
-	if err != nil {
-		nt.T.Errorf("RootSync present after deletion: %v", err)
+	// Verify RootSync no longer present.
+	if err := nomostest.WatchForNotFound(nt, kinds.RootSyncV1Beta1(), rs.GetName(), rs.GetNamespace()); err != nil {
+		nt.T.Fatal(err)
 	}
 
 	// Verify Root Reconciler deployment no longer present.


### PR DESCRIPTION
- Rewrite test cleanup to use the RSync finalizer to delete all
  managed resources by default (for e2e tests only)
- Fix TestDeleteRootSyncAndRootSyncV1Alpha1 to handle longer RSync
  deletion timeout
- Add depends-on to RepoSyncs for [Cluster]RoleBindings to ensure
  the reconciler finalizer has permission to delete before the
  binding is deleted.
- Remove test cleanup blocks that are no longer necessary.
- Delete and re-create all RootSyncs & RepoSyncs between each test,
  to ensure better test isolation, to make it easier to debug test
  failure.

This is a repeat of https://github.com/GoogleContainerTools/kpt-config-sync/pull/205, which was reverted, with modifications.

The recent fixes to `Clean` should handle forcibly deleting any RSyncs which get stuck finalizing due to race conditions in deletion ordering. So even if the reconciler gets wedged, it shouldn't break the cluster like it did last time. This way we can narrow down which tests are causing test failures more easily, if any.