### PR TITLE
Fix usages of TaskGroup in a for loop

### DIFF
--- a/e2e/nomostest/crds.go
+++ b/e2e/nomostest/crds.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	"kpt.dev/configsync/pkg/kinds"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,8 +40,10 @@ var (
 func WaitForCRDs(nt *NT, crds []string) error {
 	tg := taskgroup.New()
 	for _, crd := range crds {
+		nn := types.NamespacedName{Name: crd}
 		tg.Go(func() error {
-			return WatchObject(nt, kinds.CustomResourceDefinitionV1(), crd, "",
+			return WatchObject(nt, kinds.CustomResourceDefinitionV1(),
+				nn.Name, nn.Namespace,
 				[]Predicate{IsEstablished})
 		})
 	}

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/metrics"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
@@ -328,8 +329,9 @@ func checkRepoSyncResourcesNotPresent(nt *nomostest.NT, namespace string, secret
 		return nomostest.WatchForNotFound(nt, kinds.ServiceAccount(), controllers.RepoSyncPermissionsName(), configsync.ControllerNamespace)
 	})
 	for _, sName := range secretNames {
+		nn := types.NamespacedName{Name: sName, Namespace: configsync.ControllerNamespace}
 		tg.Go(func() error {
-			return nomostest.WatchForNotFound(nt, kinds.Secret(), sName, configsync.ControllerNamespace)
+			return nomostest.WatchForNotFound(nt, kinds.Secret(), nn.Name, nn.Namespace)
 		})
 	}
 	if err := tg.Wait(); err != nil {


### PR DESCRIPTION
Range values are re-used in a for loop.
Use indirection to avoid using the last value for every task.