### PR TITLE
Fix debian container nonroot user

### DIFF
--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -55,6 +55,17 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
     ./cmd/oci-sync \
     ./cmd/helm-sync
 
+# Debian non-root base image
+# Uses the same nonroot UID as distroless
+FROM gcr.io/gke-release/debian-base:bullseye-v1.4.3-gke.0 as debian-nonroot
+WORKDIR /
+ARG USERNAME=nonroot
+ARG USER_UID=65532
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME && \
+  useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+USER nonroot:nonroot
+
 # Hydration controller image
 FROM gcr.io/distroless/static:nonroot as hydration-controller
 WORKDIR /
@@ -106,8 +117,9 @@ USER 1000
 ENTRYPOINT ["/helm-sync"]
 
 # Hydration controller image with shell
-FROM gcr.io/gke-release/debian-base:bullseye-v1.4.3-gke.0 as hydration-controller-with-shell
+FROM debian-nonroot as hydration-controller-with-shell
 WORKDIR /
+USER root
 COPY --from=bins /go/bin/hydration-controller .
 COPY --from=bins /go/bin/render-helm-chart /usr/local/bin/render-helm-chart
 COPY --from=bins /usr/local/bin/helm /usr/local/bin/helm
@@ -164,17 +176,15 @@ ENTRYPOINT ["/admission-webhook"]
 # Nomos image
 # Not used by Config Sync backend components. Intended for use cases with the
 # nomos CLI (e.g. containerized CI/CD)
-FROM gcr.io/gke-release/debian-base:bullseye-v1.4.3-gke.0 as nomos
+FROM debian-nonroot as nomos
+USER root
 
 # https://github.com/GoogleCloudPlatform/google-cloud-go/issues/791#issuecomment-353689746
-RUN apt-get update && \
-  apt-get install -y bash git
+RUN apt-get update && apt-get install -y bash git
 
+# Install nomos CLI
 RUN mkdir -p /opt/nomos/bin
-ENV PATH="/opt/nomos/bin:${PATH}"
 WORKDIR /opt/nomos/bin
-
-# Nomos binary
 COPY --from=bins /go/bin/nomos nomos
 
 # License file required for on-prem release.
@@ -182,11 +192,8 @@ COPY LICENSE LICENSE
 COPY LICENSES.txt LICENSES.txt
 
 # Set up a HOME directory for non-root user
-RUN mkdir -p /nomos
-RUN chown 1000 /nomos
+RUN mkdir -p /nomos && chown nonroot:nonroot /nomos
+USER nonroot:nonroot
 ENV HOME="/nomos"
-
-# Switch to non-root user
-USER 1000
-
+ENV PATH="/opt/nomos/bin:${PATH}"
 ENTRYPOINT ["/opt/nomos/bin/nomos"]

--- a/e2e/nomostest/testshell/shell.go
+++ b/e2e/nomostest/testshell/shell.go
@@ -111,6 +111,21 @@ func (tc *TestShell) Git(args ...string) ([]byte, error) {
 	return out, nil
 }
 
+// Docker is a convenience method for calling docker.
+// Returns STDOUT & STDERR combined, and an error if docker exited abnormally.
+func (tc *TestShell) Docker(args ...string) ([]byte, error) {
+	tc.Logger.Debugf("docker %s", strings.Join(args, " "))
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		if !tc.Logger.IsDebugEnabled() {
+			tc.Logger.Infof("docker %s", strings.Join(args, " "))
+		}
+		tc.Logger.Info(string(out))
+		return out, err
+	}
+	return out, nil
+}
+
 // Command is a convenience method for invoking a subprocess with the
 // KUBECONFIG environment variable set. Setting the environment variable
 // directly in the test process is not thread safe.

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -928,11 +928,8 @@ func TestNomosImage(t *testing.T) {
 
 	version := nomostest.VersionFromManifest(t)
 
-	cmd := nt.Shell.Command(
-		"docker", "run", "-i", "--rm",
-		fmt.Sprintf("%s/nomos:%s", e2e.DefaultImagePrefix, version),
-	)
-	out, err := cmd.CombinedOutput()
+	out, err := nt.Shell.Docker("run", "-i", "--rm",
+		fmt.Sprintf("%s/nomos:%s", e2e.DefaultImagePrefix, version))
 	if err != nil {
 		nt.T.Fatal(err)
 	}


### PR DESCRIPTION
- Use 65532 for nonroot user & group, for all images. This is the distroless standard. Some of the containers were using 1000, the id from docker docs, which was causing files to be owned by the wrong user.
- Extract a debian-nonroot base image to avoid duplicating the nonroot user setup.
- Clean up TestNomosImage by extracting a Shell.Docker method to handle logging.

## Problem
Docker uses the 1000 UID for its dind images, and vscode uses it too, but Debian doesn't ship with a nonroot user or group. Distroess uses 65532 for nonroot. So setting `USER nonroot:nonroot` in debian wasn't actually working but also not failing the build or the test. Same with using `USER 1000` in distroless. And there was a `chown 1000` that also wasn't really doing what was intended.