### PR TITLE
test: refactor git portforwarder under gitprovider

### DIFF
--- a/e2e/nomostest/gitproviders/bitbucket.go
+++ b/e2e/nomostest/gitproviders/bitbucket.go
@@ -71,8 +71,8 @@ func (b *BitbucketClient) Type() string {
 
 // RemoteURL returns the Git URL for the Bitbucket repository.
 // name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
-func (b *BitbucketClient) RemoteURL(_ int, name string) string {
-	return b.SyncURL(name)
+func (b *BitbucketClient) RemoteURL(name string) (string, error) {
+	return b.SyncURL(name), nil
 }
 
 // SyncURL returns a URL for Config Sync to sync from.

--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -16,6 +16,7 @@ package gitproviders
 
 import (
 	"kpt.dev/configsync/e2e"
+	"kpt.dev/configsync/e2e/nomostest/portforwarder"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 )
 
@@ -33,7 +34,7 @@ type GitProvider interface {
 	// For the testing git-server, RemoteURL uses localhost and forwarded port, while SyncURL uses the DNS.
 	// For other git providers, RemoteURL should be the same as SyncURL.
 	// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
-	RemoteURL(port int, name string) string
+	RemoteURL(name string) (string, error)
 
 	// SyncURL returns the git repository URL for Config Sync to sync from.
 	// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
@@ -43,8 +44,29 @@ type GitProvider interface {
 	DeleteObsoleteRepos() error
 }
 
+// GitProviderOpt is an optional parameter for instantiating a new GitProvider
+type GitProviderOpt func(opts *GitProviderOpts)
+
+// GitProviderOpts is the set of optional parameters for instantiating a new GitProvider
+type GitProviderOpts struct {
+	portForwarder *portforwarder.PortForwarder
+}
+
+// WithPortForwarder provides a PortForwarder for the GitProvider to use.
+// Required for LocalProvider in order to establish a PortForwarder to the in-cluster
+// git server.
+func WithPortForwarder(portForwarder *portforwarder.PortForwarder) GitProviderOpt {
+	return func(opts *GitProviderOpts) {
+		opts.portForwarder = portForwarder
+	}
+}
+
 // NewGitProvider creates a GitProvider for the specific provider type.
-func NewGitProvider(t testing.NTB, provider string) GitProvider {
+func NewGitProvider(t testing.NTB, provider string, opts ...GitProviderOpt) GitProvider {
+	options := GitProviderOpts{}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	switch provider {
 	case e2e.Bitbucket:
 		client, err := newBitbucketClient()
@@ -59,6 +81,10 @@ func NewGitProvider(t testing.NTB, provider string) GitProvider {
 		}
 		return client
 	default:
-		return &LocalProvider{}
+		client, err := newLocalProvider(options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return client
 	}
 }

--- a/e2e/nomostest/gitproviders/gitlab.go
+++ b/e2e/nomostest/gitproviders/gitlab.go
@@ -56,8 +56,8 @@ func (g *GitlabClient) Type() string {
 }
 
 // RemoteURL returns the Git URL for the Gitlab project repository.
-func (g *GitlabClient) RemoteURL(_ int, name string) string {
-	return g.SyncURL(name)
+func (g *GitlabClient) RemoteURL(name string) (string, error) {
+	return g.SyncURL(name), nil
 }
 
 // SyncURL returns a URL for Config Sync to sync from.

--- a/e2e/nomostest/portforwarder/port_forwarder.go
+++ b/e2e/nomostest/portforwarder/port_forwarder.go
@@ -118,17 +118,19 @@ func (pf *PortForwarder) LocalPort() (int, error) {
 }
 
 func (pf *PortForwarder) setPort(cmd *exec.Cmd, port int, pod string, async bool) {
+	pf.logger.Infof("updating port-forward %s:%d -> %s:%d", pf.pod, pf.localPort, pod, port)
 	if async {
 		pf.mux.Lock()
-		defer pf.mux.Unlock()
-	}
-	pf.logger.Infof("updating port-forward %s:%d -> %s:%d", pf.pod, pf.localPort, pod, port)
-	if pf.setPortCallback != nil {
-		pf.setPortCallback(port, pod)
 	}
 	pf.cmd = cmd
 	pf.localPort = port
 	pf.pod = pod
+	if async {
+		pf.mux.Unlock()
+	}
+	if pf.setPortCallback != nil {
+		pf.setPortCallback(port, pod)
+	}
 }
 
 // portForwardToPod establishes a port forwarding to the provided pod name. This
@@ -188,7 +190,7 @@ func (pf *PortForwarder) portForwardToDeployment(async bool) error {
 	// subprocess will be killed with the context, and we get a random port every
 	// time. However, this cleans up subprocesses in the interim.
 	if pf.cmd != nil {
-		pf.logger.Info("stopping port-forward process for %s/%s", pf.ns, pf.deployment)
+		pf.logger.Infof("stopping port-forward process for %s/%s", pf.ns, pf.deployment)
 		if err := pf.cmd.Process.Kill(); err != nil && errors.Is(err, os.ErrProcessDone) {
 			return errors.Wrap(err, "failed to kill port forward process")
 		}


### PR DESCRIPTION
This refactors the git port forwarder abstraction to be underneath the git provider. The git port forwarder is only relevant with the in-cluster git server, and thus fits as an implementation detail of the LocalProvider.