### PR TITLE
Fix e2e to avoid double setup

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -633,13 +633,17 @@ func setupDelegatedControl(nt *NT, opts *ntopts.New) {
 		setupRepoSync(nt, nn)
 	}
 
-	// Validate multi-repo metrics in root reconcilers.
+	// Wait for all RootSyncs and all RepoSyncs to be reconciled
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// Validate metrics from root-reconcilers.
 	for rsName := range opts.RootRepos {
 		rootReconciler := core.RootReconcilerName(rsName)
 		if err := waitForReconciler(nt, rootReconciler); err != nil {
 			nt.T.Fatal(err)
 		}
-
 		err := nt.ValidateMetrics(SyncMetricsToLatestCommit(nt), func() error {
 			err := nt.ValidateMultiRepoMetrics(rootReconciler, nt.DefaultRootSyncObjectCount())
 			if err != nil {
@@ -652,13 +656,12 @@ func setupDelegatedControl(nt *NT, opts *ntopts.New) {
 		}
 	}
 
+	// Validate metrics from ns-reconcilers.
 	for nn := range opts.NamespaceRepos {
 		nsReconciler := core.NsReconcilerName(nn.Namespace, nn.Name)
 		if err := waitForReconciler(nt, nsReconciler); err != nil {
 			nt.T.Fatal(err)
 		}
-
-		// Validate multi-repo metrics in namespace reconciler.
 		err := nt.ValidateMetrics(SyncMetricsToLatestCommit(nt), func() error {
 			return nt.ValidateMultiRepoMetrics(nsReconciler, 0)
 		})

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -304,7 +304,7 @@ func newSharedNT(name string) *NT {
 	fakeNTB := &testing.FakeNTB{}
 	wrapper := testing.NewShared(fakeNTB)
 	opts := newOptStruct(name, tmpDir, wrapper)
-	nt := FreshTestEnv(wrapper, opts)
+	nt := freshTestEnv(wrapper, opts)
 	mySharedNTs.newNT(nt, fakeNTB)
 	return nt
 }


### PR DESCRIPTION
- Run sharedTestEnv or freshTestEnv, not both.
- Only run test setup once per test
- Only run WatchForAllSyncs once per test setup
- Rename test setup funcs to make them private