### PR TITLE
helm api: allow user to specify a version range

### DIFF
--- a/e2e/testcases/csr_auth_test.go
+++ b/e2e/testcases/csr_auth_test.go
@@ -296,13 +296,13 @@ func testWorkloadIdentity(t *testing.T, testSpec workloadIdentityTestSpec) {
 
 	// For helm charts, we need to push the chart to the AR before configuring the RootSync
 	if testSpec.sourceType == v1beta1.HelmSource {
-		chartName, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
+		remoteHelmChart, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
 		if err != nil {
 			nt.T.Fatalf("failed to push helm chart: %v", err)
 		}
 
-		testSpec.sourceChart = chartName
-		testSpec.rootCommitFn = helmChartVersion(chartName + ":" + testSpec.sourceVersion)
+		testSpec.sourceChart = remoteHelmChart.ChartName
+		testSpec.rootCommitFn = helmChartVersion(remoteHelmChart.ChartName + ":" + testSpec.sourceVersion)
 	}
 
 	// Reuse the RootSync instead of creating a new one so that testing resources can be cleaned up after the test.

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -165,16 +165,16 @@ func TestHelmDefaultNamespace(t *testing.T) {
 		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
 	})
 
-	chartName, err := helm.PushHelmChart(nt, privateSimpleHelmChart, privateSimpleHelmChartVersion)
+	remoteHelmChart, err := helm.PushHelmChart(nt, privateSimpleHelmChart, privateSimpleHelmChartVersion)
 	if err != nil {
 		nt.T.Fatalf("failed to push helm chart: %v", err)
 	}
 
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "namespace": "", "deployNamespace": "", "secretRef": {"name" : "foo"}}}}`,
-		v1beta1.HelmSource, helm.PrivateARHelmRegistry, chartName, privateSimpleHelmChartVersion))
-	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(chartName+":"+privateSimpleHelmChartVersion)),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: chartName}))
+		v1beta1.HelmSource, helm.PrivateARHelmRegistry, remoteHelmChart.ChartName, privateSimpleHelmChartVersion))
+	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateSimpleHelmChartVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -183,6 +183,90 @@ func TestHelmDefaultNamespace(t *testing.T) {
 		nt.T.Error(err)
 	}
 	if err := nt.Validate("deploy-ns", "ns", &appsv1.Deployment{}); err != nil {
+		nt.T.Error(err)
+	}
+}
+
+// TestHelmLatestVersion verifies the Config Sync behavior for helm charts when helm.spec.version is not specified. The helm-sync
+// binary should pull down the latest available version in this case. It also tests that if a new helm chart gets pushed, the
+// chart version gets automatically updated by Config Sync.
+// This test will work only with following pre-requisites:
+// Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
+// A JSON key file is generated for this service account and stored in Secret Manager
+func TestHelmLatestVersion(t *testing.T) {
+	nt := nomostest.New(t,
+		nomostesting.SyncSource,
+		ntopts.Unstructured,
+		ntopts.RequireGKE(t),
+	)
+
+	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	nt.T.Log("Fetch password from Secret Manager")
+	key, err := gitproviders.FetchCloudSecret("config-sync-ci-ar-key")
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Create secret for authentication")
+	_, err = nt.Shell.Kubectl("create", "secret", "generic", "foo", fmt.Sprintf("--namespace=%s", v1.NSConfigManagementSystem), "--from-literal=username=_json_key", fmt.Sprintf("--from-literal=password=%s", key))
+	if err != nil {
+		nt.T.Fatalf("failed to create secret, err: %v", err)
+	}
+	nt.T.Cleanup(func() {
+		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
+	})
+
+	remoteHelmChart, err := helm.PushHelmChart(nt, privateSimpleHelmChart, privateSimpleHelmChartVersion)
+	if err != nil {
+		nt.T.Fatalf("failed to push helm chart: %v", err)
+	}
+
+	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
+	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "", "namespace": "", "deployNamespace": "simple", "secretRef": {"name" : "foo"}}}}`,
+		v1beta1.HelmSource, helm.PrivateARHelmRegistry, remoteHelmChart.ChartName))
+	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateSimpleHelmChartVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.Validate("deploy-default", "simple", &appsv1.Deployment{}, testpredicates.HasLabel("version", privateSimpleHelmChartVersion)); err != nil {
+		nt.T.Error(err)
+	}
+
+	// helm-sync automatically detects and updates to the new helm chart version
+	newVersion := "2.5.9"
+	if err := remoteHelmChart.UpdateVersion(newVersion); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := remoteHelmChart.Push(); err != nil {
+		nt.T.Fatal("failed to push helm chart update: %v", err)
+	}
+	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+newVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.Validate("deploy-default", "simple", &appsv1.Deployment{}, testpredicates.HasLabel("version", newVersion)); err != nil {
+		nt.T.Error(err)
+	}
+}
+
+// TestHelmVersionRange verifies the Config Sync behavior for helm charts when helm.spec.version is specified as a range.
+// Helm-sync should pull the latest helm chart version within the range.
+func TestHelmVersionRange(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+
+	nt.T.Log("Create RootSync to sync from a public Helm Chart with specified version range")
+	rootSyncFilePath := "../testdata/root-sync-helm-chart-version-range-cr.yaml"
+	nt.T.Logf("Apply the RootSync object defined in %s", rootSyncFilePath)
+	nt.MustKubectl("apply", "-f", rootSyncFilePath)
+	err := nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion("wordpress:15.4.1")),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "wordpress"}))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	if err := nt.Validate("my-wordpress", "wordpress", &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
 	}
 }
@@ -221,7 +305,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 		nt.T.Fatalf("failed to create secret, err: %v", err)
 	}
 
