### PR TITLE
Bump the kustomize CLI version to fix a regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
-KUSTOMIZE_VERSION := v5.0.2
+KUSTOMIZE_VERSION := v5.0.3
 HELM_VERSION := v3.11.3
 
 # Directory used for staging Docker contexts.

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -24,7 +24,7 @@ ARG VERSION
 ARG HELM_INFLATOR_FUNCTION_VERSION=v0.3.0
 
 ARG HELM_VERSION=v3.11.3
-ARG KUSTOMIZE_VERSION=v5.0.2
+ARG KUSTOMIZE_VERSION=v5.0.3
 
 # Install Helm with license
 RUN URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \

--- a/build/test-e2e-go/gke/Dockerfile
+++ b/build/test-e2e-go/gke/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
 ARG HELM_VERSION=v3.11.3
-ARG KUSTOMIZE_VERSION=v5.0.2
+ARG KUSTOMIZE_VERSION=v5.0.3
 ARG HELM_INFLATOR_FUNCTION_VERSION=v0.3.0
 
 # Install the render-helm-chart function.

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
 ARG HELM_VERSION=v3.11.3
-ARG KUSTOMIZE_VERSION=v5.0.2
+ARG KUSTOMIZE_VERSION=v5.0.3
 ARG HELM_INFLATOR_FUNCTION_VERSION=v0.3.0
 
 # Install the render-helm-chart function.

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -45,7 +45,7 @@ const (
 	// HelmVersion is the recommended version of Helm for hydration.
 	HelmVersion = "v3.11.3"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
-	KustomizeVersion = "v5.0.2"
+	KustomizeVersion = "v5.0.3"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.


### PR DESCRIPTION
Kustomize v5.0.2 breaks helmCharts with chartHome option. This commit updates the version to address the issue.

More context: https://github.com/kubernetes-sigs/kustomize/issues/5163