### PR TITLE
Use WatchObject instead of Retry+Validate

### DIFF
--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -282,6 +282,9 @@ func deleteConfigSyncAndTestAnnotationsAndLabels(nt *NT, ns *corev1.Namespace) e
 
 func namespaceHasNoConfigSyncAnnotationsAndLabels() Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		ns, ok := o.(*corev1.Namespace)
 		if !ok {
 			return WrongTypeErr(ns, &corev1.Namespace{})
@@ -395,9 +398,9 @@ func removeKubevirt(nt *NT, failOnError FailOnError) {
 	nt.MustKubectl("delete", "validatingwebhookconfigurations", "virt-api-mutator", "virt-operator-validator", "--ignore-not-found")
 	nt.MustKubectl("patch", "kubevirt", "kubevirt", "-n=kubevirt", "--type=merge", "-p={\"metadata\":{\"finalizers\":null}}")
 
-	if _, err := Retry(120*time.Second, func() error {
-		return nt.ValidateNotFound("kubevirt", "", &corev1.Namespace{})
-	}); err != nil {
+	err := WatchForNotFound(nt, kinds.Namespace(), "kubevirt", "",
+		WatchTimeout(120*time.Second))
+	if err != nil {
 		if failOnError {
 			nt.T.Fatalf("failed to clean up the Kubevirt resources", err)
 		} else {

--- a/e2e/nomostest/sync.go
+++ b/e2e/nomostest/sync.go
@@ -48,6 +48,9 @@ func (sipe *SyncInProgressError) Error() string {
 
 // MonoRepoSyncNotInProgress ensures the Repo does not have a sync in-progress.
 func MonoRepoSyncNotInProgress(o client.Object) error {
+	if o == nil {
+		return ErrObjectNotFound
+	}
 	repo, ok := o.(*v1.Repo)
 	if !ok {
 		return WrongTypeErr(o, &v1.Repo{})
@@ -63,6 +66,9 @@ func MonoRepoSyncNotInProgress(o client.Object) error {
 // successfully synced to the repository.
 func RepoHasStatusSyncLatestToken(sha1 string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		repo, ok := o.(*v1.Repo)
 		if !ok {
 			return WrongTypeErr(o, &v1.Repo{})
@@ -107,6 +113,9 @@ func RepoHasStatusSyncLatestToken(sha1 string) Predicate {
 // latest repo commit to the cluster.
 func ClusterConfigHasToken(sha1 string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		cc, ok := o.(*v1.ClusterConfig)
 		if !ok {
 			return WrongTypeErr(o, &v1.ClusterConfig{})
@@ -128,6 +137,9 @@ func ClusterConfigHasToken(sha1 string) Predicate {
 // .status.sync.gitStatus.dir field on the passed RootSync matches the provided dir.
 func RootSyncHasStatusSyncDirectory(dir string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		rs, ok := o.(*v1beta1.RootSync)
 		if !ok {
 			return WrongTypeErr(o, &v1beta1.RootSync{})
@@ -152,6 +164,9 @@ func RootSyncHasStatusSyncDirectory(dir string) Predicate {
 // .status.sync.gitStatus.dir field on the passed RepoSync matches the provided dir.
 func RepoSyncHasStatusSyncDirectory(dir string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		rs, ok := o.(*v1beta1.RepoSync)
 		if !ok {
 			return WrongTypeErr(o, &v1beta1.RepoSync{})
@@ -176,6 +191,9 @@ func RepoSyncHasStatusSyncDirectory(dir string) Predicate {
 // .status.sync.commit field on the passed RootSync matches sha1.
 func RootSyncHasStatusSyncCommit(sha1 string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		rs, ok := o.(*v1beta1.RootSync)
 		if !ok {
 			return WrongTypeErr(o, &v1beta1.RootSync{})
@@ -209,6 +227,9 @@ func RootSyncHasStatusSyncCommit(sha1 string) Predicate {
 // .status.sync.commit field on the passed RepoSync matches sha1.
 func RepoSyncHasStatusSyncCommit(sha1 string) Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
 		rs, ok := o.(*v1beta1.RepoSync)
 		if !ok {
 			return WrongTypeErr(o, &v1beta1.RepoSync{})

--- a/e2e/nomostest/watch.go
+++ b/e2e/nomostest/watch.go
@@ -56,6 +56,7 @@ func WatchTimeout(timeout time.Duration) WatchOption {
 // or the timeout is reached. Object does not need to exist yet, as long as the
 // resource type exists.
 // All Predicates need to handle nil objects (nil means Not Found).
+// If no Predicates are specified, WatchObject watches until the object exists.
 func WatchObject(nt *NT, gvk schema.GroupVersionKind, name, namespace string, predicates []Predicate, opts ...WatchOption) error {
 	errPrefix := fmt.Sprintf("WatchObject(%s %s/%s)", gvk.Kind, namespace, name)
 
@@ -70,6 +71,11 @@ func WatchObject(nt *NT, gvk schema.GroupVersionKind, name, namespace string, pr
 	}
 	for _, opt := range opts {
 		opt(&spec)
+	}
+
+	// Default to waiting until the object exists
+	if len(predicates) == 0 {
+		predicates = append(predicates, ObjectFoundPredicate)
 	}
 
 	// Use the context to stop the List and/or Watch if they run too long.

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -42,6 +41,9 @@ func sortPolicyRules(l, r rbacv1.PolicyRule) bool {
 
 func clusterRoleHasRules(rules []rbacv1.PolicyRule) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		cr, ok := o.(*rbacv1.ClusterRole)
 		if !ok {
 			return nomostest.WrongTypeErr(cr, &rbacv1.ClusterRole{})
@@ -57,6 +59,9 @@ func clusterRoleHasRules(rules []rbacv1.PolicyRule) nomostest.Predicate {
 
 func managerFieldsNonEmpty() nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		fields := o.GetManagedFields()
 		if len(fields) == 0 {
 			return errors.New("expect non empty manager fields")
@@ -114,27 +119,10 @@ func TestRevertClusterRole(t *testing.T) {
 	}
 
 	// Ensure the conflict is reverted.
-	d, err := nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate(crName, "", &rbacv1.ClusterRole{},
-			clusterRoleHasRules(declaredRules))
-	})
-
+	err = nomostest.WatchObject(nt, kinds.ClusterRole(), crName, "",
+		[]nomostest.Predicate{clusterRoleHasRules(declaredRules)})
 	if err != nil {
-		// err is non-nil about 1% of the time, making this a flaky test.
-		// So, wait for up to ten minutes for the ClusterRole to be reverted.
-		// If it doesn't after ten minutes, this is definitely a bug.
-		d2, err := nomostest.Retry(20*time.Minute, func() error {
-			return nt.Validate(crName, "", &rbacv1.ClusterRole{},
-				clusterRoleHasRules(declaredRules))
-		})
-		if err == nil {
-			// This was probably a flake. Consider increasing test resources or
-			// reducing test parallelism.
-			nt.T.Fatalf("reverted ClusterRole conflict after %v: %v", d+d2, err)
-		}
-
-		// There is definitely some sort of bug in ACM.
-		nt.T.Errorf("bug alert: did not revert ClusterRole conflict after %v: %v", d+d2, err)
+		nt.T.Error(err)
 	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -423,6 +423,9 @@ func validateNamespaces(nt *nomostest.NT, expectedNamespaces []string, expectedO
 
 func containerImagePullPolicy(policy string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		rq, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(rq, &appsv1.Deployment{})

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -93,6 +93,9 @@ func validateKCCResourceReady(nt *nomostest.NT, gvk schema.GroupVersionKind, nam
 }
 
 func kccResourceReady(o client.Object) error {
+	if o == nil {
+		return nomostest.ErrObjectNotFound
+	}
 	u := o.(*unstructured.Unstructured)
 	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
 	if err != nil || !found || len(conditions) == 0 {

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -403,9 +403,8 @@ func TestDeleteManagedResources(t *testing.T) {
 	}
 
 	// Verify Config Sync recreates the configmap
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("cm-1", "bookstore", &corev1.ConfigMap{})
-	})
+	err = nomostest.WatchForCurrentStatus(nt, kinds.ConfigMap(), "cm-1", "bookstore",
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -417,9 +416,8 @@ func TestDeleteManagedResources(t *testing.T) {
 	}
 
 	// Verify Config Sync recreates the namespace
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{})
-	})
+	err = nomostest.WatchForCurrentStatus(nt, kinds.Namespace(), "bookstore", "",
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -463,9 +461,8 @@ func TestDeleteManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 	}
 
 	// Verify Config Sync recreates the configmap
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("cm-1", "bookstore", &corev1.ConfigMap{})
-	})
+	err = nomostest.WatchForCurrentStatus(nt, kinds.ConfigMap(), "cm-1", "bookstore",
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -477,9 +474,8 @@ func TestDeleteManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 	}
 
 	// Verify Config Sync recreates the namespace
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{})
-	})
+	err = nomostest.WatchForCurrentStatus(nt, kinds.Namespace(), "bookstore", "",
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -502,9 +498,11 @@ func TestAddFieldsIntoManagedResources(t *testing.T) {
 	}
 
 	// Verify Config Sync does not remove this field
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation("season", "summer"))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation("season", "summer"),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -529,9 +527,11 @@ func TestAddFieldsIntoManagedResources(t *testing.T) {
 	}
 
 	// Verify Config Sync does not remove this field
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -555,9 +555,11 @@ func TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation(t *testing.T)
 	}
 
 	// Verify Config Sync does not remove this field
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation("season", "summer"))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation("season", "summer"),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -596,9 +598,11 @@ func TestModifyManagedFields(t *testing.T) {
 	}
 
 	// Verify Config Sync corrects it
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation("season", "summer"))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation("season", "summer"),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -610,9 +614,11 @@ func TestModifyManagedFields(t *testing.T) {
 	}
 
 	// Verify Config Sync corrects it
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -695,9 +701,11 @@ func TestDeleteManagedFields(t *testing.T) {
 		nt.T.Fatalf("got `kubectl annotate namespace bookstore season-` error %v %s, want return nil", err, out)
 	}
 
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation("season", "summer"))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation("season", "summer"),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -708,9 +716,11 @@ func TestDeleteManagedFields(t *testing.T) {
 		nt.T.Fatalf("got `kubectl annotate namespace bookstore %s-` error %v %s, want return nil", metadata.ResourceManagementKey, err, out)
 	}
 
-	_, err = nomostest.Retry(30*time.Second, func() error {
-		return nt.Validate("bookstore", "", &corev1.Namespace{}, nomostest.HasAnnotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled))
-	})
+	err = nomostest.WatchObject(nt, kinds.Namespace(), "bookstore", "",
+		[]nomostest.Predicate{
+			nomostest.HasAnnotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
+		},
+		nomostest.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -278,11 +278,7 @@ func anvilV1CRD() *apiextensionsv1.CustomResourceDefinition {
 
 func anvilCR(version, name string, weight int64) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "acme.com",
-		Version: version,
-		Kind:    "Anvil",
-	})
+	u.SetGroupVersionKind(anvilGVK(version))
 	if name != "" {
 		u.SetName(name)
 	}
@@ -292,6 +288,14 @@ func anvilCR(version, name string, weight int64) *unstructured.Unstructured {
 		}
 	}
 	return u
+}
+
+func anvilGVK(version string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "acme.com",
+		Version: version,
+		Kind:    "Anvil",
+	}
 }
 
 func TestMultipleVersions_RoleBinding(t *testing.T) {
@@ -414,6 +418,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 
 func hasV1Subjects(subjects ...string) func(o client.Object) error {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		r, ok := o.(*rbacv1.RoleBinding)
 		if !ok {
 			return nomostest.WrongTypeErr(o, r)
@@ -438,6 +445,9 @@ func hasV1Subjects(subjects ...string) func(o client.Object) error {
 
 func hasV1Beta1Subjects(subjects ...string) func(o client.Object) error {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		r, ok := o.(*rbacv1beta1.RoleBinding)
 		if !ok {
 			return nomostest.WrongTypeErr(o, r)

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -446,6 +446,9 @@ func parseObjectFromFile(nt *nomostest.NT, absPath string) (client.Object, error
 // resourceQuotaHasHardPods validates if the RepoSync has the expected sourceType.
 func isSourceType(sourceType v1beta1.SourceType) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		rs, ok := o.(*v1beta1.RepoSync)
 		if !ok {
 			return nomostest.WrongTypeErr(rs, &v1beta1.RepoSync{})

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -136,6 +136,9 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 // resourceStatusEquals verifies that an object has actuation and reconcile status as expected
 func resourceStatusEquals(id core.ID, expectActuation, expectReconcile string) nomostest.Predicate {
 	return func(obj client.Object) error {
+		if obj == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		rg, ok := obj.(*resourcegroupv1alpha1.ResourceGroup)
 		if !ok {
 			return nomostest.WrongTypeErr(obj, &resourcegroupv1alpha1.ResourceGroup{})

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -218,6 +218,9 @@ func resetReconcilerDeploymentManifests(nt *nomostest.NT, origImg string, genera
 
 func hasGeneration(generation int64) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -230,6 +233,9 @@ func hasGeneration(generation int64) nomostest.Predicate {
 }
 func firstContainerTerminationMessagePathIs(terminationMessagePath string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -242,6 +248,9 @@ func firstContainerTerminationMessagePathIs(terminationMessagePath string) nomos
 }
 func firstContainerStdinIs(stdin bool) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -254,6 +263,9 @@ func firstContainerStdinIs(stdin bool) nomostest.Predicate {
 }
 func hasTolerations(tolerations []corev1.Toleration) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -268,6 +280,9 @@ func hasTolerations(tolerations []corev1.Toleration) nomostest.Predicate {
 }
 func hasPriorityClassName(priorityClassName string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -280,6 +295,9 @@ func hasPriorityClassName(priorityClassName string) nomostest.Predicate {
 }
 func firstContainerImageIs(image string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -293,6 +311,9 @@ func firstContainerImageIs(image string) nomostest.Predicate {
 
 func firstContainerImageIsNot(image string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -306,6 +327,9 @@ func firstContainerImageIsNot(image string) nomostest.Predicate {
 
 func hasReplicas(replicas int32) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -319,6 +343,9 @@ func hasReplicas(replicas int32) nomostest.Predicate {
 
 func firstContainerMemoryLimitIs(memoryLimit string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -333,6 +360,9 @@ func firstContainerMemoryLimitIs(memoryLimit string) nomostest.Predicate {
 
 func firstContainerCPULimitIs(cpuLimit string) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -347,6 +377,9 @@ func firstContainerCPULimitIs(cpuLimit string) nomostest.Predicate {
 
 func gitCredsVolumeDeleted(volumesCount int) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -366,6 +399,9 @@ func gitCredsVolumeDeleted(volumesCount int) nomostest.Predicate {
 
 func templateForGcpServiceAccountAuthType() nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -386,6 +422,9 @@ func templateForGcpServiceAccountAuthType() nomostest.Predicate {
 
 func templateForSSHAuthType() nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -406,6 +445,9 @@ func templateForSSHAuthType() nomostest.Predicate {
 
 func totalContainerMemoryRequestIs(memoryRequest int64) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -432,6 +474,9 @@ func getTotalContainerMemoryRequest(d *appsv1.Deployment) int {
 
 func totalContainerCPURequestIs(expectedCPURequest int64) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -458,6 +503,9 @@ func getTotalContainerCPURequest(d *appsv1.Deployment) int {
 
 func firstContainerCPURequestIs(cpuRequest int64) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return nomostest.WrongTypeErr(d, &appsv1.Deployment{})
@@ -472,6 +520,9 @@ func firstContainerCPURequestIs(cpuRequest int64) nomostest.Predicate {
 
 func firstContainerMemoryRequestIs(memoryRequest int64) nomostest.Predicate {
 	return func(o client.Object) error {
+		if o == nil {
+			return nomostest.ErrObjectNotFound
+		}
 		memoryRequest *= memoryMB
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -16,6 +16,7 @@ package kinds
 
 import (
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -256,4 +257,9 @@ func KptFile() schema.GroupVersionKind {
 // APIService returns the APIService kind.
 func APIService() schema.GroupVersionKind {
 	return schema.GroupVersionKind{Group: "apiregistration.k8s.io", Version: "v1", Kind: "APIService"}
+}
+
+// ValidatingWebhookConfiguration returns the ValidatingWebhookConfiguration kind.
+func ValidatingWebhookConfiguration() schema.GroupVersionKind {
+	return admissionv1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration")
 }


### PR DESCRIPTION
- Update most e2e usages for Retry & Valdiate to use Watch functions
  instead. This should make tests less flakey, slightly faster, and
  easier to debug.
- Use 30s as a minimum timeout to account for occationally slow CI.
- Refactor a few tests to wait in parallel with a TaskGroup
- Update more Predicates to support nil object as NotFound