### PR TITLE
Modify the metrics for CS smokedetector setup

### DIFF
--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -131,6 +131,7 @@ processors:
           - reconciler_errors
           - pipeline_error_observed
           - reconcile_duration_seconds
+          - rg_reconcile_duration_seconds
           - parser_duration_seconds
           - declared_resources
           - apply_operations_total
@@ -145,15 +146,10 @@ processors:
           - git_sync_depth_override_count_total
           - no_ssl_verify_count_total
           - kcc_resource_count
-      exclude:
-        match_type: strict
-        metric_names:
-          - rg_reconcile_duration_seconds
-          # TODO remove kcc_resource_count_total rule once Resource Group Controller
-          # 1.0.9 is updated into Config Sync. This metric was unintentionally
-          # included by the 'regex include' filter above and is not included in
-          # our Monarch metric definitions
-          - kcc_resource_count_total
+          - last_sync_timestamp
+  # Remove custom configsync metric labels that are not registered with Monarch
+  # This action applies to all metrics that are sent through the pipeline that
+  # is using this processor
   attributes/kubernetes:
     actions:
       # Remove custom configsync metric labels that are not registered with Monarch

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -46,8 +46,8 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "1e0717923a4b449bfebd2e4c67f63206"
-	// depAnnotationCustom is the expected hash of the custom
+	depAnnotationGooglecloud = "00a85865e19d827bad96615656b05cef"
+	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.
 	depAnnotationCustom = "d166bfb4bea41bdc98b5b718e6c34b44"


### PR DESCRIPTION
This change modifies metrics to align with Monarch definition

- includes rg_reconcile_duration_seconds in Monarch pipeline for future SLI setup

- clean up kcc_resource_count_total exclusion since the metric has been removed from Resource Group Controller