### PR TITLE
Disable MariaDB persistence to avoid leaking PVCs

### DIFF
--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -42,6 +42,10 @@ spec:
         limits:
           cpu: 1
           memory: 300Mi
+      mariadb:
+        primary:
+          persistence:
+            enabled: false
     releaseName: my-wordpress
     namespace: "wordpress"
     auth: none


### PR DESCRIPTION
Mariadb persistent storage is enabled by default, which creates a PVC in the namespace. When wordpress is deleted, the PVC is left behind after the test.

This commit updates the chart values to disable mariadb persistent storage.