### PR TITLE
feat: Add reconciler-manager finalizer

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -172,11 +172,11 @@ func gitDeployment() *appsv1.Deployment {
 			Spec: corev1.PodSpec{
 				Volumes: []corev1.Volume{
 					{Name: "keys", VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{SecretName: gitServerSecret},
+						Secret: &corev1.SecretVolumeSource{SecretName: gitServerSecretName},
 					}},
 					{Name: "repos", VolumeSource: corev1.VolumeSource{EmptyDir: nil}},
 					{Name: "ssl-cert", VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{SecretName: gitServerCertSecret},
+						Secret: &corev1.SecretVolumeSource{SecretName: gitServerCertSecretName},
 					}},
 				},
 				Containers: []corev1.Container{

--- a/pkg/metadata/finalizers.go
+++ b/pkg/metadata/finalizers.go
@@ -21,6 +21,14 @@ import (
 
 const (
 	// ReconcilerFinalizer is the finalizer added to the RootSync/RepoSync by
-	// the reconciler when the deletion-propagation-policy is Foreground.
+	// the reconciler when the deletion-propagation-policy is Foreground to
+	// ensure deletion of the user objects it manages, before the
+	// RootSync/RepoSync is deleted.
 	ReconcilerFinalizer = configsync.ConfigSyncPrefix + reconcilermanager.Reconciler
+
+	// ReconcilerManagerFinalizer is the finalizer added to the
+	// RootSync/RepoSync by the reconciler-manager to ensure
+	// deletion of the reconciler and its dependencies, before the
+	// RootSync/RepoSync is deleted.
+	ReconcilerManagerFinalizer = configsync.ConfigSyncPrefix + reconcilermanager.ManagerName
 )

--- a/pkg/reconcilermanager/controllers/errors.go
+++ b/pkg/reconcilermanager/controllers/errors.go
@@ -57,8 +57,8 @@ type ObjectOperationError struct {
 
 // Error returns the error string
 func (ooe *ObjectOperationError) Error() string {
-	return fmt.Sprintf("resource object operation failed (operation: %q, object: %q, objectKind: %q): %v",
-		ooe.Operation, ooe.ID.ObjectKey, ooe.ID.Kind, ooe.Cause)
+	return fmt.Sprintf("%s (%s) %s failed: %v",
+		ooe.ID.Kind, ooe.ID.ObjectKey, ooe.Operation, ooe.Cause)
 }
 
 // NewObjectOperationError constructs a new ObjectOperationError

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -289,6 +290,7 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
 		cs.Client,
+		cs.Client,
 		cs.DynamicClient,
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		cs.Client.Scheme(),
@@ -340,6 +342,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	wantRs.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -470,6 +473,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	wantRs.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -704,6 +708,7 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 	wantRs.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -743,6 +748,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	wantRs.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -1806,6 +1812,7 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 	wantRs.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -1912,6 +1919,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs1.Status.Reconciler = nsReconcilerName
 	reposync.SetReconciling(wantRs1, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
+	controllerutil.AddFinalizer(wantRs1, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
@@ -1971,6 +1979,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs2.Status.Reconciler = nsReconcilerName2
 	reposync.SetReconciling(wantRs2, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName2))
+	controllerutil.AddFinalizer(wantRs2, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
@@ -2029,6 +2038,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs3.Status.Reconciler = nsReconcilerName3
 	reposync.SetReconciling(wantRs3, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName3))
+	controllerutil.AddFinalizer(wantRs3, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
@@ -2086,6 +2096,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs4.Status.Reconciler = nsReconcilerName4
 	reposync.SetReconciling(wantRs4, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName4))
+	controllerutil.AddFinalizer(wantRs4, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
@@ -2143,6 +2154,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs5.Status.Reconciler = nsReconcilerName5
 	reposync.SetReconciling(wantRs5, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName5))
+	controllerutil.AddFinalizer(wantRs5, metadata.ReconcilerManagerFinalizer)
 	validateRepoSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{

--- a/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
@@ -39,9 +39,11 @@ import (
 	"kpt.dev/configsync/pkg/metadata"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/util/log"
+	watchutil "kpt.dev/configsync/pkg/util/watch"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // TestRootSyncReconcilerDeploymentLifecycle validates that the
@@ -105,29 +107,22 @@ func TestRootSyncReconcilerDeploymentLifecycle(t *testing.T) {
 		t.Fatal("timed out waiting for reconciler deployment to be applied")
 	}
 
-	t.Log("watching for reconciler deployment delete")
-	watchCtx2, watchCancel2 := context.WithTimeout(ctx, 10*time.Second)
-	defer watchCancel2()
+	t.Log("verifying the reconciler-manager finalizer is present")
+	rsKey := client.ObjectKeyFromObject(rs)
+	rs = &v1beta1.RootSync{}
+	err = fakeClient.Get(ctx, rsKey, rs)
+	require.NoError(t, err)
+	require.True(t, controllerutil.ContainsFinalizer(rs, metadata.ReconcilerManagerFinalizer))
 
-	watcher, err = watchObjects(watchCtx2, fakeClient, &appsv1.DeploymentList{})
+	t.Log("deleting sync object and watching for NotFound")
+	err = watchutil.DeleteAndWait(ctx, fakeClient, rs, 10*time.Second)
 	require.NoError(t, err)
 
-	// Delete RootSync
-	rs.ResourceVersion = "" // we don't care what the RV is when deleting
-	err = fakeClient.Delete(ctx, rs)
-	require.NoError(t, err)
-
-	err = watchObjectUntil(ctx, fakeClient.Scheme(), watcher, reconcilerKey, func(event watch.Event) error {
-		t.Logf("reconciler deployment %s", event.Type)
-		if event.Type == watch.Deleted {
-			reconcilerObj = event.Object.(*appsv1.Deployment)
-			// success! deployment was deleted.
-			return nil
-		}
-		// keep watching
-		return errors.Errorf("reconciler deployment %s", event.Type)
-	})
-	require.NoError(t, err)
+	// All managed objects should have been deleted by the reconciler-manager finalizer.
+	// Only the user Secret should remain.
+	secretObj.SetUID("1")
+	t.Log("verifying all managed objects were deleted")
+	fakeClient.Check(t, secretObj)
 }
 
 // TestRootSyncReconcilerDeploymentDriftProtection validates that changes to

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -130,6 +131,7 @@ func setupRootReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 		testCluster,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
+		cs.Client,
 		cs.Client,
 		cs.DynamicClient,
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RootSyncKind),
@@ -1616,6 +1618,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs1.Status.Reconciler = rootReconcilerName
 	rootsync.SetReconciling(wantRs1, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName))
+	controllerutil.AddFinalizer(wantRs1, metadata.ReconcilerManagerFinalizer)
 	validateRootSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
@@ -1672,6 +1675,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs2.Status.Reconciler = rootReconcilerName2
 	rootsync.SetReconciling(wantRs2, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName2))
+	controllerutil.AddFinalizer(wantRs2, metadata.ReconcilerManagerFinalizer)
 	validateRootSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
@@ -1726,6 +1730,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs3.Status.Reconciler = rootReconcilerName3
 	rootsync.SetReconciling(wantRs3, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName3))
+	controllerutil.AddFinalizer(wantRs3, metadata.ReconcilerManagerFinalizer)
 	validateRootSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
@@ -1784,6 +1789,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs4.Status.Reconciler = rootReconcilerName4
 	rootsync.SetReconciling(wantRs4, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName4))
