### PR TITLE
Fix abandonment

### DIFF
--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/util/log"
 	"kpt.dev/configsync/pkg/util/repo"
 )
 
@@ -482,14 +483,15 @@ func validateError(errs []v1beta1.ConfigSyncError, code, message string) error {
 	if len(errs) == 0 {
 		return errors.Errorf("no errors present")
 	}
-	var codes []string
 	for _, e := range errs {
 		if e.Code == code {
 			if message == "" || strings.Contains(e.ErrorMessage, message) {
 				return nil
 			}
 		}
-		codes = append(codes, e.Code)
 	}
-	return errors.Errorf("error %s not present, got %s", code, strings.Join(codes, ", "))
+	if message != "" {
+		return errors.Errorf("error %s not present with message %q: %s", code, message, log.AsJSON(errs))
+	}
+	return errors.Errorf("error %s not present: %s", code, log.AsJSON(errs))
 }

--- a/pkg/applier/clientset.go
+++ b/pkg/applier/clientset.go
@@ -20,7 +20,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply"
@@ -45,13 +44,12 @@ type KptDestroyer interface {
 // ClientSet wraps the various Kubernetes clients required for building a
 // Config Sync applier.Applier.
 type ClientSet struct {
-	KptApplier    KptApplier
-	KptDestroyer  KptDestroyer
-	InvClient     inventory.Client
-	Client        client.Client
-	DynamicClient dynamic.Interface
-	Mapper        meta.RESTMapper
-	StatusMode    string
+	KptApplier   KptApplier
+	KptDestroyer KptDestroyer
+	InvClient    inventory.Client
+	Client       client.Client
+	Mapper       meta.RESTMapper
+	StatusMode   string
 }
 
 // NewClientSet constructs a new ClientSet.
@@ -89,22 +87,17 @@ func NewClientSet(c client.Client, configFlags *genericclioptions.ConfigFlags, s
 		return nil, err
 	}
 
-	dynamicClient, err := f.DynamicClient()
-	if err != nil {
-		return nil, err
-	}
 	mapper, err := f.ToRESTMapper()
 	if err != nil {
 		return nil, err
 	}
 
 	return &ClientSet{
-		KptApplier:    applier,
-		KptDestroyer:  destroyer,
-		InvClient:     invClient,
-		Client:        c,
-		DynamicClient: dynamicClient,
-		Mapper:        mapper,
-		StatusMode:    statusMode,
+		KptApplier:   applier,
+		KptDestroyer: destroyer,
+		InvClient:    invClient,
+		Client:       c,
+		Mapper:       mapper,
+		StatusMode:   statusMode,
 	}, nil
 }

--- a/pkg/syncer/syncertest/fake/client.go
+++ b/pkg/syncer/syncertest/fake/client.go
@@ -435,7 +435,7 @@ func validateUpdateOptions(opts *client.UpdateOptions) error {
 	return nil
 }
 
-func validatePatchOptions(opts *client.PatchOptions) error {
+func validatePatchOptions(opts *client.PatchOptions, patch client.Patch) error {
 	if len(opts.DryRun) > 0 {
 		if len(opts.DryRun) > 1 || opts.DryRun[0] != metav1.DryRunAll {
 			return errors.Errorf("invalid dry run option: %+v", opts.DryRun)
@@ -443,6 +443,9 @@ func validatePatchOptions(opts *client.PatchOptions) error {
 	}
 	if opts.FieldManager != "" && opts.FieldManager != configsync.FieldManager {
 		return errors.Errorf("invalid field manager option: %v", opts.FieldManager)
+	}
+	if patch != client.Apply && opts.Force != nil {
+		return errors.Errorf("invalid force option: Forbidden: may not be specified for non-apply patch")
 	}
 	return nil
 }
@@ -522,7 +525,7 @@ func (c *Client) Update(_ context.Context, obj client.Object, opts ...client.Upd
 func (c *Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	patchOpts := &client.PatchOptions{}
 	patchOpts.ApplyOptions(opts)
-	err := validatePatchOptions(patchOpts)
+	err := validatePatchOptions(patchOpts, patch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Rename disableObject to abandonObject, to be consistent with terminology used in the applier.
- Fix supervisor.abandonObject to not adopt all object fields. Use merge-patch, instead of server-side apply. SSA only works if you have the source of truth for all the fields you previously applied. The way it was being used assumed that all fields were owned by configsync.
- Fix supervisor to correctly abandon objects that have their delete or prune skipped with an AnnotationPreventedDeletionError. Previously, the configsync annotations weren't being removed and then the remediator detected it as drift and removed them.
- Use the client.Client in abandonObject. There's no need to use the dynamic.Client, because the client.Client can still populate an Unstructured object, and now that we're using merge-patch, we don't care about any other populated optional fields.
- Remove the now unused dynamic.Client from the ClientSet