### PR TITLE
Configure test logging for klog 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,10 @@ lint-license-headers: "$(GOBIN)/addlicense"
 lint-yaml:
 	@./scripts/lint-yaml.sh
 
+.PHONY: test-loggers
+test-loggers:
+	GOBIN=$(GOBIN) ./scripts/generate-test-loggers.sh
+
 # Print the value of a variable
 print-%:
 	@echo $($*)

--- a/cmd/junit-report/resetfailure/main_test.go
+++ b/cmd/junit-report/resetfailure/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resetfailure
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/junit-report/resetfailure -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/cmd/nomos/initialize/main_test.go
+++ b/cmd/nomos/initialize/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package initialize
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/nomos/initialize -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/cmd/nomos/parse/main_test.go
+++ b/cmd/nomos/parse/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/nomos/parse -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/cmd/nomos/status/main_test.go
+++ b/cmd/nomos/status/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/nomos/status -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/cmd/nomos/version/main_test.go
+++ b/cmd/nomos/version/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/nomos/version -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/cmd/nomos/vet/main_test.go
+++ b/cmd/nomos/vet/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vet
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/cmd/nomos/vet -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/applier/main_test.go
+++ b/pkg/applier/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applier
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/applier -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/applier/stats/main_test.go
+++ b/pkg/applier/stats/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/applier/stats -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/bugreport/main_test.go
+++ b/pkg/bugreport/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bugreport
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/bugreport -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/core/main_test.go
+++ b/pkg/core/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/core -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/declared/main_test.go
+++ b/pkg/declared/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declared
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/declared -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/diff/main_test.go
+++ b/pkg/diff/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/diff -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/hydrate/main_test.go
+++ b/pkg/hydrate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hydrate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/hydrate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/importer/customresources/main_test.go
+++ b/pkg/importer/customresources/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customresources
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/importer/customresources -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/importer/filesystem/main_test.go
+++ b/pkg/importer/filesystem/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/importer/filesystem -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/importer/reader/main_test.go
+++ b/pkg/importer/reader/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/importer/reader -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/kinds/main_test.go
+++ b/pkg/kinds/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kinds
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/kinds -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/kmetrics/main_test.go
+++ b/pkg/kmetrics/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kmetrics
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/kmetrics -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/metadata/main_test.go
+++ b/pkg/metadata/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/metadata -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/parse/main_test.go
+++ b/pkg/parse/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/parse -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/reconciler/finalizer/main_test.go
+++ b/pkg/reconciler/finalizer/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/reconciler/finalizer -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/reconcilermanager/controllers/main_test.go
+++ b/pkg/reconcilermanager/controllers/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/reconcilermanager/controllers -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/remediator/queue/main_test.go
+++ b/pkg/remediator/queue/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/remediator/queue -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/remediator/reconcile/main_test.go
+++ b/pkg/remediator/reconcile/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/remediator/reconcile -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/remediator/watch/main_test.go
+++ b/pkg/remediator/watch/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/remediator/watch -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/reposync/main_test.go
+++ b/pkg/reposync/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reposync
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/reposync -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/rootsync/main_test.go
+++ b/pkg/rootsync/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootsync
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/rootsync -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/status/main_test.go
+++ b/pkg/status/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/status -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/client/main_test.go
+++ b/pkg/syncer/client/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/client -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/decode/main_test.go
+++ b/pkg/syncer/decode/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/decode -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/differ/main_test.go
+++ b/pkg/syncer/differ/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/differ -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/reconcile/fight/main_test.go
+++ b/pkg/syncer/reconcile/fight/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fight
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/reconcile/fight -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/reconcile/main_test.go
+++ b/pkg/syncer/reconcile/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/reconcile -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/scheme/main_test.go
+++ b/pkg/syncer/scheme/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheme
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/scheme -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/syncer/syncertest/fake/main_test.go
+++ b/pkg/syncer/syncertest/fake/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/syncer/syncertest/fake -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/util/clusterconfig/main_test.go
+++ b/pkg/util/clusterconfig/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/util/clusterconfig -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/util/compare/main_test.go
+++ b/pkg/util/compare/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/util/compare -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/util/discovery/main_test.go
+++ b/pkg/util/discovery/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/util/discovery -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/util/log/main_test.go
+++ b/pkg/util/log/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/util/log -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/util/mutate/main_test.go
+++ b/pkg/util/mutate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/util/mutate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/final/validate/main_test.go
+++ b/pkg/validate/final/validate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/final/validate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/main_test.go
+++ b/pkg/validate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/objects/main_test.go
+++ b/pkg/validate/objects/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/objects -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/raw/hydrate/main_test.go
+++ b/pkg/validate/raw/hydrate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hydrate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/raw/hydrate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/raw/validate/main_test.go
+++ b/pkg/validate/raw/validate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/raw/validate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/scoped/hydrate/main_test.go
+++ b/pkg/validate/scoped/hydrate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hydrate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/scoped/hydrate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/scoped/validate/main_test.go
+++ b/pkg/validate/scoped/validate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/scoped/validate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/tree/hydrate/main_test.go
+++ b/pkg/validate/tree/hydrate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hydrate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/tree/hydrate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/validate/tree/validate/main_test.go
+++ b/pkg/validate/tree/validate/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/tree/validate -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/vet/main_test.go
+++ b/pkg/vet/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vet
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/vet -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/configuration/main_test.go
+++ b/pkg/webhook/configuration/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configuration
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/webhook/configuration -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/webhook/main_test.go
+++ b/pkg/webhook/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/webhook -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/scripts/generate-test-loggers.sh
+++ b/scripts/generate-test-loggers.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [ "${GOBIN:-"unset"}" == "unset" ]; then
+  echo "GOBIN unset"
+  exit 1
+fi
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+cd "${REPO_ROOT}"
+
+GO_MODULE="$(grep "^module" "go.mod" | cut -d' ' -f2)"
+
+source_paths=("pkg" "cmd")
+
+function render_main_test() {
+  cat << EOF
+package ${PACKAGE_NAME}
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test ${GO_MODULE}/${PACKAGE_PATH} -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}
+EOF
+}
+
+# find_test_dirs loops through all the directories under the specified path
+# and prints the ones directly containing go tests.
+function find_test_dirs() {
+    local parent_path="$1"
+    local test_dir_path
+    declare -A test_dir_paths
+    while IFS= read -r file_path; do
+        test_dir_path="$(dirname "${file_path}")"
+        test_dir_paths[$test_dir_path]="1"
+    done <<< "$(find "${parent_path}" -type f -name "*_test.go")"
+    for test_dir_path in "${!test_dir_paths[@]}"; do
+        echo "${test_dir_path}"
+    done
+}
+
+for source_path in "${source_paths[@]}"; do
+  while IFS= read -r test_dir_path; do
+    file_name="${test_dir_path}/main_test.go"
+    echo "Generating ${file_name}"
+    PACKAGE_NAME="$(basename "${test_dir_path}")"
+    PACKAGE_PATH="${test_dir_path}"
+    render_main_test > "${file_name}"
+    "${GOBIN}/addlicense" -c "Google LLC" -f LICENSE_TEMPLATE "${file_name}"
+  done <<< "$(find_test_dirs "${source_path}")"
+done


### PR DESCRIPTION
- Add make test-loggers script to generate main_test.go files in
  each go package with unit tests.
- Optionally configure log level with -args -v=N