### PR TITLE
test: set GitProvider in ReInit

### DIFF
--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -153,6 +153,9 @@ func (g *Repository) ReInit(nt *NT, sourceFormat filesystem.SourceFormat) {
 
 	// Update test environment
 	g.T = nt.T
+	// GitProvider must be set to use the current NT's GitProvider.
+	// Using a stale GitProvider can lead to using a PortForwarder which has already been closed.
+	g.GitProvider = nt.GitProvider
 	// Reset repo contents
 	g.init(nt.gitPrivateKeyPath)
 	g.initialCommit(sourceFormat)


### PR DESCRIPTION
The GitProvider must be set here, otherwise the Repository may be using a GitProvider from a previous NT. Using a stale GitProvider means that the PortForwarder will be closed, since it is closed at the end of the test.