-	chartName, err := helm.PushHelmChart(nt, privateNSHelmChart, privateNSHelmChartVersion)
+	remoteHelmChart, err := helm.PushHelmChart(nt, privateNSHelmChart, privateNSHelmChartVersion)
 	if err != nil {
 		nt.T.Fatalf("failed to push helm chart: %v", err)
 	}
@@ -229,7 +313,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	nt.T.Log("Update RepoSync to sync from a private Artifact Registry")
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{
 		Repo:        helm.PrivateARHelmRegistry,
-		Chart:       chartName,
+		Chart:       remoteHelmChart.ChartName,
 		Auth:        configsync.AuthToken,
 		Version:     privateNSHelmChartVersion,
 		ReleaseName: "test",
@@ -237,11 +321,11 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	}}
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from a private Helm Chart without cluster scoped resources"))
-	err = nt.WatchForAllSyncs(nomostest.WithRepoSha1Func(helmChartVersion(chartName+":"+privateNSHelmChartVersion)), nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{repoSyncNN: chartName}))
+	err = nt.WatchForAllSyncs(nomostest.WithRepoSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateNSHelmChartVersion)), nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{repoSyncNN: remoteHelmChart.ChartName}))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if err := nt.Validate(rs.Spec.Helm.ReleaseName+"-"+chartName, testNs, &appsv1.Deployment{}); err != nil {
+	if err := nt.Validate(rs.Spec.Helm.ReleaseName+"-"+remoteHelmChart.ChartName, testNs, &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
 	}
 }
@@ -337,7 +421,7 @@ func TestHelmGCENode(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest)
 
-	chartName, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
+	remoteHelmChart, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
 	if err != nil {
 		nt.T.Fatalf("failed to push helm chart: %v", err)
 	}
@@ -345,13 +429,13 @@ func TestHelmGCENode(t *testing.T) {
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "%s", "auth": "gcenode", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns"}, "git": null}}`,
-		v1beta1.HelmSource, helm.PrivateARHelmRegistry, chartName, privateCoreDNSHelmChartVersion))
-	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(chartName+":"+privateCoreDNSHelmChartVersion)),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: chartName}))
+		v1beta1.HelmSource, helm.PrivateARHelmRegistry, remoteHelmChart.ChartName, privateCoreDNSHelmChartVersion))
+	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateCoreDNSHelmChartVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if err := nt.Validate(fmt.Sprintf("my-coredns-%s", chartName), "coredns", &appsv1.Deployment{},
+	if err := nt.Validate(fmt.Sprintf("my-coredns-%s", remoteHelmChart.ChartName), "coredns", &appsv1.Deployment{},
 		containerImagePullPolicy("IfNotPresent")); err != nil {
 		nt.T.Error(err)
 	}
@@ -384,20 +468,20 @@ func TestHelmARTokenAuth(t *testing.T) {
 		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
 	})
 
-	chartName, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
+	remoteHelmChart, err := helm.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)
 	if err != nil {
 		nt.T.Fatalf("failed to push helm chart: %v", err)
 	}
 
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns", "secretRef": {"name" : "foo"}}}}`,
-		v1beta1.HelmSource, helm.PrivateARHelmRegistry, chartName, privateCoreDNSHelmChartVersion))
-	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(chartName+":"+privateCoreDNSHelmChartVersion)),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: chartName}))
+		v1beta1.HelmSource, helm.PrivateARHelmRegistry, remoteHelmChart.ChartName, privateCoreDNSHelmChartVersion))
+	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateCoreDNSHelmChartVersion)),
+		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	if err := nt.Validate(fmt.Sprintf("my-coredns-%s", chartName), "coredns", &appsv1.Deployment{}); err != nil {
+	if err := nt.Validate(fmt.Sprintf("my-coredns-%s", remoteHelmChart.ChartName), "coredns", &appsv1.Deployment{}); err != nil {
 		nt.T.Error(err)
 	}
 }

--- a/e2e/testdata/helm-charts/simple/templates/deployment.yaml
+++ b/e2e/testdata/helm-charts/simple/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: foo
+    version: {{ .Chart.Version }}
   name: deploy-default
 spec:
   selector:

--- a/e2e/testdata/root-sync-helm-chart-version-range-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-version-range-cr.yaml
@@ -1,0 +1,53 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  sourceType: helm
+  helm:
+    repo: https://charts.bitnami.com/bitnami
+    chart: wordpress
+    version: ^15.0.0
+    values:
+      image:
+        digest: sha256:362cb642db481ebf6f14eb0244fbfb17d531a84ecfe099cd3bba6810db56694e
+        pullPolicy: Always
+      wordpressUsername: test-user
+      wordpressEmail: test-user@example.com
+      extraEnvVars:
+      - name: TEST_1
+        value: "val1"
+      - name: TEST_2
+        value: "val2"
+      resources:
+        requests:
+          cpu: 150m
+          memory: 250Mi
+        limits:
+          cpu: 1
+          memory: 300Mi
+      mariadb:
+        primary:
+          persistence:
+            enabled: false
+      service:
+        type: ClusterIP
+    releaseName: my-wordpress
+    namespace: "wordpress"
+    auth: none


### PR DESCRIPTION
This PR adds support for allowing users to specify a range in `spec.helm.version` in the RSync object and we pull down the latest one from the range.

- The version range syntax is natively supported by Helm CLI. See the syntax here: [https://github.com/Masterminds/semver#hyphen-range-comparisons](https://www.google.com/url?q=https://github.com/Masterminds/semver%23hyphen-range-comparisons) 
- This PR has some changes to ensure that the RSync object is reporting the actual version that was pulled down, instead of just displaying whatever was specified in `spec.helm.version`
- If someone pushes a new helm chart, helm-sync will pick up the new chart without requiring changes to the RSync object.