### PR TITLE
Update Go to v1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ REGISTRY ?= gcr.io/$(GCR_PREFIX)
 OLD_REGISTRY ?= $(REGISTRY)
 
 # Docker image used for build and test. This image does not support CGO.
-BUILDENV_IMAGE ?= gcr.io/stolos-dev/buildenv:v0.2.11
+BUILDENV_IMAGE ?= gcr.io/stolos-dev/buildenv:v0.2.12
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler
@@ -248,7 +248,7 @@ fmt-sh:
 
 .PHONY: tidy
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy
 
 .PHONY: vendor
 vendor:

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build all Config Sync go binaries
-FROM golang:1.17 as bins
+FROM golang:1.19 as bins
 
 WORKDIR /workspace
 

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -27,7 +27,7 @@
 # when the go1.17 image is released in it.
 # Note that we shouldn't use the -alpine image here
 # since it is not allowed due to busybox for licensing.
-ARG GOLANG_CONTAINER=golang:1.17.7-buster
+ARG GOLANG_CONTAINER=golang:1.19.7-buster
 
 # Environment to build the helper binaries from.
 FROM ${GOLANG_CONTAINER} AS tools-base
@@ -51,7 +51,7 @@ ENV CGO_ENABLED=0
 # This is required by the `make fmt-go` target, even though it isn't used
 # in building the Nomos image. This was previously included in golang:alpine,
 # but not any more so we have to install it ourselves.
-RUN go install golang.org/x/tools/cmd/goimports
+RUN go install golang.org/x/tools/cmd/goimports@v0.7.0
 
 # gotopt2 parses command line options
 # v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kpt.dev/configsync
 
-go 1.17
+go 1.19
 
 require (
 	cloud.google.com/go/trace v1.1.0

--- a/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1beta1
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -20,8 +20,9 @@ export CGO_ENABLED=0
 
 # TODO: It is best practice to install directly on the Docker image,
 #  but for now it's unclear how to do this sanely.
-wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.0/install.sh |
-  sh -sx -- -b .output/go/bin v1.52.0
+LINTER_VERSION="v1.52.0"
+wget -O- -nv "https://raw.githubusercontent.com/golangci/golangci-lint/${LINTER_VERSION}/install.sh" |
+  sh -sx -- -b .output/go/bin "${LINTER_VERSION}"
 
 # golangci-lint uses $HOME to determine where to store .cache information.
 # For the docker image this is running in, $HOME is set to "/", so for this


### PR DESCRIPTION
- Fix several CVEs from Go 1.17
- Update buildenv image to use golang:1.19.7-buster
- Pull out variable for golangci-lint version

This started as a cherry-pick of https://github.com/GoogleContainerTools/kpt-config-sync/pull/465, but some different choices were made previously when upgrading golangci-lint, so there weren't any more lint failures to fix. And we don't need to use the default exclusions, because we already have exclusions configured in .golangci.yaml.