### PR TITLE
test: use RemoteRepositories for setPortCallback

### DIFF
--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -153,9 +153,6 @@ func (g *Repository) ReInit(nt *NT, sourceFormat filesystem.SourceFormat) {
 
 	// Update test environment
 	g.T = nt.T
-	// GitProvider must be set to use the current NT's GitProvider.
-	// Using a stale GitProvider can lead to using a PortForwarder which has already been closed.
-	g.GitProvider = nt.GitProvider
 	// Reset repo contents
 	g.init(nt.gitPrivateKeyPath)
 	g.initialCommit(sourceFormat)

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -180,6 +180,7 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		Scheme:                  sharedNt.Scheme,
 		RemoteRepositories:      sharedNt.RemoteRepositories,
 		WebhookDisabled:         sharedNt.WebhookDisabled,
+		GitProvider:             sharedNt.GitProvider,
 	}
 
 	if opts.SkipConfigSyncInstall {
@@ -187,11 +188,6 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	}
 
 	nt.detectGKEAutopilot(opts.SkipAutopilot)
-
-	// re-init the GitProvider.
-	// The setPortCallback must be registered for this NT so that it initializes
-	// the correct repositories.
-	nt.initGitProvider()
 
 	// Print container logs in its own cleanup block to catch fatal errors from
 	// tests and test setup (including resetSyncedRepos).

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -600,10 +600,7 @@ func (nt *NT) portForwardGitServer() *portforwarder.PortForwarder {
 		}
 		// allRepos specifies the slice all repos for port forwarding.
 		var allRepos []types.NamespacedName
-		for repo := range nt.RootRepos {
-			allRepos = append(allRepos, RootSyncNN(repo))
-		}
-		for repo := range nt.NonRootRepos {
+		for repo := range nt.RemoteRepositories {
 			allRepos = append(allRepos, repo)
 		}
 		// re-init all repos


### PR DESCRIPTION
The RootRepos/NonRootRepos fields are reset for every testcase, which required for the PortForwarder to be recreated with each testcase. This switches the reset function to use RemoteRepositories, which represents all Repositories that have been created (across test cases). This change enables us to create a single GitProvider in FreshTestEnv and share it across shared test environments. This also means there is only a single PortForwarder to the git server active at a given time, which is preferred.