### PR TITLE
[CHERRYPICK] test: replace metrics timeout with wait timeout (#565)

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -169,7 +169,6 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		IsGKEAutopilot:          sharedNt.IsGKEAutopilot,
 		DefaultWaitTimeout:      sharedNt.DefaultWaitTimeout,
 		DefaultReconcileTimeout: sharedNt.DefaultReconcileTimeout,
-		DefaultMetricsTimeout:   sharedNt.DefaultMetricsTimeout,
 		kubeconfigPath:          sharedNt.kubeconfigPath,
 		ReconcilerPollingPeriod: sharedNt.ReconcilerPollingPeriod,
 		HydrationPollingPeriod:  sharedNt.HydrationPollingPeriod,
@@ -259,7 +258,6 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		Scheme:                  scheme,
 		RemoteRepositories:      make(map[types.NamespacedName]*gitproviders.Repository),
 		WebhookDisabled:         &webhookDisabled,
-		DefaultMetricsTimeout:   30 * time.Second,
 		GitProvider:             gitproviders.NewGitProvider(t, *e2e.GitProvider),
 	}
 

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -111,12 +111,6 @@ type NT struct {
 	// for object reconcilition.
 	DefaultReconcileTimeout time.Duration
 
-	// DefaultMetricsTimeout is the default timeout for tests to wait for
-	// metrics to match expectations. This needs to be long enough to account
-	// for batched metrics in the agent and collector, but short enough that
-	// the metrics don't expire in the collector.
-	DefaultMetricsTimeout time.Duration
-
 	// RootRepos is the root repositories the cluster is syncing to.
 	// The key is the RootSync name and the value points to the corresponding Repository object.
 	// Each test case was set up with a default RootSync (`root-sync`) installed.

--- a/e2e/nomostest/prometheus_metrics.go
+++ b/e2e/nomostest/prometheus_metrics.go
@@ -51,7 +51,7 @@ func ValidateMetrics(nt *NT, predicates ...MetricsPredicate) error {
 
 	nt.T.Log("[METRICS] validating prometheus metrics...")
 	for i, predicate := range predicates {
-		duration, err := retry.Retry(nt.DefaultMetricsTimeout, func() error {
+		duration, err := retry.Retry(nt.DefaultWaitTimeout, func() error {
 			port, err := nt.prometheusPortForwarder.LocalPort()
 			if err != nil {
 				return err


### PR DESCRIPTION
The metrics validation now gets the dynamic port forward in the retry loop. If the port forward has to restart during the loop, this can take longer than the default metrics timeout (esp on autopilot). This is because under this scenario we may need to wait for the Pod to be ready before we can get a valid port forward. This change replaces the metrics timeout with the standard wait timeout to account for longer delays.