### PR TITLE
Change the wordpress service type to avoid leaking GCP resources

### DIFF
--- a/e2e/testdata/hydration/compiled-json/helm-components/wordpress/service_my-wordpress.json
+++ b/e2e/testdata/hydration/compiled-json/helm-components/wordpress/service_my-wordpress.json
@@ -19,16 +19,17 @@
 				"namespace": "wordpress"
 			},
 			"spec": {
-				"externalTrafficPolicy": "Cluster",
 				"ports": [
 					{
 						"name": "http",
+						"nodePort": null,
 						"port": 80,
 						"protocol": "TCP",
 						"targetPort": "http"
 					},
 					{
 						"name": "https",
+						"nodePort": null,
 						"port": 443,
 						"protocol": "TCP",
 						"targetPort": "https"
@@ -40,7 +41,7 @@
 					"test-case": "hydration"
 				},
 				"sessionAffinity": "None",
-				"type": "LoadBalancer"
+				"type": "ClusterIP"
 			}
 		}
 	],

--- a/e2e/testdata/hydration/compiled/helm-components/wordpress/service_my-wordpress.yaml
+++ b/e2e/testdata/hydration/compiled/helm-components/wordpress/service_my-wordpress.yaml
@@ -31,13 +31,14 @@ metadata:
   name: my-wordpress
   namespace: wordpress
 spec:
-  externalTrafficPolicy: Cluster
   ports:
   - name: http
+    nodePort: null
     port: 80
     protocol: TCP
     targetPort: http
   - name: https
+    nodePort: null
     port: 443
     protocol: TCP
     targetPort: https
@@ -46,4 +47,4 @@ spec:
     app.kubernetes.io/name: wordpress
     test-case: hydration
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
@@ -22,6 +22,9 @@ helmCharts:
   version: 15.2.35
   releaseName: my-wordpress
   namespace: wordpress
+  valuesInline:
+    service:
+      type: ClusterIP
 
 commonLabels:
   test-case: hydration

--- a/e2e/testdata/hydration/helm-components/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components/kustomization.yaml
@@ -27,6 +27,8 @@ helmCharts:
       auth:
         rootPassword: abcdefg
         password: abcdefg
+    service:
+      type: ClusterIP
 
 commonLabels:
   test-case: hydration

--- a/e2e/testdata/hydration/krm-function-helm-components-kustomization.yaml
+++ b/e2e/testdata/hydration/krm-function-helm-components-kustomization.yaml
@@ -38,6 +38,10 @@ generators:
     templateOptions:
       releaseName: my-wordpress
       namespace: wordpress
+      values:
+        valuesInline:
+          service:
+            type: ClusterIP
 
 commonLabels:
   test-case: hydration

--- a/e2e/testdata/hydration/krm-function-helm-components-remote-values-kustomization.yaml
+++ b/e2e/testdata/hydration/krm-function-helm-components-remote-values-kustomization.yaml
@@ -42,6 +42,10 @@ generators:
     templateOptions:
       releaseName: my-wordpress
       namespace: wordpress
+      values:
+        valuesInline:
+          service:
+            type: ClusterIP
 
 commonLabels:
   test-case: hydration

--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -46,6 +46,8 @@ spec:
         primary:
           persistence:
             enabled: false
+      service:
+        type: ClusterIP
     releaseName: my-wordpress
     namespace: "wordpress"
     auth: none


### PR DESCRIPTION
Due to b/267197563, any Service type of LoadBalancer leaves the GCP resources (firewall rules and target pools) behind. This commit changes the wordpress Service type from the default LoadBalancer to ClusterIP to avoid leading resources.