### PR TITLE
Add type & commit metric tags

### DIFF
--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -154,14 +154,20 @@ processors:
           # included by the 'regex include' filter above and is not included in
           # our Monarch metric definitions
           - kcc_resource_count_total
-  # Remove custom configsync metric labels that are not registered with Monarch
   attributes/kubernetes:
     actions:
+      # Remove custom configsync metric labels that are not registered with Monarch
       - key: configsync.sync.kind
         action: delete
       - key: configsync.sync.name
         action: delete
       - key: configsync.sync.namespace
+        action: delete
+      # Remove high cardinality configsync metric labels when sending to Monarch.
+      # These labels are useful to users, but too noisy for global aggregation.
+      - key: commit
+        action: delete
+      - key: type
         action: delete
   metricstransform/kubernetes:
     transforms:

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -31,7 +31,7 @@ var (
 		Name:        APICallDuration.Name(),
 		Measure:     APICallDuration,
 		Description: "The latency distribution of API server calls",
-		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
+		TagKeys:     []tag.Key{KeyOperation, KeyType, KeyStatus},
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -79,7 +79,7 @@ var (
 		Name:        LastSync.Name(),
 		Measure:     LastSync,
 		Description: "The timestamp of the most recent sync from Git",
-		TagKeys:     []tag.Key{KeyStatus, KeyCommit},
+		TagKeys:     []tag.Key{KeyCommit, KeyStatus},
 		Aggregation: view.LastValue(),
 	}
 
@@ -88,6 +88,7 @@ var (
 		Name:        DeclaredResources.Name(),
 		Measure:     DeclaredResources,
 		Description: "The current number of declared resources parsed from Git",
+		TagKeys:     []tag.Key{KeyCommit},
 		Aggregation: view.LastValue(),
 	}
 
@@ -96,7 +97,7 @@ var (
 		Name:        ApplyOperations.Name() + "_total",
 		Measure:     ApplyOperations,
 		Description: "The total number of operations that have been performed to sync resources to source of truth",
-		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyStatus},
+		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyType, KeyStatus},
 		Aggregation: view.Count(),
 	}
 
@@ -105,7 +106,7 @@ var (
 		Name:        ApplyDuration.Name(),
 		Measure:     ApplyDuration,
 		Description: "The latency distribution of applier resource sync events",
-		TagKeys:     []tag.Key{KeyStatus},
+		TagKeys:     []tag.Key{KeyCommit, KeyStatus},
 		Aggregation: view.Distribution(longDistributionBounds...),
 	}
 
@@ -114,7 +115,7 @@ var (
 		Name:        LastApply.Name(),
 		Measure:     LastApply,
 		Description: "The timestamp of the most recent applier resource sync event",
-		TagKeys:     []tag.Key{KeyStatus, KeyCommit},
+		TagKeys:     []tag.Key{KeyCommit, KeyStatus},
 		Aggregation: view.LastValue(),
 	}
 
@@ -131,7 +132,7 @@ var (
 		Name:        RemediateDuration.Name(),
 		Measure:     RemediateDuration,
 		Description: "The latency distribution of remediator reconciliation events",
-		TagKeys:     []tag.Key{KeyStatus},
+		TagKeys:     []tag.Key{KeyType, KeyStatus},
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -140,6 +141,7 @@ var (
 		Name:        ResourceConflicts.Name() + "_total",
 		Measure:     ResourceConflicts,
 		Description: "The total number of resource conflicts resulting from a mismatch between the cached resources and cluster resources",
+		TagKeys:     []tag.Key{KeyCommit},
 		Aggregation: view.Count(),
 	}
 

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -46,7 +46,7 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "d32e8c1367859b810b6694ff3ba2b6a1"
+	depAnnotationGooglecloud = "1b5bbf35c839a3675b0642bbedbb2e61"
 	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -181,7 +181,7 @@ func TestFilteredWatcher(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dr := &declared.Resources{}
 			ctx := context.Background()
-			if _, err := dr.Update(ctx, tc.declared); err != nil {
+			if _, err := dr.Update(ctx, tc.declared, "unused"); err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
 


### PR DESCRIPTION
- Added `type` tag to the following metrics:
  - APICallDuration
  - ApplyOperations
  - RemediateDuration
- Added `commit` tag to the following metrics:
  - DeclaredResources
  - LastApply
  - ResourceConflicts
- Filtered the `type` and `commit` tags from all metrics when exporting to Monarch

### Reasoning
- **Type** is important for validating metrics occurred because of a specific type (aka Kind) of object. Type allows verifying that the expected number of API calls were made for the expected resource types. Without this granularity, it's really hard to debug why the count is off when it doesn't match expectations.
- **Commit** is important for validating metrics occurred because of a specific source change. Without commit, it's difficult to validate that a metric was recorded after or before any given commit. Testing expiration is especially hard without commit, because many of these metrics aggregate by count, instead of by last value. So the count keeps increasing for every new occurrence and doesn't decrease until the metric timestamps becomes older than the cache boundary.