### PR TITLE
Enable nomos status command in OSS

### DIFF
--- a/cmd/nomos/status/client.go
+++ b/cmd/nomos/status/client.go
@@ -56,7 +56,6 @@ const (
 	ACMOperatorDeployment            = "config-management-operator"
 	syncingConditionSupportedVersion = "v1.10.0-rc.1"
 	rootSyncCRDName                  = "rootsyncs.configsync.gke.io"
-	repoSyncCRDName                  = "reposyncs.configsync.gke.io"
 )
 
 // ClusterClient is the client that talks to the cluster.
@@ -378,7 +377,7 @@ func (c *ClusterClient) IsOssInstallation(ctx context.Context, cs *ClusterState)
 	_, operatorDepErr := c.K8sClient.AppsV1().Deployments(configmanagement.ControllerNamespace).Get(ctx, ACMOperatorDeployment, metav1.GetOptions{})
 	if operatorDepErr != nil && !apierrors.IsNotFound(operatorDepErr) {
 		err := fmt.Errorf("Failed to get the Operator Deployment: %v", operatorDepErr)
-		cs.Error = err.Error() 
+		cs.Error = err.Error()
 		return false, err
 	}
 
@@ -390,7 +389,7 @@ func (c *ClusterClient) IsOssInstallation(ctx context.Context, cs *ClusterState)
 	if rootSyncCRDErr == nil {
 		return true, nil
 	}
-	err := fmt.Errorf("Failed to get the RootSync CRD: %v", rootSyncCRDErr) 
+	err := fmt.Errorf("Failed to get the RootSync CRD: %v", rootSyncCRDErr)
 	cs.Error = err.Error()
 	return false, err
 }

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1034,3 +1034,19 @@ func checkFileExists(prefix string, targetFiles, allFiles []string) status.Multi
 	}
 	return err
 }
+
+func TestNomosStatus(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.NomosCLI)
+
+	// get status
+	cmd := nt.Command("nomos", "status")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		nt.T.Log(string(out))
+		nt.T.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), "git@test-git-server.config-management-system-test:/git-server/repos/config-management-system/root-sync/acme@main") {
+		nt.T.Fatalf("Expected to find Git provider string in output:\n%s\n", string(out))
+	}
+}


### PR DESCRIPTION
From Github issue https://github.com/GoogleContainerTools/kpt-config-sync/issues/226

Currently, nomos status will check for Operator pods and ConfigManagement resource, so it wouldn't work in OSS Config Sync installation.

To get nomos status to work in OSS, the function IsOssInstallation will check for the existence of ConfigManagement object, Operator deployment, and RSync CRD.  If RSync CRD exist but ConfigManagement and Operator doesn't, it indicates an OSS installation