### PR TITLE
Don't allow namespace for cluster-scope watch

### DIFF
--- a/e2e/nomostest/watch.go
+++ b/e2e/nomostest/watch.go
@@ -255,10 +255,15 @@ func newListWatchForObject(nt *NT, gvk schema.GroupVersionKind, name, namespace 
 	if err != nil {
 		return nil, err
 	}
+	resource := mapping.Resource.Resource
+	// Validate namespace is empty for cluster-scoped resources
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot && namespace != "" {
+		return nil, errors.Errorf("cannot watch cluster-scoped resource %q in namespace %q", resource, namespace)
+	}
 	// Use a selector to filter the events down to just the object we care about.
 	nameSelector := fields.OneTermEqualSelector("metadata.name", name)
 	// Create a ListerWatcher for this resource and namespace
-	lw := cache.NewListWatchFromClient(restClient, mapping.Resource.Resource, namespace, nameSelector)
+	lw := cache.NewListWatchFromClient(restClient, resource, namespace, nameSelector)
 	return lw, nil
 }
 

--- a/e2e/testcases/apiservice_test.go
+++ b/e2e/testcases/apiservice_test.go
@@ -114,7 +114,7 @@ func validateStackdriverAdapterStatusCurrent(nt *nomostest.NT) error {
 		return nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), "custom-metrics-stackdriver-adapter", "custom-metrics")
 	})
 	tg.Go(func() error {
-		return nomostest.WatchForCurrentStatus(nt, kinds.ClusterRole(), "external-metrics-reader", "custom-metrics")
+		return nomostest.WatchForCurrentStatus(nt, kinds.ClusterRole(), "external-metrics-reader", "")
 	})
 	tg.Go(func() error {
 		return nomostest.WatchForCurrentStatus(nt, kinds.RoleBinding(), "custom-metrics-auth-reader", "custom-metrics")


### PR DESCRIPTION
This validation will prevent accidentally specifying a namespace for a cluster-scoped object when using WatchObject in e2e tests.