### PR TITLE
Skip .spec.ports check for ExternalName Service

### DIFF
--- a/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
@@ -353,6 +353,21 @@ spec:
     app: nginx
 `,
 		},
+		{
+			name:   "ExternalName Service with no ports should not error",
+			expErr: false,
+			yaml: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: bookstore
+spec:
+  type: ExternalName
+  selector:
+    app: nginx
+`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
ExternalName Service is not required to have ports specified.
This change explicitly filters this type out, while maintaining
the check for other Services.