### PR TITLE
ci: bump kubekins-e2e base image

### DIFF
--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -20,7 +20,7 @@
 # Note: nothing builds this, if you update the version, you will need to rebuild manually.
 # For the version tag, concatenate the kubekins version and KIND version
 E2E_TEST_IMAGE_OSS_PROW_KUBEKINS_REGISTRY := k8s-staging-test-infra
-E2E_TEST_IMAGE_OSS_PROW_KUBEKINS := v20220708-6b0cfd300e-1.23
+E2E_TEST_IMAGE_OSS_PROW_KUBEKINS := v20230309-9a6b1b3121-1.23
 E2E_TEST_IMAGE_OSS_PROW_KIND := v0.14.0
 E2E_TEST_IMAGE_OSS_PROW_TAG := kubekins-e2e-$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS)-kind-$(E2E_TEST_IMAGE_OSS_PROW_KIND)
 E2E_TEST_IMAGE_OSS_PROW := gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:$(E2E_TEST_IMAGE_OSS_PROW_TAG)


### PR DESCRIPTION
This upgraded base image contains Go version 1.19, which will enable bumping the Go version in kpt-config-sync without breaking CI.

A subsequent change update the Kind prow jobs to use this image.