### PR TITLE
Add rsync manager lifecycle tests

### DIFF
--- a/pkg/core/names.go
+++ b/pkg/core/names.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"kpt.dev/configsync/pkg/api/configsync"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -44,4 +45,22 @@ func NsReconcilerName(namespace, name string) string {
 		return fmt.Sprintf("%s-%s", NsReconcilerPrefix, namespace)
 	}
 	return fmt.Sprintf("%s-%s-%s-%d", NsReconcilerPrefix, namespace, name, len(name))
+}
+
+// RootReconcilerObjectKey returns an ObjectKey for interacting with the
+// RootReconciler for the specified RootSync.
+func RootReconcilerObjectKey(syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      RootReconcilerName(syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
+}
+
+// NsReconcilerObjectKey returns an ObjectKey for interracting with the
+// NsReconciler for the specified RepoSync.
+func NsReconcilerObjectKey(namespace, syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      NsReconcilerName(namespace, syncName),
+		Namespace: configsync.ControllerNamespace,
+	}
 }

--- a/pkg/reconcilermanager/controllers/controller.go
+++ b/pkg/reconcilermanager/controllers/controller.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Controller implements Reconciler, but can also self-register with
+// SetupWithManager
+type Controller interface {
+	reconcile.Reconciler
+	// SetupWithManager registers the controller with the controller-manager
+	SetupWithManager(mgr controllerruntime.Manager, watchFleetMembership bool) error
+}
+
+var _ Controller = &RootSyncReconciler{}
+var _ Controller = &RepoSyncReconciler{}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -381,7 +381,11 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 func (r *RepoSyncReconciler) SetupWithManager(mgr controllerruntime.Manager, watchFleetMembership bool) error {
 	// Index the `gitSecretRefName` field, so that we will be able to lookup RepoSync be a referenced `SecretRef` name.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1beta1.RepoSync{}, gitSecretRefField, func(rawObj client.Object) []string {
-		rs := rawObj.(*v1beta1.RepoSync)
+		rs, ok := rawObj.(*v1beta1.RepoSync)
+		if !ok {
+			// Only add index for RepoSync
+			return nil
+		}
 		if rs.Spec.Git == nil || v1beta1.GetSecretName(rs.Spec.Git.SecretRef) == "" {
 			return nil
 		}
@@ -391,7 +395,11 @@ func (r *RepoSyncReconciler) SetupWithManager(mgr controllerruntime.Manager, wat
 	}
 	// Index the `caCertSecretRefField` field, so that we will be able to lookup RepoSync be a referenced `caCertSecretRefField` name.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1beta1.RepoSync{}, caCertSecretRefField, func(rawObj client.Object) []string {
-		rs := rawObj.(*v1beta1.RepoSync)
+		rs, ok := rawObj.(*v1beta1.RepoSync)
+		if !ok {
+			// Only add index for RepoSync
+			return nil
+		}
 		if rs.Spec.Git == nil || v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef) == "" {
 			return nil
 		}
@@ -401,7 +409,11 @@ func (r *RepoSyncReconciler) SetupWithManager(mgr controllerruntime.Manager, wat
 	}
 	// Index the `helmSecretRefName` field, so that we will be able to lookup RepoSync be a referenced `SecretRef` name.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1beta1.RepoSync{}, helmSecretRefField, func(rawObj client.Object) []string {
-		rs := rawObj.(*v1beta1.RepoSync)
+		rs, ok := rawObj.(*v1beta1.RepoSync)
+		if !ok {
+			// Only add index for RepoSync
+			return nil
+		}
 		if rs.Spec.Helm == nil || v1beta1.GetSecretName(rs.Spec.Helm.SecretRef) == "" {
 			return nil
 		}

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
@@ -35,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -270,18 +272,29 @@ func rolebinding(name string, opts ...core.MetaMutator) *rbacv1.RoleBinding {
 func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client, *syncerFake.DynamicClient, *RepoSyncReconciler) {
 	t.Helper()
 
-	fakeClient := syncerFake.NewClient(t, core.Scheme, objs...)
-	fakeDynamicClient := syncerFake.NewDynamicClient(t, core.Scheme)
+	// Configure controller-manager to log to the test logger
+	controllerruntime.SetLogger(testr.New(t))
+
+	cs := syncerFake.NewClientSet(t, core.Scheme)
+
+	ctx := context.Background()
+	for _, obj := range objs {
+		err := cs.Client.Create(ctx, obj)
+		if err != nil {
+			t.Fatalf("Failed to create object: %v", err)
+		}
+	}
+
 	testReconciler := NewRepoSyncReconciler(
 		testCluster,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
-		fakeClient,
-		fakeDynamicClient,
+		cs.Client,
+		cs.DynamicClient,
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
-		fakeClient.Scheme(),
+		cs.Client.Scheme(),
 	)
-	return fakeClient, fakeDynamicClient, testReconciler
+	return cs.Client, cs.DynamicClient, testReconciler
 }
 
 func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
