### PR TITLE
Update helm & kustomize (cont.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
-KUSTOMIZE_VERSION := v4.5.2
-HELM_VERSION := v3.6.3
+KUSTOMIZE_VERSION := v5.0.1
+HELM_VERSION := v3.11.2
 
 # Directory used for staging Docker contexts.
 STAGING_DIR := $(OUTPUT_DIR)/staging
@@ -280,7 +280,7 @@ lint-license: pull-buildenv buildenv-dirs
 	go install github.com/google/addlicense@v1.0.0
 
 "$(GOBIN)/kustomize":
-	CGO_ENABLED=0 go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
+	CGO_ENABLED=0 go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 # install kustomize binary for containerized testing
 "$(BIN_DIR)/kustomize": "$(GOBIN)/kustomize"

--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -29,8 +29,8 @@ ENV CGO_ENABLED=0
 RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
-ARG HELM_VERSION=v3.6.3
-ARG KUSTOMIZE_VERSION=v4.5.2
+ARG HELM_VERSION=v3.11.2
+ARG KUSTOMIZE_VERSION=v5.0.1
 ARG HELM_INFLATOR_FUNCTIOPN_VERSION=v0.2.0
 
 # Install the render-helm-chart function.

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -29,8 +29,8 @@ ENV CGO_ENABLED=0
 RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
-ARG HELM_VERSION=v3.6.3
-ARG KUSTOMIZE_VERSION=v4.5.2
+ARG HELM_VERSION=v3.11.2
+ARG KUSTOMIZE_VERSION=v5.0.1
 ARG HELM_INFLATOR_FUNCTIOPN_VERSION=v0.2.0
 
 # Install the render-helm-chart function.

--- a/manifests/patch/kustomization.yaml
+++ b/manifests/patch/kustomization.yaml
@@ -18,33 +18,32 @@ kind: Kustomization
 resources:
 - reposync-crd.yaml
 - rootsync-crd.yaml
-
-patchesStrategicMerge:
-- |-
-  apiVersion: apiextensions.k8s.io/v1
-  kind: CustomResourceDefinition
-  metadata:
-    creationTimestamp:
+patches:
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      creationTimestamp:
+        $patch: delete
+      name: rootsyncs.configsync.gke.io
+      labels:
+        configmanagement.gke.io/system: "true"
+        configmanagement.gke.io/arch: "csmr"
+    spec:
+      preserveUnknownFields: false
+    status:
       $patch: delete
-    name: rootsyncs.configsync.gke.io
-    labels:
-      configmanagement.gke.io/system: "true"
-      configmanagement.gke.io/arch: "csmr"
-  spec:
-    preserveUnknownFields: false
-  status:
-    $patch: delete
-- |-
-  apiVersion: apiextensions.k8s.io/v1
-  kind: CustomResourceDefinition
-  metadata:
-    creationTimestamp:
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      creationTimestamp:
+        $patch: delete
+      name: reposyncs.configsync.gke.io
+      labels:
+        configmanagement.gke.io/system: "true"
+        configmanagement.gke.io/arch: "csmr"
+    spec:
+      preserveUnknownFields: false
+    status:
       $patch: delete
-    name: reposyncs.configsync.gke.io
-    labels:
-      configmanagement.gke.io/system: "true"
-      configmanagement.gke.io/arch: "csmr"
-  spec:
-    preserveUnknownFields: false
-  status:
-    $patch: delete

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -43,9 +43,9 @@ import (
 
 const (
 	// HelmVersion is the minimum required version of Helm for hydration.
-	HelmVersion = "v3.6.3"
+	HelmVersion = "v3.11.2"
 	// KustomizeVersion is the minimum required version of Kustomize for hydration.
-	KustomizeVersion = "v4.5.2"
+	KustomizeVersion = "v5.0.1"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.

--- a/pkg/kmetrics/exec_test.go
+++ b/pkg/kmetrics/exec_test.go
@@ -61,7 +61,7 @@ spec:
 		},
 		"invalid kustomization": {
 			inputDir:    "./testdata/invalidkustomization",
-			expectedErr: "Error: json: cannot unmarshal string into Go struct field Kustomization.resources of type []string",
+			expectedErr: "Error: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.resources of type []string",
 		},
 		"multiple kustomization files": {
 			inputDir:    "./testdata/multiplekustomizationfiles",


### PR DESCRIPTION
- Update nomos hydrate
- Update kind & gke build images
- Update local install make target
- Update manifest/kustomize.yaml to use patches, instead of the
  deprecated patchesStrategicMerge.
- Ensure patchesStrategicMerge still works, by leaving it in the
  hydration unit tests.