### PR TITLE
Fix vulnerabilities.sh uniqueness filter

### DIFF
--- a/scripts/vulnerabilities.sh
+++ b/scripts/vulnerabilities.sh
@@ -65,7 +65,7 @@ find_manifest_images_by_name() {
   image_name="$1"
   grep -roh --color=never \
     "${image_name}:\S*" \
-    ./manifests/ | uniq -u
+    ./manifests/ | uniq
 }
 
 # Build a full list of images with tags


### PR DESCRIPTION
The -u flag was showing only the unique values, which isn't what we wanted. Now it reduces duplicate entries to single entries as intended.