### PR TITLE
Bump the default CPU request for the helm-sync container to avoid helm failures

### DIFF
--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -167,7 +167,7 @@ data:
              runAsUser: 65533
            resources:
              requests:
-               cpu: "10m"
+               cpu: "50m"
                memory: "200Mi"
          - name: otel-agent
            image: gcr.io/config-management-release/otelcontribcol:v0.54.0


### PR DESCRIPTION
When the helm-sync container pulls the wordpress chart on the autopilot clusters, it fails with a `signal: killed` error. It turns out it consumes more CPU than requested.

This commit bumps the default CPU request from 10m to 50m.