### PR TITLE
test: improve logging of gitlab/bitbucket cleanup

### DIFF
--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -17,6 +17,7 @@ package gitproviders
 import (
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testlogger"
 )
 
 const (
@@ -44,10 +45,10 @@ type GitProvider interface {
 }
 
 // NewGitProvider creates a GitProvider for the specific provider type.
-func NewGitProvider(t testing.NTB, provider string) GitProvider {
+func NewGitProvider(t testing.NTB, provider string, logger *testlogger.TestLogger) GitProvider {
 	switch provider {
 	case e2e.Bitbucket:
-		client, err := newBitbucketClient()
+		client, err := newBitbucketClient(logger)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/e2e/nomostest/gitproviders/gitlab.go
+++ b/e2e/nomostest/gitproviders/gitlab.go
@@ -185,7 +185,7 @@ func (g *GitlabClient) DeleteRepoByID(ids ...string) error {
 		}
 
 		if !strings.Contains(string(out), "\"message\":\"202 Accepted\"") {
-			return errors.New(string(out))
+			return errors.Errorf("unexpected response in DeleteRepoByID: %s", string(out))
 		}
 	}
 	return errs

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -260,7 +260,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		RemoteRepositories:      make(map[types.NamespacedName]*gitproviders.Repository),
 		WebhookDisabled:         &webhookDisabled,
 		DefaultMetricsTimeout:   30 * time.Second,
-		GitProvider:             gitproviders.NewGitProvider(t, *e2e.GitProvider),
+		GitProvider:             gitproviders.NewGitProvider(t, *e2e.GitProvider, logger),
 	}
 
 	// Speed up the delay between sync attempts to speed up testing


### PR DESCRIPTION
There seem to be some flaky failures in CI around DeleteObsoleteRepos. This extra logging is intended to help identify the source of those errors.