@@ -3511,6 +3524,194 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRepoSyncReconcilerDeploymentLifecycle validates that the
+// RepoSyncReconciler works with the ControllerManager.
+// - Create a ns-reconciler Deployment when a RootSync is created
+// - Delete the ns-reconciler Deployment when the RootSync is deleted
+func TestRepoSyncReconcilerDeploymentLifecycle(t *testing.T) {
+	// Mock out parseDeployment for testing.
+	parseDeployment = parsedDeployment
+
+	t.Log("building RepoSyncReconciler")
+	rs := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+
+	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
+
+	defer logObjectYAMLIfFailed(t, fakeClient, rs)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	errCh := startControllerManager(ctx, t, fakeClient, testReconciler)
+
+	// Wait for manager to exit before returning
+	defer func() {
+		cancel()
+		t.Log("waiting for controller-manager to stop")
+		for err := range errCh {
+			require.NoError(t, err)
+		}
+	}()
+
+	reconcilerKey := core.NsReconcilerObjectKey(rs.Namespace, rs.Name)
+
+	t.Log("watching for reconciler deployment creation")
+	watchCtx, watchCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer watchCancel()
+
+	watcher, err := watchReconcilerDeployment(watchCtx, fakeClient, reconcilerKey)
+	require.NoError(t, err)
+
+	// Create RootSync
+	err = fakeClient.Create(ctx, rs)
+	require.NoError(t, err)
+
+	var reconcilerObj *appsv1.Deployment
+	err = watchDeploymentUntil(ctx, watcher, reconcilerKey, func(event watch.Event) error {
+		t.Logf("reconciler deployment %s", event.Type)
+		if event.Type == watch.Added || event.Type == watch.Modified {
+			reconcilerObj = event.Object.(*appsv1.Deployment)
+			// success! deployment was applied.
+			// Since there's no deployment controller,
+			// don't wait for availability.
+			return nil
+		}
+		// keep watching
+		return errors.Errorf("reconciler deployment %s", event.Type)
+	})
+	require.NoError(t, err)
+	if reconcilerObj == nil {
+		t.Fatal("timed out waiting for reconciler deployment to be applied")
+	}
+
+	t.Log("watching for reconciler deployment delete")
+	watchCtx2, watchCancel2 := context.WithTimeout(ctx, 10*time.Second)
+	defer watchCancel2()
+
+	watcher, err = watchReconcilerDeployment(watchCtx2, fakeClient, reconcilerKey)
+	require.NoError(t, err)
+
+	// Delete RootSync
+	rs.ResourceVersion = "" // we don't care what the RV is when deleting
+	err = fakeClient.Delete(ctx, rs)
+	require.NoError(t, err)
+
+	err = watchDeploymentUntil(ctx, watcher, reconcilerKey, func(event watch.Event) error {
+		t.Logf("reconciler deployment %s", event.Type)
+		if event.Type == watch.Deleted {
+			reconcilerObj = event.Object.(*appsv1.Deployment)
+			// success! deployment was deleted.
+			return nil
+		}
+		// keep watching
+		return errors.Errorf("reconciler deployment %s", event.Type)
+	})
+	require.NoError(t, err)
+}
+
+// TestRepoSyncReconcilerDeploymentDriftProtection validates that changes to
+// specific managed fields of the reconciler deployment are reverted if changed
+// by another client.
+func TestRepoSyncReconcilerDeploymentDriftProtection(t *testing.T) {
+	// Mock out parseDeployment for testing.
+	parseDeployment = parsedDeployment
+
+	t.Log("building RepoSyncReconciler")
+	rs := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+
+	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
+
+	defer logObjectYAMLIfFailed(t, fakeClient, rs)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	errCh := startControllerManager(ctx, t, fakeClient, testReconciler)
+
+	// Wait for manager to exit before returning
+	defer func() {
+		cancel()
+		t.Log("waiting for controller-manager to stop")
+		for err := range errCh {
+			require.NoError(t, err)
+		}
+	}()
+
+	reconcilerKey := core.NsReconcilerObjectKey(rs.Namespace, rs.Name)
+
+	t.Log("watching reconciler deployment until created")
+	watchCtx, watchCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer watchCancel()
+
+	// Start watching
+	watcher, err := watchReconcilerDeployment(watchCtx, fakeClient, reconcilerKey)
+	require.NoError(t, err)
+
+	// Create RootSync
+	err = fakeClient.Create(ctx, rs)
+	require.NoError(t, err)
+
+	// Consume watch events until success or timeout
+	var reconcilerObj *appsv1.Deployment
+	err = watchDeploymentUntil(ctx, watcher, reconcilerKey, func(event watch.Event) error {
+		t.Logf("reconciler deployment %s", event.Type)
+		if event.Type == watch.Added || event.Type == watch.Modified {
+			reconcilerObj = event.Object.(*appsv1.Deployment)
+			// success! deployment was applied.
+			// Since there's no deployment controller,
+			// don't wait for availability.
+			return nil
+		}
+		// keep watching
+		return errors.Errorf("reconciler deployment %s", event.Type)
+	})
+	require.NoError(t, err)
+	if reconcilerObj == nil {
+		t.Fatal("timed out waiting for reconciler deployment to be applied")
+	}
+
+	initialName := reconcilerObj.Spec.Template.Spec.ServiceAccountName
+	observedNames := []string{initialName}
+	driftName := "seanboswell"
+	expectedNames := []string{initialName, driftName, initialName}
+
+	t.Log("watching reconciler deployment until drift revert")
+	watchCtx2, watchCancel2 := context.WithTimeout(ctx, 10*time.Second)
+	defer watchCancel2()
+
+	// Start watching
+	watcher, err = watchReconcilerDeployment(watchCtx2, fakeClient, reconcilerKey)
+	require.NoError(t, err)
+
+	// Update reconciler Deployment to apply unwanted drift
+	reconcilerObj.Spec.Template.Spec.ServiceAccountName = driftName
+	err = fakeClient.Update(ctx, reconcilerObj)
+	require.NoError(t, err)
+
+	// Consume watch events until success or timeout
+	err = watchDeploymentUntil(ctx, watcher, reconcilerKey, func(event watch.Event) error {
+		t.Logf("reconciler deployment %s", event.Type)
+		if event.Type == watch.Added || event.Type == watch.Modified {
+			reconcilerObj = event.Object.(*appsv1.Deployment)
+			saName := reconcilerObj.Spec.Template.Spec.ServiceAccountName
+			// Record new ServiceAccountName, if different from last known value
+			if saName != observedNames[len(observedNames)-1] {
+				t.Logf("observed ServiceAccountName change: %s", saName)
+				observedNames = append(observedNames, saName)
+			}
+			if cmp.Equal(expectedNames, observedNames) {
+				// success - deployment change observed and reverted
+				return nil
+			}
+		}
+		// keep watching
+		return errors.Errorf("reconciler deployment %s", event.Type)
+	})
+	require.NoError(t, err)
 }
 
 func validateRepoSyncStatus(t *testing.T, want *v1beta1.RepoSync, fakeClient *syncerFake.Client) {

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -338,7 +338,11 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 func (r *RootSyncReconciler) SetupWithManager(mgr controllerruntime.Manager, watchFleetMembership bool) error {
 	// Index the `gitSecretRefName` field, so that we will be able to lookup RootSync be a referenced `SecretRef` name.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1beta1.RootSync{}, gitSecretRefField, func(rawObj client.Object) []string {
-		rs := rawObj.(*v1beta1.RootSync)
+		rs, ok := rawObj.(*v1beta1.RootSync)
+		if !ok {
+			// Only add index for RootSync
+			return nil
+		}
 		if rs.Spec.Git == nil || v1beta1.GetSecretName(rs.Spec.Git.SecretRef) == "" {
 			return nil
 		}

--- a/pkg/syncer/syncertest/fake/cache.go
+++ b/pkg/syncer/syncertest/fake/cache.go
@@ -1,0 +1,367 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Cache is a fake implementation of cache.Cache.
+type Cache struct {
+	*Client
+
+	typedInformerFactory *TypedInformerFactory
+
+	// Namespace restricts the cache's ListWatch to the desired namespace
+	// Default watches all namespaces
+	namespace string
+
+	resyncPeriod time.Duration
+
+	// mux guards access to the map
+	mux sync.RWMutex
+
+	// start is true if the informers have been started
+	started bool
+
+	// startWait is a channel that is closed after the
+	// informer has been started.
+	startWait chan struct{}
+
+	// informerCtx context used to stop the informers
+	informerCtx context.Context
+
+	// informerCtxCancel is the CancelFunc to stop the informerCtx
+	informerCtxCancel context.CancelFunc
+
+	// informersByGVK is the cache of informers keyed by groupVersionKind
+	informersByGVK map[schema.GroupVersionKind]*MapEntry
+}
+
+var _ cache.Cache = &Cache{}
+
+// CacheOptions are the optional arguments for creating a new Cache object.
+type CacheOptions struct {
+	// Namespace restricts the cache's ListWatch to the desired namespace
+	// Default watches all namespaces
+	Namespace string
+
+	// ResyncPeriod is how often the objects are retrieved to re-synchronize,
+	// in case any events were missed.
+	// If zero or less, re-sync is disabled.
+	ResyncPeriod time.Duration
+}
+
+// NewCache constructs a new Cache
+func NewCache(fakeClient *Client, opts CacheOptions) *Cache {
+	return &Cache{
+		Client:               fakeClient,
+		namespace:            opts.Namespace,
+		startWait:            make(chan struct{}),
+		informersByGVK:       make(map[schema.GroupVersionKind]*MapEntry),
+		resyncPeriod:         opts.ResyncPeriod,
+		typedInformerFactory: NewTypedInformerFactory(fakeClient, opts.ResyncPeriod),
+	}
+}
+
+// Start the cache, including any previously requested informers.
+// New informers requested after start will be started immediately.
+func (c *Cache) Start(ctx context.Context) error {
+	func() {
+		c.mux.Lock()
+		defer c.mux.Unlock()
+
+		// Init the informer context.
+		// This is for the case where the cache is started before any informers are added.
+		if c.informerCtx == nil {
+			c.informerCtx, c.informerCtxCancel = context.WithCancel(context.Background())
+		}
+
+		// Start each informer
+		for gvk, informer := range c.informersByGVK {
+			klog.V(5).Infof("starting informer for %s", kinds.GVKToString(gvk))
+			go informer.Informer.Run(c.informerCtx.Done())
+		}
+
+		// Set started to true so we immediately start any informers added later.
+		c.started = true
+		close(c.startWait)
+	}()
+	<-ctx.Done()
+
+	c.mux.RLock()
+	defer c.mux.RLock()
+	// Stop the informers
+	c.informerCtxCancel()
+
+	return nil
+}
+
+// WaitForCacheSync returns true when the cached informers are all synced.
+// Returns false if the context is done first.
+func (c *Cache) WaitForCacheSync(ctx context.Context) bool {
+	select {
+	case <-c.startWait:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// HasSyncedFuncs returns all the HasSynced functions for the informers in this map.
+func (c *Cache) HasSyncedFuncs() []k8scache.InformerSynced {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	syncedFuncs := make([]k8scache.InformerSynced, 0, len(c.informersByGVK))
+	for _, informer := range c.informersByGVK {
+		syncedFuncs = append(syncedFuncs, informer.Informer.HasSynced)
+	}
+	return syncedFuncs
+}
+
+// GetInformer constructs or retrieves from cache an informer to watch the
+// specified resource.
+func (c *Cache) GetInformer(ctx context.Context, obj client.Object) (cache.Informer, error) {
+	gvk, err := kinds.Lookup(obj, c.Scheme())
+	if err != nil {
+		return nil, err
+	}
+	return c.GetInformerForKind(ctx, gvk)
+}
+
+func (c *Cache) getInformerMapEntry(ctx context.Context, gvk schema.GroupVersionKind) (*MapEntry, bool, error) {
+	// Return the informer if it is found
+	entry, started, found := func() (*MapEntry, bool, bool) {
+		c.mux.RLock()
+		defer c.mux.RUnlock()
+		entry, found := c.informersByGVK[gvk]
+		return entry, c.started, found
+	}()
+
+	if !found {
+		var err error
+		if entry, started, err = c.addInformerToMap(gvk); err != nil {
+			return nil, false, err
+		}
+	}
+
+	if started && !entry.Informer.HasSynced() {
+		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
+		if !k8scache.WaitForCacheSync(ctx.Done(), entry.Informer.HasSynced) {
+			return nil, false, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for Informer to sync: %s", kinds.GVKToString(gvk)), 0)
+		}
+	}
+
+	return entry, started, nil
+}
+
+// GetInformerForKind returns the informer for the GroupVersionKind.
+func (c *Cache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (cache.Informer, error) {
+	entry, _, err := c.getInformerMapEntry(ctx, gvk)
+	if err != nil {
+		return nil, err
+	}
+	return entry.Informer, nil
+}
+
+// IndexField adds an indexer to the underlying cache, using extraction function to get
+// value(s) from the given field. This index can then be used by passing a field selector
+// to List. For one-to-one compatibility with "normal" field selectors, only return one value.
+// The values may be anything. They will automatically be prefixed with the namespace of the
+// given object, if present. The objects passed are guaranteed to be objects of the correct type.
+func (c *Cache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	informer, err := c.GetInformer(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return indexByField(informer, field, extractValue)
+}
+
+// Get implements client.Reader.Get.
+func (c *Cache) Get(ctx context.Context, key client.ObjectKey, out client.Object, opts ...client.GetOption) error {
+	gvk, err := kinds.Lookup(out, c.Scheme())
+	if err != nil {
+		return err
+	}
+
+	entry, started, err := c.getInformerMapEntry(ctx, gvk)
+	if err != nil {
+		return err
+	}
+
+	if !started {
+		return &cache.ErrCacheNotStarted{}
+	}
+	return entry.Reader.Get(ctx, key, out, opts...)
+}
+
+// List implements client.Reader.List.
+func (c *Cache) List(ctx context.Context, out client.ObjectList, opts ...client.ListOption) error {
+	itemGVK, err := c.itemGVKForListObject(out)
+	if err != nil {
+		return err
+	}
+
+	entry, started, err := c.getInformerMapEntry(ctx, itemGVK)
+	if err != nil {
+		return err
+	}
+
+	if !started {
+		return &cache.ErrCacheNotStarted{}
+	}
+
+	return entry.Reader.List(ctx, out, opts...)
+}
+
+func (c *Cache) addInformerToMap(gvk schema.GroupVersionKind) (*MapEntry, bool, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	// Check the cache to see if we already have an Informer.  If we do, return the Informer.
+	// This is for the case where 2 routines tried to get the informer when it wasn't in the map
+	// so neither returned early, but the first one created it.
+	if entry, ok := c.informersByGVK[gvk]; ok {
+		return entry, c.started, nil
+	}
+
+	mapping, err := c.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Init the informer context.
+	// This is for the case where informers are added before the cache is started.
+	if c.informerCtx == nil {
+		c.informerCtx, c.informerCtxCancel = context.WithCancel(context.Background())
+	}
+
+	informer, err := c.typedInformerFactory.NewInformer(c.informerCtx, mapping, c.namespace)
+	if err != nil {
+		return nil, false, err
+	}
+
+	entry := &MapEntry{
+		Informer: informer,
+		Reader:   c.Client,
+	}
+	c.informersByGVK[gvk] = entry
+
+	// Start the Informer if cache is already started
+	if c.started {
+		klog.V(5).Infof("starting informer for %s", kinds.GVKToString(gvk))
+		go entry.Informer.Run(c.informerCtx.Done())
+	}
+	return entry, c.started, nil
+}
+
+// indexByField adds an indexer to the informer that indexes by the specified field.
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/cache/informer_cache.go#L180
+func indexByField(informer cache.Informer, field string, extractor client.IndexerFunc) error {
+	indexFunc := func(objRaw interface{}) ([]string, error) {
+		obj, isObj := objRaw.(client.Object)
+		if !isObj {
+			return nil, fmt.Errorf("object of type %T is not an Object", objRaw)
+		}
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		ns := meta.GetNamespace()
+
+		rawVals := extractor(obj)
+		var vals []string
+		if ns == "" {
+			// if we're not doubling the keys for the namespaced case, just create a new slice with same length
+			vals = make([]string, len(rawVals))
+		} else {
+			// if we need to add non-namespaced versions too, double the length
+			vals = make([]string, len(rawVals)*2)
+		}
+		for i, rawVal := range rawVals {
+			// save a namespaced variant, so that we can ask
+			// "what are all the object matching a given index *in a given namespace*"
+			vals[i] = keyToNamespacedKey(ns, rawVal)
+			if ns != "" {
+				// if we have a namespace, also inject a special index key for listing
+				// regardless of the object namespace
+				vals[i+len(rawVals)] = keyToNamespacedKey("", rawVal)
+			}
+		}
+
+		return vals, nil
+	}
+
+	return informer.AddIndexers(k8scache.Indexers{fieldIndexName(field): indexFunc})
+}
+
+// itemGVKForListObject tries to find the GVK for a single object
+// corresponding to the specified list type. Used as cache map key.
+func (c *Cache) itemGVKForListObject(list client.ObjectList) (schema.GroupVersionKind, error) {
+	// Lookup the List type from the scheme
+	listGVK, err := kinds.Lookup(list, c.Scheme())
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	// Convert the List type to the Item type
+	targetKind := strings.TrimSuffix(listGVK.Kind, kinds.ListSuffix)
+	if targetKind == listGVK.Kind {
+		return schema.GroupVersionKind{}, fmt.Errorf("list kind does not have required List suffix: %s", listGVK.Kind)
+	}
+	return listGVK.GroupVersion().WithKind(targetKind), nil
+}
+
+// MapEntry contains the cached data for an Informer.
+type MapEntry struct {
+	// Informer is the cached informer
+	Informer k8scache.SharedIndexInformer
+
+	// CacheReader wraps Informer and implements the CacheReader interface for a single type
+	Reader client.Reader
+}
+
+// fieldIndexName constructs the name of the index over the given field,
+// for use with an indexer.
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/cache/internal/cache_reader.go#L204
+func fieldIndexName(field string) string {
+	return "field:" + field
+}
+
+// allNamespacesNamespace is used as the "namespace" when we want to list across all namespaces.
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/cache/internal/cache_reader.go#L209
+const allNamespacesNamespace = "__all_namespaces"
+
+// keyToNamespacedKey prefixes the given index key with a namespace
+// for use in field selector indexes.
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/cache/internal/cache_reader.go#L213
+func keyToNamespacedKey(ns string, baseKey string) string {
+	if ns != "" {
+		return ns + "/" + baseKey
+	}
+	return allNamespacesNamespace + "/" + baseKey
+}

--- a/pkg/syncer/syncertest/fake/informer_factory.go
+++ b/pkg/syncer/syncertest/fake/informer_factory.go
@@ -1,0 +1,169 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TypedInformerFactory is a factory that constructs new SharedIndexInformers.
+type TypedInformerFactory struct {
+	Client       client.WithWatch
+	ResyncPeriod time.Duration
+	Indexers     cache.Indexers
+}
+
+// NewTypedInformerFactory constructs a new TypedInformerFactory
+func NewTypedInformerFactory(client client.WithWatch, resyncPeriod time.Duration) *TypedInformerFactory {
+	return &TypedInformerFactory{
+		Client:       client,
+		ResyncPeriod: resyncPeriod,
+		Indexers: cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		},
+	}
+}
+
+// NewInformer constructs a new SharedIndexInformer for the specified resource.
+func (f *TypedInformerFactory) NewInformer(ctx context.Context, mapping *meta.RESTMapping, namespace string) (cache.SharedIndexInformer, error) {
+	gvk := mapping.GroupVersionKind
+	scope := mapping.Scope
+
+	exampleObj, err := kinds.NewClientObjectForGVK(gvk, f.Client.Scheme())
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate List type exists in scheme
+	if _, err = kinds.NewTypedListForItemGVK(gvk, f.Client.Scheme()); err != nil {
+		return nil, err
+	}
+
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				opts, err := MetaListOptionsToClientListOptions(&options)
+				if err != nil {
+					return nil, err
+				}
+				isNamespaceScoped := namespace != "" && scope.Name() != meta.RESTScopeNameRoot
+				if isNamespaceScoped {
+					opts.Namespace = namespace
+				}
+				optsList := UnrollClientListOptions(opts)
+				listObj, err := kinds.NewTypedListForItemGVK(gvk, f.Client.Scheme())
+				if err != nil {
+					return nil, err
+				}
+				err = f.Client.List(ctx, listObj, optsList...)
+				return listObj, err
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				opts, err := MetaListOptionsToClientListOptions(&options)
+				if err != nil {
+					return nil, err
+				}
+				isNamespaceScoped := namespace != "" && scope.Name() != meta.RESTScopeNameRoot
+				if isNamespaceScoped {
+					opts.Namespace = namespace
+				}
+				optsList := UnrollClientListOptions(opts)
+				listObj, err := kinds.NewTypedListForItemGVK(gvk, f.Client.Scheme())
+				if err != nil {
+					return nil, err
+				}
+				return f.Client.Watch(ctx, listObj, optsList...)
+			},
+		},
+		exampleObj,
+		f.ResyncPeriod,
+		f.Indexers,
+	), nil
+}
+
+// MetaListOptionsToClientListOptions converts metav1.ListOptions to
+// client.ListOptions.
+func MetaListOptionsToClientListOptions(in *metav1.ListOptions) (*client.ListOptions, error) {
+	out := &client.ListOptions{}
+	if in == nil {
+		return out, nil
+	}
+	if in.LabelSelector != "" {
+		selector, err := labels.Parse(in.LabelSelector)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse label selector")
+		}
+		out.LabelSelector = selector
+	}
+	if in.FieldSelector != "" {
+		selector, err := fields.ParseSelector(in.FieldSelector)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse field selector")
+		}
+		out.FieldSelector = selector
+	}
+	if !in.Watch {
+		out.Limit = in.Limit
+		out.Continue = in.Continue
+	}
+	out.Raw = in
+	return out, nil
+}
+
+// UnrollClientListOptions converts client.ListOptions to []client.ListOption
+func UnrollClientListOptions(in *client.ListOptions) []client.ListOption {
+	var out []client.ListOption
+	if in == nil {
+		return out
+	}
+	if in.LabelSelector != nil {
+		out = append(out, client.MatchingLabelsSelector{Selector: in.LabelSelector})
+	}
+	if in.FieldSelector != nil {
+		out = append(out, client.MatchingFieldsSelector{Selector: in.FieldSelector})
+	}
+	if in.Limit > 0 {
+		out = append(out, client.Limit(in.Limit))
+	}
+	if in.Continue != "" {
+		out = append(out, client.Continue(in.Continue))
+	}
+	if in.Raw != nil {
+		out = append(out, RawListOptions{Raw: in.Raw})
+	}
+	return out
+}
+
+// RawListOptions filters the list operation using raw metav1.ListOptions.
+type RawListOptions struct {
+	Raw *metav1.ListOptions
+}
+
+// ApplyToList applies this configuration to the given an List options.
+func (rlo RawListOptions) ApplyToList(opts *client.ListOptions) {
+	opts.Raw = rlo.Raw
+}

