### PR TITLE
De-dupe test setup on shared environments

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -633,7 +633,12 @@ func setupDelegatedControl(nt *NT, opts *ntopts.New) {
 		setupRepoSync(nt, nn)
 	}
 
-	// Validate multi-repo metrics in root reconcilers.
+	// Wait for all RootSyncs and all RepoSyncs to be reconciled
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// Validate metrics from root-reconcilers.
 	for rsName := range opts.RootRepos {
 		rootReconciler := core.RootReconcilerName(rsName)
 		if err := waitForReconciler(nt, rootReconciler); err != nil {
@@ -652,6 +657,7 @@ func setupDelegatedControl(nt *NT, opts *ntopts.New) {
 		}
 	}
 
+	// Validate metrics from ns-reconcilers.
 	for nn := range opts.NamespaceRepos {
 		nsReconciler := core.NsReconcilerName(nn.Namespace, nn.Name)
 		if err := waitForReconciler(nt, nsReconciler); err != nil {

--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -231,25 +231,10 @@ func newTCPSocketProbe(port int, failureThreshold int32) *corev1.Probe {
 	}
 }
 
-// portForwardGitServer forwards the git-server deployment to a port.
-// Returns the localhost port which forwards to the git-server Pod.
-func portForwardGitServer(nt *NT, repos ...types.NamespacedName) int {
+// InitGitRepos initializes the specified repositories in the test-git-server
+func InitGitRepos(nt *NT, repos ...types.NamespacedName) {
 	nt.T.Helper()
 
-	podName := InitGitRepos(nt, repos...)
-
-	if nt.gitRepoPort == 0 {
-		port, err := nt.ForwardToFreePort(testGitNamespace, podName, ":22")
-		if err != nil {
-			nt.T.Fatal(err)
-		}
-		return port
-	}
-	return nt.gitRepoPort
-}
-
-// InitGitRepos initializes the repositories in the testing git-server and returns the pod names.
-func InitGitRepos(nt *NT, repos ...types.NamespacedName) string {
 	pod, err := nt.GetDeploymentPod(testGitServer, testGitNamespace)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -266,5 +251,4 @@ func InitGitRepos(nt *NT, repos ...types.NamespacedName) string {
 		nt.MustKubectl("exec", "-n", testGitNamespace, podName, "-c", testGitServer, "--",
 			"git", "-C", fmt.Sprintf("/git-server/repos/%s", repo), "config", "receive.denyNonFastforwards", "false")
 	}
-	return podName
 }

--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -147,6 +147,11 @@ func NewRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFor
 func (g *Repository) ReInit(nt *NT, sourceFormat filesystem.SourceFormat) {
 	nt.T.Helper()
 
+	// Update test environment
+	g.T = nt.T
+	// Update URL to use latest port-forward port
+	g.RemoteURL = nt.GitProvider.RemoteURL(nt.gitRepoPort, g.RemoteRepoName)
+	// Reset repo contents
 	g.init(nt.gitPrivateKeyPath)
 	g.initialCommit(sourceFormat)
 }


### PR DESCRIPTION
- Move setupTestCase out of SharedTestEnv & FreshTestEnv and into nomostest.New. This avoids setupTestCase being called when shared environments are created by newSharedNT, which was initializing Repos & Syncs redundantly. This should speed up test suites on shared environments and reduce log spam.
- Reset port-forwarding on every test for both git-server and otel-collector. Both now track the pod name, so that they can be called again within the same test if changes are made to the deployments, to re-connect to the new backend pod.
- Make GKE autopilot detection and skipping more consistent between SharedTestEnv and FreshTestEnv. Both now skip before running the reset/cleanup code, which is unnecessary for skipped tests. This should slightly speed up autopilot test suites and reduce log spam.
- Remove redundant WatchForAllSyncs in setupTestCase, because both setupDelegatedControl and setupCentralizedControl already call it before validating metrics.

Replaces https://github.com/GoogleContainerTools/kpt-config-sync/pull/457