### PR TITLE
Rewrite WatchObject to use client-go

### DIFF
--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -36,7 +36,6 @@ import (
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/client/restconfig"
-	"kpt.dev/configsync/pkg/remediator/watch"
 	resourcegroupv1alpha1 "kpt.dev/resourcegroup/apis/kpt.dev/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -114,8 +113,4 @@ func RestConfig(t testing.NTB, opts *ntopts.New) {
 		t.Fatalf("building rest.Config: %v", err)
 	}
 	opts.RESTConfig = restConfig
-
-	// Copy the RESTConfig to create the WatchConfig, but use a longer timeout.
-	opts.WatchConfig = restconfig.DeepCopy(restConfig)
-	opts.WatchConfig.Timeout = watch.RESTConfigTimeout
 }

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -143,7 +143,6 @@ func New(t *testing.T, testFeature nomostesting.Feature, ntOptions ...ntopts.Opt
 		sharedNt := SharedNT(tw)
 		t.Logf("using shared test env %s", sharedNt.ClusterName)
 		ntOptions = append(ntOptions, ntopts.WithRestConfig(sharedNt.Config))
-		ntOptions = append(ntOptions, ntopts.WithWatchConfig(sharedNt.WatchConfig))
 	}
 
 	optsStruct := newOptStruct(TestClusterName(tw), TestDir(tw), tw, ntOptions...)
@@ -165,7 +164,6 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		ClusterName:             opts.Name,
 		TmpDir:                  opts.TmpDir,
 		Config:                  opts.RESTConfig,
-		WatchConfig:             opts.WatchConfig,
 		repoSyncPermissions:     opts.RepoSyncPermissions,
 		Client:                  sharedNt.Client,
 		WatchClient:             sharedNt.WatchClient,
@@ -251,7 +249,6 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		ClusterName:             opts.Name,
 		TmpDir:                  opts.TmpDir,
 		Config:                  opts.RESTConfig,
-		WatchConfig:             opts.WatchConfig,
 		repoSyncPermissions:     opts.RepoSyncPermissions,
 		DefaultReconcileTimeout: 1 * time.Minute,
 		kubeconfigPath:          opts.KubeconfigPath,

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -75,10 +75,6 @@ type NT struct {
 	// Config specifies how to create a new connection to the cluster.
 	Config *rest.Config
 
-	// WatchConfig specifies how to create a new connection to the cluster for
-	// watches.
-	WatchConfig *rest.Config
-
 	// Client is the underlying client used to talk to the Kubernetes cluster.
 	//
 	// Most tests shouldn't need to talk directly to this, unless simulating
@@ -483,9 +479,7 @@ func DefaultRepoSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 // CRD directly to the API Server.
 func (nt *NT) RenewClient() {
 	nt.T.Helper()
-
 	nt.Client = connect(nt.T, nt.Config, nt.scheme)
-	nt.WatchClient = connect(nt.T, nt.WatchConfig, nt.scheme)
 }
 
 // Kubectl is a convenience method for calling kubectl against the

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -45,10 +45,6 @@ type New struct {
 	// RESTConfig is the config for creating a Client connection to a K8s cluster.
 	RESTConfig *rest.Config
 
-	// WatchConfig is the config for creating a Client connection to a K8s
-	// cluster for watches.
-	WatchConfig *rest.Config
-
 	// KubeconfigPath is the path to the kubeconfig file
 	KubeconfigPath string
 
@@ -110,13 +106,6 @@ func WithInitialCommit(initialCommit Commit) func(opt *New) {
 func WithRestConfig(restConfig *rest.Config) Opt {
 	return func(opt *New) {
 		opt.RESTConfig = restConfig
-	}
-}
-
-// WithWatchConfig uses the provided rest.Config for watches
-func WithWatchConfig(watchConfig *rest.Config) Opt {
-	return func(opt *New) {
-		opt.WatchConfig = watchConfig
 	}
 }
 


### PR DESCRIPTION
- Switch from using the controller-runtime client to client-go. This allows us access to the following features, which aren't exposed in the controller-runtime client.
- Use ResourceVersion between LIST and WATCH to ensure we don't miss events, especially DELETE events which were causing timeouts when missed.
- Use watch.Until with cache.NewListWatchFromClient to handle retrying watches that failed due to recoverable errors.
- Remove unused NT.WatchConfig. We can just use nt.Config with a custom timeout based on the input to WatchObject.
- Log watch events when watching, to show progress, but only log
  the diffs if --debug is enabled.

Fixes b/267941443