### PR TITLE
Increase wait timeout for reconciler

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -466,8 +466,7 @@ func setupRepoSync(nt *NT, nn types.NamespacedName) {
 
 func waitForReconciler(nt *NT, name string) error {
 	return WatchForCurrentStatus(nt, kinds.Deployment(),
-		name, configmanagement.ControllerNamespace,
-		WatchTimeout(60*time.Second))
+		name, configmanagement.ControllerNamespace)
 }
 
 // RepoSyncRoleBinding returns rolebinding that grants service account


### PR DESCRIPTION
- Change delegated control to wait the default timeout for reconciler readiness, instead of only 1m

Fixes: b/269473968