### PR TITLE
Notification helper functions

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -55,7 +55,7 @@ test-e2e-kind-multi-repo-test-group1:
 # This target runs the second group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group2
 test-e2e-kind-multi-repo-test-group2:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1" test-e2e-kind-multi-repo
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1,notification" test-e2e-kind-multi-repo
 
 # This target runs the third group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group3

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -92,5 +92,5 @@ test-e2e-gke-multi-repo-test-group7:
 
 # The CI target that runs the eighth group of tests with the multi-repo mode on GKE cluster.
 test-e2e-gke-multi-repo-test-group8:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --share-test-env --test-features=workload-identity" \
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --share-test-env --test-features=workload-identity,notification" \
 		test-e2e-go-gke-ci

--- a/e2e/nomostest/testing/feature.go
+++ b/e2e/nomostest/testing/feature.go
@@ -42,6 +42,8 @@ const (
 	SyncSource = "sync-source"
 	// WorkloadIdentity verifies authenticating with workload identity (GKE and Fleet).
 	WorkloadIdentity = "workload-identity"
+	// Notification verifies the notification feature
+	Notification = "notification"
 )
 
 // KnownFeature indicates whether the test verifies a known feature
@@ -49,7 +51,7 @@ func KnownFeature(f Feature) bool {
 	switch f {
 	case ACMController, NomosCLI, ClusterSelector, DriftControl, Hydration,
 		Lifecycle, MultiRepos, OverrideAPI, Reconciliation1, Reconciliation2,
-		SyncSource, WorkloadIdentity:
+		SyncSource, WorkloadIdentity, Notification:
 		return true
 	}
 	return false

--- a/e2e/testcases/notification_test.go
+++ b/e2e/testcases/notification_test.go
@@ -15,10 +15,9 @@
 package e2e
 
 import (
-	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"kpt.dev/configsync/e2e/nomostest"
@@ -29,9 +28,24 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/cli-utils/pkg/object/dependson"
+)
+
+const (
+	// password for RootSync notifications
+	rootSyncNotificationPassword = "pass123"
+	// hash of "user:pass123" (base64)
+	rootSyncNotificationCredentialHash = "Basic dXNlcjpwYXNzMTIz"
+	// password for RepoSync notifications
+	repoSyncNotificationPassword = "pass456"
+	// hash of "user:pass456" (base64)
+	repoSyncNotificationCredentialHash = "Basic dXNlcjpwYXNzNDU2"
 )
 
 func TestNotification(t *testing.T) {
@@ -39,7 +53,7 @@ func TestNotification(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	rootReconcilerName := core.RootReconcilerName(rootSyncNN.Name)
 	nsReconcilerName := core.NsReconcilerName(repoSyncNN.Namespace, repoSyncNN.Name)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.Notification,
 		ntopts.Unstructured,
 		ntopts.InstallNotificationServer,
 		ntopts.RootRepo(rootSyncNN.Name),
@@ -47,8 +61,8 @@ func TestNotification(t *testing.T) {
 	)
 	var err error
 	credentialMap := map[string]string{
-		rootSyncNN.Namespace: "pass123",
-		repoSyncNN.Namespace: "pass456",
+		rootSyncNN.Namespace: rootSyncNotificationPassword,
+		repoSyncNN.Namespace: repoSyncNotificationPassword,
 	}
 	for ns, pass := range credentialMap {
 		_, err = nomostest.NotificationSecret(nt, ns,
@@ -117,7 +131,7 @@ func TestNotification(t *testing.T) {
 		Records: []nomostest.NotificationRecord{
 			{
 				Message: "{\n  \"content\": {\n    \"raw\": \"RootSync root-sync-2 is synced!\"\n  }\n}",
-				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass123"))), // base64 encoded username/pass
+				Auth:    rootSyncNotificationCredentialHash, // base64 encoded username/pass
 			},
 		},
 	}, *records)
@@ -173,11 +187,11 @@ func TestNotification(t *testing.T) {
 		Records: []nomostest.NotificationRecord{
 			{
 				Message: "{\n  \"content\": {\n    \"raw\": \"RootSync root-sync-2 is synced!\"\n  }\n}",
-				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass123"))), // base64 encoded username/pass
+				Auth:    rootSyncNotificationCredentialHash, // base64 encoded username/pass
 			},
 			{
 				Message: "{\n  \"content\": {\n    \"raw\": \"RepoSync repo-sync is synced!\"\n  }\n}",
-				Auth:    fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass456"))), // base64 encoded username/pass
+				Auth:    repoSyncNotificationCredentialHash, // base64 encoded username/pass
 			},
 		},
 	}, *records)
@@ -238,10 +252,207 @@ func TestNotification(t *testing.T) {
 	}
 }
 
+func TestNotificationOnSyncFailed(t *testing.T) {
+	rootSyncNN := nomostest.RootSyncNN("root-sync-2")
+	rootReconcilerName := core.RootReconcilerName(rootSyncNN.Name)
+	nt := nomostest.New(t, nomostesting.Notification,
+		ntopts.Unstructured,
+		ntopts.InstallNotificationServer,
+		ntopts.RootRepo(rootSyncNN.Name),
+	)
+	var err error
+	credentialMap := map[string]string{
+		rootSyncNN.Namespace: rootSyncNotificationPassword,
+	}
+	for ns, pass := range credentialMap {
+		_, err = nomostest.NotificationSecret(nt, ns,
+			nomostest.WithNotificationUsername("user"),
+			nomostest.WithNotificationPassword(pass),
+		)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+		_, err = nomostest.NotificationConfigMap(nt, ns,
+			nomostest.WithOnSyncFailedTrigger,
+			nomostest.WithSyncFailedTemplate,
+			nomostest.WithLocalWebhookService,
+		)
+		if err != nil {
+			nt.T.Fatal(err)
+		}
+	}
+	// Enable notifications on RootSync
+	rootSync := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncNN.Name)
+	nomostest.SubscribeRootSyncNotification(rootSync, "on-sync-failed", "local")
+	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(rootSyncNN.Namespace, rootSyncNN.Name), rootSync)
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush("Enable notifications on RootSync")
+	err = nt.Watcher.WatchObject(kinds.Deployment(), rootReconcilerName, rootSyncNN.Namespace,
+		[]testpredicates.Predicate{testpredicates.DeploymentHasContainer(reconcilermanager.Notification)})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// cause the RootSync to break
+	rootSync.Spec.Git.Branch = "nonexistent-branch"
+	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(rootSyncNN.Namespace, rootSyncNN.Name), rootSync)
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Switch RootSync %s to nonexistent-branch", rootSyncNN.Name))
+	nt.WaitForRootSyncSourceError(rootSyncNN.Name,
+		status.SourceErrorCode,
+		"Remote branch nonexistent-branch not found in upstream")
+	// query RootSync to get the generation
+	rootSyncObj := &v1beta1.RootSync{}
+	if err := nt.KubeClient.Get(rootSyncNN.Name, rootSyncNN.Namespace, rootSyncObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	// first iteration should set AlreadyNotified to false, subsequently true
+	// skip the false check as it is a race condition whether we catch it
+	err = nt.Watcher.WatchObject(kinds.NotificationV1Beta1(), rootSyncNN.Name, rootSyncNN.Namespace,
+		[]testpredicates.Predicate{testpredicates.NotificationHasStatus(v1beta1.NotificationStatus{
+			ObservedGeneration: rootSyncObj.Generation,
+			Commit:             "", // commit is empty, because the Syncing condition does not have the commit
+			Deliveries: []v1beta1.NotificationDelivery{
+				{
+					Trigger:         "on-sync-failed",
+					Service:         "local",
+					Recipient:       "",
+					AlreadyNotified: true,
+				},
+			},
+		})},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// notification from first branch failure, including warning of new known host
+	// notification from first branch failure
+	records, err := waitForNotifications(nt, 2)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// first notification error includes a warning of known host added which includes an IP address.
+	// the IP address is dynamic, so skip checking the message for the first notification
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[0].Auth)
+	// subsequent git-sync iterations do not include the warning, but otherwise should
+	// surface a stable error message.
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[1].Auth)
+	// note the commit is empty because the branch does not exist
+	require.Equal(t, `{
+  "content": {
+    "raw": "RootSync root-sync-2 failed to sync commit  on branch nonexistent-branch!\n\nKNV2004: error in the git-sync container: {\"Msg\":\"error syncing repo, will retry\",\"Err\":\"Run(git clone -v --no-checkout -b nonexistent-branch --depth 1 git@test-git-server.config-management-system-test:/git-server/repos/config-management-system/root-sync-2 /repo/source): exit status 128: { stdout: \\\"\\\", stderr: \\\"Cloning into \'/repo/source\'...\\\\nwarning: Could not find remote branch nonexistent-branch to clone.\\\\nfatal: Remote branch nonexistent-branch not found in upstream origin\\\\nfatal: The remote end hung up unexpectedly\\\" }\"}\u000A\u000AFor more information, see https://g.co/cloud/acm-errors#knv2004\n\n"
+  }
+}`, records.Records[1].Message)
+	// creating a new error should produce another notification
+	rootSync.Spec.Git.Branch = "another-nonexistent-branch"
+	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(rootSyncNN.Namespace, rootSyncNN.Name), rootSync)
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Switch RootSync %s to another-nonexistent-branch", rootSyncNN.Name))
+	nt.WaitForRootSyncSourceError(rootSyncNN.Name,
+		status.SourceErrorCode,
+		"Remote branch another-nonexistent-branch not found in upstream")
+	// query RootSync to get the generation
+	rootSyncObj = &v1beta1.RootSync{}
+	if err := nt.KubeClient.Get(rootSyncNN.Name, rootSyncNN.Namespace, rootSyncObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	// first iteration should set AlreadyNotified to false, subsequently true
+	// skip the false check as it is a race condition whether we catch it
+	err = nt.Watcher.WatchObject(kinds.NotificationV1Beta1(), rootSyncNN.Name, rootSyncNN.Namespace,
+		[]testpredicates.Predicate{testpredicates.NotificationHasStatus(v1beta1.NotificationStatus{
+			ObservedGeneration: rootSyncObj.Generation,
+			Commit:             "", // commit is empty, because the Syncing condition does not have the commit
+			Deliveries: []v1beta1.NotificationDelivery{
+				{
+					Trigger:         "on-sync-failed",
+					Service:         "local",
+					Recipient:       "",
+					AlreadyNotified: true,
+				},
+			},
+		})},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// notification from first branch failure, including warning of new known host
+	// notification from first branch failure
+	// notification of second branch failure, including warning of new known host
+	// notification of second branch failure
+	records, err = waitForNotifications(nt, 4)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// first notification error includes a warning of known host added which includes an IP address.
+	// the IP address is dynamic, so skip checking the message for the first notification
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[2].Auth)
+	// subsequent git-sync iterations do not include the warning, but otherwise should
+	// surface a stable error message.
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[3].Auth)
+	// note the commit is empty because the branch does not exist
+	require.Equal(t, `{
+  "content": {
+    "raw": "RootSync root-sync-2 failed to sync commit  on branch another-nonexistent-branch!\n\nKNV2004: error in the git-sync container: {\"Msg\":\"error syncing repo, will retry\",\"Err\":\"Run(git clone -v --no-checkout -b another-nonexistent-branch --depth 1 git@test-git-server.config-management-system-test:/git-server/repos/config-management-system/root-sync-2 /repo/source): exit status 128: { stdout: \\\"\\\", stderr: \\\"Cloning into \'/repo/source\'...\\\\nwarning: Could not find remote branch another-nonexistent-branch to clone.\\\\nfatal: Remote branch another-nonexistent-branch not found in upstream origin\\\\nfatal: The remote end hung up unexpectedly\\\" }\"}\u000A\u000AFor more information, see https://g.co/cloud/acm-errors#knv2004\n\n"
+  }
+}`, records.Records[3].Message)
+	// fix the RootSync by resetting to a valid branch
+	rootSync.Spec.Git.Branch = nomostest.MainBranch
+	nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(rootSyncNN.Namespace, rootSyncNN.Name), rootSync)
+	nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Switch RootSync %s to master", rootSyncNN.Name))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+	// creating a new Syncing failure based on the contents of a commit
+	namespaceName := "bookstore"
+	cm1Name := "cm1"
+	cm2Name := "cm2"
+	namespace := fake.NamespaceObject(namespaceName)
+	nt.RootRepos[rootSyncNN.Name].Add("acme/ns.yaml", namespace)
+	// cm1 depends on cm2
+	nt.RootRepos[rootSyncNN.Name].Add("acme/cm1.yaml", fake.ConfigMapObject(core.Name(cm1Name), core.Namespace(namespaceName),
+		core.Annotation(dependson.Annotation, "/namespaces/bookstore/ConfigMap/cm2")))
+	// cm2 depends on cm1
+	nt.RootRepos[rootSyncNN.Name].Add("acme/cm2.yaml", fake.ConfigMapObject(core.Name(cm2Name), core.Namespace(namespaceName),
+		core.Annotation(dependson.Annotation, "/namespaces/bookstore/ConfigMap/cm1")))
+	nt.RootRepos[rootSyncNN.Name].CommitAndPush("Add namespace, and ConfigMaps (cm1 and cm2) which depend on each other")
+	nt.WaitForRootSyncSyncError(rootSyncNN.Name,
+		applier.ApplierErrorCode,
+		"cyclic dependency")
+	// notification of conflicting depends-on relationships
+	records, err = waitForNotifications(nt, 5)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	commit := nt.RootRepos[rootSyncNN.Name].Hash()
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[4].Auth)
+	require.Equal(t, fmt.Sprintf(`{
+  "content": {
+    "raw": "RootSync root-sync-2 failed to sync commit %s on branch main!\n\nKNV2009: invalid objects: [\"bookstore_cm1__ConfigMap\", \"bookstore_cm2__ConfigMap\"] cyclic dependency: /namespaces/bookstore/ConfigMap/cm1 -\u003E /namespaces/bookstore/ConfigMap/cm2; /namespaces/bookstore/ConfigMap/cm2 -\u003E /namespaces/bookstore/ConfigMap/cm1\u000A\u000AFor more information, see https://g.co/cloud/acm-errors#knv2009\n\n"
+  }
+}`, commit), records.Records[4].Message)
+	// push a new commit which should produce another notification with the same error
+	cm3Name := "cm3"
+	nt.RootRepos[rootSyncNN.Name].Add("acme/cm3.yaml", fake.ConfigMapObject(core.Name(cm3Name), core.Namespace(namespaceName)))
+	nt.RootRepos[rootSyncNN.Name].CommitAndPush("Add ConfigMap cm3")
+	nt.WaitForRootSyncSyncError(rootSyncNN.Name,
+		applier.ApplierErrorCode,
+		"cyclic dependency")
+	// same notification of conflicting depends-on relationships, but for a new commit.
+	// commit is included as part of the unique key for the trigger (oncePer)
+	records, err = waitForNotifications(nt, 6)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	commit = nt.RootRepos[rootSyncNN.Name].Hash()
+	require.Equal(t, rootSyncNotificationCredentialHash, records.Records[5].Auth)
+	require.Equal(t, fmt.Sprintf(`{
+  "content": {
+    "raw": "RootSync root-sync-2 failed to sync commit %s on branch main!\n\nKNV2009: invalid objects: [\"bookstore_cm1__ConfigMap\", \"bookstore_cm2__ConfigMap\"] cyclic dependency: /namespaces/bookstore/ConfigMap/cm1 -\u003E /namespaces/bookstore/ConfigMap/cm2; /namespaces/bookstore/ConfigMap/cm2 -\u003E /namespaces/bookstore/ConfigMap/cm1\u000A\u000AFor more information, see https://g.co/cloud/acm-errors#knv2009\n\n"
+  }
+}`, commit), records.Records[5].Message)
+}
+
 func waitForNotifications(nt *nomostest.NT, expectedNum int) (*nomostest.NotificationRecords, error) {
 	var records *nomostest.NotificationRecords
 	var err error
-	took, err := retry.Retry(30*time.Second, func() error {
+	took, err := retry.Retry(nt.DefaultWaitTimeout, func() error {
 		records, err = nt.NotificationServer.DoGet()
 		if err != nil {
 			return err
@@ -251,7 +462,11 @@ func waitForNotifications(nt *nomostest.NT, expectedNum int) (*nomostest.Notific
 		}
 		return nil
 	})
+
 	nt.T.Logf("took %v to wait for %d notification(s). Got %d", took, expectedNum, len(records.Records))
+	if jsonStr, err := json.MarshalIndent(records.Records, "", "  "); err == nil {
+		nt.T.Logf("records:\n%s", jsonStr)
+	}
 	if err != nil {
 		return records, err
 	} else if len(records.Records) != expectedNum { // check if got more records than expected

--- a/pkg/notifications/expressions/strings/strings.go
+++ b/pkg/notifications/expressions/strings/strings.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// New returns the expression functions for "strings"
+// this is a set of helper functions for strings
+func New() map[string]interface{} {
+	return map[string]interface{}{
+		"Join": join,
+		"Hash": hash,
+	}
+}
+
+func join(arr interface{}, sep string) string {
+	stringArr, ok := arr.([]string)
+	if ok {
+		return strings.Join(stringArr, sep)
+	}
+	// try to convert []interface{} to []string
+	interfaceArr, ok := arr.([]interface{})
+	if !ok {
+		klog.Warningf("expected array but got %T", arr)
+		return ""
+	}
+	stringArr = make([]string, len(interfaceArr))
+	for i, val := range interfaceArr {
+		stringElement, ok := val.(string)
+		if ok {
+			stringArr[i] = stringElement
+		} else {
+			klog.Warningf("expected string elements but got %T", val)
+			return ""
+		}
+	}
+	return strings.Join(stringArr, sep)
+}
+
+func hash(input string) string {
+	h := sha1.New()
+	_, _ = h.Write([]byte(input))
+	hash := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	klog.Infof("hash: %s\n%s", hash, input)
+	return hash
+}

--- a/pkg/notifications/expressions/strings/strings_test.go
+++ b/pkg/notifications/expressions/strings/strings_test.go
@@ -1,0 +1,92 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import "testing"
+
+func TestJoin(t *testing.T) {
+	testCases := []struct {
+		description string
+		arr         interface{}
+		sep         string
+		expected    string
+	}{
+		{
+			description: "join a string array",
+			arr:         []string{"foo", "bar"},
+			sep:         ",",
+			expected:    "foo,bar",
+		},
+		{
+			description: "join an interface array with one string",
+			arr:         []interface{}{"foo"},
+			sep:         ",",
+			expected:    "foo",
+		},
+		{
+			description: "join an interface array with multiple strings and , separator",
+			arr:         []interface{}{"foo", "bar", "baz"},
+			sep:         ",",
+			expected:    "foo,bar,baz",
+		},
+		{
+			description: "join an interface array with multiple strings and | separator",
+			arr:         []interface{}{"foo", "bar", "baz"},
+			sep:         "|",
+			expected:    "foo|bar|baz",
+		},
+		{
+			description: "invalid input type",
+			arr:         map[string]interface{}{"foo": "bar"},
+			sep:         ",",
+			expected:    "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			output := join(tc.arr, tc.sep)
+			if output != tc.expected {
+				t.Errorf("want %s, got %s", tc.expected, output)
+			}
+		})
+	}
+}
+
+func TestHash(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "hash an empty string",
+			input:       "",
+			expected:    "2jmj7l5rSw0yVb_vlWAYkK_YBwk",
+		},
+		{
+			description: "hash a string",
+			input:       "foo bar baz",
+			expected:    "x1Z-izniQo44v5ySJqxo3kxn3Dk",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			output := hash(tc.input)
+			if output != tc.expected {
+				t.Errorf("want %s, got %s", tc.expected, output)
+			}
+		})
+	}
+}

--- a/pkg/notifications/expressions/utils/utils.go
+++ b/pkg/notifications/expressions/utils/utils.go
@@ -1,0 +1,88 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/util"
+)
+
+// New returns the expression functions for "utils"
+// this is a set of helper functions for RootSync/RepoSync fields
+func New(obj *unstructured.Unstructured, apiKind string) map[string]interface{} {
+	return map[string]interface{}{
+		"LastCommit":       lastCommit(obj, apiKind),
+		"ConfigSyncErrors": configSyncErrors(obj, apiKind),
+	}
+}
+
+// return the commit from the Syncing condition
+func lastCommit(obj *unstructured.Unstructured, apiKind string) func() string {
+	cached := false
+	commit := ""
+	return func() string {
+		if cached {
+			return commit
+		}
+		cached = true
+		var err error
+		commit, err = util.LastCommit(obj, apiKind)
+		if err != nil {
+			klog.Errorf("failed to parse LastCommit: %v", err)
+		}
+		return commit
+	}
+}
+
+// return an array of all ConfigSyncError from the various status objects
+func configSyncErrors(obj *unstructured.Unstructured, apiKind string) func() []v1beta1.ConfigSyncError {
+	var cached bool
+	var errs []v1beta1.ConfigSyncError
+	return func() []v1beta1.ConfigSyncError {
+		if cached {
+			return errs
+		}
+		cached = true
+		var status *v1beta1.Status
+		switch apiKind {
+		case kinds.RootSyncV1Beta1().Kind:
+			rs := &v1beta1.RootSync{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), rs); err != nil {
+				klog.Errorf("failed to convert unstructured to RootSync: %v", err)
+				return errs
+			}
+			status = &rs.Status.Status
+		case kinds.RepoSyncV1Beta1().Kind:
+			rs := &v1beta1.RepoSync{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), rs); err != nil {
+				klog.Errorf("failed to convert unstructured to RepoSync: %v", err)
+				return errs
+			}
+			status = &rs.Status.Status
+		}
+		if status == nil {
+			klog.Errorf("failed to get Status from unstructured")
+			return errs
+		}
+		errs = append(errs, status.Source.Errors...)
+		errs = append(errs, status.Rendering.Errors...)
+		errs = append(errs, status.Sync.Errors...)
+		return errs
+	}
+}

