### PR TITLE
Modify Predicates to recieve nil for NotFound

### DIFF
--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -807,6 +807,9 @@ func configMapHasClusterName(clusterName string) nomostest.Predicate {
 // resourceQuotaHasHardPods validates if the resource quota has the expected hard pods in `.spec.hard.pods`.
 func resourceQuotaHasHardPods(nt *nomostest.NT, pods string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		rObj, err := kinds.ToTypedObject(o, nt.Client.Scheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
- Update all Predicate impls to tollerate nil objects without panic.
- Remove hacky workaround previously used to exit early when the object was not found. Now a normal predicate can handle it.