### PR TITLE
Rewrite sync controller garbage collection

### DIFF
--- a/pkg/reconcilermanager/controllers/otel_sa_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_sa_controller.go
@@ -89,7 +89,9 @@ func (r *OtelSAReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 	// On a cluster without Workload Identity, the annotation does not have any effects.
 	// Therefore, we don't check whether the cluster has Workload Identity enabled before updating the Deployment annotation.
 	if err := updateDeploymentAnnotation(ctx, r.client, GCPSAAnnotationKey, v); err != nil {
-		r.logger(ctx).Error(err, "Failed to update Deployment")
+		r.logger(ctx).Error(err, "Failed to update Deployment",
+			logFieldObjectRef, otelCollectorDeploymentRef(),
+			logFieldObjectKind, "Deployment")
 		return controllerruntime.Result{}, err
 	}
 	r.logger(ctx).Info("Deployment annotation patch successful",

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -147,7 +147,7 @@ func (r *reconcilerBase) upsertServiceAccount(
 	}
 	if op != controllerutil.OperationResultNone {
 		r.logger(ctx).Info("Managed object upsert successful",
-			logFieldObjectRef, childSA.String(),
+			logFieldObjectRef, childSARef.String(),
 			logFieldObjectKind, "ServiceAccount",
 			logFieldOperation, op)
 	}
@@ -416,7 +416,7 @@ func (r *reconcilerBase) deployment(ctx context.Context, dRef client.ObjectKey) 
 			return nil, errors.Errorf(
 				"Deployment %s not found in namespace: %s.", dRef.Name, dRef.Namespace)
 		}
-		return nil, errors.Wrapf(err, "error while retrieving deployment")
+		return nil, errors.Wrapf(err, "Deployment get failed")
 	}
 	return deployObj, nil
 }
@@ -536,7 +536,6 @@ func (r *reconcilerBase) validateCACertSecret(ctx context.Context, namespace, ca
 		}
 	}
 	return nil
-
 }
 
 // addTypeInformationToObject looks up and adds GVK to a runtime.Object based upon the loaded Scheme

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,11 +115,21 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	rs := &v1beta1.RootSync{}
 
 	if err := r.client.Get(ctx, rsRef, rs); err != nil {
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 		if apierrors.IsNotFound(err) {
-			r.logger(ctx).Info("Deleting managed objects")
-			return controllerruntime.Result{}, r.deleteClusterRoleBinding(ctx, reconcilerRef)
+			// Cleanup after already deleted RootSync.
+			if err := r.deleteManagedObjects(ctx, reconcilerRef); err != nil {
+				r.logger(ctx).Error(err, "Failed to delete managed objects")
+				// Failed to delete a managed object.
+				// Return an error to trigger retry.
+				metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
+				// requeue for retry
+				return controllerruntime.Result{}, errors.Wrap(err, "failed to delete managed objects")
+			}
+			// cleanup successful
+			metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(nil), start)
+			return controllerruntime.Result{}, nil
 		}
+		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 		return controllerruntime.Result{}, status.APIServerError(err, "failed to get RootSync")
 	}
 
@@ -143,12 +152,6 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, updateErr
 	}
 
-	owRefs := ownerReference(
-		rs.GroupVersionKind().Kind,
-		rs.Name,
-		rs.UID,
-	)
-
 	if errs := validation.IsDNS1123Subdomain(reconcilerRef.Name); errs != nil {
 		err := errors.Errorf("Invalid reconciler name %q: %s.", reconcilerRef.Name, strings.Join(errs, ", "))
 		r.logger(ctx).Error(err, "Sync name or namespace invalid")
@@ -161,7 +164,7 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, updateErr
 	}
 
-	if err := r.validateSpec(ctx, rs); err != nil {
+	if err := r.validateSpec(ctx, rs, reconcilerRef.Name); err != nil {
 		r.logger(ctx).Error(err, "Sync spec invalid")
 		rootsync.SetStalled(rs, "Validation", err)
 		// Validation errors should not trigger retry (return error),
@@ -171,6 +174,22 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 		return controllerruntime.Result{}, updateErr
 	}
+
+	if err := r.upsertManagedObjects(ctx, reconcilerRef, currentRS, rs); err != nil {
+		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
+		return controllerruntime.Result{}, err
+	}
+
+	metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(nil), start)
+	return controllerruntime.Result{}, nil
+}
+
+func (r *RootSyncReconciler) upsertManagedObjects(ctx context.Context, reconcilerRef types.NamespacedName, currentRS, rs *v1beta1.RootSync) error {
+	r.logger(ctx).V(3).Info("Reconciling managed objects")
+
+	// Note: RootSync Secret is managed by the user, not the ReconcilerManager.
+	// This is because it's in the same namespace as the Deployment, so we don't
+	// need to copy it to the config-management-system namespace.
 
 	labelMap := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
@@ -191,8 +210,11 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	case v1beta1.HelmSource:
 		auth = rs.Spec.Helm.Auth
 		gcpSAEmail = rs.Spec.Helm.GCPServiceAccountEmail
+	default:
+		// Should have been caught by validation
+		return errors.Errorf("invalid source type: %s", rs.Spec.SourceType)
 	}
