### PR TITLE
fix edge case in namespace safegaurd logic

### DIFF
--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -339,7 +339,7 @@ func Generate() AllExamples {
 
 	// 2006
 	result.add(status.EmptySourceError(10, "namespaces"))
-	result.add(declared.DeleteAllNamespacesError([]string{"shipping", "billing"}))
+	result.add(declared.DeleteAllNamespacesError(map[string]struct{}{"shipping": {}, "billing": {}}))
 
 	// 2007 is Deprecated.
 	result.markDeprecated("2007")

--- a/pkg/declared/namespace_safeguard_test.go
+++ b/pkg/declared/namespace_safeguard_test.go
@@ -66,7 +66,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 			name:     "two to zero",
 			previous: []string{"foo", "bar"},
 			current:  []string{},
-			want:     DeleteAllNamespacesError([]string{"foo", "bar"}),
+			want:     DeleteAllNamespacesError(map[string]struct{}{"foo": {}, "bar": {}}),
 		},
 		{
 			name:     "two to one",
@@ -77,6 +77,12 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 			name:     "two to two",
 			previous: []string{"foo", "bar"},
 			current:  []string{"foo", "bar"},
+		},
+		{
+			name:     "two to new two",
+			previous: []string{"foo", "bar"},
+			current:  []string{"baz", "qux"},
+			want:     DeleteAllNamespacesError(map[string]struct{}{"foo": {}, "bar": {}}),
 		},
 	}
 


### PR DESCRIPTION
The current logic for namespace safeguard deletion only checks for the length of the namespaces to see if all the namespaces are being deleted. But it should check for the contents instead. Reason being, there is an edge case where if you simply replace the namespaces with new ones it would still end up deleting all the previous namespaces. 

I think the test case I added would explain the bug more eloquently