### PR TITLE
Watch for sync in e2e tests, instead of polling

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -888,7 +888,9 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 
 	if len(opts.NamespaceRepos) == 0 {
 		// Wait for the RootSyncs and exit early
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 		return
 	}
 
@@ -942,7 +944,9 @@ func setupCentralizedControl(nt *NT, opts *ntopts.New) {
 	}
 
 	// Wait for all RootSyncs and all RepoSyncs to be reconciled
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate all RepoSyncs exist
 	for nn := range opts.NamespaceRepos {

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -412,7 +412,9 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 		setupCentralizedControl(nt, opts)
 	}
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 // TestDir creates a unique temporary directory for the E2E test.

--- a/e2e/testcases/acme_test.go
+++ b/e2e/testcases/acme_test.go
@@ -54,7 +54,9 @@ func TestAcmeCorpRepo(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].SafetyNSName: ""}
 	nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme", ".")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Initialize the acme directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	checkResourceCount(nt, kinds.Namespace(), "", len(nsToFolder), nil, configSyncManagementAnnotations)
 	for namespace, folder := range nsToFolder {
@@ -172,7 +174,9 @@ func TestAcmeCorpRepo(t *testing.T) {
 	// Add back the safety ClusterRole to pass the safety check (KNV2006).
 	nt.RootRepos[configsync.RootSyncName].AddSafetyClusterRole()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Reset the acme directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 // TestObjectInCMSNamespace will test that user can sync object to CMS namespace
@@ -181,7 +185,9 @@ func TestObjectInCMSNamespace(t *testing.T) {
 
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/object-in-cms-namespace", "acme")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("adding resource to config-management-system namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// validate the resources synced successfully in CMS namespace
 	namespace := configmanagement.ControllerNamespace

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -40,7 +40,9 @@ func TestAdmission(t *testing.T) {
 		fake.NamespaceObject("hello",
 			core.Annotation("goodbye", "moon")))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure we properly forbid changing declared information.
 
@@ -156,7 +158,9 @@ metadata:
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", fake.NamespaceObject("hello"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "webhook.yaml"), webhook, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
@@ -179,7 +183,9 @@ metadata:
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/test/ns.yaml", fake.NamespaceObject("test"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add another Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.WaitForWebhookReadiness(nt)
 

--- a/e2e/testcases/adopt_client_side_applied_test.go
+++ b/e2e/testcases/adopt_client_side_applied_test.go
@@ -57,7 +57,9 @@ func TestAdoptClientSideAppliedResource(t *testing.T) {
 	}}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/ns-viewer-cr.yaml", nsViewer)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add namespace-viewer ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate the ClusterRole exist and the Rules are the same as the one
 	// in "acme/cluster/ns-viewer-cr.yaml".

--- a/e2e/testcases/apiservice_test.go
+++ b/e2e/testcases/apiservice_test.go
@@ -48,7 +48,9 @@ func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/apiservice/apiservice.yaml", "acme/cluster/apiservice.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("adding apiservice resources")
 	nt.T.Log("Waiting for nomos to sync new APIService")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := validateStackdriverAdapterStatusCurrent(nt)
 	if err != nil {
@@ -59,13 +61,17 @@ func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 	// the test repo from cleaning up
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/apiservice.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove custom metric stackdriver adapter API service")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Remove the backend Deployment of test APIService
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/custom-metrics/namespace-custom-metrics.yaml")
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/custom-metrics/namespace.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove custom metric stackdriver adapter namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
@@ -93,7 +99,9 @@ func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add testing resources")
 
 	nt.T.Log("Wait for test resource to have status CURRENT")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nomostest.WatchForCurrentStatus(nt, kinds.Namespace(), "resilient", "")
 	if err != nil {
@@ -105,7 +113,9 @@ func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
 	nt.MustKubectl("apply", "-f", "../testdata/apiservice/rbac.yaml")
 	nt.MustKubectl("apply", "-f", "../testdata/apiservice/namespace-custom-metrics.yaml")
 	nt.T.Log("Waiting for nomos to stabilize")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateStackdriverAdapterStatusCurrent(nt)
 	if err != nil {

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -433,7 +433,9 @@ func testSyncFromNomosHydrateOutput(t *testing.T, config string) {
 
 	nt.RootRepos[configsync.RootSyncName].Copy(config, "acme")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add cluster-dev configs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	if err := nt.Validate("bookstore1", "", &corev1.Namespace{}); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -94,7 +94,9 @@ func TestRevertClusterRole(t *testing.T) {
 	declaredCr.Rules = declaredRules
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate(crName, "", &rbacv1.ClusterRole{},
 		clusterRoleHasRules(declaredRules))
@@ -157,7 +159,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	declaredCr.Rules = declaredRules
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate(crName, "", &rbacv1.ClusterRole{},
 		clusterRoleHasRules(declaredRules), managerFieldsNonEmpty())
@@ -191,7 +195,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	updatedCr.Rules = updatedRules
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", updatedCr)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("update ClusterRole to get/list")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure the resource is updated.
 	if err = nt.Validate(crName, "", &rbacv1.ClusterRole{}, clusterRoleHasRules(updatedRules), managerFieldsNonEmpty()); err != nil {
@@ -215,7 +221,9 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	// Delete the ClusterRole from the SOT.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/clusterrole.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("deleting ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.ValidateNotFound(crName, "", &rbacv1.ClusterRole{})
 	if err != nil {

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -122,13 +122,17 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/frontend/quota-inline.yaml", rqInline)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/frontend/quota-legacy.yaml", rqLegacy)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a resource quota")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(resourceQuotaName, frontendNamespace, &corev1.ResourceQuota{}, resourceQuotaHasHardPods(nt, prodPodsQuota)); err != nil {
 		nt.T.Fatal(err)
 	}
 
 	renameCluster(nt, configMapName, testClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -143,7 +147,9 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 		}))
 
 	renameCluster(nt, configMapName, prodClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -177,7 +183,9 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 		namespaceObject(backendNamespace, map[string]string{}))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -193,13 +201,17 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 	rb.Annotations = legacyTestClusterSelectorAnnotation
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change cluster selector to match test cluster")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
 
 	renameCluster(nt, configMapName, testClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -216,13 +228,17 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 	rb.Annotations = inlineProdClusterSelectorAnnotation
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Revert cluster selector to match prod cluster")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
 
 	renameCluster(nt, configMapName, prodClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -257,7 +273,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a namespace and a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(namespace.Name, namespace.Namespace, &corev1.Namespace{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -290,7 +308,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	namespace.Annotations = legacyTestClusterSelectorAnnotation
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change namespace to match test cluster")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -313,7 +333,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	}
 
 	renameCluster(nt, configMapName, testClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -351,7 +373,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	rb.Annotations = map[string]string{}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update bob-rolebinding to NOT have cluster-selector")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -374,7 +398,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	namespace.Annotations = inlineProdClusterSelectorAnnotation
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Revert namespace to match prod cluster")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -397,7 +423,9 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 	}
 
 	renameCluster(nt, configMapName, prodClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -441,7 +469,9 @@ func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 		namespaceObject(backendNamespace, map[string]string{}))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -450,7 +480,9 @@ func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a, b, c"}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modify the cluster selector to select an excluded cluster list")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -480,7 +512,9 @@ func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 		namespaceObject(backendNamespace, map[string]string{}))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -489,7 +523,9 @@ func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 	prodClusterWithADifferentSelector := clusterSelector(prodClusterSelectorName, environmentLabelKey, "other")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterWithADifferentSelector)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modify the cluster selector to select a different environment")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -524,7 +560,9 @@ func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/anvil-2.yaml", cr2)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource without its CRD")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		return nt.ValidateErrorMetricsNotFound()
@@ -546,7 +584,9 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 	nn := nomostest.RepoSyncNN(namespaceRepo, configsync.RepoSyncName)
 	nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb)
 	nt.NonRootRepos[nn].CommitAndPush("Add a valid cluster selector annotation to a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -555,7 +595,9 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a,b,,,c,d"}
 	nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb)
 	nt.NonRootRepos[nn].CommitAndPush("Modify the cluster selector to select an excluded cluster list")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -568,7 +610,9 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName}
 	nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb)
 	nt.NonRootRepos[nn].CommitAndPush("Add cluster registry data and use the legacy ClusterSelector")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -594,7 +638,9 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 		namespaceObject(backendNamespace, map[string]string{}))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a role binding without any cluster selectors")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -603,13 +649,17 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	rb.Annotations = inlineProdClusterSelectorAnnotation
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a prod cluster selector to the role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
 
 	renameCluster(nt, configMapName, prodClusterName)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// TODO: Confirm that the change was Synced.
 	// This is not currently possible using the RootSync status API, because
 	// the commit didn't change, and the commit was already previously Synced.
@@ -626,7 +676,9 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: ""}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add an empty cluster selector annotation to a role binding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -635,7 +687,9 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: fmt.Sprintf("a,%s,b", prodClusterName)}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -644,7 +698,9 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a,,b"}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of excluded clusters")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.ValidateNotFound(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -653,7 +709,9 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: fmt.Sprintf("a , %s , b", prodClusterName)}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters (with spaces)")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(rb.Name, rb.Namespace, &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -697,7 +755,9 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	crd := anvilV1CRD()
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(crd.Name, "", &apiextensionsv1.CustomResourceDefinition{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -707,7 +767,9 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	crd.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: testClusterName})
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an unselected cluster-name-selector annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// CRD should be marked as deleted, but may not be NotFound yet, because its
 	// finalizer will block until all objects of that type are deleted.
 	err := nomostest.WatchForNotFound(nt, kinds.CustomResourceDefinitionV1(), crd.Name, crd.Namespace)
