### PR TITLE
test: only update ns if it was changed (#472)

### DIFF
--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -215,6 +215,10 @@ func deleteConfigSyncAndTestAnnotationsAndLabels(nt *NT, ns *corev1.Namespace) e
 			labels[k] = v
 		}
 	}
+	// return without updating if no annotations/labels were removed
+	if len(annotations) == len(ns.Annotations) && len(labels) == len(ns.Labels) {
+		return nil
+	}
 
 	ns.Annotations = annotations
 	ns.Labels = labels


### PR DESCRIPTION
This is an optimization to simply return if the namespace had no annotations or labels removed. We are also seeing an issue on autopilot where the update is being denied by a webhook, so this should hopefully fix that.