### PR TITLE
test: add notification server test component

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -280,3 +280,21 @@ build-http-git-server:
 		-t $(E2E_TEST_IMAGE_HTTP_GIT_SERVER) \
 		test/docker/http-git-server/
 	@docker push $(E2E_TEST_IMAGE_HTTP_GIT_SERVER)
+
+###################################
+# E2E Notification Webhook Server
+###################################
+
+# NOTE: when updating the test-notification-webhook version, update
+# e2e/nomostest/notification_server.go to reflect the version change
+E2E_TEST_IMAGE_HTTP_NOTIFICATION_WEBHOOK_TAG := v1.0.0
+E2E_TEST_IMAGE_HTTP_NOTIFICATION_WEBHOOK_SERVER := gcr.io/stolos-dev/test-notification-webhook:$(E2E_TEST_IMAGE_HTTP_NOTIFICATION_WEBHOOK_TAG)
+# Builds the container used by e2e tests to test notifications using a webhook.
+.PHONY: build-http-notification-webhook
+build-http-notification-webhook:
+	@echo "+++ Building the test-notification-webhook image"
+	docker buildx build \
+		-t $(E2E_TEST_IMAGE_HTTP_NOTIFICATION_WEBHOOK_SERVER) \
+		-f ./test/docker/http-notification-webhook/Dockerfile \
+		.
+	@docker push $(E2E_TEST_IMAGE_HTTP_NOTIFICATION_WEBHOOK_SERVER)

