### PR TITLE
extend portforward watch timeout and improve logging

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -242,6 +242,7 @@ func InitGitRepos(nt *NT, repos ...types.NamespacedName) {
 	podName := pod.Name
 
 	for _, repo := range repos {
+		nt.T.Logf("initializing repo %s", repo.String())
 		nt.MustKubectl("exec", "-n", testGitNamespace, podName, "-c", testGitServer, "--",
 			"git", "init", "--bare", "--shared", fmt.Sprintf("/git-server/repos/%s/%s", repo.Namespace, repo.Name))
 		// We set receive.denyNonFastforwards to allow force pushes for legacy test support (bats).  In the future we may

--- a/e2e/nomostest/git.go
+++ b/e2e/nomostest/git.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -508,12 +509,12 @@ func (g *Repository) Push(refspec string, flags ...string) {
 		args = append(args, flags...)
 		remoteURL, err := g.GitProvider.RemoteURL(g.RemoteRepoName)
 		if err != nil {
-			return err
+			return errors.Wrap(err, fmt.Sprintf("failed to get URL for remote to repo %s", g.RemoteRepoName))
 		}
 		args = append(args, remoteURL, refspec)
 		cmd := g.gitCmd(args...)
 		out, err = cmd.CombinedOutput()
-		return err
+		return errors.Wrap(err, fmt.Sprintf("failed to push to remote %s", remoteURL))
 	})
 	if err != nil {
 		g.T.Log(string(out))
@@ -526,6 +527,7 @@ func (g *Repository) pushAllToRemote() {
 	if err != nil {
 		g.T.Errorf("failed to get remote URL: %v", err)
 	}
+	g.Logger.Infof("push all refs to remote %s", remote)
 	cmd := g.gitCmd("push", remote, "--all")
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
The timeout was not long enough for some CI jobs, e.g. autopilot. This also improves the logging in a few key areas to help with debugging.