-	if saRef, err := r.upsertServiceAccount(ctx, reconcilerRef, auth, gcpSAEmail, labelMap, owRefs); err != nil {
+	if saRef, err := r.upsertServiceAccount(ctx, reconcilerRef, auth, gcpSAEmail, labelMap); err != nil {
 		r.logger(ctx).Error(err, "Managed object upsert failed",
 			logFieldObjectRef, saRef.String(),
 			logFieldObjectKind, "ServiceAccount",
@@ -205,9 +227,8 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		if updateErr != nil {
 			r.logger(ctx).Error(updateErr, "Sync status update failed")
 		}
-		// Use the upsert error for metric tagging.
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-		return controllerruntime.Result{}, errors.Wrap(err, "ServiceAccount reconcile failed")
+		// Return the upsertServiceAccount error, not the updateStatus error.
+		return errors.Wrap(err, "ServiceAccount upsert failed")
 	}
 
 	// Overwrite reconciler clusterrolebinding.
@@ -222,9 +243,8 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		if updateErr != nil {
 			r.logger(ctx).Error(updateErr, "Sync status update failed")
 		}
-		// Use the upsert error for metric tagging.
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-		return controllerruntime.Result{}, errors.Wrap(err, "ClusterRoleBinding reconcile failed")
+		// Return the upsertClusterRoleBinding error, not the updateStatus error.
+		return errors.Wrap(err, "ClusterRoleBinding upsert failed")
 	}
 
 	containerEnvs := r.populateContainerEnvs(ctx, rs, reconcilerRef.Name)
@@ -243,9 +263,8 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		if updateErr != nil {
 			r.logger(ctx).Error(updateErr, "Sync status update failed")
 		}
-		// Use the upsert error for metric tagging.
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-		return controllerruntime.Result{}, errors.Wrap(err, "Deployment reconcile failed")
+		// Return the upsertDeployment error, not the updateStatus error.
+		return errors.Wrap(err, "Deployment upsert failed")
 	}
 	rs.Status.Reconciler = reconcilerRef.Name
 
@@ -264,9 +283,8 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 			if updateErr != nil {
 				r.logger(ctx).Error(updateErr, "Sync status update failed")
 			}
-			// Use the deployment get error for metric tagging.
-			metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-			return controllerruntime.Result{}, err
+			// Return the deployment get error, not the updateStatus error.
+			return err
 		}
 	}
 
@@ -282,9 +300,8 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		if updateErr != nil {
 			r.logger(ctx).Error(updateErr, "Sync status update failed")
 		}
-		// Use the compute error for metric tagging.
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-		return controllerruntime.Result{}, err
+		// Return the Compute error, not the updateStatus error.
+		return errors.Wrap(err, "computing reconciler Deployment status failed")
 	}
 
 	r.logger(ctx).V(3).Info("Reconciler status",
@@ -325,22 +342,52 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		if updateErr != nil {
 			r.logger(ctx).Error(updateErr, "Sync status update failed")
 		}
-		// Use the status error for metric tagging.
-		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
-		return controllerruntime.Result{}, err
+		// Return the type error, not the updateStatus error.
+		return err
 	}
 
 	updated, err := r.updateStatus(ctx, currentRS, rs)
-	// Use the status update error for metric tagging, if no other errors.
-	metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 	if err != nil {
-		return controllerruntime.Result{}, err
+		return err
 	}
 
 	if updated && result.Status == kstatus.CurrentStatus {
 		r.logger(ctx).Info("Sync object reconcile successful")
 	}