--- a/e2e/nomostest/notification_server.go
+++ b/e2e/nomostest/notification_server.go
@@ -1,0 +1,237 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"go.uber.org/multierr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestNotificationWebhookPort is the port exposed by the notification-webhook server
+const TestNotificationWebhookPort = 8080
+const testNotificationWebhookServer = "test-notification-webhook"
+const testNotificationWebhookNamespace = "notification-system-test"
+const testNotificationWebhookImage = "gcr.io/stolos-dev/test-notification-webhook:v1.0.0"
+
+// NotificationRecord represents a notification delivery record.
+// This contains data used for validation in the e2e tests
+type NotificationRecord struct {
+	// Message contains the notification payload
+	Message string `json:"message,omitempty"`
+	// Auth contains auth header from the request. These should be contrived auth
+	// values used by test cases and not real credentials.
+	Auth string `json:"auth,omitempty"`
+}
+
+// NotificationRecords represents a list of NotificationRecord which were delivered
+// over some time interval
+type NotificationRecords struct {
+	// Records is a list of notification deliveries that were recorded
+	Records []NotificationRecord `json:"records,omitempty"`
+}
+
+// NotificationServer is an in-cluster test component used for capturing notifications.
+// It receives notifications from the Config Sync notification controller and
+// can be queried by the test framework.
+type NotificationServer struct {
+	localPort int
+}
+
+func (ns *NotificationServer) install(nt *NT) error {
+	nt.T.Helper()
+
+	objs := notificationWebhookServer()
+
+	for _, o := range objs {
+		err := nt.Create(o)
+		if err != nil {
+			return fmt.Errorf("installing %v %s: %v", o.GetObjectKind().GroupVersionKind(),
+				client.ObjectKey{Name: o.GetName(), Namespace: o.GetNamespace()}, err)
+		}
+	}
+
+	return WatchForCurrentStatus(nt, kinds.Deployment(), testNotificationWebhookServer, testNotificationWebhookNamespace)
+}
+
+func (ns *NotificationServer) uninstall(nt *NT) error {
+	namespace := notificationWebhookNamespace()
+	err := nt.Delete(namespace)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func (ns *NotificationServer) portForward(nt *NT) error {
+	nt.T.Helper()
+
+	podName, err := notificationWebhookPodName(nt)
+	if err != nil {
+		return err
+	}
+
+	if ns.localPort == 0 {
+		port, err := nt.ForwardToFreePort(
+			testNotificationWebhookNamespace,
+			podName,
+			fmt.Sprintf(":%d", TestNotificationWebhookPort),
+		)
+		if err != nil {
+			return err
+		}
+		ns.localPort = port
+	}
+	return nil
+}
+
+func (ns *NotificationServer) url() string {
+	return fmt.Sprintf("http://localhost:%d/", ns.localPort)
+}
+
+// DoGet performs a GET request to the in-cluster notification server
+func (ns *NotificationServer) DoGet() (nr *NotificationRecords, retErr error) {
+	resp, err := http.Get(ns.url())
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			retErr = multierr.Append(retErr, fmt.Errorf("error closing GET response body: %v", err))
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code. want %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %v", err)
+	}
+	records := NotificationRecords{}
+	if err := json.Unmarshal(body, &records); err != nil {
+		return nil, fmt.Errorf("error unmarshalling response: %v", err)
+	}
+	return &records, nil
+}
+
+// DoDelete performs a DELETE request to the in-cluster notification server
+func (ns *NotificationServer) DoDelete() (retErr error) {
+	httpClient := &http.Client{}
+	req, err := http.NewRequest(http.MethodDelete, ns.url(), nil)
+	if err != nil {
+		return fmt.Errorf("error constructing request: %v", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error performing Delete request: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			retErr = multierr.Append(retErr, fmt.Errorf("error closing DELETE response body: %v", err))
+		}
+	}()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code. want %d, got %d", http.StatusNoContent, resp.StatusCode)
+	}
+	return nil
+}
+
+func notificationWebhookPodName(nt *NT) (string, error) {
+	podList := &corev1.PodList{}
+	err := nt.List(podList, client.InNamespace(testNotificationWebhookNamespace))
+	if err != nil {
+		return "", err
+	}
+	if nPods := len(podList.Items); nPods != 1 {
+		podsJSON, err := json.MarshalIndent(podList, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		nt.T.Log(string(podsJSON))
+		return "", fmt.Errorf("got len(podList.Items) = %d, want 1", nPods)
+	}
+	podName := podList.Items[0].Name
+	return podName, nil
+}
+
+func testNotificationWebhookServerSelector() map[string]string {
+	// Note that maps are copied by reference into objects.
+	// If this were just a variable, then concurrent usages by Clients may result
+	// in concurrent map writes (and thus flaky test panics).
+	return map[string]string{"app": testNotificationWebhookServer}
+}
+
+func notificationWebhookServer() []client.Object {
+	objs := []client.Object{
+		notificationWebhookNamespace(),
+		notificationWebhookDeployment(),
+		notificationWebhookService(),
+	}
+	return objs
+}
+
+func notificationWebhookNamespace() *corev1.Namespace {
+	return fake.NamespaceObject(testNotificationWebhookNamespace)
+}
+
+func notificationWebhookDeployment() *appsv1.Deployment {
+	deployment := fake.DeploymentObject(core.Name(testNotificationWebhookServer),
+		core.Namespace(testNotificationWebhookNamespace),
+		core.Labels(testNotificationWebhookServerSelector()),
+	)
+	deployment.Spec = appsv1.DeploymentSpec{
+		MinReadySeconds: 2,
+		Strategy:        appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+		Selector:        &v1.LabelSelector{MatchLabels: testNotificationWebhookServerSelector()},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: v1.ObjectMeta{
+				Labels: testNotificationWebhookServerSelector(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  testNotificationWebhookServer,
+						Image: testNotificationWebhookImage,
+						Ports: []corev1.ContainerPort{{ContainerPort: TestNotificationWebhookPort}},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func notificationWebhookService() *corev1.Service {
+	service := fake.ServiceObject(
+		core.Name(testNotificationWebhookServer),
+		core.Namespace(testNotificationWebhookNamespace),
+	)
+	service.Spec.Selector = testNotificationWebhookServerSelector()
+	service.Spec.Ports = []corev1.ServicePort{
+		{Name: "http", Port: TestNotificationWebhookPort},
+	}
+	return service
+}

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -163,6 +163,11 @@ type NT struct {
 
 	// repoSyncPermissions will grant a list of PolicyRules to NS reconcilers
 	repoSyncPermissions []rbacv1.PolicyRule
+
+	// NotificationServer is the e2e test http notification server component.
+	// It is a test-only component that helps perform in-cluster testing of
+	// notifications using webhooks.
+	NotificationServer *NotificationServer
 }
 
 // CSNamespaces is the namespaces of the Config Sync components.

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -60,6 +60,9 @@ type New struct {
 	// TestFeature is the feature that the test verifies
 	TestFeature testing.Feature
 
+	// InstallNotificationServer will install the test-notification-webhook server in cluster.
+	InstallNotificationServer bool
+
 	Nomos
 	MultiRepo
 	TestType
@@ -112,4 +115,9 @@ func WithRestConfig(restConfig *rest.Config) Opt {
 // SkipConfigSyncInstall skip installation of Config Sync components in cluster
 func SkipConfigSyncInstall(opt *New) {
 	opt.SkipConfigSyncInstall = true
+}
+
+// InstallNotificationServer install the test-notification-webhook component in cluster
+func InstallNotificationServer(opt *New) {
+	opt.InstallNotificationServer = true
 }

--- a/test/docker/http-notification-webhook/Dockerfile
+++ b/test/docker/http-notification-webhook/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.19 as bins
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
+  go install \
+    ./test/docker/http-notification-webhook
+
+# notification-webhook image
+FROM gcr.io/distroless/static:nonroot as notification-webhook
+WORKDIR /
+COPY --from=bins /go/bin/http-notification-webhook .
+
+# Switch to non-root user
+USER 1000
+
+ENTRYPOINT ["/http-notification-webhook"]

--- a/test/docker/http-notification-webhook/main.go
+++ b/test/docker/http-notification-webhook/main.go
@@ -1,0 +1,102 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"kpt.dev/configsync/e2e/nomostest"
+)
+
+// mux is used to synchronize operations across the various endpoints
+var mux sync.Mutex
+
+// store is a simple in memory storage of notification records.
+var store nomostest.NotificationRecords
+
+func doGet(w http.ResponseWriter, r *http.Request) {
+	mux.Lock()
+	defer mux.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	err := json.NewEncoder(w).Encode(store)
+	if err != nil {
+		msg := fmt.Sprintf("error encoding response: %v", err)
+		log.Print(msg)
+		_, writeErr := io.WriteString(w, msg)
+		if writeErr != nil {
+			log.Printf("error writing string for GET response: %v", writeErr)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func doPost(w http.ResponseWriter, r *http.Request) {
+	mux.Lock()
+	defer mux.Unlock()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("error reading body: %v", err)
+		log.Print(msg)
+		_, writeErr := io.WriteString(w, msg)
+		if writeErr != nil {
+			log.Printf("error writing string for POST response: %v", writeErr)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	record := nomostest.NotificationRecord{
+		Message: string(body),
+		Auth:    r.Header.Get("Authorization"),
+	}
+	store.Records = append(store.Records, record)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func doDelete(w http.ResponseWriter, r *http.Request) {
+	mux.Lock()
+	defer mux.Unlock()
+	store.Records = nil
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func rootHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s %s", r.Method, r.URL.String())
+	switch strings.ToUpper(r.Method) {
+	case http.MethodGet:
+		doGet(w, r)
+	case http.MethodPost:
+		doPost(w, r)
+	case http.MethodDelete:
+		doDelete(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// This is a simple http server used for recording notification deliveries in e2e
+// tests.
+func main() {
+	http.HandleFunc("/", rootHandler)
+
+	port := fmt.Sprintf(":%d", nomostest.TestNotificationWebhookPort)
+	log.Printf("listening on port %s", port)
+	log.Fatal(http.ListenAndServe(port, nil))
+}


### PR DESCRIPTION
This is an in cluster test component that enables simple testing of the notification controller using http/webhooks. It hosts a few http endpoints which record requests from the notification controller and can be queried from the test framework using a port forward.

Creating this PR before the notification controller to provide smaller/incremental code reviews and so that the test scaffolding is available before the notification controller PR is created