### PR TITLE
fix typo in helm chart version

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -40,7 +40,7 @@ const (
 	privateCoreDNSHelmChart        = "coredns"
 	privateNSHelmChart             = "ns-chart"
 	privateNSHelmChartVersion      = "0.1.0"
-	privateSimpleHelmChartVersion  = "v1.0.0"
+	privateSimpleHelmChartVersion  = "1.0.0"
 	privateSimpleHelmChart         = "simple"
 	publicHelmRepo                 = "https://kubernetes-sigs.github.io/metrics-server"
 	publicHelmChart                = "metrics-server"


### PR DESCRIPTION
Accidentally put a v in front of the helm chart version when I should not have. This PR fixes the typo.