### PR TITLE
fix: support auth for artifact registry with push-images

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -117,7 +117,7 @@ push-images:
 	@echo "+++ Pushing Config Sync images to $(REGISTRY)"
 	@echo "+++ Using account:"
 	gcloud config get-value account
-	@gcloud $(GCLOUD_QUIET) auth configure-docker
+	@gcloud $(GCLOUD_QUIET) auth configure-docker $(firstword $(subst /, ,$(REGISTRY)))
 	docker push $(RECONCILER_TAG)
 	docker push $(RECONCILER_MANAGER_TAG)
 	docker push $(ADMISSION_WEBHOOK_TAG)


### PR DESCRIPTION
gcloud auth configure-docker takes a list of host names to set up a credential helper for. This change updates the invocation to select the hostname from the provided REGISTRY, which enables pushing to artifact registry repositories.