### PR TITLE
Bump the test prometheus memory request to 1.5Gi (#581)

### DIFF
--- a/e2e/testdata/prometheus/prometheus.yaml
+++ b/e2e/testdata/prometheus/prometheus.yaml
@@ -175,10 +175,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 1.5Gi
             limits:
               cpu: 1
-              memory: 1Gi
+              memory: 1.5Gi
           volumeMounts:
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/


### PR DESCRIPTION
We're still seeing OOMKilled issues for the Prometheus Pod running on Autopilot rapid-latest channel after clearing the cache.

This commit further increases the memory request to 1.5GiB.