### PR TITLE
Surface the fight errors in the R*Sync status field

### DIFF
--- a/e2e/testcases/remediator_test.go
+++ b/e2e/testcases/remediator_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/metrics"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/testing/fake"
+)
+
+func TestSurfaceFightError(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl)
+
+	nt.T.Logf("Stop the admission webhook to generate the fights")
+	nomostest.StopWebhook(nt)
+
+	ns := fake.NamespaceObject("test-ns", core.Annotation("foo", "bar"))
+	rb := roleBinding("test-rb", ns.Name, map[string]string{"foo": "bar"})
+	nt.RootRepos[configsync.RootSyncName].Add(
+		fmt.Sprintf("acme/namespaces/%s/ns.yaml", ns.Name), ns)
+	nt.RootRepos[configsync.RootSyncName].Add(
+		fmt.Sprintf("acme/namespaces/%s/rb.yaml", ns.Name), rb)
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add Namespace and RoleBinding")
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// Make the # of updates exceed the fightThreshold defined in pkg/syncer/reconcile/fight_detector.go
+	go func() {
+		for i := 0; i <= 5; i++ {
+			nt.MustMergePatch(ns, `{"metadata": {"annotations": {"foo": "baz"}}}`)
+			nt.MustMergePatch(rb, `{"metadata": {"annotations": {"foo": "baz"}}}`)
+			time.Sleep(time.Second)
+		}
+	}()
+
+	nt.T.Log("The RootSync reports a fight error")
+	nt.WaitForRootSyncSyncError(configsync.RootSyncName, status.FightErrorCode,
+		"This may indicate Config Sync is fighting with another controller over the object.")
+
+	rootReconcilerPod, err := nt.KubeClient.GetDeploymentPod(
+		nomostest.DefaultRootReconcilerName, configmanagement.ControllerNamespace,
+		nt.DefaultWaitTimeout)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	commitHash := nt.RootRepos[configsync.RootSyncName].Hash()
+
+	err = nomostest.ValidateMetrics(nt,
+		nomostest.ReconcilerErrorMetrics(nt, rootReconcilerPod.Name, commitHash, metrics.ErrorSummary{
+			Fights: 5,
+		}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("The fight error should be auto-resolved if no more fights")
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+}

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -28,7 +28,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery"
 	"k8s.io/utils/pointer"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -70,6 +70,10 @@ func (r *noOpRemediator) Pause() {}
 func (r *noOpRemediator) Resume() {}
 
 func (r *noOpRemediator) ConflictErrors() []status.ManagementConflictError {
+	return nil
+}
+
+func (r *noOpRemediator) FightErrors() map[core.ID]status.Error {
 	return nil
 }
 

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -237,7 +237,7 @@ func TestRemediator_Reconcile(t *testing.T) {
 			// Simulate the Parser having already parsed the resource and recorded it.
 			d := makeDeclared(t, "unused", tc.declared)
 
-			r := newReconciler(declared.RootReconciler, configsync.RootSyncName, c.Applier(), d)
+			r := newReconciler(declared.RootReconciler, configsync.RootSyncName, c.Applier(), d, testingfake.NewFightHandler())
 
 			// Get the triggering object for the reconcile event.
 			var obj client.Object
@@ -362,7 +362,7 @@ func TestRemediator_Reconcile_Metrics(t *testing.T) {
 			fakeApplier.UpdateError = tc.updateError
 			fakeApplier.DeleteError = tc.deleteError
 
-			reconciler := newReconciler(declared.RootReconciler, configsync.RootSyncName, fakeApplier, d)
+			reconciler := newReconciler(declared.RootReconciler, configsync.RootSyncName, fakeApplier, d, testingfake.NewFightHandler())
 
 			// Get the triggering object for the reconcile event.
 			var obj client.Object

--- a/pkg/remediator/reconcile/worker.go
+++ b/pkg/remediator/reconcile/worker.go
@@ -29,6 +29,7 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	syncerclient "kpt.dev/configsync/pkg/syncer/client"
 	syncerreconcile "kpt.dev/configsync/pkg/syncer/reconcile"
+	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,10 +41,11 @@ type Worker struct {
 }
 
 // NewWorker returns a new Worker for the given queue and declared resources.
-func NewWorker(scope declared.Scope, syncName string, a syncerreconcile.Applier, q *queue.ObjectQueue, d *declared.Resources) *Worker {
+func NewWorker(scope declared.Scope, syncName string, a syncerreconcile.Applier,
+	q *queue.ObjectQueue, d *declared.Resources, fh fight.Handler) *Worker {
 	return &Worker{
 		objectQueue: q,
-		reconciler:  newReconciler(scope, syncName, a, d),
+		reconciler:  newReconciler(scope, syncName, a, d, fh),
 	}
 }
 

--- a/pkg/remediator/reconcile/worker_test.go
+++ b/pkg/remediator/reconcile/worker_test.go
@@ -81,7 +81,7 @@ func TestWorker_Run_Remediates(t *testing.T) {
 	}
 
 	d := makeDeclared(t, randomCommitHash(), declaredObjs...)
-	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d)
+	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d, syncertestfake.NewFightHandler())
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -188,7 +188,7 @@ func TestWorker_Run_RemediatesExisting(t *testing.T) {
 	}
 
 	d := makeDeclared(t, randomCommitHash(), declaredObjs...)
-	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d)
+	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d, syncertestfake.NewFightHandler())
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -296,7 +296,7 @@ func TestWorker_ProcessNextObject(t *testing.T) {
 			}
 
 			d := makeDeclared(t, randomCommitHash(), tc.declared...)
