### PR TITLE
Change nomos version output in standalone OSS to match image version

### DIFF
--- a/cmd/nomos/util/configmanagement.go
+++ b/cmd/nomos/util/configmanagement.go
@@ -42,6 +42,8 @@ const (
 	ACMOperatorDeployment = "config-management-operator"
 	// rootSyncCRDName is the name of RootSync CRD
 	rootSyncCRDName = "rootsyncs.configsync.gke.io"
+	// ConfigSyncName is the name of the ConfigSync object for OSS installation.
+	ConfigSyncName = "config-sync"
 )
 
 // DynamicClient obtains a client based on the supplied REST config.  Can be overridden in tests.

--- a/cmd/nomos/util/configmanagement.go
+++ b/cmd/nomos/util/configmanagement.go
@@ -44,6 +44,8 @@ const (
 	rootSyncCRDName = "rootsyncs.configsync.gke.io"
 	// ConfigSyncName is the name of the ConfigSync object for OSS installation.
 	ConfigSyncName = "config-sync"
+	// ReconcilerManagerName is the name of reconciler-manger
+	ReconcilerManagerName = "reconciler-manager"
 )
 
 // DynamicClient obtains a client based on the supplied REST config.  Can be overridden in tests.

--- a/cmd/nomos/version/version.go
+++ b/cmd/nomos/version/version.go
@@ -21,17 +21,21 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/cmd/nomos/flags"
 	"kpt.dev/configsync/cmd/nomos/util"
+	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -136,44 +140,61 @@ func filterConfigs(contexts []string, all map[string]*rest.Config) map[string]*r
 	return cfgs
 }
 
-func lookupVersionAndMode(ctx context.Context, cfg *rest.Config) (string, *bool, error) {
+func getImageVersion(deployment *v1.Deployment) (string, error) {
+	reconcilerImage := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":")
+	if len(reconcilerImage) <= 1 {
+		return "", fmt.Errorf("Failed to get valid image version from: %s", reconcilerImage)
+	}
+	return reconcilerImage[1], nil
+}
+
+func lookupVersionAndMode(ctx context.Context, cfg *rest.Config) (string, *bool, string, error) {
 	cmClient, err := util.NewConfigManagementClient(cfg)
 	if err != nil {
-		return util.ErrorMsg, nil, err
+		return util.ErrorMsg, nil, "", err
 	}
 	if cfg != nil {
 		cl, err := ctrl.New(cfg, ctrl.Options{})
 		if err != nil {
-			return util.ErrorMsg, nil, err
+			return util.ErrorMsg, nil, "", err
 		}
 		ck, err := kubernetes.NewForConfig(cfg)
 		if err != nil {
-			return util.ErrorMsg, nil, err
+			return util.ErrorMsg, nil, "", err
 		}
 		isOss, err := util.IsOssInstallation(ctx, cmClient, cl, ck)
 		if err != nil {
-			return util.ErrorMsg, nil, err
+			return util.ErrorMsg, nil, "", err
 		}
 		if isOss {
-			return util.OSSMsg, &isOss, nil
+			reconcilerDeployment, err := ck.AppsV1().Deployments(configmanagement.ControllerNamespace).Get(ctx, "reconciler-manager", metav1.GetOptions{})
+			if err != nil {
+				return util.ErrorMsg, nil, "", err
+			}
+			imageVersion, err := getImageVersion(reconcilerDeployment)
+			if err != nil {
+				return util.ErrorMsg, nil, "", err
+			}
+			return imageVersion, &isOss, util.ConfigSyncName, nil
 		}
 	}
 
 	v, err := cmClient.Version(ctx)
 	if err != nil {
-		return util.ErrorMsg, nil, err
+		return util.ErrorMsg, nil, "", err
 	}
 	isMulti, err := cmClient.IsMultiRepo(ctx)
 	if apierrors.IsNotFound(err) {
-		return v, isMulti, nil
+		return v, isMulti, util.ConfigManagementName, nil
 	}
-	return v, isMulti, err
+	return v, isMulti, util.ConfigManagementName, err
 }
 
 // vErr is either a version or an error.
 type vErr struct {
-	version string
-	err     error
+	version   string
+	component string
+	err       error
 }
 
 // versions obtains the versions of all configmanagements from the contexts
@@ -194,7 +215,7 @@ func versions(ctx context.Context, cfgs map[string]*rest.Config) (map[string]vEr
 			defer g.Done()
 			var ve vErr
 			var isMulti *bool
-			ve.version, isMulti, ve.err = lookupVersionAndMode(ctx, c)
+			ve.version, isMulti, ve.component, ve.err = lookupVersionAndMode(ctx, c)
 			if isMulti != nil && !*isMulti {
 				monoRepoClusters = append(monoRepoClusters, n)
 			}
@@ -234,7 +255,7 @@ func entries(vs map[string]vErr) []entry {
 		if n == currentContext && err == nil {
 			curr = "*"
 		}
-		es = append(es, entry{current: curr, name: n, component: util.ConfigManagementName, vErr: v})
+		es = append(es, entry{current: curr, name: n, component: v.component, vErr: v})
 	}
 	// Also fill in the client version here.
 	es = append(es, entry{

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1062,7 +1062,7 @@ func TestNomosVersion(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	if !strings.Contains(string(out), "OSS Installation") {
+	if !strings.Contains(string(out), "config-sync") {
 		nt.T.Fatalf("Expected to find Git provider string in output:\n%s\n", string(out))
 	}
 }

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1063,6 +1063,6 @@ func TestNomosVersion(t *testing.T) {
 	}
 
 	if !strings.Contains(string(out), "config-sync") {
-		nt.T.Fatalf("Expected to find Git provider string in output:\n%s\n", string(out))
+		nt.T.Fatalf("Expected to find config-sync component in output:\n%s\n", string(out))
 	}
 }


### PR DESCRIPTION
nomos version output in standalone OSS installation will now display the matching version with the image that is used for installation