### PR TITLE
Nomos status rsync filter

### DIFF
--- a/cmd/nomos/status/client.go
+++ b/cmd/nomos/status/client.go
@@ -293,7 +293,7 @@ func (c *ClusterClient) rootRepoClusterStatus(ctx context.Context, cs *ClusterSt
 
 	if len(errs) > 0 {
 		cs.status = util.ErrorMsg
-		cs.Error = strings.Join(errs, ", ")
+		cs.Error += strings.Join(errs, ", ")
 	} else if len(cs.repos) == 0 {
 		cs.status = util.UnknownMsg
 		cs.Error = "No RootSync or RepoSync resources found"
@@ -337,7 +337,7 @@ func (c *ClusterClient) namespaceRepoClusterStatus(ctx context.Context, cs *Clus
 
 	if len(errs) > 0 {
 		cs.status = util.ErrorMsg
-		cs.Error = strings.Join(errs, ", ")
+		cs.Error += strings.Join(errs, ", ")
 	} else if len(cs.repos) == 0 {
 		cs.status = util.UnknownMsg
 		cs.Error = "No RepoSync resources found"

--- a/cmd/nomos/status/cluster_state.go
+++ b/cmd/nomos/status/cluster_state.go
@@ -55,7 +55,9 @@ func (c *ClusterState) printRows(writer io.Writer) {
 	}
 	for _, repo := range c.repos {
 		fmt.Fprintf(writer, "%s%s\n", util.Indent, util.Separator)
-		repo.printRows(writer)
+		if name == "" || name == repo.syncName {
+			repo.printRows(writer)
+		}
 	}
 }
 

--- a/cmd/nomos/status/status.go
+++ b/cmd/nomos/status/status.go
@@ -45,6 +45,7 @@ var (
 	pollingInterval time.Duration
 	namespace       string
 	resourceStatus  bool
+	name            string
 )
 
 func init() {
@@ -53,6 +54,7 @@ func init() {
 	Cmd.Flags().DurationVar(&pollingInterval, "poll", 0*time.Second, "Polling interval (leave unset to run once)")
 	Cmd.Flags().StringVar(&namespace, "namespace", "", "Namespace repo to get status for (multi-repo only, leave unset to get all repos)")
 	Cmd.Flags().BoolVar(&resourceStatus, "resources", true, "show resource level status for Namespace repo (multi-repo only)")
+	Cmd.Flags().StringVar(&name, "name", "", "name to filter root and repo sync name)")
 }
 
 // SaveToTempFile writes the `nomos status` output into a temporary file, and


### PR DESCRIPTION
Customers have been requesting a feature to filter the result of `nomos status` based on their selected RootSync object. To accommodate this, we added `name` flag that will filter the output of `nomos status` based on the provided root or repo sync name. This will work in conjunction with `namespace` flag that will filter based on namespace, and have been used by customer to filter RepoSync.

In this PR:
- add --name flag for sync name filtering
- update --namespace flag to work when the value is config-management-system
- update nomos status usage in OSS cluster to work with the new name and namespace flag
- e2e test for use cases and different combination of name and namepsace flag