--- a/vendor/github.com/go-logr/logr/funcr/funcr.go
+++ b/vendor/github.com/go-logr/logr/funcr/funcr.go
@@ -1,0 +1,787 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package funcr implements formatting of structured log messages and
+// optionally captures the call site and timestamp.
+//
+// The simplest way to use it is via its implementation of a
+// github.com/go-logr/logr.LogSink with output through an arbitrary
+// "write" function.  See New and NewJSON for details.
+//
+// Custom LogSinks
+//
+// For users who need more control, a funcr.Formatter can be embedded inside
+// your own custom LogSink implementation. This is useful when the LogSink
+// needs to implement additional methods, for example.
+//
+// Formatting
+//
+// This will respect logr.Marshaler, fmt.Stringer, and error interfaces for
+// values which are being logged.  When rendering a struct, funcr will use Go's
+// standard JSON tags (all except "string").
+package funcr
+
+import (
+	"bytes"
+	"encoding"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// New returns a logr.Logger which is implemented by an arbitrary function.
+func New(fn func(prefix, args string), opts Options) logr.Logger {
+	return logr.New(newSink(fn, NewFormatter(opts)))
+}
+
+// NewJSON returns a logr.Logger which is implemented by an arbitrary function
+// and produces JSON output.
+func NewJSON(fn func(obj string), opts Options) logr.Logger {
+	fnWrapper := func(_, obj string) {
+		fn(obj)
+	}
+	return logr.New(newSink(fnWrapper, NewFormatterJSON(opts)))
+}
+
+// Underlier exposes access to the underlying logging function. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() func(prefix, args string)
+}
+
+func newSink(fn func(prefix, args string), formatter Formatter) logr.LogSink {
+	l := &fnlogger{
+		Formatter: formatter,
+		write:     fn,
+	}
+	// For skipping fnlogger.Info and fnlogger.Error.
+	l.Formatter.AddCallDepth(1)
+	return l
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogCaller tells funcr to add a "caller" key to some or all log lines.
+	// This has some overhead, so some users might not want it.
+	LogCaller MessageClass
+
+	// LogCallerFunc tells funcr to also log the calling function name.  This
+	// has no effect if caller logging is not enabled (see Options.LogCaller).
+	LogCallerFunc bool
+
+	// LogTimestamp tells funcr to add a "ts" key to log lines.  This has some
+	// overhead, so some users might not want it.
+	LogTimestamp bool
+
+	// TimestampFormat tells funcr how to render timestamps when LogTimestamp
+	// is enabled.  If not specified, a default format will be used.  For more
+	// details, see docs for Go's time.Layout.
+	TimestampFormat string
+
+	// Verbosity tells funcr which V logs to produce.  Higher values enable
+	// more logs.  Info logs at or below this level will be written, while logs
+	// above this level will be discarded.
+	Verbosity int
+
+	// RenderBuiltinsHook allows users to mutate the list of key-value pairs
+	// while a log line is being rendered.  The kvList argument follows logr
+	// conventions - each pair of slice elements is comprised of a string key
+	// and an arbitrary value (verified and sanitized before calling this
+	// hook).  The value returned must follow the same conventions.  This hook
+	// can be used to audit or modify logged data.  For example, you might want
+	// to prefix all of funcr's built-in keys with some string.  This hook is
+	// only called for built-in (provided by funcr itself) key-value pairs.
+	// Equivalent hooks are offered for key-value pairs saved via
+	// logr.Logger.WithValues or Formatter.AddValues (see RenderValuesHook) and
+	// for user-provided pairs (see RenderArgsHook).
+	RenderBuiltinsHook func(kvList []interface{}) []interface{}
+
+	// RenderValuesHook is the same as RenderBuiltinsHook, except that it is
+	// only called for key-value pairs saved via logr.Logger.WithValues.  See
+	// RenderBuiltinsHook for more details.
+	RenderValuesHook func(kvList []interface{}) []interface{}
+
+	// RenderArgsHook is the same as RenderBuiltinsHook, except that it is only
+	// called for key-value pairs passed directly to Info and Error.  See
+	// RenderBuiltinsHook for more details.
+	RenderArgsHook func(kvList []interface{}) []interface{}
+
+	// MaxLogDepth tells funcr how many levels of nested fields (e.g. a struct
+	// that contains a struct, etc.) it may log.  Every time it finds a struct,
+	// slice, array, or map the depth is increased by one.  When the maximum is
+	// reached, the value will be converted to a string indicating that the max
+	// depth has been exceeded.  If this field is not specified, a default
+	// value will be used.
+	MaxLogDepth int
+}
+
+// MessageClass indicates which category or categories of messages to consider.
+type MessageClass int
+
+const (
+	// None ignores all message classes.
+	None MessageClass = iota
+	// All considers all message classes.
+	All
+	// Info only considers info messages.
+	Info
+	// Error only considers error messages.
+	Error
+)
+
+// fnlogger inherits some of its LogSink implementation from Formatter
+// and just needs to add some glue code.
+type fnlogger struct {
+	Formatter
+	write func(prefix, args string)
+}
+
+func (l fnlogger) WithName(name string) logr.LogSink {
+	l.Formatter.AddName(name)
+	return &l
+}
+
+func (l fnlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.Formatter.AddValues(kvList)
+	return &l
+}
+
+func (l fnlogger) WithCallDepth(depth int) logr.LogSink {
+	l.Formatter.AddCallDepth(depth)
+	return &l
+}
+
+func (l fnlogger) Info(level int, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatInfo(level, msg, kvList)
+	l.write(prefix, args)
+}
+
+func (l fnlogger) Error(err error, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatError(err, msg, kvList)
+	l.write(prefix, args)
+}
+
+func (l fnlogger) GetUnderlying() func(prefix, args string) {
+	return l.write
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &fnlogger{}
+var _ logr.CallDepthLogSink = &fnlogger{}
+var _ Underlier = &fnlogger{}
+
+// NewFormatter constructs a Formatter which emits a JSON-like key=value format.
+func NewFormatter(opts Options) Formatter {
+	return newFormatter(opts, outputKeyValue)
+}
+
+// NewFormatterJSON constructs a Formatter which emits strict JSON.
+func NewFormatterJSON(opts Options) Formatter {
+	return newFormatter(opts, outputJSON)
+}
+
+// Defaults for Options.
+const defaultTimestampFormat = "2006-01-02 15:04:05.000000"
+const defaultMaxLogDepth = 16
+
+func newFormatter(opts Options, outfmt outputFormat) Formatter {
+	if opts.TimestampFormat == "" {
+		opts.TimestampFormat = defaultTimestampFormat
+	}
+	if opts.MaxLogDepth == 0 {
+		opts.MaxLogDepth = defaultMaxLogDepth
+	}
+	f := Formatter{
+		outputFormat: outfmt,
+		prefix:       "",
+		values:       nil,
+		depth:        0,
+		opts:         opts,
+	}
+	return f
+}
+
+// Formatter is an opaque struct which can be embedded in a LogSink
+// implementation. It should be constructed with NewFormatter. Some of
+// its methods directly implement logr.LogSink.
+type Formatter struct {
+	outputFormat outputFormat
+	prefix       string
+	values       []interface{}
+	valuesStr    string
+	depth        int
+	opts         Options
+}
+
+// outputFormat indicates which outputFormat to use.
+type outputFormat int
+
+const (
+	// outputKeyValue emits a JSON-like key=value format, but not strict JSON.
+	outputKeyValue outputFormat = iota
+	// outputJSON emits strict JSON.
+	outputJSON
+)
+
+// PseudoStruct is a list of key-value pairs that gets logged as a struct.
+type PseudoStruct []interface{}
+
+// render produces a log line, ready to use.
+func (f Formatter) render(builtins, args []interface{}) string {
+	// Empirically bytes.Buffer is faster than strings.Builder for this.
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+	if f.outputFormat == outputJSON {
+		buf.WriteByte('{')
+	}
+	vals := builtins
+	if hook := f.opts.RenderBuiltinsHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+	f.flatten(buf, vals, false, false) // keys are ours, no need to escape
+	continuing := len(builtins) > 0
+	if len(f.valuesStr) > 0 {
+		if continuing {
+			if f.outputFormat == outputJSON {
+				buf.WriteByte(',')
+			} else {
+				buf.WriteByte(' ')
+			}
+		}
+		continuing = true
+		buf.WriteString(f.valuesStr)
+	}
+	vals = args
+	if hook := f.opts.RenderArgsHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+	f.flatten(buf, vals, continuing, true) // escape user-provided keys
+	if f.outputFormat == outputJSON {
+		buf.WriteByte('}')
+	}
+	return buf.String()
+}
+
+// flatten renders a list of key-value pairs into a buffer.  If continuing is
+// true, it assumes that the buffer has previous values and will emit a
+// separator (which depends on the output format) before the first pair it
+// writes.  If escapeKeys is true, the keys are assumed to have
+// non-JSON-compatible characters in them and must be evaluated for escapes.
+//
+// This function returns a potentially modified version of kvList, which
+// ensures that there is a value for every key (adding a value if needed) and
+// that each key is a string (substituting a key if needed).
+func (f Formatter) flatten(buf *bytes.Buffer, kvList []interface{}, continuing bool, escapeKeys bool) []interface{} {
+	// This logic overlaps with sanitize() but saves one type-cast per key,
+	// which can be measurable.
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		k, ok := kvList[i].(string)
+		if !ok {
+			k = f.nonStringKey(kvList[i])
+			kvList[i] = k
+		}
+		v := kvList[i+1]
+
+		if i > 0 || continuing {
+			if f.outputFormat == outputJSON {
+				buf.WriteByte(',')
+			} else {
+				// In theory the format could be something we don't understand.  In
+				// practice, we control it, so it won't be.
+				buf.WriteByte(' ')
+			}
+		}
+
+		if escapeKeys {
+			buf.WriteString(prettyString(k))
+		} else {
+			// this is faster
+			buf.WriteByte('"')
+			buf.WriteString(k)
+			buf.WriteByte('"')
+		}
+		if f.outputFormat == outputJSON {
+			buf.WriteByte(':')
+		} else {
+			buf.WriteByte('=')
+		}
+		buf.WriteString(f.pretty(v))
+	}
+	return kvList
+}
+
+func (f Formatter) pretty(value interface{}) string {
+	return f.prettyWithFlags(value, 0, 0)
+}
+
+const (
+	flagRawStruct = 0x1 // do not print braces on structs
+)
+
+// TODO: This is not fast. Most of the overhead goes here.
+func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) string {
+	if depth > f.opts.MaxLogDepth {
+		return `"<max-log-depth-exceeded>"`
+	}
+
+	// Handle types that take full control of logging.
+	if v, ok := value.(logr.Marshaler); ok {
+		// Replace the value with what the type wants to get logged.
+		// That then gets handled below via reflection.
+		value = invokeMarshaler(v)
+	}
+
+	// Handle types that want to format themselves.
+	switch v := value.(type) {
+	case fmt.Stringer:
+		value = invokeStringer(v)
+	case error:
+		value = invokeError(v)
+	}
+
+	// Handling the most common types without reflect is a small perf win.
+	switch v := value.(type) {
+	case bool:
+		return strconv.FormatBool(v)
+	case string:
+		return prettyString(v)
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(int64(v), 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uintptr:
+		return strconv.FormatUint(uint64(v), 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case complex64:
+		return `"` + strconv.FormatComplex(complex128(v), 'f', -1, 64) + `"`
+	case complex128:
+		return `"` + strconv.FormatComplex(v, 'f', -1, 128) + `"`
+	case PseudoStruct:
+		buf := bytes.NewBuffer(make([]byte, 0, 1024))
+		v = f.sanitize(v)
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < len(v); i += 2 {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			k, _ := v[i].(string) // sanitize() above means no need to check success
+			// arbitrary keys might need escaping
+			buf.WriteString(prettyString(k))
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v[i+1], 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	t := reflect.TypeOf(value)
+	if t == nil {
+		return "null"
+	}
+	v := reflect.ValueOf(value)
+	switch t.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.String:
+		return prettyString(v.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(int64(v.Int()), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(uint64(v.Uint()), 10)
+	case reflect.Float32:
+		return strconv.FormatFloat(float64(v.Float()), 'f', -1, 32)
+	case reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.Complex64:
+		return `"` + strconv.FormatComplex(complex128(v.Complex()), 'f', -1, 64) + `"`
+	case reflect.Complex128:
+		return `"` + strconv.FormatComplex(v.Complex(), 'f', -1, 128) + `"`
+	case reflect.Struct:
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < t.NumField(); i++ {
+			fld := t.Field(i)
+			if fld.PkgPath != "" {
+				// reflect says this field is only defined for non-exported fields.
+				continue
+			}
+			if !v.Field(i).CanInterface() {
+				// reflect isn't clear exactly what this means, but we can't use it.
+				continue
+			}
+			name := ""
+			omitempty := false
+			if tag, found := fld.Tag.Lookup("json"); found {
+				if tag == "-" {
+					continue
+				}
+				if comma := strings.Index(tag, ","); comma != -1 {
+					if n := tag[:comma]; n != "" {
+						name = n
+					}
+					rest := tag[comma:]
+					if strings.Contains(rest, ",omitempty,") || strings.HasSuffix(rest, ",omitempty") {
+						omitempty = true
+					}
+				} else {
+					name = tag
+				}
+			}
+			if omitempty && isEmpty(v.Field(i)) {
+				continue
+			}
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if fld.Anonymous && fld.Type.Kind() == reflect.Struct && name == "" {
+				buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), flags|flagRawStruct, depth+1))
+				continue
+			}
+			if name == "" {
+				name = fld.Name
+			}
+			// field names can't contain characters which need escaping
+			buf.WriteByte('"')
+			buf.WriteString(name)
+			buf.WriteByte('"')
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	case reflect.Slice, reflect.Array:
+		buf.WriteByte('[')
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			e := v.Index(i)
+			buf.WriteString(f.prettyWithFlags(e.Interface(), 0, depth+1))
+		}
+		buf.WriteByte(']')
+		return buf.String()
+	case reflect.Map:
+		buf.WriteByte('{')
+		// This does not sort the map keys, for best perf.
+		it := v.MapRange()
+		i := 0
+		for it.Next() {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			// If a map key supports TextMarshaler, use it.
+			keystr := ""
+			if m, ok := it.Key().Interface().(encoding.TextMarshaler); ok {
+				txt, err := m.MarshalText()
+				if err != nil {
+					keystr = fmt.Sprintf("<error-MarshalText: %s>", err.Error())
+				} else {
+					keystr = string(txt)
+				}
+				keystr = prettyString(keystr)
+			} else {
+				// prettyWithFlags will produce already-escaped values
+				keystr = f.prettyWithFlags(it.Key().Interface(), 0, depth+1)
+				if t.Key().Kind() != reflect.String {
+					// JSON only does string keys.  Unlike Go's standard JSON, we'll
+					// convert just about anything to a string.
+					keystr = prettyString(keystr)
+				}
+			}
+			buf.WriteString(keystr)
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(it.Value().Interface(), 0, depth+1))
+			i++
+		}
+		buf.WriteByte('}')
+		return buf.String()
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return "null"
+		}
+		return f.prettyWithFlags(v.Elem().Interface(), 0, depth)
+	}
+	return fmt.Sprintf(`"<unhandled-%s>"`, t.Kind().String())
+}
+
+func prettyString(s string) string {
+	// Avoid escaping (which does allocations) if we can.
+	if needsEscape(s) {
+		return strconv.Quote(s)
+	}
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b.WriteByte('"')
+	b.WriteString(s)
+	b.WriteByte('"')
+	return b.String()
+}
+
+// needsEscape determines whether the input string needs to be escaped or not,
+// without doing any allocations.
+func needsEscape(s string) bool {
+	for _, r := range s {
+		if !strconv.IsPrint(r) || r == '\\' || r == '"' {
+			return true
+		}
+	}
+	return false
+}
+
+func isEmpty(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func invokeMarshaler(m logr.Marshaler) (ret interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return m.MarshalLog()
+}
+
+func invokeStringer(s fmt.Stringer) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return s.String()
+}
+
+func invokeError(e error) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return e.Error()
+}
+
+// Caller represents the original call site for a log line, after considering
+// logr.Logger.WithCallDepth and logr.Logger.WithCallStackHelper.  The File and
+// Line fields will always be provided, while the Func field is optional.
+// Users can set the render hook fields in Options to examine logged key-value
+// pairs, one of which will be {"caller", Caller} if the Options.LogCaller
+// field is enabled for the given MessageClass.
+type Caller struct {
+	// File is the basename of the file for this call site.
+	File string `json:"file"`
+	// Line is the line number in the file for this call site.
+	Line int `json:"line"`
+	// Func is the function name for this call site, or empty if
+	// Options.LogCallerFunc is not enabled.
+	Func string `json:"function,omitempty"`
+}
+
+func (f Formatter) caller() Caller {
+	// +1 for this frame, +1 for Info/Error.
+	pc, file, line, ok := runtime.Caller(f.depth + 2)
+	if !ok {
+		return Caller{"<unknown>", 0, ""}
+	}
+	fn := ""
+	if f.opts.LogCallerFunc {
+		if fp := runtime.FuncForPC(pc); fp != nil {
+			fn = fp.Name()
+		}
+	}
+
+	return Caller{filepath.Base(file), line, fn}
+}
+
+const noValue = "<no-value>"
+
+func (f Formatter) nonStringKey(v interface{}) string {
+	return fmt.Sprintf("<non-string-key: %s>", f.snippet(v))
+}
+
+// snippet produces a short snippet string of an arbitrary value.
+func (f Formatter) snippet(v interface{}) string {
+	const snipLen = 16
+
+	snip := f.pretty(v)
+	if len(snip) > snipLen {
+		snip = snip[:snipLen]
+	}
+	return snip
+}
+
+// sanitize ensures that a list of key-value pairs has a value for every key
+// (adding a value if needed) and that each key is a string (substituting a key
+// if needed).
+func (f Formatter) sanitize(kvList []interface{}) []interface{} {
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		_, ok := kvList[i].(string)
+		if !ok {
+			kvList[i] = f.nonStringKey(kvList[i])
+		}
+	}
+	return kvList
+}
+
+// Init configures this Formatter from runtime info, such as the call depth
+// imposed by logr itself.
+// Note that this receiver is a pointer, so depth can be saved.
+func (f *Formatter) Init(info logr.RuntimeInfo) {
+	f.depth += info.CallDepth
+}
+
+// Enabled checks whether an info message at the given level should be logged.
+func (f Formatter) Enabled(level int) bool {
+	return level <= f.opts.Verbosity
+}
+
+// GetDepth returns the current depth of this Formatter.  This is useful for
+// implementations which do their own caller attribution.
+func (f Formatter) GetDepth() int {
+	return f.depth
+}
+
+// FormatInfo renders an Info log message into strings.  The prefix will be
+// empty when no names were set (via AddNames), or when the output is
+// configured for JSON.
+func (f Formatter) FormatInfo(level int, msg string, kvList []interface{}) (prefix, argsStr string) {
+	args := make([]interface{}, 0, 64) // using a constant here impacts perf
+	prefix = f.prefix
+	if f.outputFormat == outputJSON {
+		args = append(args, "logger", prefix)
+		prefix = ""
+	}
+	if f.opts.LogTimestamp {
+		args = append(args, "ts", time.Now().Format(f.opts.TimestampFormat))
+	}
+	if policy := f.opts.LogCaller; policy == All || policy == Info {
+		args = append(args, "caller", f.caller())
+	}
+	args = append(args, "level", level, "msg", msg)
+	return prefix, f.render(args, kvList)
+}
+
+// FormatError renders an Error log message into strings.  The prefix will be
+// empty when no names were set (via AddNames),  or when the output is
+// configured for JSON.
+func (f Formatter) FormatError(err error, msg string, kvList []interface{}) (prefix, argsStr string) {
+	args := make([]interface{}, 0, 64) // using a constant here impacts perf
+	prefix = f.prefix
+	if f.outputFormat == outputJSON {
+		args = append(args, "logger", prefix)
+		prefix = ""
+	}
+	if f.opts.LogTimestamp {
+		args = append(args, "ts", time.Now().Format(f.opts.TimestampFormat))
+	}
+	if policy := f.opts.LogCaller; policy == All || policy == Error {
+		args = append(args, "caller", f.caller())
+	}
+	args = append(args, "msg", msg)
+	var loggableErr interface{}
+	if err != nil {
+		loggableErr = err.Error()
+	}
+	args = append(args, "error", loggableErr)
+	return f.prefix, f.render(args, kvList)
+}
+
+// AddName appends the specified name.  funcr uses '/' characters to separate
+// name elements.  Callers should not pass '/' in the provided name string, but
+// this library does not actually enforce that.
+func (f *Formatter) AddName(name string) {
+	if len(f.prefix) > 0 {
+		f.prefix += "/"
+	}
+	f.prefix += name
+}
+
+// AddValues adds key-value pairs to the set of saved values to be logged with
+// each log line.
+func (f *Formatter) AddValues(kvList []interface{}) {
+	// Three slice args forces a copy.
+	n := len(f.values)
+	f.values = append(f.values[:n:n], kvList...)
+
+	vals := f.values
+	if hook := f.opts.RenderValuesHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+
+	// Pre-render values, so we don't have to do it on each Info/Error call.
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+	f.flatten(buf, vals, false, true) // escape user-provided keys
+	f.valuesStr = buf.String()
+}
+
+// AddCallDepth increases the number of stack-frames to skip when attributing
+// the log line to a file and line.
+func (f *Formatter) AddCallDepth(depth int) {
+	f.depth += depth
+}