+	controllerutil.AddFinalizer(wantRs4, metadata.ReconcilerManagerFinalizer)
 	validateRootSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
@@ -1842,6 +1848,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs5.Status.Reconciler = rootReconcilerName5
 	rootsync.SetReconciling(wantRs5, "Deployment",
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName5))
+	controllerutil.AddFinalizer(wantRs5, metadata.ReconcilerManagerFinalizer)
 	validateRootSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{

--- a/pkg/util/watch/delete.go
+++ b/pkg/util/watch/delete.go
@@ -1,0 +1,186 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// These constants are used for log field keys.
+// They mirror the keys used by the controller-manager.
+const (
+	logFieldObjectRef  = "object"
+	logFieldObjectKind = "objectKind"
+)
+
+// DeleteAndWait deletes the object (if not already deleted) and blocks until it
+// is fully deleted (NotFound, not just deleteTimestamp). This allows for any
+// finalizers to complete.
+//
+// Exits early if the object is already deleted or doesn't exist.
+//
+// The Object contents will be replaced with updated state for each new event
+// received while waiting for deletion.
+//
+// If you want to time out the full function, use a context.WithTimeout.
+// If you want to time out just the waiting after the delete, use reconcileTimeout.
+func DeleteAndWait(ctx context.Context, c client.WithWatch, obj client.Object, reconcileTimeout time.Duration) error {
+	gvk, err := kinds.Lookup(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	id := core.ID{
+		ObjectKey: client.ObjectKeyFromObject(obj),
+		GroupKind: gvk.GroupKind(),
+	}
+
+	// Use cancellable context to delay starting the timer until after the
+	// watcher has synchronized and the delete call has completed.
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	// Stop early, if done or errored before timeout.
+	defer watchCancel()
+	// Delay timer start until after Sync and Delete.
+	startTimer := func() {
+		timerCtx, timerCancel := context.WithTimeout(watchCtx, reconcileTimeout)
+		go func() {
+			<-timerCtx.Done()
+			watchCancel()
+			timerCancel()
+		}()
+	}
+
+	klog.V(3).Infof("Deletion watcher starting %q=%q, %q=%q",
+		logFieldObjectRef, id.ObjectKey.String(),
+		logFieldObjectKind, id.Kind)
+
+	// Wait until the object is actually deleted.
+	// Delete may be delayed by finalizers.
+	// Perform the Delete in the precondition, which executes after the list and
+	// watch calls have started, to ensure the delete event is received by the watch.
+	err = UntilDeletedWithSync(watchCtx, c, obj, func(store cache.Store) (bool, error) {
+		// Start timer after predicate returns.
+		// The timer will be cancelled eventually, whether there's an error,
+		// early exit, or timeout.
+		defer startTimer()
+
+		klog.V(3).Infof("Deletion watcher synced %q=%q, %q=%q",
+			logFieldObjectRef, id.ObjectKey.String(),
+			logFieldObjectKind, id.Kind)
+
+		klog.V(3).Infof("Deletion watcher cache keys: %v", store.ListKeys())
+
+		// Synced - test for existence
+		lastKnownObj, exists, err := store.Get(obj)
+		if err != nil {
+			// Stop waiting
+			return false, err
+		}
+		if !exists {
+			// Stop waiting - object already deleted or never existed
+			klog.V(3).Infof("Object already deleted %q=%q, %q=%q",
+				logFieldObjectRef, id.ObjectKey.String(),
+				logFieldObjectKind, id.Kind)
+			klog.V(3).Infof("Cache Keys: %#v", store.ListKeys())
+			return true, nil
+		}
+
+		// UntilDeletedWithSync->UntilWithSync->NewIndexerInformerWatcher->NewIndexerInformer.
+		// NewIndexerInformer returns cache.cache as the indexer that implements
+		// the cache.Store, but the cache is populated by DeltaFIFO, which
+		// wraps objects with DeletedFinalStateUnknown sometimes.
+		staleObj, stale := lastKnownObj.(cache.DeletedFinalStateUnknown)
+		if stale {
+			// Object was deleted but the watch deletion event was missed while
+			// disconnected from apiserver. So the last known object may be
+			// stale, but metadata.deletionTimestamp may still be available, if
+			// that update was received before the disconnect.
+			lastKnownObj = staleObj.Obj
+		}
+		if lastKnownObj == nil {
+			// The object either never existed or was deleted before the initial
+			// List or both created and deleted after List but while Watch was
+			// disconnected from the apiserver.
+			// Alternatively, the cache/Indexer.Get may have errored
+			// (errors are swallowed by DeltaFIFO.Replace).
+
+			// Stop waiting - object already deleted or never existed
+			klog.V(3).Infof("Object already deleted %q=%q, %q=%q",
+				logFieldObjectRef, id.ObjectKey.String(),
+				logFieldObjectKind, id.Kind)
+			return true, nil
+		}
+		// Since we supplied a client.Object, we know the objects returned
+		// will be client.Object.
+		cObj, ok := lastKnownObj.(client.Object)
+		if !ok {
+			return false, errors.Errorf("unexpected watch cache object %T for object %s %s: %+v",
+				lastKnownObj, id.Kind, id.ObjectKey, lastKnownObj)
+		}
+		// Check if the object was already deleted but still terminating
+		if cObj.GetDeletionTimestamp() != nil {
+			// Continue waiting until fully deleted - already deleting
+			klog.V(3).Infof("Object already deleting %q=%q, %q=%q",
+				logFieldObjectRef, id.ObjectKey.String(),
+				logFieldObjectKind, id.Kind)
+			// Note: Whoever initiated the delete chose what deletion
+			// propagation policy to use. We can't change that now.
+			// If Foreground was used, the metav1.FinalizerDeleteDependents
+			// finalizer will have been added to enforce it.
+			return false, nil
+		}
+
+		klog.V(1).Infof("Deleting object %q=%q, %q=%q",
+			logFieldObjectRef, id.ObjectKey.String(),
+			logFieldObjectKind, id.Kind)
+
+		// Object exists - safe to delete now
+		// Use foreground deletion to ensure all managed objects are garbage
+		// collected by the apiserver before continuing.
+		if err := c.Delete(ctx, cObj, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.V(3).Infof("Object already deleted %q=%q, %q=%q",
+					logFieldObjectRef, id.ObjectKey.String(),
+					logFieldObjectKind, id.Kind)
+				// Stop waiting - object already deleted
+				return true, nil
+			}
+			// Stop waiting
+			return false, err
+		}
+		klog.V(3).Infof("Object delete successful %q=%q, %q=%q",
+			logFieldObjectRef, id.ObjectKey.String(),
+			logFieldObjectKind, id.Kind)
+
+		// Continue waiting until fully deleted
+		return false, nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to watch for deletion of %s: %s", id.Kind, id.ObjectKey)
+	}
+	klog.V(1).Infof("Object delete confirmed %q=%q, %q=%q",
+		logFieldObjectRef, id.ObjectKey.String(),
+		logFieldObjectKind, id.Kind)
+	return nil
+}

--- a/pkg/util/watch/listerwatcher.go
+++ b/pkg/util/watch/listerwatcher.go
@@ -1,0 +1,297 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClientListerWatcher wraps a client.WithWatch and implements the
+// cache.ListerWatcher interface.
+//
+// The following optional filters are supported:
+// - Key (name and/or namespace)
+// - Labels
+//
+// These filters are converted into ListOptions and merged with any ListOptions
+// passed to each List and Watch.
+type ClientListerWatcher struct {
+	// Context to pass to client list and watch methods
+	Context context.Context
+
+	// Client to list and watch with
+	Client client.WithWatch
+
+	// ExampleList is an example of the list type of resource to list & watch
+	ExampleList client.ObjectList
+
+	// Key is the name & namespace to watch (both optional)
+	Key client.ObjectKey
+
+	// Labels to filter with (optional)
+	Labels map[string]string
+}
+
+// List satisfies the cache.Lister interface.
+// The ListOptions specified here are merged with the ClientListerWatcher
+func (fw *ClientListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	objList, err := kinds.ObjectAsClientObjectList(fw.ExampleList.DeepCopyObject())
+	if err != nil {
+		return nil, err
+	}
+	cOpts, err := ConvertListOptions(&options)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+	}
+	cOpts, err = MergeListOptions(cOpts, fw.listOptions())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to merge list options")
+	}
+	optsList := UnrollListOptions(cOpts)
+	klog.V(5).Infof("Listing %T %s: %v", objList, objList.GetObjectKind().GroupVersionKind().Kind, optsList)
+	err = fw.Client.List(fw.Context, objList, optsList...)
+	return objList, err
+}
+
+// Watch satisfies the cache.Watcher interface
+func (fw *ClientListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	objList, err := kinds.ObjectAsClientObjectList(fw.ExampleList.DeepCopyObject())
+	if err != nil {
+		return nil, err
+	}
+	cOpts, err := ConvertListOptions(&options)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+	}
+	cOpts, err = MergeListOptions(cOpts, fw.listOptions())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to merge list options")
+	}
+	optsList := UnrollListOptions(cOpts)
+	klog.V(5).Infof("Watching %T %s: %v", objList, objList.GetObjectKind().GroupVersionKind().Kind, optsList)
+	return fw.Client.Watch(fw.Context, objList, optsList...)
+}
+
+// listOptions builds a set of List filters for the flexWatcher's Key and Labels.
+func (fw *ClientListerWatcher) listOptions() *client.ListOptions {
+	opts := client.ListOptions{}
+	if len(fw.Key.Namespace) > 0 {
+		opts.Namespace = fw.Key.Namespace
+	}
+	if len(fw.Key.Name) > 0 {
+		opts.FieldSelector = fields.OneTermEqualSelector(metav1.ObjectNameField, fw.Key.Name)
+	}
+	if len(fw.Labels) > 0 {
+		opts.LabelSelector = client.MatchingLabelsSelector{
+			Selector: labels.SelectorFromSet(fw.Labels),
+		}
+	}
+	return &opts
+}
+
+// MergeListOptions merges two sets of ListOptions.
+// - For Namespace, Limit, and Continue, at most one may be specified, unless they're the same
+// - For FieldSelector and LabelSelector, the result requires both filters to match (AND)
+// - For Raw, at most one may be specified
+func MergeListOptions(a, b *client.ListOptions) (*client.ListOptions, error) {
+	switch {
+	case a == nil && b == nil:
+		return nil, nil
+	case a == nil:
+		return b, nil
+	case b == nil:
+		return a, nil
+	}
+
+	c := client.ListOptions{}
+
+	switch {
+	case a.LabelSelector != nil && b.LabelSelector != nil:
+		bReqs, selectable := b.LabelSelector.Requirements()
+		if selectable {
+			c.LabelSelector = a.LabelSelector.Add(bReqs...)
+		} else {
+			// not selectable means Matches() always returns false
+			c.LabelSelector = labels.Nothing()
+		}
+	case a.LabelSelector != nil:
+		c.LabelSelector = a.LabelSelector
+	case b.LabelSelector != nil:
+		c.LabelSelector = b.LabelSelector
+	}
+
+	switch {
+	case a.FieldSelector != nil && b.FieldSelector != nil:
+		if a.FieldSelector == fields.Nothing() || b.FieldSelector == fields.Nothing() {
+			// Nothing means Matches() always returns false
+			c.FieldSelector = fields.Nothing()
+		} else {
+			c.FieldSelector = fields.AndSelectors(a.FieldSelector, b.FieldSelector)
+		}
+	case a.FieldSelector != nil:
+		c.FieldSelector = a.FieldSelector
+	case b.FieldSelector != nil:
+		c.FieldSelector = b.FieldSelector
+	}
+
+	switch {
+	case a.Namespace != "" && b.Namespace != "":
+		if a.Namespace != b.Namespace {
+			return nil, errors.Errorf("cannot merge two different namespaces: %s & %s",
+				a.Namespace, b.Namespace)
+		}
+		c.Namespace = a.Namespace
+	case a.Namespace != "":
+		c.Namespace = a.Namespace
+	case b.Namespace != "":
+		c.Namespace = b.Namespace
+	}
+
+	switch {
+	case a.Limit > 0 && b.Limit > 0:
+		if a.Limit != b.Limit {
+			return nil, errors.Errorf("cannot merge two different limits: %d & %d",
+				a.Limit, b.Limit)
+		}
+		c.Limit = a.Limit
+	case a.Limit > 0:
+		c.Limit = a.Limit
+	case b.Limit > 0:
+		c.Limit = b.Limit
+	}
+
+	switch {
+	case a.Continue != "" && b.Continue != "":
+		if a.Continue != b.Continue {
+			return nil, errors.Errorf("cannot merge two different continue tokens: %s & %s",
+				a.Continue, b.Continue)
+		}
+		c.Continue = a.Continue
+	case a.Continue != "":
+		c.Continue = a.Continue
+	case b.Continue != "":
+		c.Continue = b.Continue
+	}
+
+	switch {
+	case a.Raw != nil && b.Raw != nil:
+		// TODO: merge raw ListOptions
+		// It should be possible to merge raw ListOptions, but we don't need it
+		// yet, because we're only using MergeListOptions in ClientListerWatcher
+		// with UntilDeletedWithSync, which merges client.ListOptions from
+		// the ClientListerWatcher with metav1.ListOptions from the Reflector
+		// used by the Informer built by UntilWithoutRetry.
+		return nil, errors.Errorf("not yet implemented: merging two different raw ListOptions: %+v & %+v",
+			a.Raw, b.Raw)
+	case a.Raw != nil:
+		c.Raw = a.Raw
+	case b.Raw != nil:
+		c.Raw = b.Raw
+	}
+
+	return &c, nil
+}
+
+// ConvertListOptions converts from `metav1.ListOptions` to `client.ListOptions`.
+//
+// For the reverse, see `client.ListOptions.AsListOptions()`.
+func ConvertListOptions(mOpts *metav1.ListOptions) (*client.ListOptions, error) {
+	if mOpts == nil {
+		return nil, nil
+	}
+	cOpts := client.ListOptions{}
+
+	if mOpts.LabelSelector != "" {
+		ls, err := labels.Parse(mOpts.LabelSelector)
+		if err != nil {
+			return &cOpts, errors.Wrap(err, "failed to parse LabelSelector")
+		}
+		cOpts.LabelSelector = ls
+	}
+	if mOpts.FieldSelector != "" {
+		fs, err := fields.ParseSelector(mOpts.FieldSelector)
+		if err != nil {
+			return &cOpts, errors.Wrap(err, "failed to parse FieldSelector")
+		}
+		cOpts.FieldSelector = fs
+	}
+	if mOpts.Limit > 0 {
+		cOpts.Limit = mOpts.Limit
+	}
+	if mOpts.Continue != "" {
+		cOpts.Continue = mOpts.Continue
+	}
+
+	// Pass raw metav1.ListOptions, in case some options are specified that
+	// aren't fields of client.ListOptions.
+	// The fields on client.ListOptions will take precedence over the raw
+	// metav1.ListOptions fields.
+	cOpts.Raw = mOpts
+
+	return &cOpts, nil
+}
+
+// UnrollListOptions converts from ListOptions to a slice of ListOption.
+//
+// For the reverse, see `client.ListOptions.ApplyOptions([]client.ListOption)`.
+func UnrollListOptions(in *client.ListOptions) []client.ListOption {
+	if in == nil {
+		return nil
+	}
+	var out []client.ListOption
+	if in.LabelSelector != nil {
+		out = append(out, client.MatchingLabelsSelector{Selector: in.LabelSelector})
+	}
+	if in.FieldSelector != nil {
+		out = append(out, client.MatchingFieldsSelector{Selector: in.FieldSelector})
+	}
+	if in.Namespace != "" {
+		out = append(out, client.InNamespace(in.Namespace))
+	}
+	if in.Limit > 0 {
+		out = append(out, client.Limit(in.Limit))
+	}
+	if in.Continue != "" {
+		out = append(out, client.Continue(in.Continue))
+	}
+	if in.Raw != nil {
+		out = append(out, &RawListOptions{Raw: in.Raw})
+	}
+	return out
+}
+
+// RawListOptions wraps a `metav1.ListOptions` to allow passing as
+// `client.ListOption` to controller-runtime clients.
+type RawListOptions struct {
+	Raw *metav1.ListOptions
+}
+
+// ApplyToList sets the Raw metav1.ListOptions on the specified
+// client.ListOptions.
+func (rlo *RawListOptions) ApplyToList(lo *client.ListOptions) {
+	if rlo.Raw != nil {
+		lo.Raw = rlo.Raw
+	}
+}

