### PR TITLE
Remove the unused boolean from the remediator's applier methods

### DIFF
--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -104,8 +104,7 @@ func (r *reconciler) remediate(ctx context.Context, id core.ID, objDiff diff.Dif
 			return err
 		}
 		klog.V(3).Infof("Remediator creating object: %v", id)
-		_, err = r.applier.Create(ctx, declared)
-		return err
+		return r.applier.Create(ctx, declared)
 	case diff.Update:
 		declared, err := objDiff.UnstructuredDeclared()
 		if err != nil {
@@ -116,16 +115,14 @@ func (r *reconciler) remediate(ctx context.Context, id core.ID, objDiff diff.Dif
 			return err
 		}
 		klog.V(3).Infof("Remediator updating object: %v", id)
-		_, err = r.applier.Update(ctx, declared, actual)
-		return err
+		return r.applier.Update(ctx, declared, actual)
 	case diff.Delete:
 		actual, err := objDiff.UnstructuredActual()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Remediator deleting object: %v", id)
-		_, err = r.applier.Delete(ctx, actual)
-		return err
+		return r.applier.Delete(ctx, actual)
 	case diff.Error:
 		// This is the case where the annotation in the *repository* is invalid.
 		// Should never happen as the Parser would have thrown an error.
@@ -139,8 +136,7 @@ func (r *reconciler) remediate(ctx context.Context, id core.ID, objDiff diff.Dif
 			return err
 		}
 		klog.V(3).Infof("Remediator abandoning object %v", id)
-		_, err = r.applier.RemoveNomosMeta(ctx, actual, metrics.RemediatorController)
-		return err
+		return r.applier.RemoveNomosMeta(ctx, actual, metrics.RemediatorController)
 	default:
 		// e.g. differ.DeleteNsConfig, which shouldn't be possible to get to any way.
 		metrics.RecordInternalError(ctx, "remediator")

--- a/pkg/syncer/syncertest/fake/applier.go
+++ b/pkg/syncer/syncertest/fake/applier.go
@@ -37,53 +37,53 @@ type Applier struct {
 var _ reconcile.Applier = &Applier{}
 
 // Create implements reconcile.Applier.
-func (a *Applier) Create(ctx context.Context, obj *unstructured.Unstructured) (bool, status.Error) {
+func (a *Applier) Create(ctx context.Context, obj *unstructured.Unstructured) status.Error {
 	if a.CreateError != nil {
-		return false, a.CreateError
+		return a.CreateError
 	}
 	err := a.Client.Create(ctx, obj)
 	if err != nil {
-		return false, status.APIServerError(err, "creating")
+		return status.APIServerError(err, "creating")
 	}
-	return true, nil
+	return nil
 }
 
 // Update implements reconcile.Applier.
-func (a *Applier) Update(ctx context.Context, intendedState, _ *unstructured.Unstructured) (bool, status.Error) {
+func (a *Applier) Update(ctx context.Context, intendedState, _ *unstructured.Unstructured) status.Error {
 	if a.UpdateError != nil {
-		return false, a.UpdateError
+		return a.UpdateError
 	}
 	err := a.Client.Update(ctx, intendedState)
 	if err != nil {
-		return false, status.APIServerError(err, "updating")
+		return status.APIServerError(err, "updating")
 	}
-	return true, nil
+	return nil
 }
 
 // RemoveNomosMeta implements reconcile.Applier.
-func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured, _ string) (bool, status.Error) {
+func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured, _ string) status.Error {
 	updated := metadata.RemoveConfigSyncMetadata(intent)
 	if !updated {
-		return false, nil
+		return nil
 	}
 
 	err := a.Client.Update(ctx, intent)
 	if err != nil {
-		return false, status.APIServerError(err, "removing meta")
+		return status.APIServerError(err, "removing meta")
 	}
-	return true, nil
+	return nil
 }
 
 // Delete implements reconcile.Applier.
-func (a *Applier) Delete(ctx context.Context, obj *unstructured.Unstructured) (bool, status.Error) {
+func (a *Applier) Delete(ctx context.Context, obj *unstructured.Unstructured) status.Error {
 	if a.DeleteError != nil {
-		return false, a.DeleteError
+		return a.DeleteError
 	}
 	err := a.Client.Delete(ctx, obj)
 	if err != nil {
-		return false, status.APIServerError(err, "deleting")
+		return status.APIServerError(err, "deleting")
 	}
-	return true, nil
+	return nil
 }
 
 // GetClient implements reconcile.Applier.


### PR DESCRIPTION
The remediator's applier defines a list of methods that return both a boolean and an error, but the boolean value is never used. This commit removes the unused boolean value.