### PR TITLE
feat: manage notification controller

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -195,6 +195,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
 	@ echo "    $(ADMISSION_WEBHOOK_IMAGE): $(ADMISSION_WEBHOOK_TAG)"
 	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
 	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
+	@ echo "    $(NOTIFICATION_IMAGE): $(NOTIFICATION_TAG)"
 	@ rm -f $(OSS_MANIFEST_STAGING_DIR)/*
 	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/oss \
 		| sed \
@@ -203,6 +204,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
 			-e "s|HELM_SYNC_IMAGE_NAME|$(HELM_SYNC_TAG)|g" \
 			-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HYDRATION_CONTROLLER_TAG)|g" \
 			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|g" \
+			-e "s|NOTIFICATION_IMAGE_NAME|$(NOTIFICATION_TAG)|g" \
 		> $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(GOBIN)/addlicense" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 
@@ -227,6 +229,7 @@ build-manifests-operator: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DI
 	@ echo "    $(ADMISSION_WEBHOOK_IMAGE): $(ADMISSION_WEBHOOK_TAG)"
 	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
 	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
+	@ echo "    $(NOTIFICATION_IMAGE): $(NOTIFICATION_TAG)"
 	@ rm -f $(NOMOS_MANIFEST_STAGING_DIR)/*
 	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/operator \
 		| sed \
@@ -236,6 +239,7 @@ build-manifests-operator: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DI
 			-e "s|HYDRATION_CONTROLLER_IMAGE_NAME|$(HYDRATION_CONTROLLER_TAG)|g" \
 			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(RECONCILER_MANAGER_TAG)|g" \
 			-e "s|WEBHOOK_IMAGE_NAME|$(ADMISSION_WEBHOOK_TAG)|g" \
+			-e "s|NOTIFICATION_IMAGE_NAME|$(NOTIFICATION_TAG)|g" \
 		> $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(GOBIN)/addlicense" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 

--- a/e2e/nomostest/notification_config.go
+++ b/e2e/nomostest/notification_config.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import "fmt"
+
+type ConfigMapMutator func(map[string]string)
+type SecretMutator func(map[string][]byte)
+
+const notificationUsernameSecretKey = "username"
+const notificationPasswordSecretKey = "password"
+
+func WithNotificationUsername(username string) SecretMutator {
+	return func(secretData map[string][]byte) {
+		secretData[notificationUsernameSecretKey] = []byte(username)
+	}
+}
+
+func WithNotificationPassword(password string) SecretMutator {
+	return func(secretData map[string][]byte) {
+		secretData[notificationPasswordSecretKey] = []byte(password)
+	}
+}
+
+func WithLocalWebhookService(cmData map[string]string) {
+	cmData["service.webhook.local"] = fmt.Sprintf(
+		`url: http://%s.%s:%d
+headers: #optional headers
+- name: Content-Type
+  value: application/json
+basicAuth:
+  username: $%s
+  password: $%s`,
+		testNotificationWebhookServer,
+		testNotificationWebhookNamespace,
+		TestNotificationWebhookPort,
+		notificationUsernameSecretKey,
+		notificationPasswordSecretKey,
+	)
+}
+
+func WithOnSyncSyncedTrigger(cmData map[string]string) {
+	cmData["trigger.on-sync-synced"] = `- when: any(sync.status.conditions, {.commit != nil && .type == 'Syncing' && .status == 'False' && .message == 'Sync Completed' && .errorSourceRefs == nil && .errors == nil})
+  oncePer: sync.status.lastSyncedCommit
+  send: [sync-synced]`
+}
+
+func WithSyncSyncedTemplate(cmData map[string]string) {
+	cmData["template.sync-synced"] = `webhook:
+  local:
+    method: POST
+    path: /
+    body: |
+      {
+        "content": {
+          "raw": "{{.sync.kind}} {{.sync.metadata.name}} is synced!"
+        }
+      }`
+}

--- a/e2e/nomostest/predicates.go
+++ b/e2e/nomostest/predicates.go
@@ -370,6 +370,62 @@ func AllResourcesAreCurrent() Predicate {
 	}
 }
 
+// DeploymentHasContainer checks that the Deployment exists and contains the
+// specified container.
+func DeploymentHasContainer(containerName string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		d, ok := o.(*appsv1.Deployment)
+		if !ok {
+			return WrongTypeErr(o, d)
+		}
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				return nil
+			}
+		}
+		return errors.Errorf("Deployment %s does not have container %s", d.Name, containerName)
+	}
+}
+
+// DeploymentMissingContainer checks that the Deployment exists and does not contain
+// the specified container
+func DeploymentMissingContainer(containerName string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		d, ok := o.(*appsv1.Deployment)
+		if !ok {
+			return WrongTypeErr(o, d)
+		}
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				return errors.Errorf("Deployment %s has container %s", d.Name, containerName)
+			}
+		}
+		return nil
+	}
+}
+
+// ObjectHasAnnotation checks that the Object has the specified annotation key
+func ObjectHasAnnotation(key string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		annotations := o.GetAnnotations()
+		for k := range annotations {
+			if k == key {
+				return nil
+			}
+		}
+		return errors.Errorf("%s missing annotation (%s). Got %v", o.GetName(), key, annotations)
+	}
+}
+
 // DeploymentHasEnvVar check whether the deployment contains environment variable
 // with specified name and value
 func DeploymentHasEnvVar(containerName, key, value string) Predicate {

--- a/e2e/testcases/notification_test.go
+++ b/e2e/testcases/notification_test.go
@@ -1,0 +1,187 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	"kpt.dev/configsync/e2e/nomostest/taskgroup"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+)
+
+func TestNotification(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	repoSyncNN := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
+	rootReconcilerName := core.RootReconcilerName(rootSyncNN.Name)
+	backendReconcilerName := core.NsReconcilerName(repoSyncNN.Namespace, repoSyncNN.Name)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.InstallNotificationServer,
+		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name),
+	)
+	var err error
+	credentialMap := map[string]string{
+		rootSyncNN.Namespace: "pass123",
+		repoSyncNN.Namespace: "pass456",
+	}
+	for ns, pass := range credentialMap {
+		_, err = nomostest.NotificationSecret(nt, ns,
+			nomostest.WithNotificationUsername("user"),
+			nomostest.WithNotificationPassword(pass),
+		)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+		_, err = nomostest.NotificationConfigMap(nt, ns,
+			nomostest.WithOnSyncSyncedTrigger,
+			nomostest.WithSyncSyncedTemplate,
+			nomostest.WithLocalWebhookService,
+		)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+
+	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSyncNN)
+	rootSync := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncNN.Name)
+	if err := nt.Get(rootSyncNN.Name, rootSyncNN.Namespace, rootSync); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nomostest.SubscribeRootSyncNotification(rootSync, "on-sync-synced", "local")
+	if err := nt.Update(rootSync); err != nil {
+		nt.T.Fatal(err)
+	}
+	tg := taskgroup.New()
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.Deployment(), rootReconcilerName, rootSyncNN.Namespace,
+			[]nomostest.Predicate{nomostest.DeploymentHasContainer(reconcilermanager.Notification)})
+	})
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.RootSyncV1Beta1(), rootSyncNN.Name, rootSyncNN.Namespace,
+			[]nomostest.Predicate{nomostest.ObjectHasAnnotation("notified.notifications.configsync.gke.io")})
+	})
+	if err := tg.Wait(); err != nil {
+		nt.T.Fatal(err)
+	}
+	records, err := waitForNotifications(nt, 1)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	require.Equal(nt.T, nomostest.NotificationRecords{
+		Records: []nomostest.NotificationRecord{
+			{
+				Message: "{\n  \"content\": {\n    \"raw\": \"RootSync root-sync is synced!\"\n  }\n}",
+				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass123"))), // base64 encoded username/pass
+			},
+		},
+	}, *records)
+
+	nomostest.SubscribeRepoSyncNotification(repoSyncBackend, "on-sync-synced", "local")
+	nt.RootRepos[rootSyncNN.Name].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), repoSyncBackend)
+	nt.RootRepos[rootSyncNN.Name].CommitAndPush("Enable notifications on backend RepoSync")
+	tg = taskgroup.New()
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.Deployment(),
+			core.NsReconcilerName(repoSyncNN.Namespace, repoSyncNN.Name), configsync.ControllerNamespace,
+			[]nomostest.Predicate{nomostest.DeploymentHasContainer(reconcilermanager.Notification)})
+	})
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.RepoSyncV1Beta1(), repoSyncNN.Name, repoSyncNN.Namespace,
+			[]nomostest.Predicate{nomostest.ObjectHasAnnotation("notified.notifications.configsync.gke.io")})
+	})
+	if err := tg.Wait(); err != nil {
+		nt.T.Fatal(err)
+	}
+	records, err = waitForNotifications(nt, 3)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// RootSync notification for two commits, RepoSync notification for one commit
+	require.Equal(nt.T, nomostest.NotificationRecords{
+		Records: []nomostest.NotificationRecord{
+			{
+				Message: "{\n  \"content\": {\n    \"raw\": \"RootSync root-sync is synced!\"\n  }\n}",
+				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass123"))), // base64 encoded username/pass
+			},
+			{
+				Message: "{\n  \"content\": {\n    \"raw\": \"RootSync root-sync is synced!\"\n  }\n}",
+				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass123"))), // base64 encoded username/pass
+			},
+			{
+				Message: "{\n  \"content\": {\n    \"raw\": \"RepoSync repo-sync is synced!\"\n  }\n}",
+				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass456"))), // base64 encoded username/pass
+			},
+		},
+	}, *records)
+
+	rootSync = nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncNN.Name)
+	if err := nt.Get(rootSyncNN.Name, rootSyncNN.Namespace, rootSync); err != nil {
+		nt.T.Fatal(err)
+	}
+	nomostest.UnsubscribeRootSyncNotification(rootSync)
+	if err := nt.Update(rootSync); err != nil {
+		nt.T.Fatal(err)
+	}
+	nomostest.UnsubscribeRepoSyncNotification(repoSyncBackend)
+	nt.RootRepos[rootSyncNN.Name].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), repoSyncBackend)
+	nt.RootRepos[rootSyncNN.Name].CommitAndPush("Disable notifications on backend RepoSync")
+
+	tg = taskgroup.New()
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.Deployment(), rootReconcilerName, rootSyncNN.Namespace,
+			[]nomostest.Predicate{nomostest.DeploymentMissingContainer(reconcilermanager.Notification)},
+		)
+	})
+	tg.Go(func() error {
+		return nomostest.WatchObject(nt, kinds.Deployment(), backendReconcilerName, rootSyncNN.Namespace,
+			[]nomostest.Predicate{nomostest.DeploymentMissingContainer(reconcilermanager.Notification)},
+		)
+	})
+	if err := tg.Wait(); err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func waitForNotifications(nt *nomostest.NT, expectedNum int) (*nomostest.NotificationRecords, error) {
+	var records *nomostest.NotificationRecords
+	var err error
+	took, err := nomostest.Retry(30*time.Second, func() error {
+		records, err = nt.NotificationServer.DoGet()
+		if err != nil {
+			return err
+		}
+		if len(records.Records) < expectedNum {
+			return fmt.Errorf("want %d, got %d", expectedNum, len(records.Records))
+		}
+		return nil
+	})
+	nt.T.Logf("took %v to wait for %d notification(s). Got %d", took, expectedNum, len(records.Records))
+	if err != nil {
+		return records, err
+	} else if len(records.Records) != expectedNum { // check if got more records than expected
+		return records, fmt.Errorf("want %d, got %d", expectedNum, len(records.Records))
+	}
+	return records, nil
+}

--- a/manifests/ns-reconciler-cluster-role.yaml
+++ b/manifests/ns-reconciler-cluster-role.yaml
@@ -32,6 +32,9 @@ rules:
 - apiGroups: ["kpt.dev"]
   resources: ["resourcegroups/status"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - policy
   resources:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -169,6 +169,20 @@ data:
              requests:
                cpu: "50m"
                memory: "200Mi"
+         - name: notification
+           image: NOTIFICATION_IMAGE_NAME
+           command:
+           - /notification
+           terminationMessagePath: "/dev/termination-log"
+           terminationMessagePolicy: File
+           imagePullPolicy: IfNotPresent
+           securityContext:
+             allowPrivilegeEscalation: false
+             readOnlyRootFilesystem: true
+           resources:
+             requests:
+               cpu: 10m
+               memory: 50Mi
          - name: otel-agent
            image: gcr.io/config-management-release/otelcontribcol:v0.54.0
            command:

--- a/pkg/api/configsync/v1beta1/getters.go
+++ b/pkg/api/configsync/v1beta1/getters.go
@@ -37,6 +37,15 @@ func GetSecretName(secretRef *SecretReference) string {
 	return ""
 }
 
+// GetConfigMapName will return an empty string if the configmapRef.name is
+// empty or the configmapRef doesn't exist
+func GetConfigMapName(configmapRef *ConfigMapReference) string {
+	if configmapRef != nil {
+		return configmapRef.Name
+	}
+	return ""
+}
+
 // SafeOverride creates an override or returns an existing one
 // use it if you need to ensure that you are assigning
 // to an object, but not to test for nil (current existance)

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -58,6 +58,9 @@ const (
 	// HelmSync is the name of the helm-sync container in reconciler pods.
 	HelmSync = "helm-sync"
 
+	// Notification is the name of the notification container in reconciler pods.
+	Notification = "notification"
+
 	// HydrationController is the name of the hydration-controller container in reconciler pods.
 	HydrationController = "hydration-controller"
 

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -46,6 +46,7 @@ import (
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util"
 	"kpt.dev/configsync/pkg/util/compare"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -292,8 +293,25 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, errors.Wrap(err, "RoleBinding reconcile failed")
 	}
 
-	containerEnvs := r.populateContainerEnvs(ctx, rs, reconcilerRef.Name)
-	mut := r.mutationsFor(ctx, rs, containerEnvs)
+	notificationEnabled, err := util.NotificationEnabled(ctx, r.client, rs.Namespace, rs.Annotations, rs.Spec.NotificationConfig)
+	if err != nil {
+		log.Error(err, "Check notification configuration failed")
+		reposync.SetStalled(rs, "Notification", err)
+		// check notification subscription errors should always trigger retry (return error),
+		// even if status update is successful.
+		_, updateErr := r.updateStatus(ctx, currentRS, rs)
+		if updateErr != nil {
+			log.Error(updateErr, "Object status update failed",
+				logFieldObject, rsRef.String(),
+				logFieldKind, r.syncKind)
+		}
+		// Use the upsert error for metric tagging.
+		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
+		return controllerruntime.Result{}, errors.Wrap(err, "Check notification configuration failed")
+	}
+
+	containerEnvs := r.populateContainerEnvs(ctx, rs, reconcilerRef.Name, notificationEnabled)
+	mut := r.mutationsFor(ctx, rs, notificationEnabled, containerEnvs)
 
 	// Upsert Namespace reconciler deployment.
 	deployObj, op, err := r.upsertDeployment(ctx, reconcilerRef, labelMap, mut)
@@ -664,10 +682,13 @@ func requeueRepoSyncRequest(obj client.Object, rs *v1beta1.RepoSync) []reconcile
 	}
 }
 
-func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RepoSync, reconcilerName string) map[string][]corev1.EnvVar {
+func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RepoSync, reconcilerName string, notificationEnabled bool) map[string][]corev1.EnvVar {
 	result := map[string][]corev1.EnvVar{
 		reconcilermanager.HydrationController: hydrationEnvs(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, declared.Scope(rs.Namespace), reconcilerName, r.hydrationPollingPeriod.String()),
 		reconcilermanager.Reconciler:          reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.Scope(rs.Namespace), rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, reposync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.SafeOverride().StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.SafeOverride().ReconcileTimeout), v1beta1.GetAPIServerTimeout(rs.Spec.SafeOverride().APIServerTimeout)),
+	}
+	if notificationEnabled {
+		result[reconcilermanager.Notification] = notificationEnvs(r.syncKind, rs.Namespace, rs.Name, rs.Spec.NotificationConfig)
 	}
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
 	case v1beta1.GitSource:
@@ -802,7 +823,7 @@ func (r *RepoSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 	return true, nil
 }
 
-func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoSync, containerEnvs map[string][]corev1.EnvVar) mutateFn {
+func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoSync, notificationEnabled bool, containerEnvs map[string][]corev1.EnvVar) mutateFn {
 	return func(obj client.Object) error {
 		d, ok := obj.(*appsv1.Deployment)
 		if !ok {
@@ -909,6 +930,12 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 					keys := GetSecretKeys(ctx, r.client, sRef)
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
 					mutateContainerResource(&container, rs.Spec.Override)
+				}
+			case reconcilermanager.Notification:
+				if !notificationEnabled {
+					addContainer = false
+				} else {
+					container.Env = append(container.Env, containerEnvs[container.Name]...)
 				}
 			case metrics.OtelAgentName:
 				// The no-op case to avoid unknown container error after

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -47,6 +47,7 @@ import (
 	"kpt.dev/configsync/pkg/reposync"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/util"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -217,6 +218,16 @@ func reposyncCACert(caCertSecretRef string) func(sync *v1beta1.RepoSync) {
 	}
 }
 
+func reposyncNotificationConfig(notificationConfig *v1beta1.NotificationConfig) func(sync *v1beta1.RepoSync) {
+	return func(rs *v1beta1.RepoSync) {
+		if rs.Annotations == nil {
+			rs.Annotations = make(map[string]string)
+		}
+		rs.Annotations[fmt.Sprintf("%s/subscribe.foo.bar", util.AnnotationsPrefix)] = ""
+		rs.Spec.NotificationConfig = notificationConfig
+	}
+}
+
 func repoSync(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1(ns, name)
 	rs.Spec.SourceType = string(v1beta1.GitSource)
@@ -329,7 +340,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -456,7 +467,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -685,7 +696,7 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -723,7 +734,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -859,7 +870,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1000,7 +1011,7 @@ func TestRepoSyncCreateWithCACert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 
 	nsSecretName := nsReconcilerName + "-" + secretName
 	nsCACertSecret := nsReconcilerName + "-" + caCertSecret
@@ -1039,7 +1050,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	nsSecretName := nsReconcilerName + "-" + secretName
 	repoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1087,7 +1098,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	nsCACertSecret := nsReconcilerName + "-" + caCertSecret
 	updatedRepoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1128,6 +1139,75 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 	t.Log("Deployment successfully updated")
 }
 
+func TestRepoSyncCreateWithNotifications(t *testing.T) {
+	// Mock out parseDeployment for testing.
+	parseDeployment = parsedDeployment
+	configMapNN := types.NamespacedName{
+		Name:      "test-notification-cm",
+		Namespace: reposyncNs,
+	}
+	secretNN := types.NamespacedName{
+		Name:      "test-notification-secret",
+		Namespace: reposyncNs,
+	}
+	rs := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch),
+		reposyncSecretType(configsync.AuthToken), reposyncSecretRef(secretName),
+		reposyncNotificationConfig(&v1beta1.NotificationConfig{
+			ConfigMapRef: &v1beta1.ConfigMapReference{Name: configMapNN.Name},
+			SecretRef:    &v1beta1.SecretReference{Name: secretNN.Name},
+		}),
+	)
+	repoSyncNN := namespacedName(rs.Name, rs.Namespace)
+	gitSecret := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
+	gitSecret.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
+
+	notificationConfigMap := fake.ConfigMapObject(core.Name(configMapNN.Name), core.Namespace(configMapNN.Namespace))
+	notificationSecret := fake.SecretObject(secretNN.Name, core.Namespace(secretNN.Namespace))
+
+	// initial create without ConfigMap to check for error
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, notificationSecret, gitSecret)
+
+	// Test creating Deployment resources.
+	ctx := context.Background()
+	if _, err := testReconciler.Reconcile(ctx, repoSyncNN); err == nil {
+		t.Fatal("expected reconciliation error")
+	}
+
+	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
+	reposync.SetStalled(wantRs, "Notification",
+		fmt.Errorf("notification ConfigMap %s not found in the %s namespace", configMapNN.Name, configMapNN.Namespace),
+	)
+	validateRepoSyncStatus(t, wantRs, fakeClient)
+
+	if err := fakeClient.Create(ctx, notificationConfigMap); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := testReconciler.Reconcile(ctx, repoSyncNN); err != nil {
+		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
+	}
+
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, true)
+
+	nsSecretName := nsReconcilerName + "-" + secretName
+	rootDeployment := repoSyncDeployment(nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsSecretName),
+		envVarMutator("HTTPS_PROXY", nsSecretName, "https_proxy"),
+		envVarMutator(gitSyncName, nsSecretName, GitSecretConfigKeyTokenUsername),
+		envVarMutator(gitSyncPassword, nsSecretName, GitSecretConfigKeyToken),
+		notificationMutator(),
+		containerEnvMutator(repoContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
+	)
+	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
+
+	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
+		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	t.Log("Deployment successfully created")
+}
+
 func TestRepoSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 	// Mock out parseDeployment for testing.
 	parseDeployment = parsedDeployment
@@ -1142,7 +1222,7 @@ func TestRepoSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1174,7 +1254,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1206,7 +1286,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1238,7 +1318,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	updatedRepoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1315,7 +1395,7 @@ func TestRepoSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1347,7 +1427,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1379,7 +1459,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1456,7 +1536,7 @@ func TestRepoSyncCreateWithOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
@@ -1486,7 +1566,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1515,7 +1595,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	updatedRepoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1605,7 +1685,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1644,7 +1724,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1675,7 +1755,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1714,7 +1794,7 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1849,7 +1929,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	roleBinding1.Subjects = addSubjectByName(roleBinding1.Subjects, nsReconcilerName)
 	wantRoleBindings := map[core.ID]*rbacv1.RoleBinding{core.IDOf(roleBinding1): roleBinding1}
 
-	repoContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName)
+	repoContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName, false)
 	repoDeployment1 := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -1897,7 +1977,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
-	repoContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
+	repoContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2, false)
 	repoDeployment2 := repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
@@ -1960,7 +2040,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
-	repoContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
+	repoContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3, false)
 	repoDeployment3 := repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
@@ -2022,7 +2102,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
-	repoContainerEnv4 := testReconciler.populateContainerEnvs(ctx, rs4, nsReconcilerName4)
+	repoContainerEnv4 := testReconciler.populateContainerEnvs(ctx, rs4, nsReconcilerName4, false)
 	repoDeployment4 := repoSyncDeployment(
 		nsReconcilerName4,
 		setServiceAccountName(nsReconcilerName4),
@@ -2084,7 +2164,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		metadata.SyncKindLabel:      testReconciler.syncKind,
 	}
 
-	repoContainerEnv5 := testReconciler.populateContainerEnvs(ctx, rs5, nsReconcilerName5)
+	repoContainerEnv5 := testReconciler.populateContainerEnvs(ctx, rs5, nsReconcilerName5, false)
 	repoDeployment5 := repoSyncDeployment(
 		nsReconcilerName5,
 		setServiceAccountName(nsReconcilerName5),
@@ -2134,7 +2214,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	reposync.SetReconciling(wantRs1, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs1, fakeClient)
 
-	repoContainerEnv1 = testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName)
+	repoContainerEnv1 = testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName, false)
 	repoDeployment1 = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2168,7 +2248,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	reposync.SetReconciling(wantRs2, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs2, fakeClient)
 
-	repoContainerEnv2 = testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
+	repoContainerEnv2 = testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2, false)
 	repoDeployment2 = repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
@@ -2202,7 +2282,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	reposync.SetReconciling(wantRs3, "Deployment", "Replicas: 0/1")
 	validateRepoSyncStatus(t, wantRs3, fakeClient)
 
-	repoContainerEnv3 = testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
+	repoContainerEnv3 = testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3, false)
 	repoDeployment3 = repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
@@ -2653,7 +2733,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
@@ -2720,7 +2800,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
@@ -2753,7 +2833,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2788,7 +2868,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
-	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 
 	repoDeployment := rootSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2818,7 +2898,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
@@ -2911,7 +2991,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
-	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2953,7 +3033,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		t.Errorf("ServiceAccount validation failed: %v", err)
 	}
 
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2982,7 +3062,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
-	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName, false)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -3441,7 +3521,7 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, testReconciler := setupNSReconciler(t, tc.repoSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(tc.repoSync.Namespace)))
 
-			env := testReconciler.populateContainerEnvs(ctx, tc.repoSync, nsReconcilerName)
+			env := testReconciler.populateContainerEnvs(ctx, tc.repoSync, nsReconcilerName, false)
 
 			for container, vars := range env {
 				if diff := cmp.Diff(tc.expected[container], vars, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b corev1.EnvVar) bool { return a.Name < b.Name })); diff != "" {

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -46,6 +46,7 @@ import (
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util"
 	"kpt.dev/configsync/pkg/util/compare"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -245,8 +246,24 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, errors.Wrap(err, "ClusterRoleBinding reconcile failed")
 	}
 
-	containerEnvs := r.populateContainerEnvs(ctx, rs, reconcilerRef.Name)
-	mut := r.mutationsFor(ctx, rs, containerEnvs)
+	notificationEnabled, err := util.NotificationEnabled(ctx, r.client, rs.Namespace, rs.Annotations, rs.Spec.NotificationConfig)
+	if err != nil {
+		log.Error(err, "Check notification configuration failed")
+		rootsync.SetStalled(rs, "Notification", err)
+		// check notification subscription errors should always trigger retry (return error),
+		// even if status update is successful.
+		_, updateErr := r.updateStatus(ctx, currentRS, rs)
+		if updateErr != nil {
+			log.Error(updateErr, "Object status update failed",
+				logFieldObject, rsRef.String(),
+				logFieldKind, r.syncKind)
+		}
+		// Use the upsert error for metric tagging.
+		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
+		return controllerruntime.Result{}, errors.Wrap(err, "Check notification configuration failed")
+	}
+	containerEnvs := r.populateContainerEnvs(ctx, rs, reconcilerRef.Name, notificationEnabled)
+	mut := r.mutationsFor(ctx, rs, notificationEnabled, containerEnvs)
 
 	// Upsert Root reconciler deployment.
 	deployObj, op, err := r.upsertDeployment(ctx, reconcilerRef, labelMap, mut)
@@ -471,10 +488,13 @@ func (r *RootSyncReconciler) mapSecretToRootSyncs(secret client.Object) []reconc
 	return requests
 }
 
-func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string) map[string][]corev1.EnvVar {
+func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string, notificationEnabled bool) map[string][]corev1.EnvVar {
 	result := map[string][]corev1.EnvVar{
 		reconcilermanager.HydrationController: hydrationEnvs(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, declared.RootReconciler, reconcilerName, r.hydrationPollingPeriod.String()),
 		reconcilermanager.Reconciler:          append(reconcilerEnvs(r.clusterName, rs.Name, reconcilerName, declared.RootReconciler, rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, rootsync.GetHelmBase(rs.Spec.Helm), r.reconcilerPollingPeriod.String(), rs.Spec.SafeOverride().StatusMode, v1beta1.GetReconcileTimeout(rs.Spec.SafeOverride().ReconcileTimeout), v1beta1.GetAPIServerTimeout(rs.Spec.SafeOverride().APIServerTimeout)), sourceFormatEnv(rs.Spec.SourceFormat)),
+	}
+	if notificationEnabled {
+		result[reconcilermanager.Notification] = notificationEnvs(r.syncKind, rs.Namespace, rs.Name, rs.Spec.NotificationConfig)
 	}
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
 	case v1beta1.GitSource:
@@ -591,7 +611,7 @@ func (r *RootSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 	return true, nil
 }
 
-func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootSync, containerEnvs map[string][]corev1.EnvVar) mutateFn {
+func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootSync, notificationEnabled bool, containerEnvs map[string][]corev1.EnvVar) mutateFn {
 	return func(obj client.Object) error {
 		d, ok := obj.(*appsv1.Deployment)
 		if !ok {
@@ -707,6 +727,12 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 					keys := GetSecretKeys(ctx, r.client, sRef)
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
 					mutateContainerResource(&container, rs.Spec.Override)
+				}
+			case reconcilermanager.Notification:
+				if !notificationEnabled {
+					addContainer = false
+				} else {
+					container.Env = append(container.Env, containerEnvs[container.Name]...)
 				}
 			case metrics.OtelAgentName:
 				// The no-op case to avoid unknown container error after

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -29,6 +29,7 @@ import (
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +74,39 @@ func hydrationEnvs(sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1
 			Name:  reconcilermanager.HydrationPollingPeriod,
 			Value: pollPeriod,
 		})
+	return result
+}
+
+// notificationEnvs returns environment variables for the notification controller.
+func notificationEnvs(kind, rsNamespace, rsName string, notificationConfig *v1beta1.NotificationConfig) []corev1.EnvVar {
+	var result []corev1.EnvVar
+	result = append(result,
+		corev1.EnvVar{
+			Name:  util.NotificationAPIKind,
+			Value: kind,
+		},
+		corev1.EnvVar{
+			Name:  util.NotificationConfigMapName,
+			Value: v1beta1.GetConfigMapName(notificationConfig.ConfigMapRef),
+		},
+		corev1.EnvVar{
+			Name:  util.NotificationResourceName,
+			Value: rsName,
+		},
+		corev1.EnvVar{
+			Name:  util.NotificationResourceNamespace,
+			Value: rsNamespace,
+		},
+	)
+	secretName := v1beta1.GetSecretName(notificationConfig.SecretRef)
+	if secretName != "" {
+		result = append(result,
+			corev1.EnvVar{
+				Name:  util.NotificationSecretName,
+				Value: secretName,
+			},
+		)
+	}
 	return result
 }
 

--- a/pkg/util/notification.go
+++ b/pkg/util/notification.go
@@ -15,7 +15,16 @@
 package util
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -38,4 +47,68 @@ const (
 
 	// AnnotationsPrefix is the notification annotations prefix
 	AnnotationsPrefix = "notifications." + configsync.GroupName
+
+	// SubscribeAnnotationPrefix is the annotation prefix of the notification subscription.
+	SubscribeAnnotationPrefix = AnnotationsPrefix + "/subscribe."
+
+	// MultiSubscriptionsField is the field name for subscriptions configured globally.
+	MultiSubscriptionsField = "subscriptions"
+
+	// NotifiedAnnotationPath is the annotation path that indicates it has been notified.
+	NotifiedAnnotationPath = ".metadata.annotations.notified." + AnnotationsPrefix
 )
+
+// NotificationEnabled returns whether the notification is enabled for the RSync object.
+func NotificationEnabled(ctx context.Context, client client.Client, rsNamespace string, annotations map[string]string, notificationConfig *v1beta1.NotificationConfig) (bool, error) {
+	hasSubscriptionAnnotation := false
+	// subscription via prefix
+	for key := range annotations {
+		if strings.HasPrefix(key, SubscribeAnnotationPrefix) {
+			hasSubscriptionAnnotation = true
+		}
+	}
+	if hasSubscriptionAnnotation && notificationConfig == nil {
+		return false, fmt.Errorf("subscription annotation was provided without a notificationConfig")
+	}
+	if notificationConfig == nil {
+		return false, nil
+	}
+	// ConfigMapRef must be defined
+	configMapName := v1beta1.GetConfigMapName(notificationConfig.ConfigMapRef)
+	if configMapName == "" && hasSubscriptionAnnotation {
+		return false, fmt.Errorf("notificationConfig must have a configMapRef")
+	} else if configMapName == "" && !hasSubscriptionAnnotation {
+		return false, nil
+	}
+	// ensure ConfigMap exists
+	cm := &corev1.ConfigMap{}
+	cmObjectKey := types.NamespacedName{
+		Namespace: rsNamespace,
+		Name:      configMapName,
+	}
+	if err := client.Get(ctx, cmObjectKey, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("notification ConfigMap %s not found in the %s namespace", cmObjectKey.Name, cmObjectKey.Namespace)
+		}
+		return false, err
+	}
+	// subscription via ConfigMap
+	_, found := cm.Data[MultiSubscriptionsField]
+	if !hasSubscriptionAnnotation && !found {
+		return false, nil
+	}
+	secretName := v1beta1.GetSecretName(notificationConfig.SecretRef)
+	if secretName != "" {
+		secretObjectKey := types.NamespacedName{
+			Name:      secretName,
+			Namespace: rsNamespace,
+		}
+		if err := client.Get(ctx, secretObjectKey, &corev1.Secret{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("notification Secret %s not found in the %s namespace", secretObjectKey.Name, secretObjectKey.Namespace)
+			}
+			return false, err
+		}
+	}
+	return true, nil
+}

--- a/pkg/util/notification_test.go
+++ b/pkg/util/notification_test.go
@@ -1,0 +1,216 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const configMapRef = "test-notification-cm"
+const secretRef = "test-notification-secret"
+const namespace = "bookinfo"
+
+func notificationConfigMapWithSubscription() *corev1.ConfigMap {
+	cm := fake.ConfigMapObject(core.Name(configMapRef), core.Namespace(namespace))
+	cm.Data = map[string]string{
+		MultiSubscriptionsField: `- recipients
+  - email:user@example.com
+  triggers:
+    - on-sync-synced`,
+	}
+	return cm
+}
+
+func TestNotificationEnabled(t *testing.T) {
+	testCases := []struct {
+		description        string
+		namespace          string
+		annotations        map[string]string
+		notificationConfig *v1beta1.NotificationConfig
+		objects            []client.Object
+		wantError          error
+		wantEnabled        bool
+	}{
+		{
+			description:        "Notifications are disabled",
+			namespace:          namespace,
+			annotations:        nil,
+			notificationConfig: nil,
+			wantError:          nil,
+			wantEnabled:        false,
+		},
+		{
+			description: "Notifications subscription provided without notificationConfig",
+			namespace:   namespace,
+			annotations: map[string]string{
+				fmt.Sprintf("%s/subscribe.on-sync-synced.local", AnnotationsPrefix): "",
+			},
+			notificationConfig: nil,
+			wantError:          fmt.Errorf("subscription annotation was provided without a notificationConfig"),
+			wantEnabled:        false,
+		},
+		{
+			description:        "notificationConfig provided without configMapRef and without annotation",
+			namespace:          namespace,
+			annotations:        nil,
+			notificationConfig: &v1beta1.NotificationConfig{},
+			wantError:          nil,
+			wantEnabled:        false,
+		},
+		{
+			description: "notificationConfig provided without configMapRef and with annotation",
+			namespace:   namespace,
+			annotations: map[string]string{
+				fmt.Sprintf("%s/subscribe.on-sync-synced.local", AnnotationsPrefix): "",
+			},
+			notificationConfig: &v1beta1.NotificationConfig{},
+			wantError:          fmt.Errorf("notificationConfig must have a configMapRef"),
+			wantEnabled:        false,
+		},
+		{
+			description: "Notification configMapRef provided but ConfigMap not found",
+			namespace:   namespace,
+			annotations: nil,
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+			},
+			wantError:   fmt.Errorf("notification ConfigMap test-notification-cm not found in the bookinfo namespace"),
+			wantEnabled: false,
+		},
+		{
+			description: "notificationConfig provided without any subscriptions",
+			namespace:   namespace,
+			annotations: nil,
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+			},
+			objects: []client.Object{
+				fake.ConfigMapObject(core.Name(configMapRef), core.Namespace(namespace)),
+			},
+			wantError:   nil,
+			wantEnabled: false,
+		},
+		{
+			description: "Notification secretRef provided but Secret not found",
+			namespace:   namespace,
+			annotations: map[string]string{
+				fmt.Sprintf("%s/subscribe.on-sync-synced.local", AnnotationsPrefix): "",
+			},
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+				SecretRef: &v1beta1.SecretReference{
+					Name: secretRef,
+				},
+			},
+			objects: []client.Object{
+				fake.ConfigMapObject(core.Name(configMapRef), core.Namespace(namespace)),
+			},
+			wantError:   fmt.Errorf("notification Secret test-notification-secret not found in the bookinfo namespace"),
+			wantEnabled: false,
+		},
+		{
+			description: "Notification properly configured with annotation based subscription",
+			namespace:   namespace,
+			annotations: map[string]string{
+				fmt.Sprintf("%s/subscribe.on-sync-synced.local", AnnotationsPrefix): "",
+			},
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+				SecretRef: &v1beta1.SecretReference{
+					Name: secretRef,
+				},
+			},
+			objects: []client.Object{
+				fake.ConfigMapObject(core.Name(configMapRef), core.Namespace(namespace)),
+				fake.SecretObject(secretRef, core.Namespace(namespace)),
+			},
+			wantError:   nil,
+			wantEnabled: true,
+		},
+		{
+			description: "Notification properly configured with ConfigMap based subscription",
+			namespace:   namespace,
+			annotations: nil,
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+				SecretRef: &v1beta1.SecretReference{
+					Name: secretRef,
+				},
+			},
+			objects: []client.Object{
+				notificationConfigMapWithSubscription(),
+				fake.SecretObject(secretRef, core.Namespace(namespace)),
+			},
+			wantError:   nil,
+			wantEnabled: true,
+		},
+		{
+			description: "Notification properly configured with combination of subscriptions",
+			namespace:   namespace,
+			annotations: map[string]string{
+				fmt.Sprintf("%s/subscribe.on-sync-synced.local", AnnotationsPrefix): "",
+			},
+			notificationConfig: &v1beta1.NotificationConfig{
+				ConfigMapRef: &v1beta1.ConfigMapReference{
+					Name: configMapRef,
+				},
+				SecretRef: &v1beta1.SecretReference{
+					Name: secretRef,
+				},
+			},
+			objects: []client.Object{
+				notificationConfigMapWithSubscription(),
+				fake.SecretObject(secretRef, core.Namespace(namespace)),
+			},
+			wantError:   nil,
+			wantEnabled: true,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			fakeClient := syncerFake.NewClient(t, core.Scheme, tc.objects...)
+			enabled, err := NotificationEnabled(ctx, fakeClient, tc.namespace, tc.annotations, tc.notificationConfig)
+			if !reflect.DeepEqual(err, tc.wantError) {
+				t.Errorf("NotificationEnabled() got error: %q, want error %q", err, tc.wantError)
+			}
+			if enabled != tc.wantEnabled {
+				t.Errorf("NotificationEnabled() got enabled: %v, want error %v", enabled, tc.wantEnabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds logic to manage the notification controller via the reconciler-manager. The reconciler-manager will create the notification controller as a pod in the reconciler deployment if the notification API is enabled in the RSync.