--- a/pkg/util/watch/listerwatcher_test.go
+++ b/pkg/util/watch/listerwatcher_test.go
@@ -1,0 +1,895 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMergeListOptions(t *testing.T) {
+	testCases := []struct {
+		name          string
+		a, b          *client.ListOptions
+		expectedError error
+		expectedOpts  *client.ListOptions
+	}{
+		{
+			a:            nil,
+			b:            nil,
+			expectedOpts: nil,
+		},
+		{
+			a:            &client.ListOptions{},
+			b:            nil,
+			expectedOpts: &client.ListOptions{},
+		},
+		{
+			a:            nil,
+			b:            &client.ListOptions{},
+			expectedOpts: &client.ListOptions{},
+		},
+		// LabelSelectors
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: nil,
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			b: &client.ListOptions{
+				LabelSelector: nil,
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.Nothing(),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+			b: &client.ListOptions{},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a:    &client.ListOptions{},
+			b: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+					// TODO: add LabelSelector de-duping (minor optimization)
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+			},
+		},
+		{
+			name: "LabelSelectors",
+			a: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+				),
+			},
+			b: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				),
+			},
+		},
+		// FieldSelectors
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: nil,
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			b: &client.ListOptions{
+				FieldSelector: nil,
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.Everything(),
+					// TODO: add ListOptions de-duping (minor optimization)
+					fields.Everything(),
+				),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.Everything(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.Nothing(),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+			b: &client.ListOptions{},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a:    &client.ListOptions{},
+			b: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key", "value"),
+					// TODO: add ListOptions de-duping (minor optimization)
+					fields.OneTermEqualSelector("key", "value"),
+				),
+			},
+		},
+		{
+			name: "FieldSelectors",
+			a: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key1", "value1"),
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key2", "value2"),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				),
+			},
+		},
+		// Namespace
+		{
+			name: "Namespace",
+			a: &client.ListOptions{
+				Namespace: "",
+			},
+			b: &client.ListOptions{
+				Namespace: "example",
+			},
+			expectedOpts: &client.ListOptions{
+				Namespace: "example",
+			},
+		},
+		{
+			name: "Namespace",
+			a: &client.ListOptions{
+				Namespace: "example",
+			},
+			b: &client.ListOptions{
+				Namespace: "",
+			},
+			expectedOpts: &client.ListOptions{
+				Namespace: "example",
+			},
+		},
+		{
+			name: "Namespace",
+			a: &client.ListOptions{
+				Namespace: "example",
+			},
+			b: &client.ListOptions{
+				Namespace: "example",
+			},
+			expectedOpts: &client.ListOptions{
+				Namespace: "example",
+			},
+		},
+		{
+			name: "Namespace",
+			a: &client.ListOptions{
+				Namespace: "example1",
+			},
+			b: &client.ListOptions{
+				Namespace: "example2",
+			},
+			expectedError: testutil.EqualError(
+				errors.New("cannot merge two different namespaces: example1 & example2")),
+		},
+		// Limit
+		{
+			name: "Limit",
+			a: &client.ListOptions{
+				Limit: 0,
+			},
+			b: &client.ListOptions{
+				Limit: 10,
+			},
+			expectedOpts: &client.ListOptions{
+				Limit: 10,
+			},
+		},
+		{
+			name: "Limit",
+			a: &client.ListOptions{
+				Limit: 10,
+			},
+			b: &client.ListOptions{
+				Limit: 0,
+			},
+			expectedOpts: &client.ListOptions{
+				Limit: 10,
+			},
+		},
+		{
+			name: "Limit",
+			a: &client.ListOptions{
+				Limit: 10,
+			},
+			b: &client.ListOptions{
+				Limit: 10,
+			},
+			expectedOpts: &client.ListOptions{
+				Limit: 10,
+			},
+		},
+		{
+			name: "Limit",
+			a: &client.ListOptions{
+				Limit: 5,
+			},
+			b: &client.ListOptions{
+				Limit: 10,
+			},
+			expectedError: testutil.EqualError(
+				errors.New("cannot merge two different limits: 5 & 10")),
+		},
+		// Continue
+		{
+			name: "Continue",
+			a: &client.ListOptions{
+				Continue: "",
+			},
+			b: &client.ListOptions{
+				Continue: "abc123",
+			},
+			expectedOpts: &client.ListOptions{
+				Continue: "abc123",
+			},
+		},
+		{
+			name: "Continue",
+			a: &client.ListOptions{
+				Continue: "abc123",
+			},
+			b: &client.ListOptions{
+				Continue: "",
+			},
+			expectedOpts: &client.ListOptions{
+				Continue: "abc123",
+			},
+		},
+		{
+			name: "Continue",
+			a: &client.ListOptions{
+				Continue: "abc123",
+			},
+			b: &client.ListOptions{
+				Continue: "abc123",
+			},
+			expectedOpts: &client.ListOptions{
+				Continue: "abc123",
+			},
+		},
+		{
+			name: "Continue",
+			a: &client.ListOptions{
+				Continue: "abc123",
+			},
+			b: &client.ListOptions{
+				Continue: "123abc",
+			},
+			expectedError: testutil.EqualError(
+				errors.New("cannot merge two different continue tokens: abc123 & 123abc")),
+		},
+		// Raw
+		{
+			name: "Raw",
+			a: &client.ListOptions{
+				Raw: nil,
+			},
+			b: &client.ListOptions{
+				Raw: &metav1.ListOptions{},
+			},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{},
+			},
+		},
+		{
+			name: "Raw",
+			a: &client.ListOptions{
+				Raw: &metav1.ListOptions{},
+			},
+			b: &client.ListOptions{
+				Raw: nil,
+			},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{},
+			},
+		},
+		{
+			name: "Raw",
+			a: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "abc123",
+				},
+			},
+			b: &client.ListOptions{
+				Raw: nil,
+			},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "abc123",
+				},
+			},
+		},
+		{
+			name: "Raw",
+			a: &client.ListOptions{
+				Raw: nil,
+			},
+			b: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "abc123",
+				},
+			},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "abc123",
+				},
+			},
+		},
+		{
+			name: "Raw",
+			a: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "",
+				},
+			},
+			b: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					ResourceVersion: "abc123",
+				},
+			},
+			expectedError: testutil.EqualError(
+				errors.New("not yet implemented: merging two different raw ListOptions: " +
+					"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,} & " +
+					"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:abc123,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,}")),
+		},
+		// AllTheThings!
+		{
+			name: "AllTheThings",
+			a: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key1", "value1"),
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+				Namespace: "example",
+			},
+			b: &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("key2", "value2"),
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+				Limit:    10,
+				Continue: "123abc",
+				Raw: &metav1.ListOptions{
+					Watch:                true,
+					AllowWatchBookmarks:  true,
+					ResourceVersion:      "abc123",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+					TimeoutSeconds:       pointer.Int64(10),
+				},
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				),
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+					// TODO: add LabelSelector de-duping (minor optimization)
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+				Namespace: "example",
+				Limit:     10,
+				Continue:  "123abc",
+				Raw: &metav1.ListOptions{
+					Watch:                true,
+					AllowWatchBookmarks:  true,
+					ResourceVersion:      "abc123",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+					TimeoutSeconds:       pointer.Int64(10),
+				},
+			},
+		},
+	}
+
+	// Compare *hasTerm Selectors by String value
+	// (the struct is private and the fields are private)
+	hasTermFieldSelectorType := reflect.TypeOf(fields.OneTermEqualSelector("", ""))
+	hasTermFieldSelectorComparer := cmp.FilterValues(func(a, b fields.Selector) bool {
+		return reflect.TypeOf(a) == hasTermFieldSelectorType &&
+			reflect.TypeOf(b) == hasTermFieldSelectorType
+	}, cmp.Comparer(func(a, b fields.Selector) bool {
+		if a == nil && b == nil {
+			return true
+		}
+		if a == nil || b == nil {
+			return false
+		}
+		return a.String() == b.String()
+	}))
+
+	asserter := testutil.NewAsserter(
+		cmpopts.EquateErrors(),
+		hasTermFieldSelectorComparer,
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := MergeListOptions(tc.a, tc.b)
+			asserter.Equal(t, tc.expectedError, err)
+			asserter.Equal(t, tc.expectedOpts, result)
+		})
+	}
+}
+
+func TestConvertListOptions(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         *metav1.ListOptions
+		expectedError error
+		expectedOpts  *client.ListOptions
+	}{
+		{
+			input:        nil,
+			expectedOpts: nil,
+		},
+		{
+			input: &metav1.ListOptions{},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{},
+			},
+		},
+		{
+			name: "LabelSelectors",
+			input: &metav1.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				).String(),
+			},
+			expectedOpts: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				),
+				Raw: &metav1.ListOptions{
+					LabelSelector: labels.NewSelector().Add(
+						newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+						newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+					).String(),
+				},
+			},
+		},
+		{
+			name: "FieldSelector",
+			input: &metav1.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				).String(),
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				),
+				Raw: &metav1.ListOptions{
+					FieldSelector: fields.AndSelectors(
+						fields.OneTermEqualSelector("key1", "value1"),
+						fields.OneTermEqualSelector("key2", "value2"),
+					).String(),
+				},
+			},
+		},
+		{
+			name: "Limit",
+			input: &metav1.ListOptions{
+				Limit: 10,
+			},
+			expectedOpts: &client.ListOptions{
+				Limit: 10,
+				Raw: &metav1.ListOptions{
+					Limit: 10,
+				},
+			},
+		},
+		{
+			name: "Continue",
+			input: &metav1.ListOptions{
+				Continue: "abc123",
+			},
+			expectedOpts: &client.ListOptions{
+				Continue: "abc123",
+				Raw: &metav1.ListOptions{
+					Continue: "abc123",
+				},
+			},
+		},
+		{
+			name: "Ignored",
+			input: &metav1.ListOptions{
+				Watch:                true,
+				AllowWatchBookmarks:  true,
+				ResourceVersion:      "abc123",
+				ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+				TimeoutSeconds:       pointer.Int64(10),
+			},
+			expectedOpts: &client.ListOptions{
+				Raw: &metav1.ListOptions{
+					Watch:                true,
+					AllowWatchBookmarks:  true,
+					ResourceVersion:      "abc123",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+					TimeoutSeconds:       pointer.Int64(10),
+				},
+			},
+		},
+		{
+			name: "AllTheThings",
+			input: &metav1.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				).String(),
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				).String(),
+				Watch:                true,
+				AllowWatchBookmarks:  true,
+				ResourceVersion:      "abc123",
+				ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+				TimeoutSeconds:       pointer.Int64(10),
+				Limit:                10,
+				Continue:             "123abc",
+			},
+			expectedOpts: &client.ListOptions{
+				FieldSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("key1", "value1"),
+					fields.OneTermEqualSelector("key2", "value2"),
+				),
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+					newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+				),
+				Limit:    10,
+				Continue: "123abc",
+				Raw: &metav1.ListOptions{
+					FieldSelector: fields.AndSelectors(
+						fields.OneTermEqualSelector("key1", "value1"),
+						fields.OneTermEqualSelector("key2", "value2"),
+					).String(),
+					LabelSelector: labels.NewSelector().Add(
+						newLabelRequirement(t, "key1", selection.Equals, []string{"value1"}),
+						newLabelRequirement(t, "key2", selection.Equals, []string{"value2"}),
+					).String(),
+					Watch:                true,
+					AllowWatchBookmarks:  true,
+					ResourceVersion:      "abc123",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+					TimeoutSeconds:       pointer.Int64(10),
+					Limit:                10,
+					Continue:             "123abc",
+				},
+			},
+		},
+	}
+
+	// Compare *hasTerm Selectors by String value
+	// (the struct is private and the fields are private)
+	hasTermFieldSelectorType := reflect.TypeOf(fields.OneTermEqualSelector("", ""))
+	hasTermFieldSelectorComparer := cmp.FilterValues(func(a, b fields.Selector) bool {
+		return reflect.TypeOf(a) == hasTermFieldSelectorType &&
+			reflect.TypeOf(b) == hasTermFieldSelectorType
+	}, cmp.Comparer(func(a, b fields.Selector) bool {
+		if a == nil && b == nil {
+			return true
+		}
+		if a == nil || b == nil {
+			return false
+		}
+		return a.String() == b.String()
+	}))
+
+	asserter := testutil.NewAsserter(
+		cmpopts.EquateErrors(),
+		hasTermFieldSelectorComparer,
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ConvertListOptions(tc.input)
+			asserter.Equal(t, tc.expectedError, err)
+			asserter.Equal(t, tc.expectedOpts, result)
+		})
+	}
+}
+
+func TestUnrollListOptions(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        *client.ListOptions
+		expectedOpts []client.ListOption
+	}{
+		{
+			input:        nil,
+			expectedOpts: nil,
+		},
+		{
+			input:        &client.ListOptions{},
+			expectedOpts: nil,
+		},
+		{
+			input: &client.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+				),
+				FieldSelector: fields.OneTermEqualSelector("key", "value"),
+				Namespace:     "example",
+				Limit:         10,
+				Continue:      "abc123",
+				Raw: &metav1.ListOptions{
+					Watch:                true,
+					AllowWatchBookmarks:  true,
+					ResourceVersion:      "abc123",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+					TimeoutSeconds:       pointer.Int64(10),
+				},
+			},
+			expectedOpts: []client.ListOption{
+				client.MatchingLabelsSelector{
+					Selector: labels.NewSelector().Add(
+						newLabelRequirement(t, "key", selection.Equals, []string{"value"}),
+					),
+				},
+				client.MatchingFieldsSelector{
+					Selector: fields.OneTermEqualSelector("key", "value"),
+				},
+				client.InNamespace("example"),
+				client.Limit(10),
+				client.Continue("abc123"),
+				&RawListOptions{
+					Raw: &metav1.ListOptions{
+						Watch:                true,
+						AllowWatchBookmarks:  true,
+						ResourceVersion:      "abc123",
+						ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+						TimeoutSeconds:       pointer.Int64(10),
+					},
+				},
+			},
+		},
+	}
+
+	// Compare *hasTerm Selectors by String value
+	// (the struct is private and the fields are private)
+	hasTermFieldSelectorType := reflect.TypeOf(fields.OneTermEqualSelector("", ""))
+	hasTermFieldSelectorComparer := cmp.FilterValues(func(a, b fields.Selector) bool {
+		return reflect.TypeOf(a) == hasTermFieldSelectorType &&
+			reflect.TypeOf(b) == hasTermFieldSelectorType
+	}, cmp.Comparer(func(a, b fields.Selector) bool {
+		if a == nil && b == nil {
+			return true
+		}
+		if a == nil || b == nil {
+			return false
+		}
+		return a.String() == b.String()
+	}))
+
+	asserter := testutil.NewAsserter(
+		cmpopts.EquateErrors(),
+		hasTermFieldSelectorComparer,
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := UnrollListOptions(tc.input)
+			asserter.Equal(t, tc.expectedOpts, result)
+		})
+	}
+}
+
+func newLabelRequirement(t *testing.T, key string, op selection.Operator, vals []string, opts ...field.PathOption) labels.Requirement {
+	t.Helper()
+	req, err := labels.NewRequirement(key, op, vals, opts...)
+	require.NoError(t, err)
+	return *req
+}