--- a/pkg/notifications/expressions/utils/utils_test.go
+++ b/pkg/notifications/expressions/utils/utils_test.go
@@ -1,0 +1,263 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+)
+
+func TestLastCommit(t *testing.T) {
+	testCases := []struct {
+		description string
+		obj         runtime.Object
+		apiKind     string
+		expected    string
+	}{
+		{
+			description: "LastCommit for a RootSync",
+			obj: &v1beta1.RootSync{
+				Status: v1beta1.RootSyncStatus{
+					Conditions: []v1beta1.RootSyncCondition{
+						{
+							Type:   v1beta1.RootSyncReconciling,
+							Commit: "foo",
+						},
+						{
+							Type:   v1beta1.RootSyncSyncing,
+							Commit: "bar",
+						},
+					},
+				},
+			},
+			apiKind:  configsync.RootSyncKind,
+			expected: "bar",
+		},
+		{
+			description: "LastCommit for a RootSync with no Syncing condition",
+			obj: &v1beta1.RootSync{
+				Status: v1beta1.RootSyncStatus{
+					Conditions: []v1beta1.RootSyncCondition{
+						{
+							Type:   v1beta1.RootSyncReconciling,
+							Commit: "foo",
+						},
+					},
+				},
+			},
+			apiKind:  configsync.RootSyncKind,
+			expected: "",
+		},
+		{
+			description: "LastCommit for a RepoSync",
+			obj: &v1beta1.RepoSync{
+				Status: v1beta1.RepoSyncStatus{
+					Conditions: []v1beta1.RepoSyncCondition{
+						{
+							Type:   v1beta1.RepoSyncReconciling,
+							Commit: "foo",
+						},
+						{
+							Type:   v1beta1.RepoSyncSyncing,
+							Commit: "bar",
+						},
+					},
+				},
+			},
+			apiKind:  configsync.RepoSyncKind,
+			expected: "bar",
+		},
+		{
+			description: "LastCommit for a RepoSync with no Syncing condition",
+			obj: &v1beta1.RepoSync{
+				Status: v1beta1.RepoSyncStatus{
+					Conditions: []v1beta1.RepoSyncCondition{
+						{
+							Type:   v1beta1.RepoSyncReconciling,
+							Commit: "foo",
+						},
+					},
+				},
+			},
+			apiKind:  configsync.RepoSyncKind,
+			expected: "",
+		},
+		{
+			description: "LastCommit for an unsupported kind",
+			obj:         &corev1.ConfigMap{Data: map[string]string{}},
+			apiKind:     configsync.RepoSyncKind,
+			expected:    "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			un, err := kinds.ToUnstructured(tc.obj, core.Scheme)
+			if err != nil {
+				t.Fatal(err)
+			}
+			output := lastCommit(un, tc.apiKind)()
+			if output != tc.expected {
+				t.Errorf("want %s, got %s", tc.expected, output)
+			}
+		})
+	}
+}
+
+func TestConfigSyncErrors(t *testing.T) {
+	testCases := []struct {
+		description string
+		obj         runtime.Object
+		apiKind     string
+		expected    []v1beta1.ConfigSyncError
+	}{
+		{
+			description: "multiple errors for a RootSync",
+			obj: &v1beta1.RootSync{
+				Status: v1beta1.RootSyncStatus{
+					Status: v1beta1.Status{
+						Source: v1beta1.SourceStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "source error 1"},
+								{ErrorMessage: "source error 2"},
+							},
+						},
+						Rendering: v1beta1.RenderingStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "rendering error 1"},
+								{ErrorMessage: "rendering error 2"},
+							},
+						},
+						Sync: v1beta1.SyncStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "sync error 1"},
+								{ErrorMessage: "sync error 2"},
+							},
+						},
+					},
+				},
+			},
+			apiKind: configsync.RootSyncKind,
+			expected: []v1beta1.ConfigSyncError{
+				{ErrorMessage: "source error 1"},
+				{ErrorMessage: "source error 2"},
+				{ErrorMessage: "rendering error 1"},
+				{ErrorMessage: "rendering error 2"},
+				{ErrorMessage: "sync error 1"},
+				{ErrorMessage: "sync error 2"},
+			},
+		},
+		{
+			description: "sync errors for a RootSync",
+			obj: &v1beta1.RootSync{
+				Status: v1beta1.RootSyncStatus{
+					Status: v1beta1.Status{
+						Source: v1beta1.SourceStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "source error 1"},
+								{ErrorMessage: "source error 2"},
+							},
+						},
+					},
+				},
+			},
+			apiKind: configsync.RootSyncKind,
+			expected: []v1beta1.ConfigSyncError{
+				{ErrorMessage: "source error 1"},
+				{ErrorMessage: "source error 2"},
+			},
+		},
+		{
+			description: "multiple errors for a RepoSync",
+			obj: &v1beta1.RepoSync{
+				Status: v1beta1.RepoSyncStatus{
+					Status: v1beta1.Status{
+						Source: v1beta1.SourceStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "source error 1"},
+								{ErrorMessage: "source error 2"},
+							},
+						},
+						Rendering: v1beta1.RenderingStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "rendering error 1"},
+								{ErrorMessage: "rendering error 2"},
+							},
+						},
+						Sync: v1beta1.SyncStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "sync error 1"},
+								{ErrorMessage: "sync error 2"},
+							},
+						},
+					},
+				},
+			},
+			apiKind: configsync.RepoSyncKind,
+			expected: []v1beta1.ConfigSyncError{
+				{ErrorMessage: "source error 1"},
+				{ErrorMessage: "source error 2"},
+				{ErrorMessage: "rendering error 1"},
+				{ErrorMessage: "rendering error 2"},
+				{ErrorMessage: "sync error 1"},
+				{ErrorMessage: "sync error 2"},
+			},
+		},
+		{
+			description: "sync errors for a RepoSync",
+			obj: &v1beta1.RepoSync{
+				Status: v1beta1.RepoSyncStatus{
+					Status: v1beta1.Status{
+						Source: v1beta1.SourceStatus{
+							Errors: []v1beta1.ConfigSyncError{
+								{ErrorMessage: "source error 1"},
+								{ErrorMessage: "source error 2"},
+							},
+						},
+					},
+				},
+			},
+			apiKind: configsync.RepoSyncKind,
+			expected: []v1beta1.ConfigSyncError{
+				{ErrorMessage: "source error 1"},
+				{ErrorMessage: "source error 2"},
+			},
+		},
+		{
+			description: "errors for an unsupported kind",
+			obj:         &corev1.ConfigMap{Data: map[string]string{}},
+			apiKind:     configsync.RepoSyncKind,
+			expected:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			un, err := kinds.ToUnstructured(tc.obj, core.Scheme)
+			if err != nil {
+				t.Fatal(err)
+			}
+			output := configSyncErrors(un, tc.apiKind)()
+			if !reflect.DeepEqual(tc.expected, output) {
+				t.Fatalf("want %v, got %v", tc.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a set of functions which can be invoked from
notification templates and triggers. These functions are intended to
help with configuring notifications for common use cases, such as a sync
failure.