### PR TITLE
test: init GitProvider before setupTestCase

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -622,6 +622,14 @@ func (nt *NT) portForwardGitServer() *portforwarder.PortForwarder {
 	)
 }
 
+func (nt *NT) initGitProvider() {
+	var gitProviderOpts []gitproviders.GitProviderOpt
+	if *e2e.GitProvider == e2e.Local {
+		gitProviderOpts = append(gitProviderOpts, gitproviders.WithPortForwarder(nt.portForwardGitServer()))
+	}
+	nt.GitProvider = gitproviders.NewGitProvider(nt.T, *e2e.GitProvider, gitProviderOpts...)
+}
+
 // portForwardGitServer forwards the prometheus deployment to a port.
 func (nt *NT) portForwardPrometheus() {
 	nt.T.Helper()


### PR DESCRIPTION
There are certain code paths which expect the GitProvider to be set, such as Clean for shared test environments on GKE. Initializing the GitProvider later in setupTestCase was leading to a null pointer exception. This moves the initialization to FreshTestEnv/SharedTestEnv.