### PR TITLE
Update the public helm chart used by the namespace repo

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -39,9 +39,9 @@ const (
 	privateHelmChart          = "coredns"
 	privateNSHelmChart        = "ns-chart"
 	privateNSHelmChartVersion = "0.1.0"
-	publicHelmRepo            = "https://charts.bitnami.com/bitnami"
-	publicHelmChart           = "wordpress"
-	publicHelmChartVersion    = "15.2.35"
+	publicHelmRepo            = "https://kubernetes-sigs.github.io/metrics-server"
+	publicHelmChart           = "metrics-server"
+	publicHelmChartVersion    = "3.8.3"
 )
 
 var privateARHelmRegistry = fmt.Sprintf("oci://us-docker.pkg.dev/%s/config-sync-test-ar-helm", nomostesting.GCPProjectIDFromEnv)


### PR DESCRIPTION
`TestHelmNamespaceRepo` validates that a namespace reconciler gets a source error when syncing from a public helm chart that includes cluster-scoped resources. The wordpress chart doesn't include any cluster-scoped resources, so this commit updates the chart to pass the validation.