-			w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d)
+			w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d, syncertestfake.NewFightHandler())
 
 			for _, obj := range tc.toProcess {
 				if err := w.processNextObject(context.Background()); err != nil {
@@ -316,7 +316,7 @@ func TestWorker_Run_CancelledWhenEmpty(t *testing.T) {
 	defer q.ShutDown()
 	c := testingfake.NewClient(t, core.Scheme)
 	d := makeDeclared(t, randomCommitHash()) // no resources declared
-	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d)
+	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, c.Applier(), q, d, syncertestfake.NewFightHandler())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -389,7 +389,7 @@ func TestWorker_Run_CancelledWhenNotEmpty(t *testing.T) {
 
 	d := makeDeclared(t, randomCommitHash(), declaredObjs...)
 	a := &testingfake.Applier{Client: c}
-	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, a, q, d)
+	w := NewWorker(declared.RootReconciler, configsync.RootSyncName, a, q, d, syncertestfake.NewFightHandler())
 
 	// Run worker in the background
 	doneCh := make(chan struct{})

--- a/pkg/syncer/reconcile/fight/handler.go
+++ b/pkg/syncer/reconcile/fight/handler.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fight
+
+import (
+	"sync"
+
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/status"
+)
+
+// Handler is the generic interface of the fight handler.
+type Handler interface {
+	AddFightError(core.ID, status.Error)
+	RemoveFightError(core.ID)
+
+	// FightErrors returns the fight errors (KNV2005) the remediator encounters.
+	FightErrors() map[core.ID]status.Error
+}
+
+// handler implements Handler.
+type handler struct {
+	// mux guards the fightErrs
+	mux sync.Mutex
+	// fightErrs tracks all the controller fights (KNV2005) the remediator encounters,
+	// and report to RootSync|RepoSync status.
+	fightErrs map[core.ID]status.Error
+}
+
+var _ Handler = &handler{}
+
+// NewHandler instantiates a fight handler
+func NewHandler() Handler {
+	return &handler{
+		fightErrs: map[core.ID]status.Error{},
+	}
+}
+
+func (h *handler) AddFightError(id core.ID, err status.Error) {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+
+	h.fightErrs[id] = err
+}
+
+func (h *handler) RemoveFightError(id core.ID) {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+
+	delete(h.fightErrs, id)
+}
+
+func (h *handler) FightErrors() map[core.ID]status.Error {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+
+	// Return a copy
+	fightErrs := map[core.ID]status.Error{}
+	for k, v := range h.fightErrs {
+		fightErrs[k] = v
+	}
+	return fightErrs
+}

--- a/pkg/syncer/reconcile/fight/logger.go
+++ b/pkg/syncer/reconcile/fight/logger.go
@@ -58,7 +58,7 @@ func (l *logger) logFight(now time.Time, err status.ResourceError) bool {
 		return false
 	}
 
-	klog.Warning(err)
+	klog.Error(err)
 	l.lastLogged[id] = now
 	return true
 }

--- a/pkg/syncer/syncertest/fake/fight_handler.go
+++ b/pkg/syncer/syncertest/fake/fight_handler.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
+)
+
+// FightHandler is a fake implementation of fight.Handler.
+type FightHandler struct{}
+
+// AddFightError is a fake implementation of the AddFightError of fight.Handler.
+func (h *FightHandler) AddFightError(core.ID, status.Error) {}
+
+// RemoveFightError is a fake implementation of the RemoveFightError of fight.Handler.
+func (h *FightHandler) RemoveFightError(core.ID) {
+}
+
+// FightErrors is a fake implementation of the FightErrors of fight.Handler.
+func (h *FightHandler) FightErrors() map[core.ID]status.Error {
+	return map[core.ID]status.Error{}
+}
+
+var _ fight.Handler = &FightHandler{}
+
+// NewFightHandler initiates a fake implementation of fight.Handler.
+func NewFightHandler() fight.Handler {
+	return &FightHandler{}
+}


### PR DESCRIPTION
Previously, if Config Sync constantly fights with other controllers on certain resources, Config Sync only logs the fight as a warning in the reconciler log. The fight is not exposed to the user in the R*Sync status.

This commit adds the fight errors to the `status.sync` field, which is more visible to the user so they can take actions to address the fight.