--- a/pkg/util/watch/until.go
+++ b/pkg/util/watch/until.go
@@ -1,0 +1,149 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	watchapi "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UntilDeletedWithSync watches the specified object and blocks until it is
+// fully deleted (NotFound, not just deleteTimestamp). This allows for any
+// finalizers to complete.
+//
+// The optional Precondition will be called after the Informer is Synced,
+// meaning that both the List and Watch call have been made, after which it's
+// safe to Delete the object and assume the watch will receive the delete event.
+//
+// The Precondition Store argument uses "<namespace>/<name>" or "<name>" keys
+// and returns either a cache.DeletedFinalStateUnknown or an object of the type
+// specified by the `items` field of the provided ObjectList (Kind without the
+// "List" suffix). For example, UnstructuredList caches Unstructured objects.
+//
+// The Object ResourceVersion of the input object is ignored, because a new
+// Informer is created which will do a ListAndWatch to determine which
+// ResourceVersion to start watching from.
+//
+// The Object contents will be replaced with updated state for each new event
+// received while waiting for deletion.
+//
+// For timeout, use:
+// watchCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+// defer cancel()
+//
+// If you want to make sure something is deleted, delete it if it's not yet
+// deleted, and then wait for it to be fully deleted, use DeleteAndWait instead.
+func UntilDeletedWithSync(ctx context.Context, c client.WithWatch, obj client.Object, precondition watchtools.PreconditionFunc) error {
+	itemGVK, err := kinds.Lookup(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	var objList client.ObjectList
+	if _, ok := obj.(*unstructured.Unstructured); ok {
+		objList = kinds.NewUnstructuredListForItemGVK(itemGVK)
+	} else {
+		objList, err = kinds.NewTypedListForItemGVK(itemGVK, c.Scheme())
+		if err != nil {
+			return err
+		}
+	}
+	watcher := &ClientListerWatcher{
+		Context:     ctx,
+		Client:      c,
+		Key:         client.ObjectKeyFromObject(obj),
+		Labels:      obj.GetLabels(),
+		ExampleList: objList,
+	}
+	// Precondition runs after Watch and Sync but before Watch events are handled.
+	// So use it to confirm that the object still exists in the watch cache,
+	// otherwise the watcher will never receive the deletion event.
+	// In that case, just exit early.
+	// Precondition returning true means exit early & cancel the Watch.
+	wrappedPrecondition := func(store cache.Store) (bool, error) {
+		// Run the caller's precondition first, if one was supplied.
+		if precondition != nil {
+			met, err := precondition(store)
+			if err != nil {
+				// Stop waiting - precondition errored
+				return true, err
+			}
+			if met {
+				// Stop waiting - precondition met
+				return true, nil
+			}
+		}
+
+		_, exists, err := store.Get(obj)
+		if err != nil {
+			// Stop waiting - storage retrieval errored
+			return true, err
+		}
+		if !exists {
+			// Stop waiting - object already deleted
+			return true, nil
+		}
+
+		// Continue waiting until deleted
+		return false, nil
+	}
+	yamlSerializer := jserializer.NewYAMLSerializer(jserializer.DefaultMetaFactory, c.Scheme(), c.Scheme())
+	decoder := serializer.NewCodecFactory(c.Scheme()).UniversalDeserializer()
+	_, err = watchtools.UntilWithSync(ctx, watcher, obj, wrappedPrecondition, func(e watchapi.Event) (bool, error) {
+		klog.V(5).Infof("Received %s event for %T", e.Type, e.Object)
+		switch e.Type {
+		case watchapi.Error:
+			// Stop waiting - UntilWithSync uses UntilWithoutRetry
+			return true, errors.Wrapf(apierrors.FromObject(e.Object),
+				"error event while watching: %s", kinds.ObjectSummary(obj))
+		case watchapi.Added, watchapi.Modified, watchapi.Bookmark:
+			// Simulate DeepCopyInto by encoding the new object into the object
+			// passed in by the caller.
+			yamlBytes, err := runtime.Encode(yamlSerializer, e.Object)
+			if err != nil {
+				// Stop waiting - invalid object
+				return true, errors.Wrapf(err, "encoding event object to YAML while watching: %s",
+					kinds.ObjectSummary(obj))
+			}
+			_, _, err = decoder.Decode(yamlBytes, nil, obj)
+			if err != nil {
+				// Stop waiting - invalid object
+				return true, errors.Wrapf(err, "decoding event object YAML to %T while watching: %s",
+					obj, kinds.ObjectSummary(obj))
+			}
+			// Keep waiting - object still exists
+			return false, nil
+		case watchapi.Deleted:
+			// Stop waiting - object successfully deleted
+			return true, nil
+		default:
+			// Stop waiting - invalid event type
+			return true, errors.Errorf("unexpected event type %s while watching: %s: %v",
+				e.Type, kinds.ObjectSummary(obj), e)
+		}
+	})
+	return err
+}


### PR DESCRIPTION
- The reconciler-manager now adds a finalizer onto all RootSyncs &
  RepoSyncs ("configsync.gke.io/reconciler-manager") which blocks
  removal of these objects until garbage collection is complete.
  This ensures that garbage collection has completed when the object
  is reconciled (Not Found), making it safer to use RootSyncs &
  RepoSyncs as dependencies.
- Watch for object deletion before completing garbage collection.
  This ensures the objects are Not Found before allowing RSync
  removal.
- Add watch.DeleteAndWait & watch.UntilDeletedWithSync to help work
  around limitations of the controller-runtime client.Delete.

b/236892981

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/582
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/583
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/587
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/650