### PR TITLE
Change e2e test validation to use sync status output

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1046,7 +1046,8 @@ func TestNomosStatus(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	if !strings.Contains(string(out), "git@test-git-server.config-management-system-test:/git-server/repos/config-management-system/root-sync/acme@main") {
-		nt.T.Fatalf("Expected to find Git provider string in output:\n%s\n", string(out))
+	if !strings.Contains(string(out), "SYNCED") && !strings.Contains(string(out), "PENDING") &&
+		!strings.Contains(string(out), "RECONCILING") && !strings.Contains(string(out), "STALLED") {
+		nt.T.Fatalf("Expected to find sync status in string output:\n%s\n", string(out))
 	}
 }

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1046,8 +1046,7 @@ func TestNomosStatus(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	if !strings.Contains(string(out), "SYNCED") && !strings.Contains(string(out), "PENDING") &&
-		!strings.Contains(string(out), "RECONCILING") && !strings.Contains(string(out), "STALLED") {
+	if !strings.Contains(string(out), "SYNCED") {
 		nt.T.Fatalf("Expected to find sync status in string output:\n%s\n", string(out))
 	}
 }


### PR DESCRIPTION
e2e test for nomos status was using git server string as its validation, which can vary in other git providers. Validation is changed to use sync status instead, which value is only SYCED/PENDING/RECONCILING/STALLED