### PR TITLE
test: fix git portforward to support non-local provider

### DIFF
--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -139,9 +139,14 @@ func NewRepository(nt *NT, repoType RepoType, nn types.NamespacedName, sourceFor
 		nt.T.Fatal(err)
 	}
 	g.RemoteRepoName = repoName
-	port, err := nt.gitRepoPortForwarder.LocalPort()
-	if err != nil {
-		nt.T.Fatal(err)
+	var port int
+	// port argument is used for in-cluster git provider with the local port forward.
+	// the argument is ignored for other providers, e.g. Gitlab/Bitbucket
+	if nt.gitRepoPortForwarder != nil {
+		port, err = nt.gitRepoPortForwarder.LocalPort()
+		if err != nil {
+			nt.T.Fatal(err)
+		}
 	}
 	g.RemoteURL = nt.GitProvider.RemoteURL(port, repoName)
 
@@ -157,9 +162,15 @@ func (g *Repository) ReInit(nt *NT, sourceFormat filesystem.SourceFormat) {
 
 	// Update test environment
 	g.T = nt.T
-	port, err := nt.gitRepoPortForwarder.LocalPort()
-	if err != nil {
-		nt.T.Fatal(err)
+	var port int
+	// port argument is used for in-cluster git provider with the local port forward.
+	// the argument is ignored for other providers, e.g. Gitlab/Bitbucket
+	if nt.gitRepoPortForwarder != nil {
+		var err error
+		port, err = nt.gitRepoPortForwarder.LocalPort()
+		if err != nil {
+			nt.T.Fatal(err)
+		}
 	}
 	// Update URL to use latest port-forward port
 	g.RemoteURL = nt.GitProvider.RemoteURL(port, g.RemoteRepoName)


### PR DESCRIPTION
The port argument only needs to be provided for the in-cluster git provider. In other cases, such as Gitlab or Bitbucket, the gitRepoPortForwarder is nil and the port argument is unused. This updates the logic for git repository setup to support the other git provider types.