### PR TITLE
Pause the remediator while the Applier is running

### DIFF
--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -240,7 +240,9 @@ data:
 	}
 
 	// Config Sync should remove `test-ns`.
-	if err := nomostest.WatchForNotFound(nt, kinds.ConfigMap(), "test-cm1", "bookstore"); err != nil {
+	err = nomostest.WatchForNotFound(nt, kinds.ConfigMap(), "test-cm1", "bookstore",
+		nomostest.WatchTimeout(30*time.Second))
+	if err != nil {
 		nt.T.Fatal(err)
 	}
 

--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -91,8 +91,8 @@ func (r *Resources) Get(id core.ID) (*unstructured.Unstructured, bool) {
 	return u.DeepCopy(), found
 }
 
-// Declarations returns all resource declarations from Git.
-func (r *Resources) Declarations() []*unstructured.Unstructured {
+// DeclaredUnstructureds returns all resource objects declared in the source.
+func (r *Resources) DeclaredUnstructureds() []*unstructured.Unstructured {
 	var objects []*unstructured.Unstructured
 	objSet := r.getObjectSet()
 
@@ -104,18 +104,28 @@ func (r *Resources) Declarations() []*unstructured.Unstructured {
 	return objects
 }
 
-// GVKSet returns the set of all GroupVersionKind found in the git repo.
-func (r *Resources) GVKSet() map[schema.GroupVersionKind]bool {
-	gvkSet := make(map[schema.GroupVersionKind]bool)
+// DeclaredObjects returns all resource objects declared in the source.
+func (r *Resources) DeclaredObjects() []client.Object {
+	var objects []client.Object
+	objSet := r.getObjectSet()
+
+	// A local reference to the map is threadsafe since only the struct reference
+	// is replaced on update.
+	for _, obj := range objSet {
+		objects = append(objects, obj)
+	}
+	return objects
+}
+
+// DeclaredGVKs returns the set of all GroupVersionKind found in the source.
+func (r *Resources) DeclaredGVKs() map[schema.GroupVersionKind]struct{} {
+	gvkSet := make(map[schema.GroupVersionKind]struct{})
 	objSet := r.getObjectSet()
 
 	// A local reference to the objSet map is threadsafe since only the pointer to
 	// the map is replaced on update.
 	for _, obj := range objSet {
-		gvk := obj.GroupVersionKind()
-		if !gvkSet[gvk] {
-			gvkSet[gvk] = true
-		}
+		gvkSet[obj.GroupVersionKind()] = struct{}{}
 	}
 	return gvkSet
 }

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -130,7 +130,7 @@ func TestDeclarations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := dr.Declarations()
+	got := dr.DeclaredUnstructureds()
 	// Sort got decls to ensure determinism.
 	sort.Slice(got, func(i, j int) bool {
 		return core.IDOf(got[i]).String() < core.IDOf(got[j]).String()
@@ -177,10 +177,10 @@ func TestGVKSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := dr.GVKSet()
-	want := map[schema.GroupVersionKind]bool{
-		obj1.GroupVersionKind(): true,
-		obj2.GroupVersionKind(): true,
+	got := dr.DeclaredGVKs()
+	want := map[schema.GroupVersionKind]struct{}{
+		obj1.GroupVersionKind(): {},
+		obj2.GroupVersionKind(): {},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Error(diff)

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -65,6 +65,10 @@ type noOpRemediator struct {
 	needsUpdate bool
 }
 
+func (r *noOpRemediator) Pause() {}
+
+func (r *noOpRemediator) Resume() {}
+
 func (r *noOpRemediator) ConflictErrors() []status.ManagementConflictError {
 	return nil
 }

--- a/pkg/remediator/queue/queue_test.go
+++ b/pkg/remediator/queue/queue_test.go
@@ -15,6 +15,7 @@
 package queue
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -38,9 +39,9 @@ func add(toAdd client.Object, wantLen int) action {
 func get(wantObj client.Object, wantLen int) action {
 	return func(t *testing.T, q *ObjectQueue) {
 		t.Helper()
-		got, shutdown := q.Get()
-		if shutdown {
-			t.Fatal("unexpected shutdown of queue")
+		got, err := q.Get(context.Background())
+		if err != nil {
+			t.Fatalf("Object queue was shut down unexpectedly: %v", err)
 		}
 		if diff := cmp.Diff(got, wantObj); diff != "" {
 			t.Errorf("unexpected object from queue; diff: %s", diff)

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -215,9 +215,9 @@ func TestFilteredWatcher(t *testing.T) {
 
 			var got []core.ID
 			for q.Len() > 0 {
-				obj, shutdown := q.Get()
-				if shutdown {
-					t.Fatal("Object queue was shut down unexpectedly.")
+				obj, err := q.Get(context.Background())
+				if err != nil {
+					t.Fatalf("Object queue was shut down unexpectedly: %v", err)
 				}
 				got = append(got, core.IDOf(obj))
 			}

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -140,6 +140,8 @@ func (m *Manager) UpdateWatches(ctx context.Context, gvkMap map[schema.GroupVers
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
+	klog.V(3).Infof("UpdateWatches(%v)", gvkMap)
+
 	m.needsUpdate = false
 
 	var startedWatches, stoppedWatches uint64


### PR DESCRIPTION
- Fix a bug that might cause objects to be applied or deleted
  in the wrong order. This was being caused by the remediator
  detecting new changes as drift, when an object was updated
  asynchronously, before the applier had a chance to apply
  the new intended state.
  The reconciler now pauses the remediator before syncing,
  and resumes remediating after syncing is successful.
  The remediator will continue watching and enqueuing
  objects to remediate when changed while paused. This
  way no drift is missed while other objects are being applied.
- Fix a bug where sync retries might use unsanitized objects.
  This following fields are silently ignored:
  - status
  - metadata.creationTimestamp
  - metadata.finalizers
  This helps when applying objects from 3rd party sources
  which can't be easily sanitized.
- Fix RootSync vs RootSync conflicts when the webhook is enabled.
  Previously, the remediator would detect and report the conflict
  to the other RootSync, but now that the remediator is paused
  during apply, there is no conflict. The webhook prevents it.
  So only the 2nd RootSync reports the error, when attempting to
  apply. This is how RepoSyncs already worked.
- Fix e2e metrics validation to tolerate missing RemediateDuration
  metric. Now that the remediator is paused while applying, it's
  possible that no objects are remediated during the course of a test.
- Move ObjectQueue shutdown into the Remediator and
  modify ObjectQueue.Get to take a context. This allows
  Workers to be stopped without shutting down the queue.
- Add additional logging that was useful for debugging

Fixes: b/235358559

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/431
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/432
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/433
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/434
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/435
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/437
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/442
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/447
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/449