### PR TITLE
chore: fix kubevirt file naming

### DIFF
--- a/e2e/testcases/apply_scoped_resource_test.go
+++ b/e2e/testcases/apply_scoped_resource_test.go
@@ -77,7 +77,7 @@ func TestApplyScopedResources(t *testing.T) {
 		// Avoids KNV2006 since the repo contains a number of cluster scoped resources
 		// https://cloud.google.com/anthos-config-management/docs/reference/errors#knv2006
 		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt-operator.yaml"))
-		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt.io:operator.yaml"))
+		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrole_kubevirt.io-operator.yaml"))
 		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/clusterrolebinding_kubevirt-operator.yaml"))
 		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/priorityclass_kubevirt-cluster-critical.yaml"))
 		nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove cluster roles and priority class"))

--- a/examples/kubevirt-compiled/bookstore1/virtualmachine_testvm.yaml
+++ b/examples/kubevirt-compiled/bookstore1/virtualmachine_testvm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/clusterrole_kubevirt-operator.yaml
+++ b/examples/kubevirt-compiled/clusterrole_kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/clusterrole_kubevirt.io-operator.yaml
+++ b/examples/kubevirt-compiled/clusterrole_kubevirt.io-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ metadata:
   labels:
     operator.kubevirt.io: ""
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: kubevirt.io:operator
+  name: kubevirt.io-operator
 rules:
 - apiGroups:
   - kubevirt.io

--- a/examples/kubevirt-compiled/clusterrolebinding_kubevirt-operator.yaml
+++ b/examples/kubevirt-compiled/clusterrolebinding_kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/customresourcedefinition_kubevirts.kubevirt.io.yaml
+++ b/examples/kubevirt-compiled/customresourcedefinition_kubevirts.kubevirt.io.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/kubevirt/deployment_virt-operator.yaml
+++ b/examples/kubevirt-compiled/kubevirt/deployment_virt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/kubevirt/kubevirt_kubevirt.yaml
+++ b/examples/kubevirt-compiled/kubevirt/kubevirt_kubevirt.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/kubevirt/role_kubevirt-operator.yaml
+++ b/examples/kubevirt-compiled/kubevirt/role_kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/kubevirt/rolebinding_kubevirt-operator-rolebinding.yaml
+++ b/examples/kubevirt-compiled/kubevirt/rolebinding_kubevirt-operator-rolebinding.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/kubevirt/serviceaccount_kubevirt-operator.yaml
+++ b/examples/kubevirt-compiled/kubevirt/serviceaccount_kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/namespace_bookstore1.yaml
+++ b/examples/kubevirt-compiled/namespace_bookstore1.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/namespace_kubevirt.yaml
+++ b/examples/kubevirt-compiled/namespace_kubevirt.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt-compiled/priorityclass_kubevirt-cluster-critical.yaml
+++ b/examples/kubevirt-compiled/priorityclass_kubevirt-cluster-critical.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/kubevirt/README.md
+++ b/examples/kubevirt/README.md
@@ -25,9 +25,13 @@ Here are the steps for updating kubevirt-operator:
   ```
   wget https://github.com/kubevirt/kubevirt/releases/download/v0.58.0/kubevirt-operator.yaml -O kubevirt-operator.yaml
   ```
-* Add the license header into kubevirt-oprator.yaml
+* Add the license header into kubevirt-operator.yaml
   ```
   addlicense -v -c "Google LLC" -f ../../LICENSE_TEMPLATE -ignore=vendor/** kubevirt-operator.yaml 2>&1 | sed '/ skipping: / d'
+  ```
+* Remove colons from resource names. This prevents colons in file names (which break Go import).
+  ```shell
+  sed -i -e 's/kubevirt.io:operator/kubevirt.io-operator/g' kubevirt-operator.yaml
   ```
 * Update the `../kubevirt-compiled` directory
   ```

--- a/examples/kubevirt/kubevirt-operator.yaml
+++ b/examples/kubevirt/kubevirt-operator.yaml
@@ -5469,7 +5469,7 @@ description: "This priority class should be used for core kubevirt components on
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubevirt.io:operator
+  name: kubevirt.io-operator
   labels:
     operator.kubevirt.io: ""
     rbac.authorization.k8s.io/aggregate-to-admin: "true"


### PR DESCRIPTION
The colon in the file name breaks Go imports. This updates the kubevirt examples to not include any colons in file names.

Fixes:
- https://github.com/GoogleContainerTools/kpt-config-sync/issues/552

Context:
- https://github.com/GoogleContainerTools/kpt-config-sync/issues/4
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/8
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/297