### PR TITLE
Set Prometheus retention size to limit the memory usage (#601)

### DIFF
--- a/e2e/testdata/prometheus/prometheus.yaml
+++ b/e2e/testdata/prometheus/prometheus.yaml
@@ -162,6 +162,9 @@ spec:
             # this will count towards the containers memory usage.
             - --storage.tsdb.retention.time=30m
             - --storage.tsdb.wal-compression
+            # Limit the maximum number of bytes of storage blocks to retain.
+            # The oldest data will be removed first.
+            - --storage.tsdb.retention.size=1GB
             # Effectively disable compaction and make blocks short enough so
             # that our retention window can be kept in practice.
             - --storage.tsdb.min-block-duration=10m


### PR DESCRIPTION
The Prometheus Pod consumes more than 1.5GiB memory on Autopilot 1.26 clusters. We tried to clear the cache before each test case (PR#579), but WAL replays the deleted data series, which caused the Pod to crash again.

This commit limits the retention size to 1GB, so that old data can be removed to avoid exceeding the limit.