### PR TITLE
Fix the check for the membership existence message (#486)

### DIFF
--- a/e2e/testcases/csr_auth_test.go
+++ b/e2e/testcases/csr_auth_test.go
@@ -153,8 +153,13 @@ func getMembership(fleetMembership, gcpProject string) (bool, error) {
 	bytes, err := exec.Command("gcloud", "container", "fleet", "memberships", "describe", fleetMembership, "--project", gcpProject).CombinedOutput()
 	out := string(bytes)
 	if err != nil {
-		// ERROR: (gcloud.container.fleet.memberships.describe) Membership xxx not found in the fleet.
-		if strings.Contains(out, fmt.Sprintf("Membership %s not found in the fleet", fleetMembership)) {
+		// There are different error messages returned from the fleet:
+		// - ERROR: (gcloud.container.fleet.memberships.describe) Membership xxx not found in the fleet.
+		// - ERROR: (gcloud.container.fleet.memberships.describe) No memberships available in the fleet.
+		// - ERROR: (gcloud.container.fleet.memberships.describe) NOT_FOUND: Resource 'projects/gcpProject/locations/global/memberships/fleetMembership' was not found
+		if strings.Contains(out, fmt.Sprintf("Membership %s not found in the fleet", fleetMembership)) ||
+			strings.Contains(out, "No memberships available in the fleet") ||
+			strings.Contains(out, "NOT_FOUND") {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to describe the membership %s in project %s (out: %s\nerror: %w)", fleetMembership, gcpProject, out, err)


### PR DESCRIPTION
There're different error messages returned from the fleet. This commit updates the check to include all possible messages.

Examples:
$ gcloud container fleet memberships describe kpt-config-sync-ci-r-multi-repo-8-standard-regular --project kpt-config-sync-ci-release ERROR: (gcloud.container.fleet.memberships.describe) No memberships available in the fleet.

$ gcloud container fleet memberships describe kpt-config-sync-ci-r-multi-repo-8-standard-regular --project cs-dev-hub ERROR: (gcloud.container.fleet.memberships.describe) Membership kpt-config-sync-ci-r-multi-repo-8-standard-regular not found in the fleet.

$ gcloud container fleet memberships describe kpt-config-sync-ci-r-multi-repo-8-standard-regular --project kpt-config-sync-ci-release ERROR: (gcloud.container.fleet.memberships.describe) Membership kpt-config-sync-ci-r-multi-repo-8-standard-regular not found in the fleet.

ERROR: Unable to check the membership: failed to describe the membership oss-prow-build-kpt-c-multi-repo-8-standard-rapid-latest in project oss-prow-build-kpt-config-sync (out: ERROR: (gcloud.container.fleet.memberships.describe) NOT_FOUND: Resource 'projects/oss-prow-build-kpt-config-sync/locations/global/memberships/oss-prow-build-kpt-c-multi-repo-8-standard-rapid-latest' was not found
        - '@type': type.googleapis.com/google.rpc.ResourceInfo
          resourceName: projects/oss-prow-build-kpt-config-sync/locations/global/memberships/oss-prow-build-kpt-c-multi-repo-8-standard-rapid-latest