### PR TITLE
Add a new reconciler into reconciler-manager (#539)

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -107,6 +107,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	otelSA := controllers.NewOtelSAReconciler(*clusterName, mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName(controllers.OtelSALoggerName),
+		mgr.GetScheme())
+	if err := otelSA.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "OtelSA")
+		os.Exit(1)
+	}
+
 	// Register the OpenCensus views
 	if err := metrics.RegisterReconcilerManagerMetricsViews(); err != nil {
 		setupLog.Error(err, "failed to register OpenCensus views")

--- a/pkg/reconcilermanager/controllers/constants.go
+++ b/pkg/reconcilermanager/controllers/constants.go
@@ -15,10 +15,16 @@
 package controllers
 
 const (
-	// GCPSAAnnotationKey is used to annotate RepoSync/RootSync controller SA when
+	// GCPSAAnnotationKey is used to annotate the following service accounts:
+	// 1) the RepoSync/RootSync controller SA when
 	// spec.git.auth: gcpserviceaccount is used with Workload Identity enabled on a
 	// GKE cluster.
 	// https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+	// 2) the `default` SA in the `config-management-monitoring` namespace, which
+	// is used by the `otel-collector` Deployment. Adding this annotation allows
+	// the `otel-collector` Deployment to impersonate GCP service accounts to
+	// export metrics to Cloud Monitoring and Cloud Monarch on a GKE cluster with
+	// Workload Identity eanbled.
 	GCPSAAnnotationKey = "iam.gke.io/gcp-service-account"
 )
 

--- a/pkg/reconcilermanager/controllers/otel_sa_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_sa_controller.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/status"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ reconcile.Reconciler = &OtelSAReconciler{}
+
+const (
+	defaultSAName = "default"
+	// OtelSALoggerName defines the logger name for OtelSAReconciler
+	OtelSALoggerName = "OtelSA"
+)
+
+// OtelSAReconciler reconciles the default service account under the config-management-monitoring namespace.
+type OtelSAReconciler struct {
+	clusterName string
+	client      client.Client
+	log         logr.Logger
+	scheme      *runtime.Scheme
+}
+
+// NewOtelSAReconciler returns a new OtelSAReconciler.
+func NewOtelSAReconciler(clusterName string, client client.Client, log logr.Logger, scheme *runtime.Scheme) *OtelSAReconciler {
+	if clusterName == "" {
+		clusterName = "unknown_cluster"
+	}
+	return &OtelSAReconciler{
+		clusterName: clusterName,
+		client:      client,
+		log:         log,
+		scheme:      scheme,
+	}
+}
+
+// Reconcile reconciles the default service account under the config-management-monitoring namespace and updates the Deployment annotation.
+// This triggers the `otel-collector` Deployment to restart in the event of an annotation update.
+func (r *OtelSAReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues(OtelSALoggerName, req.NamespacedName.String())
+
+	if req.Name != defaultSAName {
+		return controllerruntime.Result{}, nil
+	}
+
+	sa := &corev1.ServiceAccount{}
+	if err := r.client.Get(ctx, req.NamespacedName, sa); err != nil {
+		if apierrors.IsNotFound(err) {
+			return controllerruntime.Result{}, nil
+		}
+		return controllerruntime.Result{}, status.APIServerErrorf(err, "failed to get service account %s", req.NamespacedName.String())
+	}
+	var v string
+	if sa.GetAnnotations() != nil && len(sa.GetAnnotations()) > 0 {
+		v = sa.GetAnnotations()[GCPSAAnnotationKey]
+	}
+	// Setting the `iam.gke.io/gcp-service-account` annotation on the default service account under the config-management-monitoring
+	// namespace allows the `otel-collector` Deployment to impersonate a GCP service account to export metrics to Cloud Monitoring
+	// and Cloud Monarch on a GKE cluster with Workload Identity eanbled.
+	// On a cluster without Workload Identity, the annotation does not have any effects.
+	// Therefore, we don't check whether the cluster has Workload Identity enabled before updating the Deployment annotation.
+	if err := updateDeploymentAnnotation(ctx, r.client, GCPSAAnnotationKey, v); err != nil {
+		log.Error(err, "Failed to update Deployment")
+		return controllerruntime.Result{}, err
+	}
+	r.log.Info("Deployment annotation patch successful", logFieldObject, fmt.Sprintf("%s/%s", metrics.MonitoringNamespace,
+		metrics.OtelCollectorName), GCPSAAnnotationKey, v)
+	return controllerruntime.Result{}, nil
+}
+
+// SetupWithManager registers otel Service Account controller with reconciler-manager.
+func (r *OtelSAReconciler) SetupWithManager(mgr controllerruntime.Manager) error {
+	// Process create / update events for service accounts in the `config-management-monitoring` namespace.
+	p := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetNamespace() == metrics.MonitoringNamespace
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetNamespace() == metrics.MonitoringNamespace
+		},
+	}
+	return controllerruntime.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		For(&corev1.ServiceAccount{}).
+		WithEventFilter(p).
+		Complete(r)
+}


### PR DESCRIPTION
Add a new reconciler into reconciler-manager watching the default service account under the config-management-monitoring namespace

Currently, to export CS metrics to Cloud Monitoring and Cloud Monarch on a GKE cluster with Workload Identity enabled, the customers need to: 1) bind the `default` service account in the
   `config-management-monitoring` namespace to a GSA with the metric
   writer role;
2) set the `iam.gke.io/gcp-service-account` annotation of the k8s
   service account to the email address of the GSA;
3) restart the `otel-collector` Deployment.

This PR automates the third step by adding a new reconciler into reconciler-manager. The new reconciler watches the default service account under the config-management-monitoring namespace, and adds/updates the `iam.gke.io/gcp-service-account` annotation in the `spec.template.annotation` field of the otel-collector Deployment. This triggers the Deployment to restart in the event of an annotation upate.

The automation of the first two steps will be explored seperately.