-	return controllerruntime.Result{}, nil
+	return nil
+}
+
+// deleteManagedObjects deletes objects managed by the reconciler-manager for
+// this RootSync. If updateStatus is true, the RootSync status will be updated
+// to reflect the teardown progress.
+func (r *RootSyncReconciler) deleteManagedObjects(ctx context.Context, reconcilerRef types.NamespacedName) error {
+	r.logger(ctx).Info("Deleting managed objects")
+
+	err := r.deleteDeployment(ctx, reconcilerRef)
+	if err != nil {
+		return errors.Wrap(err, "RootSync Deployment delete failed")
+	}
+
+	// Note: ConfigMaps have been replaced by Deployment env vars.
+	// Using env vars auto-updates the Deployment when they change.
+	// This deletion remains to clean up after users upgrade.
+
+	if err := r.deleteConfigMaps(ctx, reconcilerRef); err != nil {
+		return errors.Wrap(err, "RootSync ConfigMap delete failed")
+	}
+
+	// Note: ReconcilerManager doesn't manage the RootSync Secret.
+	// So we don't need to delete it here.
+
+	if err := r.deleteClusterRoleBinding(ctx, reconcilerRef); err != nil {
+		return errors.Wrap(err, "RootSync RoleBinding delete failed")
+	}
+
+	if err := r.deleteServiceAccount(ctx, reconcilerRef); err != nil {
+		return errors.Wrap(err, "RootSync ServiceAccount delete failed")
+	}
+
+	return nil
 }
 
 // SetupWithManager registers RootSync controller with reconciler-manager.
@@ -398,7 +445,7 @@ func (r *RootSyncReconciler) mapMembershipToRootSyncs() func(client.Object) []re
 		// Clear the membership if the cluster is unregistered
 		if err := r.client.Get(context.Background(), types.NamespacedName{Name: fleetMembershipName}, &hubv1.Membership{}); err != nil {
 			if apierrors.IsNotFound(err) {
-				klog.Infof("Fleet Membership not found, clearing membership cache")
+				klog.Info("Fleet Membership not found, clearing membership cache")
 				r.membership = nil
 				return r.requeueAllRootSyncs()
 			}
@@ -576,10 +623,10 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 	return result
 }
 
