### PR TITLE
Remove GKE requirement in API service test

### DIFF
--- a/e2e/testcases/apiservice_test.go
+++ b/e2e/testcases/apiservice_test.go
@@ -33,7 +33,6 @@ const (
 
 func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.RequireGKE(t),
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.
 		ntopts.WithReconcileTimeout(5*time.Minute))
@@ -70,7 +69,7 @@ func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 }
 
 func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.RequireGKE(t),
+	nt := nomostest.New(t, nomostesting.Reconciliation1,
 		ntopts.Unstructured,
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.


### PR DESCRIPTION
The test can now run and pass on Kind clusters. Removing this constraint.