### PR TITLE
test: restart PortForwarder if process is killed

### DIFF
--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -16,7 +16,6 @@ package gitproviders
 
 import (
 	"kpt.dev/configsync/e2e"
-	"kpt.dev/configsync/e2e/nomostest/portforwarder"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 )
 
@@ -44,29 +43,8 @@ type GitProvider interface {
 	DeleteObsoleteRepos() error
 }
 
-// GitProviderOpt is an optional parameter for instantiating a new GitProvider
-type GitProviderOpt func(opts *GitProviderOpts)
-
-// GitProviderOpts is the set of optional parameters for instantiating a new GitProvider
-type GitProviderOpts struct {
-	portForwarder *portforwarder.PortForwarder
-}
-
-// WithPortForwarder provides a PortForwarder for the GitProvider to use.
-// Required for LocalProvider in order to establish a PortForwarder to the in-cluster
-// git server.
-func WithPortForwarder(portForwarder *portforwarder.PortForwarder) GitProviderOpt {
-	return func(opts *GitProviderOpts) {
-		opts.portForwarder = portForwarder
-	}
-}
-
 // NewGitProvider creates a GitProvider for the specific provider type.
-func NewGitProvider(t testing.NTB, provider string, opts ...GitProviderOpt) GitProvider {
-	options := GitProviderOpts{}
-	for _, opt := range opts {
-		opt(&options)
-	}
+func NewGitProvider(t testing.NTB, provider string) GitProvider {
 	switch provider {
 	case e2e.Bitbucket:
 		client, err := newBitbucketClient()
@@ -81,10 +59,6 @@ func NewGitProvider(t testing.NTB, provider string, opts ...GitProviderOpt) GitP
 		}
 		return client
 	default:
-		client, err := newLocalProvider(options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return client
+		return &LocalProvider{}
 	}
 }


### PR DESCRIPTION
Prior to this change the port forward was restarted only if the Pod was
restarted. This change makes it so that the port forward is restarted
either if the Pod is restarted or if the port-forward process is killed.