### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,23 +1,20 @@
-approvers:
-  - sdowell
-  - mortent
-  - janetkuo
-  - karlkfi
-  - mikebz
-  - nan-yu
-  - xinnywinne
-  - tiffanny29631
-  - haiyanmeng
-  - victorpras
-
-reviewers:
-  - sdowell
-  - mortent
-  - janetkuo
-  - karlkfi
-  - mikebz
-  - nan-yu
-  - xinnywinne
-  - tiffanny29631
-  - haiyanmeng
-  - victorpras
+filters:
+  ".*":
+    approvers:
+      - maintainers
+    reviewers:
+      - maintainers
+  "^docs/.*":
+    approvers:
+      - sig-docs
+      - maintainers
+    reviewers:
+      - sig-docs
+      - maintainers
+  ".*.md$":
+    approvers:
+      - sig-docs
+      - maintainers
+    reviewers:
+      - sig-docs
+      - maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+aliases:
+  maintainers:
+    - haiyanmeng
+    - janetkuo
+    - karlkfi
+    - nan-yu
+    - sdowell
+    - tiffanny29631
+    - victorpras
+  sig-docs:
+    - mikebz
+  # emeritus:
+  # - mortent
+  # - rquitales
+  # - xinnywinne


### PR DESCRIPTION
- Move mortent, rquitales, and xinnywinne to emeritus
- Move mikebz to sig-docs
- Use regex filters and aliases to avoid sig-docs being assigned for code PRs.