@@ -719,7 +781,9 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	crd.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: prodClusterName})
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an selected cluster-name-selector annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(crd.Name, "", &apiextensionsv1.CustomResourceDefinition{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -738,7 +802,9 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	crd.SetAnnotations(legacyTestClusterSelectorAnnotation)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an unselected ClusterSelector")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// CRD should be marked as deleted, but may not be NotFound yet, because its
 	// finalizer will block until all objects of that type are deleted.
 	err = nomostest.WatchForNotFound(nt, kinds.CustomResourceDefinitionV1(), crd.Name, crd.Namespace)
@@ -750,7 +816,9 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	crd.SetAnnotations(map[string]string{metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName})
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an selected ClusterSelector")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate(crd.Name, "", &apiextensionsv1.CustomResourceDefinition{}); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/custom_resource_definitions_schema_test.go
+++ b/e2e/testcases/custom_resource_definitions_schema_test.go
@@ -48,7 +48,9 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/cr.yaml", crContent)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a CRD and CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("my-cron-object", "foo", crForSchema())
 	if err != nil {
@@ -58,7 +60,9 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	// Restart the ConfigSync importer or reconciler pods.
 	// So that the old schema of the CRD is picked.
 	nt.MustKubectl("delete", "pods", "-n", "config-management-system", "-l", "configsync.gke.io/reconciler=root-reconciler")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Add the CRD with a new schema and a CR using the new schema to the repo
 	crdContent, err = ioutil.ReadFile(newCRDFile)
@@ -72,7 +76,9 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/cr.yaml", crContent)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding the CRD with new schema and a CR using the new schema")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("my-new-cron-object", "foo", crForSchema())
 	if err != nil {

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -42,7 +42,9 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD and one Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err := nt.Validate(configuration.Name, "", &admissionv1.ValidatingWebhookConfiguration{},
@@ -92,7 +94,9 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 	// This should fix the error.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/anvil-v1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CR as well")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate reconciler error is cleared.
 	// The applier can prune both the CR and CRD in the same pass. So for this
@@ -138,7 +142,9 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", fake.NamespaceObject("prod"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil.yaml", anvilCR("v1", "e2e-test-anvil", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD and one Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
@@ -163,7 +169,9 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	// Remove the CustomResource.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/prod/anvil.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing Anvil CR but leaving Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.ValidateNotFound("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -172,7 +180,9 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	// Remove the CustomResourceDefinition.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/anvil-crd.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CRD as well")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Fatal(err)
@@ -204,7 +214,9 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/anvil-crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", fake.NamespaceObject("prod"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	// Validate multi-repo metrics.
@@ -235,7 +247,9 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 	// Remove the CustomResourceDefinition.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/anvil-crd.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
 	if err != nil {
@@ -267,7 +281,9 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/clusteranvil-crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusteranvil.yaml", clusteranvilCR("v1", "e2e-test-clusteranvil", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding clusterscoped Anvil CRD and CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err = nt.Validate("e2e-test-clusteranvil", "", clusteranvilCR("v1", "", 10))
@@ -305,7 +321,9 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	}
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/clusteranvil-crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updating the Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("clusteranvils.acme.com", "", fake.CustomResourceDefinitionV1Object(), hasTwoVersions)
 	if err != nil {
@@ -324,7 +342,9 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	// Add back the safety ClusterRole to pass the safety check (KNV2006).
 	nt.RootRepos[configsync.RootSyncName].AddSafetyClusterRole()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CRD as well")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.ValidateNotFoundOrNoMatch("e2e-test-clusteranvil", "prod", clusteranvilCR("v2", "", 10))
 	if err != nil {
 		nt.T.Error(err)
@@ -363,7 +383,9 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil.yaml", anvilCR("v1", "e2e-test-anvil", 10))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", fake.NamespaceObject("prod"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding namespacescoped Anvil CRD and CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
@@ -399,7 +421,9 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	}
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/anvil-crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updating the Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v2", "", 10))
 	if err != nil {
@@ -419,7 +443,9 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/anvil-crd.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil.yaml", anvilCR("v2", "e2e-test-anvil", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update the Anvil CRD and CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object(), nomostest.IsEstablished, hasTwoVersions)
 	if err != nil {
@@ -435,7 +461,9 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/anvil-crd.yaml")
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/prod/anvil.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the Anvil CRD and CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate the CustomResource is also deleted from cluster.
 	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
@@ -471,7 +499,9 @@ func TestLargeCRD(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].AddFile(fmt.Sprintf("acme/cluster/%s", file), crdContent)
 	}
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding two large CRDs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err := nomostest.WatchObject(nt, kinds.CustomResourceDefinitionV1(), "challenges.acme.cert-manager.io", "", nil,
@@ -509,7 +539,9 @@ func TestLargeCRD(t *testing.T) {
 	}
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/challenges-acme-cert-manager-io.yaml", crdContent)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update label for one CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nomostest.WatchObject(nt, kinds.CustomResourceDefinitionV1(), "challenges.acme.cert-manager.io", "",
 		[]nomostest.Predicate{nomostest.HasLabel("random-key", "random-value")},

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -65,7 +65,9 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", fake.NamespaceObject("prod"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil-v1.yaml", anvilCR("v1", "heavy", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Reset discovery client to pick up Anvil CRD
 	nt.RenewClient()
@@ -124,7 +126,9 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 	// This should fix the error.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/prod/anvil-v1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CR as well")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
@@ -149,7 +153,9 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Reset discovery client to pick up Anvil CRD
 	nt.RenewClient()
@@ -212,7 +218,9 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 	// This should fix the error.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/anvil-v1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing the Anvil CR as well")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestSyncUpdateCustomResource(t *testing.T) {
@@ -242,7 +250,9 @@ func TestSyncUpdateCustomResource(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 10))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err = nt.Validate("heavy", "foo", anvilCR("v1", "", 0), weightEqual10)
@@ -253,7 +263,9 @@ func TestSyncUpdateCustomResource(t *testing.T) {
 	// Update CustomResource
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 100))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updating Anvil CR")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err = nt.Validate("heavy", "foo", anvilCR("v1", "", 0), weightEqual100)

--- a/e2e/testcases/declared_fields_test.go
+++ b/e2e/testcases/declared_fields_test.go
@@ -49,7 +49,9 @@ spec:
     - containerPort: 80
 `))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add pod missing protocol from port")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Parse the pod yaml into an object
 	pod := nt.RootRepos[configsync.RootSyncName].Get("acme/pod.yaml")
@@ -61,7 +63,9 @@ spec:
 
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/pod.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the pod")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nomostest.WatchForNotFound(nt, kinds.Pod(), pod.GetName(), pod.GetNamespace())
 	if err != nil {

--- a/e2e/testcases/gatekeeper_test.go
+++ b/e2e/testcases/gatekeeper_test.go
@@ -74,7 +74,9 @@ func TestConstraintTemplateAndConstraintInSameCommit(t *testing.T) {
 			// Add back the safety ClusterRole to pass the safety check (KNV2006).
 			nt.RootRepos[configsync.RootSyncName].AddSafetyClusterRole()
 			nt.RootRepos[configsync.RootSyncName].CommitAndPush("Reset the acme directory")
-			nt.WaitForRepoSyncs()
+			if err := nt.WatchForAllSyncs(); err != nil {
+				nt.T.Fatal(err)
+			}
 		}
 	})
 
@@ -91,12 +93,16 @@ func TestConstraintTemplateAndConstraintInSameCommit(t *testing.T) {
 		nt.T.Fatalf("Failed to create constraint CRD: %v", err)
 	}
 	// Sync should eventually succeed on retry, now that all the required CRDs exist.
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Cleanup before deleting the ConstraintTemplate and Constraint CRDs to avoid resource conflict errors from the webhook.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster")
 	// Add back the safety ClusterRole to pass the safety check (KNV2006).
 	nt.RootRepos[configsync.RootSyncName].AddSafetyClusterRole()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Reset the acme directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -59,7 +59,10 @@ func TestHydrateKustomizeComponents(t *testing.T) {
 	nt.T.Log("Update RootSync to sync from the kustomize-components directory")
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "kustomize-components"}}}`)
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "kustomize-components"}))
+	err := nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "kustomize-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rs = getUpdatedRootSync(nt, configsync.RootSyncName, configsync.ControllerNamespace)
 	rsCommit, rsStatus, rsErrorSummary := getRootSyncCommitStatusErrorSummary(rs, nil, false)
@@ -87,7 +90,10 @@ func TestHydrateKustomizeComponents(t *testing.T) {
 	nt.T.Log("Add kustomization.yaml back")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/kustomize-components/kustomization.yml", "./kustomize-components/kustomization.yml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add kustomization.yml back")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "kustomize-components"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "kustomize-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rs = getUpdatedRootSync(nt, configsync.RootSyncName, configsync.ControllerNamespace)
 	rsCommit, rsStatus, rsErrorSummary = getRootSyncCommitStatusErrorSummary(rs, nil, false)
@@ -130,7 +136,10 @@ func TestHydrateHelmComponents(t *testing.T) {
 		nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "helm-components"}}}`)
 	}
 
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	err := nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rs = getUpdatedRootSync(nt, configsync.RootSyncName, configsync.ControllerNamespace)
 	rsCommit, rsStatus, rsErrorSummary := getRootSyncCommitStatusErrorSummary(rs, nil, false)
@@ -145,7 +154,10 @@ func TestHydrateHelmComponents(t *testing.T) {
 	nt.T.Log("Use a remote values.yaml file from a public repo")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/helm-components-remote-values-kustomization.yaml", "./helm-components/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Render with a remote values.yaml file from a public repo")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
 		containerImagePullPolicy("Always"), firstContainerImageIs("coredns/coredns:1.8.4"),
 		nomostest.HasAnnotation(metadata.KustomizeOrigin, expectedBuiltinOrigin)); err != nil {
@@ -163,7 +175,10 @@ func TestHydrateHelmComponents(t *testing.T) {
 	nt.T.Log("Use the render-helm-chart function to render the charts")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/krm-function-helm-components-kustomization.yaml", "./helm-components/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update kustomization.yaml to use the render-helm-chart function")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
 		containerImagePullPolicy("IfNotPresent"), firstContainerImageIs("coredns/coredns:1.8.4"),
 		nomostest.HasAnnotation(metadata.KustomizeOrigin, expectedKrmFnOrigin)); err != nil {
@@ -180,7 +195,10 @@ func TestHydrateHelmComponents(t *testing.T) {
 	nt.T.Log("Use the render-helm-chart function to render the charts with multiple remote values.yaml files")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/krm-function-helm-components-remote-values-kustomization.yaml", "./helm-components/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update kustomization.yaml to use the render-helm-chart function with multiple remote values.yaml files from a public repo")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-components"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
 		containerImagePullPolicy("Always"), firstContainerImageIs("coredns/coredns:1.9.3"),
 		nomostest.HasAnnotation(metadata.KustomizeOrigin, expectedKrmFnOrigin)); err != nil {
@@ -214,7 +232,10 @@ func TestHydrateHelmOverlay(t *testing.T) {
 		nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "helm-overlay"}}}`)
 	}
 
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-overlay"}))
+	err := nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-overlay"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.T.Log("Validate resources are synced")
 	if err := nt.Validate("my-coredns-coredns", "coredns", &appsv1.Deployment{},
@@ -265,7 +286,10 @@ func TestHydrateHelmOverlay(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/helm-overlay/kustomization.yaml", "./helm-overlay/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/krm-function-helm-overlay-kustomization.yaml", "./helm-overlay/base/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update kustomization.yaml to use the render-helm-chart function")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-overlay"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "helm-overlay"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rs = getUpdatedRootSync(nt, configsync.RootSyncName, configsync.ControllerNamespace)
 	rsCommit, rsStatus, rsErrorSummary = getRootSyncCommitStatusErrorSummary(rs, nil, false)
@@ -312,7 +336,10 @@ func TestHydrateRemoteResources(t *testing.T) {
 
 	nt.T.Log("Enable shell in hydration controller")
 	nt.MustMergePatch(rs, `{"spec": {"override": {"enableShellInRendering": true}}}`)
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
 		nomostest.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell, "", ""))
 	if err != nil {
@@ -326,7 +353,10 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.T.Log("Update kustomization.yaml to use a remote overlay")
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/remote-overlay-kustomization.yaml", "./remote-base/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update kustomization.yaml to use a remote overlay")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.T.Log("Validate resources are synced")
 	expectedNamespaces = []string{"tenant-b"}
@@ -335,7 +365,10 @@ func TestHydrateRemoteResources(t *testing.T) {
 	// Update kustomization.yaml to use remote resources
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/remote-resources-kustomization.yaml", "./remote-base/kustomization.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update kustomization.yaml to use remote resources")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "remote-base"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.T.Log("Validate resources are synced")
 	expectedNamespaces = []string{"tenant-a", "tenant-b", "tenant-c"}
@@ -346,7 +379,9 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove remote-base repository")
 	nt.T.Log("Disable shell in hydration controller")
 	nt.MustMergePatch(rs, `{"spec": {"override": {"enableShellInRendering": false}, "git": {"dir": "acme"}}}`)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/remote-base", ".")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository")
 	nt.T.Log("Update RootSync to sync from the remote-base directory when disable shell in hydration controller")
@@ -373,7 +408,10 @@ func TestHydrateResourcesInRelativePath(t *testing.T) {
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "relative-path/overlays/dev"}}}`)
 
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "relative-path/overlays/dev"}))
+	err := nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "relative-path/overlays/dev"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rs = getUpdatedRootSync(nt, configsync.RootSyncName, configsync.ControllerNamespace)
 	rsCommit, rsStatus, rsErrorSummary := getRootSyncCommitStatusErrorSummary(rs, nil, false)

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -46,7 +46,9 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 	// Update RootSync to valid branch name
 	nomostest.SetGitBranch(nt, configsync.RootSyncName, nomostest.MainBranch)
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		return nt.ValidateErrorMetricsNotFound()
@@ -83,7 +85,9 @@ func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(namespaceRepo, rs.Name), rs)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to valid branch name")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		return nt.ValidateErrorMetricsNotFound()
@@ -99,7 +103,9 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 		nt.T.Log("Resetting all RootSync branches to main")
 		nt.RootRepos[configsync.RootSyncName].CheckoutBranch(nomostest.MainBranch)
 		nomostest.SetGitBranch(nt, configsync.RootSyncName, nomostest.MainBranch)
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 	})
 
 	// Add audit namespace.
@@ -115,7 +121,9 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 
 	// Update RootSync to sync from the dev branch
 	nomostest.SetGitBranch(nt, configsync.RootSyncName, devBranch)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'acme' created.
 	err := nt.Validate(auditNS, "", fake.NamespaceObject(auditNS))
@@ -129,5 +137,7 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 
 	// Change the remote branch name back to the original name.
 	nt.RootRepos[configsync.RootSyncName].RenameBranch("invalid-branch", devBranch)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -33,7 +33,9 @@ func TestIgnoreKptfiles(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/subdir/Kptfile", []byte("# some comment"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding multiple Kptfiles")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	err := nt.Validate("foo", "", fake.NamespaceObject("foo"))

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -56,7 +56,9 @@ func TestPreventDeletionNamespace(t *testing.T) {
 		fake.NamespaceObject("shipping", preventDeletion))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Namespace with prevent deletion lifecycle annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("shipping", "", &corev1.Namespace{},
 		nomostest.NotPendingDeletion,
@@ -84,7 +86,9 @@ func TestPreventDeletionNamespace(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/ns.yaml")
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/role.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove Namespace shipping declaration")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure we kept the undeclared Namespace that had the "deletion: prevent" annotation.
 	err = nt.Validate("shipping", "", &corev1.Namespace{},
@@ -117,7 +121,9 @@ func TestPreventDeletionNamespace(t *testing.T) {
 	// Remove the lifecycle annotation from the namespace so that the namespace can be deleted after the test case.
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", fake.NamespaceObject("shipping"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestPreventDeletionRole(t *testing.T) {
@@ -139,7 +145,9 @@ func TestPreventDeletionRole(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", fake.NamespaceObject("shipping"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Role with prevent deletion lifecycle annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// ensure that the Role is created with the preventDeletion annotation
 	err = nt.Validate("shipping-admin", "shipping", &rbacv1.Role{},
@@ -153,7 +161,9 @@ func TestPreventDeletionRole(t *testing.T) {
 	// Delete the declaration and ensure the Namespace isn't deleted.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/role.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove Role declaration")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("shipping-admin", "shipping", &rbacv1.Role{},
 		nomostest.NotPendingDeletion,
@@ -167,7 +177,9 @@ func TestPreventDeletionRole(t *testing.T) {
 	delete(role.Annotations, common.LifecycleDeleteAnnotation)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from Role")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("shipping-admin", "shipping", &rbacv1.Role{},
 		nomostest.NotPendingDeletion,
@@ -203,7 +215,9 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 	}}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/cr.yaml", clusterRole)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare ClusterRole with prevent deletion lifecycle annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("test-admin", "", &rbacv1.ClusterRole{},
 		nomostest.NotPendingDeletion,
@@ -216,7 +230,9 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 	// Delete the declaration and ensure the ClusterRole isn't deleted.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/cr.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove ClusterRole bar declaration")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("test-admin", "", &rbacv1.ClusterRole{},
 		nomostest.NotPendingDeletion,
@@ -230,7 +246,9 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 	delete(clusterRole.Annotations, common.LifecycleDeleteAnnotation)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/cr.yaml", clusterRole)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("test-admin", "", &rbacv1.ClusterRole{},
 		nomostest.NotPendingDeletion,
@@ -272,7 +290,9 @@ func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 	bookstoreNS := fake.NamespaceObject("bookstore")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns-bookstore.yaml", bookstoreNS)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add special namespaces and one non-special namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Verify that the special namespaces have the `client.lifecycle.config.k8s.io/deletion: detach` annotation.
 	for ns := range specialNamespaces {
@@ -298,7 +318,9 @@ func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 	}
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/ns-bookstore.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove namespaces")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Verify that the special namespaces still exist and have the `client.lifecycle.config.k8s.io/deletion: detach` annotation.
 	for ns := range specialNamespaces {

--- a/e2e/testcases/local_config_test.go
+++ b/e2e/testcases/local_config_test.go
@@ -41,7 +41,9 @@ func TestLocalConfig(t *testing.T) {
 	cm := fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap as local config")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap doesn't exist in the cluster
 	err := nt.ValidateNotFound(cmName, ns, &corev1.ConfigMap{})
@@ -53,7 +55,9 @@ func TestLocalConfig(t *testing.T) {
 	cm = fake.ConfigMapObject(core.Name(cmName))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap without local-config annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap exist
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{})
@@ -66,7 +70,9 @@ func TestLocalConfig(t *testing.T) {
 	cm = fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Changing ConfigMap to local config")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap is pruned.
 	err = nt.ValidateNotFound(cmName, ns, &corev1.ConfigMap{})
@@ -87,7 +93,9 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	cm := fake.ConfigMapObject(core.Name(cmName))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap exist
 	err := nt.Validate(cmName, ns, &corev1.ConfigMap{})
@@ -99,7 +107,9 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	cm = fake.ConfigMapObject(core.Name(cmName), syncertest.ManagementDisabled)
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Disable the management of ConfigMap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap exist
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{})
@@ -112,7 +122,9 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 		core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change the ConfigMap to local config")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap exist
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{})
@@ -124,7 +136,9 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	cm = fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the managed disabled annotation and keep the local-config annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the configmap exist
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{})

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -63,7 +63,9 @@ func TestKubectlCreatesManagedNamespaceResourceMultiRepo(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	/* A new test */
 	ns := []byte(`
@@ -209,11 +211,15 @@ func TestKubectlCreatesManagedConfigMapResource(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore")))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	/* A new test */
 	cm := []byte(`
@@ -407,11 +413,15 @@ func TestDeleteManagedResources(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore")))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.WaitForWebhookReadiness(nt)
 
@@ -465,11 +475,15 @@ func TestDeleteManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore")))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.WaitForWebhookReadiness(nt)
 
@@ -522,7 +536,9 @@ func TestAddFieldsIntoManagedResources(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Add a new annotation into the namespace object
 	out, err := nt.Kubectl("annotate", "namespace", "bookstore", "season=summer")
@@ -579,7 +595,9 @@ func TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation(t *testing.T)
 	namespace := fake.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Add a new annotation into the namespace object
 	out, err := nt.Kubectl("annotate", "namespace", "bookstore", "season=summer")
@@ -605,7 +623,9 @@ func TestModifyManagedFields(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.WaitForWebhookReadiness(nt)
 
@@ -667,7 +687,9 @@ func TestModifyManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Modify a managed field
 	out, err := nt.Kubectl("annotate", "namespace", "bookstore", "--overwrite", "season=winter")
@@ -709,7 +731,9 @@ func TestDeleteManagedFields(t *testing.T) {
 	namespace := fake.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.WaitForWebhookReadiness(nt)
 
@@ -769,7 +793,9 @@ func TestDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Delete a managed field
 	out, err := nt.Kubectl("annotate", "namespace", "bookstore", "season-")

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -48,7 +48,9 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 	// Add the Anvil CRD.
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", anvilV1Beta1CRD())
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	// Add the v1 and v1beta1 Anvils and verify they are created.
@@ -56,7 +58,9 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilCR("v1", "first", 10))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilCR("v2", "second", 100))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 and v2 Anvil CRs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("first", "foo", anvilCR("v1", "", 0))
 	if err != nil {
@@ -93,7 +97,9 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilCR("v1", "first", 20))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilCR("v2", "second", 200))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modifying v1 and v2 Anvil CRs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("first", "foo", anvilCR("v1", "", 0))
 	if err != nil {
@@ -174,7 +180,9 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	// Add the Anvil CRD.
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", anvilV1CRD())
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.RenewClient()
 
 	// Add the v1 and v1beta1 Anvils and verify they are created.
@@ -182,7 +190,9 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilCR("v1", "first", 10))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilCR("v2", "second", 100))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 and v2 Anvil CRs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nt.Validate("first", "foo", anvilCR("v1", "", 0))
 	if err != nil {
@@ -197,7 +207,9 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilCR("v1", "first", 20))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilCR("v2", "second", 200))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modifying v1 and v2 Anvil CRs")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("first", "foo", anvilCR("v1", "", 0))
 	if err != nil {
@@ -336,7 +348,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/rbv1beta1.yaml", rbV1Beta1)
 	}
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 and v1beta1 RoleBindings")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("v1user", "foo", &rbacv1.RoleBinding{},
 		hasV1Subjects("v1user@acme.com"))
@@ -370,7 +384,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/rbv1beta1.yaml", rbV1Beta1)
 	}
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modifying v1 and v1beta1 RoleBindings")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate("v1user", "foo", &rbacv1.RoleBinding{},
 		hasV1Subjects("v1user@acme.com", "v1admin@acme.com"))
@@ -389,7 +405,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 		// Remove the v1beta1 RoleBinding and verify that only it is deleted.
 		nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/rbv1beta1.yaml")
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing v1beta1 RoleBinding")
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 
 		if err := nt.Validate("v1user", "foo", &rbacv1.RoleBinding{}); err != nil {
 			nt.T.Fatal(err)
@@ -402,7 +420,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 	// Remove the v1 RoleBinding and verify that it is also deleted.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/rbv1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing v1 RoleBinding")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	if err := nt.ValidateNotFound("v1user", "foo", &rbacv1.RoleBinding{}); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -82,7 +82,9 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 	sa := fake.ServiceAccountObject("store", core.Namespace(bsNamespace))
 	repo.Add("acme/sa.yaml", sa)
 	repo.CommitAndPush("Adding service account")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate service account 'store' is current.
 	err = nomostest.WatchForCurrentStatus(nt, kinds.ServiceAccount(), "store", bsNamespace,
@@ -164,7 +166,9 @@ func TestNamespaceRepo_Delegated(t *testing.T) {
 	sa := fake.ServiceAccountObject("store", core.Namespace(bsNamespaceRepo))
 	repo.Add("acme/sa.yaml", sa)
 	repo.CommitAndPush("Adding service account")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate service account 'store' is present.
 	err = nt.Validate("store", bsNamespaceRepo, &corev1.ServiceAccount{})
@@ -217,7 +221,9 @@ func TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1(t *testing.T) {
 	if err := nt.Create(rsv1alpha1); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
@@ -246,7 +252,9 @@ func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
 	nn := nomostest.RepoSyncNN(bsNamespace, configsync.RepoSyncName)
 	nsRepo := nt.NonRootRepos[nn]
 	delete(nt.NonRootRepos, nn)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	checkRepoSyncResourcesNotPresent(nt, bsNamespace, secretNames)
 
@@ -270,7 +278,9 @@ func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(bsNamespace, rs.Name), rs)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add RepoSync v1alpha1")
 	// Add the bookstore namespace repo back to NamespaceRepos to verify that it is synced.
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestManageSelfRepoSync(t *testing.T) {

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -52,7 +52,9 @@ func TestDeclareNamespace(t *testing.T) {
 
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the Namespace "foo" exists.
 	err = nt.Validate("foo", "", &corev1.Namespace{})
@@ -83,7 +85,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 	fooNamespace := fake.NamespaceObject("foo")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fooNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Create foo namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists.
 	err := nt.Validate(fooNamespace.Name, "", &corev1.Namespace{})
@@ -110,7 +114,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 	fooNamespace.Annotations["annotation"] = "test-annotation"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fooNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updated foo namespace to include label and annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists with label and annotation.
 	err = nt.Validate(fooNamespace.Name, "", &corev1.Namespace{}, nomostest.HasLabel("label", "test-label"), nomostest.HasAnnotation("annotation", "test-annotation"))
@@ -137,7 +143,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 	fooNamespace.Annotations["annotation"] = "updated-test-annotation"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fooNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updated foo namespace to include label and annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists with the updated label and annotation.
 	err = nt.Validate(fooNamespace.Name, "", &corev1.Namespace{}, nomostest.HasLabel("label", "updated-test-label"), nomostest.HasAnnotation("annotation", "updated-test-annotation"))
@@ -164,7 +172,9 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 	delete(fooNamespace.Annotations, "annotation")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fooNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Updated foo namespace, removing label and annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists without the label and annotation.
 	err = nt.Validate(fooNamespace.Name, "", &corev1.Namespace{}, nomostest.MissingLabel("label"), nomostest.MissingAnnotation("annotation"))
@@ -196,7 +206,9 @@ func TestNamespaceExistsAndDeclared(t *testing.T) {
 	nt.MustKubectl("apply", "-f", filepath.Join(nt.RootRepos[configsync.RootSyncName].Root, "acme/namespaces/decl-namespace-annotation-none/ns.yaml"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add namespace")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists after sync.
 	err := nt.Validate(namespace.Name, "", &corev1.Namespace{})
@@ -229,7 +241,9 @@ func TestNamespaceEnabledAnnotationNotDeclared(t *testing.T) {
 	nt.MustKubectl("apply", "-f", filepath.Join(nt.RootRepos[configsync.RootSyncName].Root, "ns.yaml"))
 	nt.RootRepos[configsync.RootSyncName].Remove("ns.yaml")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists after sync.
 	err := nt.Validate(namespace.Name, "", &corev1.Namespace{})
@@ -266,7 +280,9 @@ func TestManagementDisabledNamespace(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/ns.yaml", nsName), namespace)
 		nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/cm1.yaml", nsName), cm1)
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Create a namespace and a configmap")
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 
 		// Test that the namespace exists with expected config management labels and annotations.
 		err := nt.Validate(namespace.Name, "", &corev1.Namespace{}, nomostest.HasAllNomosMetadata())
@@ -300,7 +316,9 @@ func TestManagementDisabledNamespace(t *testing.T) {
 		nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/ns.yaml", nsName), namespace)
 		nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/cm1.yaml", nsName), cm1)
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Unmanage the namespace and the configmap")
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 
 		// Test that the now unmanaged namespace does not contain any config management labels or annotations
 		err = nt.Validate(namespace.Name, "", &corev1.Namespace{}, nomostest.NoConfigSyncMetadata())
@@ -331,7 +349,9 @@ func TestManagementDisabledNamespace(t *testing.T) {
 		// Remove the namspace and the configmap from the repository
 		nt.RootRepos[configsync.RootSyncName].Remove(fmt.Sprintf("acme/namespaces/%s", nsName))
 		nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the namespace and the configmap")
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 
 		// Test that the namespace still exists on the cluster, and does not contain any config management labels or annotations
 		err = nt.Validate(namespace.Name, "", &corev1.Namespace{}, nomostest.NoConfigSyncMetadata())
@@ -422,7 +442,9 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/cm1.yaml", cm1)
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/cm3.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Unmanage cm1 and remove cm3")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the now unmanaged configmap does not contain any config management labels or annotations
 	err = nt.Validate(cm1.Name, cm1.Namespace, &corev1.ConfigMap{}, nomostest.NoConfigSyncMetadata())
@@ -454,7 +476,9 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 	// Remove the configmap from the repository
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/cm1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the configmap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the configmap still exists on the cluster, and does not contain any config management labels or annotations
 	err = nt.Validate(cm1.Name, cm1.Namespace, &corev1.ConfigMap{}, nomostest.NoConfigSyncMetadata())
@@ -488,7 +512,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 	kubeSystemNamespace.Annotations["test-corp.com/awesome-controller-mixin"] = "green"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/kube-system/ns.yaml", kubeSystemNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the kube-system namespace exists with label and annotation.
 	err := nt.Validate(kubeSystemNamespace.Name, "", &corev1.Namespace{},
@@ -518,7 +544,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 	delete(kubeSystemNamespace.Annotations, "test-corp.com/awesome-controller-mixin")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/kube-system/ns.yaml", kubeSystemNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove label and annotation")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the kube-system namespace exists without the label and annotation.
 	err = nt.Validate(kubeSystemNamespace.Name, "", &corev1.Namespace{},
@@ -545,7 +573,9 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 	kubeSystemNamespace.Annotations["configmanagement.gke.io/managed"] = "disabled"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/kube-system/ns.yaml", kubeSystemNamespace)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update namespace to no longer be managed")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the now unmanaged kube-system namespace does not contain any config management labels or annotations.
 	err = nt.Validate(kubeSystemNamespace.Name, "", &corev1.Namespace{}, nomostest.NoConfigSyncMetadata())
@@ -578,7 +608,9 @@ func TestDoNotRemoveManagedByLabelExceptForConfigManagement(t *testing.T) {
 	nt.MustKubectl("apply", "-f", filepath.Join(nt.RootRepos[configsync.RootSyncName].Root, "ns.yaml"))
 	nt.RootRepos[configsync.RootSyncName].Remove("ns.yaml")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Test that the namespace exists with managed by helm label.
 	err := nt.Validate(helmManagedNamespace.Name, "", &corev1.Namespace{},
@@ -619,7 +651,9 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 	// gets created.
 	nt.RootRepos[configsync.RootSyncName].Add("acme/role.yaml", fake.RoleObject(core.Name("admin"), core.Namespace(implicitNamespace)))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Role in implicit Namespace " + implicitNamespace)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate(implicitNamespace, "", &corev1.Namespace{}, nomostest.HasAnnotation(common.LifecycleDeleteAnnotation, common.PreventDeletion))
 	if err != nil {
@@ -648,7 +682,9 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 	// Phase 2: Remove the Role, and ensure the implicit Namespace is NOT deleted.
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/role.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove Role")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate(implicitNamespace, "", &corev1.Namespace{}, nomostest.HasAnnotation(common.LifecycleDeleteAnnotation, common.PreventDeletion))
 	if err != nil {
@@ -684,7 +720,9 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	barNS := fake.NamespaceObject("bar")
 	nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/bar/ns.yaml", fake.NamespaceObject("bar"))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare multiple Namespaces")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nt.Validate(fooNS.Name, fooNS.Namespace, &corev1.Namespace{})
 	if err != nil {
@@ -764,7 +802,9 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	safetyNs := nt.RootRepos[configsync.RootSyncName].SafetyNSName
 	nt.RootRepos[configsync.RootSyncName].AddSafetyNamespace()
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("re-declare safety Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.Validate(safetyNs, "", &corev1.Namespace{})
 	if err != nil {
@@ -810,7 +850,9 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	// all Namespaces to be removed.
 	nt.RootRepos[configsync.RootSyncName].Remove(nt.RootRepos[configsync.RootSyncName].SafetyNSPath)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("undeclare safety Namespace")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Namespace should be marked as deleted, but may not be NotFound yet,
 	// because its  finalizer will block until all objects in that namespace are

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -33,7 +33,9 @@ import (
 func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SSL_NO_VERIFY"
 	rootReconcilerNN := types.NamespacedName{
@@ -74,7 +76,9 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.NoSSLVerify = true
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to true")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "true")
@@ -94,7 +98,9 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.NoSSLVerify = false
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to false")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerMissingEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key)
@@ -106,7 +112,9 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SSL_NO_VERIFY"
 	rootReconcilerNN := types.NamespacedName{
@@ -147,7 +155,9 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.NoSSLVerify = true
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to true")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "true")
@@ -167,7 +177,9 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.NoSSLVerify = false
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to false")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerMissingEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key)

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -36,7 +36,9 @@ import (
 func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SYNC_DEPTH"
 	rootReconcilerNN := types.NamespacedName{
@@ -78,7 +80,9 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 33")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "33")
@@ -102,7 +106,9 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 0")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "0")
@@ -114,7 +120,9 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.Override = &v1alpha1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "1")
@@ -126,7 +134,9 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SYNC_DEPTH"
 	rootReconcilerNN := types.NamespacedName{
@@ -168,7 +178,9 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 33")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "33")
@@ -192,7 +204,9 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 0")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "0")
@@ -204,7 +218,9 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.Override = &v1beta1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = validateDeploymentContainerHasEnvVar(nt, nsReconcilerNN,
 		reconcilermanager.GitSync, key, "1")

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -48,7 +48,9 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 		nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []nomostest.Predicate{
 			nomostest.RootSyncHasObservedGenerationNoLessThan(rootSync.Generation),
 		}))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	// Pre-provision a low priority workload to force the cluster to scale up.
 	// Later, when the real workload is being scheduled, if there's no more resources available
 	// (common on Autopilot clusters, which are optimized for utilization),
@@ -94,7 +96,9 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add("acme/pod-1.yaml", pod1)
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns-1.yaml", fake.NamespaceObject(namespaceName))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Add namespace/%s & pod/%s (never ready)", namespaceName, pod1Name))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	expectActuationStatus := "Succeeded"
 	expectReconcileStatus := "Timeout"
 	if err := nt.Validate("root-sync", "config-management-system", &resourcegroupv1alpha1.ResourceGroup{},
@@ -111,11 +115,15 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 		nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []nomostest.Predicate{
 			nomostest.RootSyncHasObservedGenerationNoLessThan(rootSync.Generation),
 		}))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nt.RootRepos[configsync.RootSyncName].Remove("acme/pod-1.yaml")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Remove pod/%s", pod1Name))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Verify pod is deleted.
 	if err := nt.ValidateNotFound(pod1Name, namespaceName, &corev1.Pod{}); err != nil {
@@ -123,7 +131,9 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 	}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/pod-1.yaml", pod1)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Add pod/%s", pod1Name))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	expectActuationStatus = "Succeeded"
 	expectReconcileStatus = "Succeeded"

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -82,7 +82,9 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
 		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
@@ -220,7 +222,9 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend and frontend RepoSync resource limits")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nsReconcilerBackendDeploymentGeneration++
 	nsReconcilerFrontendDeploymentGeneration++
@@ -326,7 +330,9 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.Override = &v1alpha1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nsReconcilerBackendDeploymentGeneration++
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
@@ -360,7 +366,9 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	repoSyncFrontend.Spec.Override = &v1alpha1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nsReconcilerFrontendDeploymentGeneration++
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits
@@ -377,7 +385,9 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
 		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
@@ -515,7 +525,9 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend and frontend RepoSync resource limits")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nsReconcilerBackendDeploymentGeneration++
 	nsReconcilerFrontendDeploymentGeneration++
@@ -621,7 +633,9 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.Override = &v1beta1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nsReconcilerBackendDeploymentGeneration++
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
@@ -655,7 +669,9 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	repoSyncFrontend.Spec.Override = &v1beta1.OverrideSpec{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	nsReconcilerFrontendDeploymentGeneration++
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits

--- a/e2e/testcases/policy_dir_test.go
+++ b/e2e/testcases/policy_dir_test.go
@@ -49,10 +49,15 @@ func TestPolicyDirUnset(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme/namespaces", ".")
 	nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme/system", ".")
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Initialize the root directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	nomostest.SetPolicyDir(nt, configsync.RootSyncName, "")
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "."}))
+	err := nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "."}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestInvalidPolicyDir(t *testing.T) {
@@ -67,5 +72,7 @@ func TestInvalidPolicyDir(t *testing.T) {
 	nt.T.Log("Fix the policydir in the repo")
 	nomostest.SetPolicyDir(nt, configsync.RootSyncName, "acme")
 	nt.T.Log("Expect repo to recover from the error in source message")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }

--- a/e2e/testcases/preserve_fields_test.go
+++ b/e2e/testcases/preserve_fields_test.go
@@ -64,7 +64,9 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/service.yaml", ns), service)
 
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Namespace and Service")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure the Service has the target port we set.
 	err := nomostest.WatchObject(nt, kinds.Service(), serviceName, ns,
@@ -131,7 +133,9 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 	updatedService.Spec.Ports[0].TargetPort = intstr.FromInt(targetPort2)
 	nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/service.yaml", ns), updatedService)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("update declared Service")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure the Service has the new target port we set.
 	err = nomostest.WatchObject(nt, kinds.Service(), serviceName, ns,
@@ -192,7 +196,9 @@ aggregationRule:
       permissions: viewer`))
 
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare ClusterRoles")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure the aggregate rule is actually aggregated.
 	err := nomostest.WatchObject(nt, kinds.ClusterRole(), aggregateRoleName, "",
@@ -219,7 +225,9 @@ aggregationRule:
   - matchLabels:
       permissions: viewer`))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add label to aggregate ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Ensure we don't overwrite the aggregate rules.
 	err = nt.Validate(aggregateRoleName, "", &rbacv1.ClusterRole{},
@@ -255,7 +263,9 @@ func TestPreserveLastApplied(t *testing.T) {
 	}}
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/ns-viewer-cr.yaml", nsViewer)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add namespace-viewer ClusterRole")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nt.Validate(nsViewerName, "", &rbacv1.ClusterRole{})
 	if err != nil {
@@ -301,7 +311,9 @@ func TestAddUpdateDeleteLabels(t *testing.T) {
 	cm := fake.ConfigMapObject(core.Name(cmName))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap with no labels to repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	var defaultLabels = []string{metadata.ManagedByKey, metadata.DeclaredVersionLabel}
 
@@ -316,7 +328,9 @@ func TestAddUpdateDeleteLabels(t *testing.T) {
 	cm.Labels["baz"] = "qux"
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update label for ConfigMap in repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that label is updated after syncing an update.
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{},
@@ -328,7 +342,9 @@ func TestAddUpdateDeleteLabels(t *testing.T) {
 	delete(cm.Labels, "baz")
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Delete label for configmap in repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Check that the label is deleted after syncing.
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{},
@@ -357,7 +373,9 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 	cm := fake.ConfigMapObject(core.Name(cmName))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap with no annotations to repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	annotationKeys := metadata.GetNomosAnnotationKeys()
 
@@ -386,7 +404,9 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 	cm.Annotations["baz"] = "qux"
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update annotation for ConfigMap in repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	updatedKeys := append([]string{"baz"}, annotationKeys...)
 
@@ -415,7 +435,9 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 	delete(cm.Annotations, "baz")
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Delete annotation for configmap in repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Check that the annotation is deleted after syncing.
 	err = nt.Validate(cmName, ns, &corev1.ConfigMap{},

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -60,7 +60,9 @@ func secretDataPatch(key, value string) string {
 func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SSL_CAINFO"
 	caCertSecret := "git-cert-pub"
@@ -94,7 +96,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 
 	// Set caCertSecret for RootSync
 	nt.MustMergePatch(rootSync, caCertSecretPatch(caCertSecret))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -119,7 +123,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.Git.CACertSecretRef = &v1alpha1.SecretReference{Name: caCertSecret}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync set caCertSecret")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -137,7 +143,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	// Set RootSync to use SSH again
 	rootSyncSSHURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 	nt.MustMergePatch(rootSync, syncURLSSHPatch(rootSyncSSHURL))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", rootSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -161,7 +169,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	repoSyncBackend.Spec.Git.SecretRef = &v1alpha1.SecretReference{Name: "ssh-key"}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use SSH")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -171,7 +181,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	key := "GIT_SSL_CAINFO"
 	caCertSecret := "git-cert-pub"
@@ -205,7 +217,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 
 	// Set caCertSecret for RootSync
 	nt.MustMergePatch(rootSync, caCertSecretPatch(caCertSecret))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -229,7 +243,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.Git.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync set caCertSecret")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -253,7 +269,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	// Set RootSync to use SSH again
 	rootSyncSSHURL := nt.GitProvider.SyncURL(nt.RootRepos[configsync.RootSyncName].RemoteRepoName)
 	nt.MustMergePatch(rootSync, syncURLSSHPatch(rootSyncSSHURL))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", rootSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -277,7 +295,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	repoSyncBackend.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: "ssh-key"}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use SSH")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -287,7 +307,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 func TestCACertSecretWatch(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	key := "GIT_SSL_CAINFO"
 	caCertSecret := "git-cert-pub"
 	caCertPath := "/etc/ca-cert/cert"
@@ -315,7 +337,9 @@ func TestCACertSecretWatch(t *testing.T) {
 	repoSyncBackend.Spec.Git.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use HTTPS with caCertSecret")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -355,7 +379,9 @@ func TestCACertSecretWatch(t *testing.T) {
 	repoSyncBackend.Spec.Git.CACertSecretRef = &v1beta1.SecretReference{}
 	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync unset caCertSecret and use SSH")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, nomostest.DeploymentHasEnvVar(reconcilermanager.GitSync, "GIT_SYNC_REPO", repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -68,8 +68,14 @@ func TestSyncingThroughAProxy(t *testing.T) {
 	if err = nt.Get("root-sync", configmanagement.ControllerNamespace, rs); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRepoSyncs(nomostest.WithRootSha1Func(nomostest.RemoteRootRepoSha1Fn),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "hierarchical-format/config"}))
+	err = nt.WatchForAllSyncs(
+		nomostest.WithRootSha1Func(nomostest.RemoteRootRepoSha1Fn),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
+			nomostest.DefaultRootRepoNamespacedName: "hierarchical-format/config",
+		}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func hasReadyReplicas(replicas int32) nomostest.Predicate {

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -75,7 +75,9 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	deployment1.SetNamespace(deployment1NN.Namespace)
 	rootRepo.Add(deployment1Path, deployment1)
 	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment1.Name, deployment1.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -161,7 +163,9 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	deployment1.SetNamespace(deployment1NN.Namespace)
 	rootRepo.Add(deployment1Path, deployment1)
 	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment1.Name, deployment1.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -252,7 +256,9 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	deployment1.SetNamespace(deployment1NN.Namespace)
 	rootRepo.Add(deployment1Path, deployment1)
 	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment1.Name, deployment1.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -264,7 +270,9 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	deployment2.SetNamespace(deployment1NN.Namespace)
 	nsRepo.Add(deployment2Path, deployment2)
 	nsRepo.CommitAndPush("Adding deployment helloworld-2 to RepoSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment2.Name, deployment2.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -302,7 +310,9 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Enabling RepoSync deletion propagation")
 	}
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	require.NoError(nt.T,
 		nomostest.WatchObject(nt, kinds.RepoSyncV1Beta1(), repoSync.GetName(), repoSync.GetNamespace(), []nomostest.Predicate{
 			nomostest.StatusEquals(nt, kstatus.CurrentStatus),
@@ -372,7 +382,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	deployment1.SetNamespace(deployment2NN.Namespace)
 	rootRepo.Add(deployment1Path, deployment1)
 	rootRepo.CommitAndPush("Adding deployment helloworld-1 to RootSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment1.Name, deployment1.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -384,7 +396,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	deployment2.SetNamespace(deployment2NN.Namespace)
 	nsRepo.Add(deployment2Path, deployment2)
 	nsRepo.CommitAndPush("Adding deployment helloworld-2 to RepoSync")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 	if err := nomostest.WatchForCurrentStatus(nt, kinds.Deployment(), deployment2.Name, deployment2.Namespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -421,7 +435,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	if nomostest.RemoveDeletionPropagationPolicy(repoSync) {
 		rootRepo.Add(repoSyncPath, repoSync)
 		rootRepo.CommitAndPush("Disabling RepoSync deletion propagation")
-		nt.WaitForRepoSyncs()
+		if err := nt.WatchForAllSyncs(); err != nil {
+			nt.T.Fatal(err)
+		}
 	}
 	require.NoError(nt.T,
 		nomostest.WatchObject(nt, kinds.RepoSyncV1Beta1(), repoSync.GetName(), repoSync.GetNamespace(), []nomostest.Predicate{
@@ -435,7 +451,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	core.SetAnnotation(namespace1, common.LifecycleDeleteAnnotation, common.PreventDeletion)
 	rootRepo.Add(namespace1Path, namespace1)
 	rootRepo.CommitAndPush("Adding annotation to keep test namespace on removal from git")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Delete the RootSync
 	// DeletePropagationBackground is required when deleting RootSync, to

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -39,7 +39,9 @@ func TestResourceGroupController(t *testing.T) {
 	cm := fake.ConfigMapObject(core.Name(cmName), core.Namespace(ns))
 	nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm)
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a ConfigMap to repo")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Checking that the ResourceGroup controller captures the status of the
 	// managed resources.

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -84,7 +84,9 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 	if err := nt.Create(rsv1alpha1); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 }
 
 func TestUpdateRootSyncGitDirectory(t *testing.T) {
@@ -113,7 +115,9 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 		fake.RepoObject())
 
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add namespace to acme directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'audit' created.
 	err = nt.Validate(acmeNS, "", fake.NamespaceObject(acmeNS))
@@ -144,7 +148,10 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 	// Update RootSync.
 	nomostest.SetPolicyDir(nt, configsync.RootSyncName, fooDir)
 	syncDirectoryMap := map[types.NamespacedName]string{nomostest.RootSyncNN(configsync.RootSyncName): fooDir}
-	nt.WaitForRepoSyncs(nomostest.WithSyncDirectoryMap(syncDirectoryMap))
+	err = nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(syncDirectoryMap))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'shipping' created with the correct sourcePath annotation.
 	if err := nt.Validate(fooNS, "", fake.NamespaceObject(fooNS),
@@ -191,7 +198,9 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/ns.yaml", auditNS),
 		fake.NamespaceObject(auditNS))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("add namespace to acme directory")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'acme' created.
 	err := nt.Validate(auditNS, "", fake.NamespaceObject(auditNS))
@@ -219,7 +228,9 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 	// Set branch to "test-branch"
 	nomostest.SetGitBranch(nt, configsync.RootSyncName, testBranch)
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'audit-test' created after updating rootsync.
 	err = nt.Validate(testNS, "", fake.NamespaceObject(testNS))
@@ -232,7 +243,9 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 
 	// Checkout back to 'main' branch to get the correct HEAD commit sha1.
 	nt.RootRepos[configsync.RootSyncName].CheckoutBranch(nomostest.MainBranch)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	// Validate namespace 'acme' present.
 	err = nt.Validate(auditNS, "", fake.NamespaceObject(auditNS))
@@ -277,7 +290,9 @@ func TestForceRevert(t *testing.T) {
 	nt.RootRepos[configsync.RootSyncName].Git("reset", "--hard", "HEAD^")
 	nt.RootRepos[configsync.RootSyncName].Git("push", "-f", "origin", "main")
 
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		return nt.ValidateReconcilerErrors(nomostest.DefaultRootReconcilerName, 0, 0)

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -43,13 +43,17 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 	// Override the statusMode for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"statusMode": "disabled"}}}`)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	namespaceName := "status-test"
 	nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespaceObject(namespaceName, nil))
 	nt.RootRepos[configsync.RootSyncName].Add("acme/cm1.yaml", fake.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName)))
 	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a namespace and a configmap")
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err := nomostest.WatchObject(nt, kinds.ResourceGroup(),
 		configsync.RootSyncName, configsync.ControllerNamespace,
@@ -64,7 +68,9 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 
 	// Override the statusMode for root-reconciler to re-enable the status
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"statusMode": "enabled"}}}`)
-	nt.WaitForRepoSyncs()
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
 
 	err = nomostest.WatchObject(nt, kinds.ResourceGroup(),
 		configsync.RootSyncName, configsync.ControllerNamespace,


### PR DESCRIPTION
- WaitForRepoSyncs -> WatchForAllSyncs
- WaitForSync -> WatchForSync
- Make both return error, instead of failing the test, to allow
  the caller the option to choose whether to fail the test immediately
  or continue.
- Exec the Sha1Fn up front and cache the result, instead of retrying.
  This should reduce debug log spam and unnecessary git API calls.
- Watch in parallel where possible.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/452
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/453