### PR TITLE
add build-status script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,10 @@ clean:
 	@echo "+++ Cleaning $(OUTPUT_DIR)"
 	@rm -rf $(OUTPUT_DIR)
 
+.PHONY: build-status
+build-status:
+	@./scripts/build-status.sh
+
 .PHONY: test-unit
 test-unit: pull-buildenv buildenv-dirs "$(BIN_DIR)/kustomize"
 	@echo "+++ Running unit tests in a docker container"

--- a/docs/development.md
+++ b/docs/development.md
@@ -134,6 +134,16 @@ Here is an example for how these can be provided at runtime:
 make build-images IMAGE_TAG=latest
 ```
 
+### Check build status
+
+The following command provides information on the current build status. It
+parses the local manifests and checks for the build status of docker images
+referenced in the manifest.
+
+```shell
+make build-status
+```
+
 ### Use postsubmit artifacts
 
 After a change is submitted to one of the official branches (e.g. `main`, `v1.15`, etc.),

--- a/scripts/build-status.sh
+++ b/scripts/build-status.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script prints out the build status of Config Sync
+# Intended for developer use to help understand the build state
+
+set -euo pipefail
+
+scripts_dir="$(dirname "$(realpath "$0")")"
+# shellcheck source=scripts/lib/manifests.sh
+source "${scripts_dir}/lib/manifests.sh"
+
+# convenience function for printing two args where the second string is aligned
+function pretty_print {
+  printf "%-50s %s\n" "$1:" "$2"
+}
+
+function local_image_exists {
+  image="$1"
+  docker image inspect "${image}" &> /dev/null
+}
+
+function remote_image_exists {
+  image="$1"
+  flags=()
+  # must pass --insecure flag for local registry (e.g. localhost:5000)
+  [[ "${image}" == "localhost"* ]] && flags+=("--insecure")
+  docker manifest inspect "${flags[@]}" "${image}" &> /dev/null
+}
+
+pretty_print "Current commit" "$(git describe --tags --always --dirty --long)"
+
+read -r -a images <<< "$(config_sync_images)"
+[[ ${#images[@]} -eq 0 ]] && exit 1
+declare -A status_map
+cs_tag=""
+
+echo -n "Scanning" >&2
+for image in "${images[@]}"; do
+  echo -n "."
+  if [[ "${image}" == *"/reconciler-manager:"* ]]; then
+    cs_tag="${image##*:}"
+  fi
+  status=()
+  local_image_exists "${image}" && status+=("LOCAL")
+  remote_image_exists "${image}" && status+=("REMOTE")
+  [[ ${#status[@]} == 0 ]] && status+=("NOT_FOUND")
+  status_map[${image}]="$(printf "%s" "${status[@]}")"
+done
+
+echo # done scanning
+pretty_print "Build version (reconciler-manager)" "${cs_tag}"
+
+(
+  echo -e "IMAGE\tSTATUS"
+  (
+    for image in "${!status_map[@]}"; do
+      echo -e "${image}\t${status_map[${image}]}"
+    done
+  ) | sort
+) | column -ts $'\t'

--- a/scripts/lib/manifests.sh
+++ b/scripts/lib/manifests.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# find the tag for the gcenode-askpass-sidecar image by reading it from a Go constant.
+# This sidecar is injected at runtime. So it's not in any local manifest files.
+find_askpass_image_tag() {
+  grep -ohE --color=never 'gceNodeAskpassImageTag\s*=.*' pkg/reconcilermanager/controllers/gcenode_askpass_sidecar.go |
+    sed -E 's/gceNodeAskpassImageTag\s*=\s*"(\S+)"/\1/'
+}
+
+# find the "name:tag" of images in the manifests directory.
+find_manifest_images() {
+  grep -rohE --color=never "image:\s+\S+:\S+" .output/staging/oss/*.yaml |
+    awk '{print $2}' | sort | uniq
+}
+
+config_sync_images() {
+  # Build a full list of images with tags
+  gcenode_askpass_tag=$(find_askpass_image_tag)
+  images=(
+    "gcr.io/config-management-release/gcenode-askpass-sidecar:${gcenode_askpass_tag}"
+  )
+
+  echo "++++ Parsing image tags from rendered manifests at: .output/staging" >&2
+
+  manifest_images="$(find_manifest_images || echo -n "")"
+  if [[ "${manifest_images}" == "" ]]; then
+    echo "++++ No images found in rendered manifests at: .output/staging" >&2
+    echo "++++ For instructions on how to build or pull manifests, see https://github.com/GoogleContainerTools/kpt-config-sync/blob/main/docs/development.md#build" >&2
+    return 1
+  fi
+
+  registry=""
+  cs_tag=""
+  # Add dependencies from the manifests
+  while IFS='' read -r image; do
+    images+=("${image}")
+    # use reconciler-manager image as an representative of the CS registry/tag
+    if [[ "${image}" == *"/reconciler-manager:"* ]]; then
+      registry="${image%/reconciler-manager:*}"
+      cs_tag="${image##*:}"
+    fi
+  done <<<"${manifest_images}"
+
+  # add CS images not included in manifest
+  images+=("${registry}/nomos:${cs_tag}")
+  images+=("${registry}/hydration-controller-with-shell:${cs_tag}")
+  echo "${images[@]}"
+  return 0
+}
+
+
+
+


### PR DESCRIPTION
This script is parses the rendered manifests on the local filesystem and provides some build status information. This is intended for developer use cases to help with understanding the build state.

These manifests are used as inputs for other commands, such as deploying config sync or running the e2e tests.