### PR TITLE
ci: install gke-auth-plugin in e2e image

### DIFF
--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Build intermediate image for gcloud / kubectl
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:369.0.0-slim as gcloud-install
-RUN apt-get install -y kubectl
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:425.0.0-slim as gcloud-install
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Build e2e image
 FROM golang:1.17.7-alpine as kpt-config-sync-e2e

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Build intermediate image for gcloud / kubectl
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:369.0.0-slim as gcloud-install
-RUN apt-get install -y kubectl
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:425.0.0-slim as gcloud-install
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Build e2e image
 FROM golang:1.17.7-alpine as kpt-config-sync-e2e


### PR DESCRIPTION
This change installs the gke-gcloud-auth-plugin in the image which the e2e tests run in. This change will be needed to support authentication with GKE clusters starting with v1.26.