-func (r *RootSyncReconciler) validateSpec(ctx context.Context, rs *v1beta1.RootSync) error {
+func (r *RootSyncReconciler) validateSpec(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string) error {
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
 	case v1beta1.GitSource:
-		return r.validateGitSpec(ctx, rs)
+		return r.validateGitSpec(ctx, rs, reconcilerName)
 	case v1beta1.OciSource:
 		return validate.OciSpec(rs.Spec.Oci, rs)
 	case v1beta1.HelmSource:
@@ -595,14 +642,14 @@ func (r *RootSyncReconciler) validateSpec(ctx context.Context, rs *v1beta1.RootS
 	}
 }
 
-func (r *RootSyncReconciler) validateGitSpec(ctx context.Context, rs *v1beta1.RootSync) error {
+func (r *RootSyncReconciler) validateGitSpec(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string) error {
 	if err := validate.GitSpec(rs.Spec.Git, rs); err != nil {
 		return err
 	}
 	if err := r.validateCACertSecret(ctx, rs.Namespace, v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef)); err != nil {
 		return err
 	}
-	return r.validateRootSecret(ctx, rs)
+	return r.validateRootSecret(ctx, rs, reconcilerName)
 }
 
 func (r *RootSyncReconciler) validateNamespaceName(namespaceName string) error {
@@ -613,11 +660,17 @@ func (r *RootSyncReconciler) validateNamespaceName(namespaceName string) error {
 }
 
 // validateRootSecret verify that any necessary Secret is present before creating ConfigMaps and Deployments.
-func (r *RootSyncReconciler) validateRootSecret(ctx context.Context, rootSync *v1beta1.RootSync) error {
+func (r *RootSyncReconciler) validateRootSecret(ctx context.Context, rootSync *v1beta1.RootSync, reconcilerName string) error {
 	if SkipForAuth(rootSync.Spec.Auth) {
 		// There is no Secret to check for the Config object.
 		return nil
 	}
+
+	secretName := ReconcilerResourceName(reconcilerName, rootSync.Spec.SecretRef.Name)
+	if errs := validation.IsDNS1123Label(secretName); errs != nil {
+		return errors.Errorf("The managed secret name %q is invalid: %s. To fix it, update '.spec.git.secretRef.name'", secretName, strings.Join(errs, ", "))
+	}
+
 	secret, err := validateSecretExist(ctx,
 		v1beta1.GetSecretName(rootSync.Spec.SecretRef),
 		rootSync.Namespace,
@@ -640,6 +693,8 @@ func (r *RootSyncReconciler) upsertClusterRoleBinding(ctx context.Context, recon
 		childCRB.OwnerReferences = nil
 		childCRB.RoleRef = rolereference("cluster-admin", "ClusterRole")
 		childCRB.Subjects = addSubject(childCRB.Subjects, r.serviceAccountSubject(reconcilerRef))
+		// Remove existing OwnerReferences, now that we're using finalizers.
+		childCRB.OwnerReferences = nil
 		return nil
 	})
 	if err != nil {
@@ -683,15 +738,8 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 		if !ok {
 			return errors.Errorf("expected appsv1 Deployment, got: %T", obj)
 		}
-		// OwnerReferences, so that when the RootSync CustomResource is deleted,
-		// the corresponding Deployment is also deleted.
-		d.OwnerReferences = []metav1.OwnerReference{
-			ownerReference(
-				rs.GroupVersionKind().Kind,
-				rs.Name,
-				rs.UID,
-			),
-		}
+		// Remove existing OwnerReferences, now that we're using finalizers.
+		d.OwnerReferences = nil
 		reconcilerName := core.RootReconcilerName(rs.Name)
 
 		// Only inject the FWI credentials when the auth type is gcpserviceaccount and the membership info is available.

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1395,9 +1395,6 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
-		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -1615,9 +1612,6 @@ func TestMultipleRootSyncs(t *testing.T) {
 	serviceAccount1 := fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs1.Name, "1"),
-		}),
 		core.Labels(label1),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -1684,9 +1678,6 @@ func TestMultipleRootSyncs(t *testing.T) {
 	serviceAccount2 := fake.ServiceAccountObject(
 		rootReconcilerName2,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs2.Name, "1"),
-		}),
 		core.Labels(label2),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -1740,9 +1731,6 @@ func TestMultipleRootSyncs(t *testing.T) {
 	serviceAccount3 := fake.ServiceAccountObject(
 		rootReconcilerName3,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs3.Name, "1"),
-		}),
 		core.Annotation(GCPSAAnnotationKey, rs3.Spec.GCPServiceAccountEmail),
 		core.Labels(label3),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -1801,9 +1789,6 @@ func TestMultipleRootSyncs(t *testing.T) {
 	serviceAccount4 := fake.ServiceAccountObject(
 		rootReconcilerName4,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs4.Name, "1"),
-		}),
 		core.Labels(label4),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -1862,9 +1847,6 @@ func TestMultipleRootSyncs(t *testing.T) {
 	serviceAccount5 := fake.ServiceAccountObject(
 		rootReconcilerName5,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rs5.Name, "1"),
-		}),
 		core.Labels(label5),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2477,9 +2459,6 @@ func TestRootSyncWithOCI(t *testing.T) {
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
-		}),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2558,9 +2537,6 @@ func TestRootSyncWithOCI(t *testing.T) {
 	wantServiceAccount = fake.ServiceAccountObject(
 		rootReconcilerName,
 		core.Namespace(v1.NSConfigManagementSystem),
-		core.OwnerReference([]metav1.OwnerReference{
-			ownerReference(kinds.RootSyncV1Beta1().Kind, rootsyncName, "1"),
-		}),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("2"), core.Generation(1),

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -31,7 +29,6 @@ import (
 	"kpt.dev/configsync/pkg/reconcilermanager"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // hydrationEnvs returns environment variables for the hydration controller.
@@ -280,17 +277,6 @@ func helmSyncTokenAuthEnv(secretRef string) []corev1.EnvVar {
 			Name:      helmSyncPassword,
 			ValueFrom: helmSyncPswd,
 		},
-	}
-}
-
-func ownerReference(kind, name string, uid types.UID) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion:         v1beta1.SchemeGroupVersion.String(),
-		Kind:               kind,
-		Name:               name,
-		Controller:         pointer.BoolPtr(true),
-		BlockOwnerDeletion: pointer.BoolPtr(true),
-		UID:                uid,
 	}
 }
 


### PR DESCRIPTION
- Convert RootSync controller to manage cleanup the same way the
  RepoSync controller does: delete everything after the RSync is
  Not Found, instead of using the K8s Garbage collector.
  This makes the behavior and code more consistent, in prep for the
  upcoming reconciler-manager finalizer.
- Combine cleanup methods in the reconcilerBase class.
- Extract upsertManagedObjects and deleteManagedObjects methods
- Log & skip managed object upserts when an RSync is being deleted.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/594
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/597
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/598
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/637
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/640