### PR TITLE
Increase the test prometheus memory request (#569)

### DIFF
--- a/e2e/testdata/prometheus/prometheus.yaml
+++ b/e2e/testdata/prometheus/prometheus.yaml
@@ -174,7 +174,7 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 500M
+              memory: 1Gi
             limits:
               cpu: 1
               memory: 1Gi


### PR DESCRIPTION
Recent test failures in release-multi-repo-8-autopilot-rapid-latest were caused by OOMKilled failures in the prometheus container:
```
containerStatuses:
  - containerID: containerd://eda177e63e2c28e473c95a17287015cae17af4503ad8ad04f99a138fa14dfd6f
    image: docker.io/prom/prometheus:v2.37.6
    imageID: docker.io/prom/prometheus@sha256:92ceb93400dd4c887c76685d258bd75b9dcfe3419b71932821e9dcc70288d851
    lastState:
      terminated:
        containerID: containerd://eda177e63e2c28e473c95a17287015cae17af4503ad8ad04f99a138fa14dfd6f
        exitCode: 137
        finishedAt: "2023-05-03T18:05:49Z"
        reason: OOMKilled
        startedAt: "2023-05-03T18:05:16Z"
    name: prometheus
    ready: false
    restartCount: 7
    started: false
    state:
      waiting:
        message: back-off 5m0s restarting failed container=prometheus pod=prometheus-deployment-76f4b58fb4-k7mgj_prometheus(779e3acb-82fc-4430-9946-714aa471ba16)
        reason: CrashLoopBackOff
```
This commit increases the memory request from 500Mi to 1Gi.