### PR TITLE
Fix test setup metric validation 

### DIFF
--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -169,10 +169,13 @@ func TestClusterRoleLifecycle(t *testing.T) {
 		nt.T.Fatalf("validating ClusterRole precondition: %v", err)
 	}
 
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, declaredCr)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+1, // 1 for the test ClusterRole
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("ClusterRole"))
 		if err != nil {
 			return err
@@ -204,10 +207,12 @@ func TestClusterRoleLifecycle(t *testing.T) {
 		nt.T.Errorf("updating ClusterRole: %v", err)
 	}
 
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, updatedCr)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+1, // 1 for the test ClusterRole
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourcePatched("ClusterRole", 2))
 		if err != nil {
 			return err
@@ -230,10 +235,12 @@ func TestClusterRoleLifecycle(t *testing.T) {
 		nt.T.Errorf("deleting ClusterRole: %v", err)
 	}
 
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, updatedCr)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount(),
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceDeleted("ClusterRole"))
 		if err != nil {
 			return err

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -283,10 +283,14 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, namespace)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err := nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err
@@ -318,10 +322,13 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, namespace)
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount(),
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceDeleted("RoleBinding"))
 		if err != nil {
 			return err
@@ -355,10 +362,13 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, namespace)
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err
@@ -380,11 +390,13 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
-			metrics.ResourceCreated("RoleBinding"))
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
+			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err
 		}
@@ -408,10 +420,13 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, namespace)
+	nt.RemoveExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount(),
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceDeleted("RoleBinding"))
 		if err != nil {
 			return err
@@ -444,10 +459,13 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, namespace)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, rb)
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & RoleBinding
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("RoleBinding"))
 		if err != nil {
 			return err

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -84,9 +84,13 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, nt.RootRepos[configsync.RootSyncName].Get("acme/namespaces/prod/ns.yaml"))
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, nt.RootRepos[configsync.RootSyncName].Get("acme/namespaces/prod/anvil-v1.yaml"))
+
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Anvil
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Anvil"))
 		if err != nil {
 			return err
@@ -176,9 +180,13 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, nt.RootRepos[configsync.RootSyncName].Get("acme/namespaces/foo/ns.yaml"))
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, nt.RootRepos[configsync.RootSyncName].Get("acme/namespaces/foo/anvil-v1.yaml"))
+
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err := nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+2, // 2 for the test Namespace & Anvil
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"), metrics.ResourceCreated("Anvil"))
 		if err != nil {
 			return err

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -43,10 +43,13 @@ func TestIgnoreKptfiles(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	nt.AddExpectedObject(configsync.RootSyncKind, rootSyncNN, nt.RootRepos[configsync.RootSyncName].Get("acme/namespaces/foo/ns.yaml"))
+
 	// Validate multi-repo metrics.
 	err = nt.ValidateMetrics(nomostest.SyncMetricsToLatestCommit(nt), func() error {
 		err = nt.ValidateMultiRepoMetrics(nomostest.DefaultRootReconcilerName,
-			nt.DefaultRootSyncObjectCount()+1, // 1 for the test Namespace
+			nt.ExpectedRootSyncObjectCount(configsync.RootSyncName),
 			metrics.ResourceCreated("Namespace"))
 		if err != nil {
 			return err


### PR DESCRIPTION
- Always validate a standard set of metrics after test setup.
- Record the expected "declared resources" populated by test setup.
  This is used when validating standard metrics or as a base-line
  when calculating declared resources from a test.
- Clean up setupDelegatedControl and setupCentralizedControl to use
  RootRepos/NonRootRepos created by setupTestCase, rather than using
  the opts they came from.
- Configure reconcile timeout consistently.