### PR TITLE
do not error test if port forward finished

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -870,7 +870,7 @@ func (nt *NT) ForwardToFreePort(ns, pod, port string) (int, error) {
 		cleanup = true
 		nt.T.Log("stopping port-forward %s/%s:%s process", ns, pod, port)
 		err := cmd.Process.Kill()
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrProcessDone) {
 			nt.T.Errorf("killing port-forward %s/%s:%s process: %v", ns, pod, port, err)
 		}
 	})


### PR DESCRIPTION
This scenario occurs during test cleanup - if killing the port-forward process fails because the process is already finished, we can treat this as a non-fatal error.