### PR TITLE
Pass Kind instead of GVK to the record metrics functions

### DIFF
--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -38,10 +37,10 @@ func record(ctx context.Context, ms ...stats.Measurement) {
 }
 
 // RecordAPICallDuration produces a measurement for the APICallDuration view.
-func RecordAPICallDuration(ctx context.Context, operation, status string, gvk schema.GroupVersionKind, startTime time.Time) {
+func RecordAPICallDuration(ctx context.Context, operation, status, kind string, startTime time.Time) {
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyOperation, operation),
-		tag.Upsert(KeyType, gvk.Kind),
+		tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := APICallDuration.M(time.Since(startTime).Seconds())
 	record(tagCtx, measurement)
@@ -111,12 +110,12 @@ func RecordDeclaredResources(ctx context.Context, commit string, numResources in
 }
 
 // RecordApplyOperation produces a measurement for the ApplyOperations view.
-func RecordApplyOperation(ctx context.Context, controller, operation, status string, gvk schema.GroupVersionKind) {
+func RecordApplyOperation(ctx context.Context, controller, operation, status, kind string) {
 	tagCtx, _ := tag.New(ctx,
 		//tag.Upsert(KeyName, GetResourceLabels()),
 		tag.Upsert(KeyOperation, operation),
 		tag.Upsert(KeyController, controller),
-		tag.Upsert(KeyType, gvk.Kind),
+		tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := ApplyOperations.M(1)
 	record(tagCtx, measurement)
@@ -139,31 +138,31 @@ func RecordApplyDuration(ctx context.Context, status, commit string, startTime t
 }
 
 // RecordResourceFight produces measurements for the ResourceFights view.
-func RecordResourceFight(ctx context.Context, _ string, _ schema.GroupVersionKind) {
+func RecordResourceFight(ctx context.Context, _, _ string) {
 	//tagCtx, _ := tag.New(ctx,
 	//tag.Upsert(KeyName, GetResourceLabels()),
 	//tag.Upsert(KeyOperation, operation),
-	//tag.Upsert(KeyType, gvk.Kind),
+	//tag.Upsert(KeyType, kind),
 	//)
 	measurement := ResourceFights.M(1)
 	record(ctx, measurement)
 }
 
 // RecordRemediateDuration produces measurements for the RemediateDuration view.
-func RecordRemediateDuration(ctx context.Context, status string, gvk schema.GroupVersionKind, startTime time.Time) {
+func RecordRemediateDuration(ctx context.Context, status, kind string, startTime time.Time) {
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyStatus, status),
-		tag.Upsert(KeyType, gvk.Kind),
+		tag.Upsert(KeyType, kind),
 	)
 	measurement := RemediateDuration.M(time.Since(startTime).Seconds())
 	record(tagCtx, measurement)
 }
 
 // RecordResourceConflict produces measurements for the ResourceConflicts view.
-func RecordResourceConflict(ctx context.Context, _ schema.GroupVersionKind, commit string) {
+func RecordResourceConflict(ctx context.Context, _, commit string) {
 	tagCtx, _ := tag.New(ctx,
 		// tag.Upsert(KeyName, GetResourceLabels()),
-		// tag.Upsert(KeyType, gvk.Kind),
+		// tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyCommit, commit),
 	)
 	measurement := ResourceConflicts.M(1)

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -88,16 +88,16 @@ func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Objec
 	err := r.remediate(ctx, id, objDiff)
 
 	// Record duration, even if there's an error
-	metrics.RecordRemediateDuration(ctx, metrics.StatusTagKey(err), id.WithVersion(""), start)
+	metrics.RecordRemediateDuration(ctx, metrics.StatusTagKey(err), id.Kind, start)
 
 	if err != nil {
 		switch err.Code() {
 		case syncerclient.ResourceConflictCode:
 			// Record conflict, if there was one
-			metrics.RecordResourceConflict(ctx, id.WithVersion(""), commit)
+			metrics.RecordResourceConflict(ctx, id.Kind, commit)
 		case status.FightErrorCode:
 			operation := objDiff.Operation(r.scope, r.syncName)
-			metrics.RecordResourceFight(ctx, string(operation), id.WithVersion(""))
+			metrics.RecordResourceFight(ctx, string(operation), id.Kind)
 			r.fightHandler.AddFightError(id, err)
 		}
 		return err

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -191,7 +191,7 @@ func (w *filteredWatcher) SetManagementConflict(object client.Object, commit str
 		core.GKNN(object), newManager, manager)
 	gvknn := queue.GVKNNOf(object)
 	w.conflictHandler.AddConflictError(gvknn, status.ManagementConflictErrorWrap(object, newManager))
-	metrics.RecordResourceConflict(context.Background(), object.GetObjectKind().GroupVersionKind(), commit)
+	metrics.RecordResourceConflict(context.Background(), gvknn.Kind, commit)
 }
 
 func (w *filteredWatcher) ClearManagementConflict() {

--- a/pkg/syncer/client/client.go
+++ b/pkg/syncer/client/client.go
@@ -65,7 +65,7 @@ func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.C
 	start := time.Now()
 	err := c.Client.Create(ctx, obj, opts...)
 	c.recordLatency(start, "Create", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "create", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind(), start)
+	m.RecordAPICallDuration(ctx, "create", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
 
 	switch {
 	case apierrors.IsAlreadyExists(err):
@@ -113,7 +113,7 @@ func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.D
 	}
 
 	c.recordLatency(start, "delete", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "delete", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind(), start)
+	m.RecordAPICallDuration(ctx, "delete", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
 
 	if err != nil {
 		return status.ResourceWrap(err, "failed to delete", obj)
@@ -177,7 +177,7 @@ func (c *Client) apply(ctx context.Context, obj client.Object, updateFn update,
 		start := time.Now()
 		err = clientUpdateFn(ctx, newObj)
 		c.recordLatency(start, "update", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-		m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind(), start)
+		m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
 
 		if err == nil {
 			newV := resourceVersion(newObj)
@@ -211,7 +211,7 @@ func (c *Client) Update(ctx context.Context, obj client.Object) status.Error {
 	start := time.Now()
 	err := c.Client.Update(ctx, obj)
 	c.recordLatency(start, "update", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind(), start)
+	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
 	switch {
 	case apierrors.IsNotFound(err):
 		return ConflictUpdateDoesNotExist(err, obj)


### PR DESCRIPTION
The record functions only use the Kind tag. Passing GVK requires providing an empty version string to the callers.

It also sets the name tag.