### PR TITLE
Update gcenode-askpass-sidecar to 20230410212312

### DIFF
--- a/pkg/reconcilermanager/controllers/gcenode_askpass_sidecar.go
+++ b/pkg/reconcilermanager/controllers/gcenode_askpass_sidecar.go
@@ -24,7 +24,7 @@ import (
 const (
 	// The GCENode* values are interpolated in the prepareGCENodeSnippet function
 	// Keep the image tag consistent with nomos-operator.
-	gceNodeAskpassImageTag = "20220326001639"
+	gceNodeAskpassImageTag = "20230410212312"
 	// GceNodeAskpassSidecarName is the container name of gcenode-askpass-sidecar.
 	GceNodeAskpassSidecarName = "gcenode-askpass-sidecar"
 	// gceNodeAskpassPort is the port number of the askpass-sidecar container.


### PR DESCRIPTION
This fixes a few CVEs by using Go 1.9