--- a/vendor/github.com/go-logr/logr/testr/testr.go
+++ b/vendor/github.com/go-logr/logr/testr/testr.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testr provides support for using logr in tests.
+package testr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+// New returns a logr.Logger that prints through a testing.T object.
+// Info logs are only enabled at V(0).
+func New(t *testing.T) logr.Logger {
+	l := &testlogger{
+		Formatter: funcr.NewFormatter(funcr.Options{}),
+		t:         t,
+	}
+	return logr.New(l)
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogTimestamp tells the logger to add a "ts" key to log
+	// lines. This has some overhead, so some users might not want
+	// it.
+	LogTimestamp bool
+
+	// Verbosity tells the logger which V logs to be write.
+	// Higher values enable more logs.
+	Verbosity int
+}
+
+// NewWithOptions returns a logr.Logger that prints through a testing.T object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithOptions(t *testing.T, opts Options) logr.Logger {
+	l := &testlogger{
+		Formatter: funcr.NewFormatter(funcr.Options{
+			LogTimestamp: opts.LogTimestamp,
+			Verbosity:    opts.Verbosity,
+		}),
+		t: t,
+	}
+	return logr.New(l)
+}
+
+// Underlier exposes access to the underlying testing.T instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() *testing.T
+}
+
+type testlogger struct {
+	funcr.Formatter
+	t *testing.T
+}
+
+func (l testlogger) WithName(name string) logr.LogSink {
+	l.Formatter.AddName(name)
+	return &l
+}
+
+func (l testlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.Formatter.AddValues(kvList)
+	return &l
+}
+
+func (l testlogger) GetCallStackHelper() func() {
+	return l.t.Helper
+}
+
+func (l testlogger) Info(level int, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatInfo(level, msg, kvList)
+	l.t.Helper()
+	if prefix != "" {
+		l.t.Logf("%s: %s", prefix, args)
+	} else {
+		l.t.Log(args)
+	}
+}
+
+func (l testlogger) Error(err error, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatError(err, msg, kvList)
+	l.t.Helper()
+	if prefix != "" {
+		l.t.Logf("%s: %s", prefix, args)
+	} else {
+		l.t.Log(args)
+	}
+}
+
+func (l testlogger) GetUnderlying() *testing.T {
+	return l.t
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &testlogger{}
+var _ logr.CallStackHelperLogSink = &testlogger{}
+var _ Underlier = &testlogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,6 +135,8 @@ github.com/go-errors/errors
 # github.com/go-logr/logr v1.2.3
 ## explicit; go 1.16
 github.com/go-logr/logr
+github.com/go-logr/logr/funcr
+github.com/go-logr/logr/testr
 # github.com/go-openapi/jsonpointer v0.19.5
 ## explicit; go 1.13
 github.com/go-openapi/jsonpointer


### PR DESCRIPTION
- Add fake.Cache and fake.TypedInformerFactory to facilitate building testable controller-runtime managers.
- Add core.RootReconcilerObjectKey and core.NsReconcilerObjectKey to make it easier to build ObjectKey/NamespacedName for reconciler deployments.
- Add a Controller interface for self-registering controllers, like RootSyncReconciler and RepoSyncReconciler
- Configure controller-runtime logs to print to the test log for reconciler-manager controller unit tests.