### PR TITLE
update vulnerability scan script for CI usage

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -281,6 +281,22 @@ build-http-git-server:
 		test/docker/http-git-server/
 	@docker push $(E2E_TEST_IMAGE_HTTP_GIT_SERVER)
 
+# Used by the vulnerability scanning periodic prow job.
+VULNERABILITY_SCANNER_VERSION := v1.0.0-$(shell git rev-parse --short HEAD)
+VULNERABILITY_SCANNER_IMAGE_TAG := us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:$(VULNERABILITY_SCANNER_VERSION)
+.PHONY: build-vulnerability-scanner
+build-vulnerability-scanner:
+	@echo "+++ Building $(VULNERABILITY_SCANNER_IMAGE_TAG)"
+	docker buildx build \
+		-t $(VULNERABILITY_SCANNER_IMAGE_TAG) \
+		build/prow/vulnerability-scanner/
+
+# Push vulnerability-scanner image to registry. For now this is done manually.
+.PHONY: push-vulnerability-scanner
+push-vulnerability-scanner:
+	@echo "+++ Pushing $(VULNERABILITY_SCANNER_IMAGE_TAG)"
+	docker push $(VULNERABILITY_SCANNER_IMAGE_TAG)
+
 .PHONY: deploy
 deploy:
 	kubectl apply -f $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -123,5 +123,16 @@ pull-gcs:
 pull-gcs-postsubmit: clean $(OUTPUT_DIR)
 	$(MAKE) pull-gcs GCS_PREFIX=$(POSTSUBMIT_GCS_PREFIX)
 
+.PHONY: pull-postsubmit-retry
+pull-postsubmit-retry:
+	./scripts/pull-postsubmit-retry.sh
+
 .PHONY: deploy-postsubmit
 deploy-postsubmit: pull-gcs-postsubmit deploy
+
+.PHONY: vulnerability-scan-postsubmit
+vulnerability-scan-postsubmit: pull-postsubmit-retry vulnerability-scan
+
+.PHONY: vulnerability-scan
+vulnerability-scan:
+	./scripts/vulnerabilities.sh

--- a/build/prow/vulnerability-scanner/Dockerfile
+++ b/build/prow/vulnerability-scanner/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:431.0.0 as gcloud-install
+
+FROM golang:1.19
+
+RUN apt-get update && apt-get install -y \
+    jq \
+    bsdmainutils # needed for "column" util
+
+COPY --from=gcloud-install /usr/lib/google-cloud-sdk /opt/gcloud/google-cloud-sdk
+ENV PATH /opt/gcloud/google-cloud-sdk/bin:$PATH

--- a/scripts/pull-postsubmit-retry.sh
+++ b/scripts/pull-postsubmit-retry.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The postsubmit job which publishes artifacts takes some time to complete.
+# This script retries pulling the postsubmit artifacts for a reasonable amount
+# of time and then errors if not found.
+
+set -euo pipefail
+
+# Wait up to 20 minutes for postsubmit artifacts
+n=0
+num_intervals=80
+interval=15
+SECONDS=0
+until [[ "$n" -ge $num_intervals ]]; do
+   make pull-gcs-postsubmit && exit 0
+   echo "++++ Failed to pull postsubmit artifacts. Waiting ${interval} seconds to retry."
+   n=$((n+1))
+   sleep "${interval}"
+done
+
+echo "++++ Postsubmit artifacts not found after retrying for ${SECONDS} seconds"
+exit 1


### PR DESCRIPTION
- Use manifests for getting image tags. This makes it straightforward to pull down the manifest and get all images included with that manifest.
- Fix assumptions about GCP project/registries. It should be assumed that all images are hosted on either GCR/GAR with container scanning enabled. These may also be hosted in different projects/registries, e.g. git-sync, gcenode-askpass-sidecar, etc.