### PR TITLE
use same ignore list for add/lint license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,11 +283,11 @@ lint-license: pull-buildenv buildenv-dirs
 
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"
-	"$(GOBIN)/addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE -ignore=vendor/** . 2>&1 | sed '/ skipping: / d'
+	GOBIN=$(GOBIN) ./scripts/license-headers.sh add
 
 .PHONY: lint-license-headers
 lint-license-headers: "$(GOBIN)/addlicense"
-	GOBIN=$(GOBIN) ./scripts/lint-license-headers.sh
+	GOBIN=$(GOBIN) ./scripts/license-headers.sh lint
 
 .PHONY: lint-yaml
 lint-yaml:

--- a/scripts/license-headers.sh
+++ b/scripts/license-headers.sh
@@ -20,7 +20,24 @@ if [ "${GOBIN:-"unset"}" == "unset" ]; then
   exit 1
 fi
 
-"${GOBIN}/addlicense" -check -ignore=vendor/** \
-  -ignore=e2e/testdata/helm-charts/** \
-  -ignore=.output/** \
-  -ignore=e2e/testdata/*.xml . 2>&1 | sed '/ skipping: / d'
+ignores=(
+  "-ignore=vendor/**"
+  "-ignore=e2e/testdata/helm-charts/**"
+  "-ignore=.output/**"
+  "-ignore=e2e/testdata/*.xml"
+)
+
+case "$1" in
+  lint)
+    "${GOBIN}/addlicense" -check "${ignores[@]}" . 2>&1 | sed '/ skipping: / d'
+    ;;
+  add)
+    "${GOBIN}/addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE \
+     		"${ignores[@]}" \
+     		. 2>&1 | sed '/ skipping: / d'
+    ;;
+  *)
+    echo "Usage: $0 (lint|add)"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The linting script was using a different ignore list than the add script, requiring manual fixing after adding the license headers using the script. This ensures both targets use the same ignore definitions.