### PR TITLE
increase timeout for not found after deletion

### DIFF
--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -296,7 +296,7 @@ func getNsReconcilerSecrets(nt *nomostest.NT, ns string) []string {
 }
 
 func checkRepoSyncResourcesNotPresent(namespace string, secretNames []string, nt *nomostest.NT) {
-	_, err := nomostest.Retry(5*time.Second, func() error {
+	_, err := nomostest.Retry(30*time.Second, func() error {
 		return nt.ValidateNotFound(configsync.RepoSyncName, namespace, fake.RepoSyncObjectV1Beta1(namespace, configsync.RepoSyncName))
 	})
 	if err != nil {


### PR DESCRIPTION
This check is flaky in some of our CI jobs. It stands to reason that it may take longer for the RepoSync to be NotFound after deletion due to the introduction of a finalizer. This change increases the timeout accordingly in an attempt to reduce flakiness of the associated tests.

Impacted tests:
- TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1
- TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1