### PR TITLE
Fix reconciler-manager missing object updates

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -107,15 +107,6 @@ type reconcilerBase struct {
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string
-
-	// lastReconciledResourceVersions is a cache of the last reconciled
-	// ResourceVersion for each R*Sync objects.
-	//
-	// This is used for an optimization to avoid re-reconciling.
-	// However, since ResourceVersion must be treated as opaque, we can't know
-	// if it's the latest or not. So this is just an optimization, not a guarantee.
-	// https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
-	lastReconciledResourceVersions map[types.NamespacedName]string
 }
 
 func (r *reconcilerBase) serviceAccountSubject(reconcilerRef types.NamespacedName) rbacv1.Subject {
@@ -525,40 +516,6 @@ func (r *reconcilerBase) addTemplateLabels(deployment *appsv1.Deployment, labelM
 	}
 
 	deployment.Spec.Template.Labels = currentLabels
-}
-
-// setLastReconciled sets the last resourceVersion that was fully reconciled for
-// a specific R*Sync object. This should only be set if the reconciler
-// successfully performed an update of the R*Sync in this reconcile attempt.
-func (r *reconcilerBase) setLastReconciled(nn types.NamespacedName, resourceVersion string) {
-	if r.lastReconciledResourceVersions == nil {
-		r.lastReconciledResourceVersions = make(map[types.NamespacedName]string)
-	}
-	r.lastReconciledResourceVersions[nn] = resourceVersion
-}
-
-// clearLastReconciled clears the last reconciled resourceVersion for a specific
-// R*Sync object. This should be called after a R*Sync is deleted.
-func (r *reconcilerBase) clearLastReconciled(nn types.NamespacedName) {
-	if r.lastReconciledResourceVersions == nil {
-		return
-	}
-	delete(r.lastReconciledResourceVersions, nn)
-}
-
-// isLastReconciled checks if a resourceVersion for a specific R*Sync object is
-// the same as last one that was reconciled. If true, reconciliation can safely
-// be skipped, because that resourceVersion is no longer the latest, and a new
-// reconcile should be queued to handle the latest.
-func (r *reconcilerBase) isLastReconciled(nn types.NamespacedName, resourceVersion string) bool {
-	if r.lastReconciledResourceVersions == nil {
-		return false
-	}
-	lastReconciled := r.lastReconciledResourceVersions[nn]
-	if lastReconciled == "" {
-		return false
-	}
-	return resourceVersion == lastReconciled
 }
 
 // validateCACertSecret verify that caCertSecretRef is well formed with a key named "cert"

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -111,7 +111,6 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	if err := r.client.Get(ctx, rsRef, rs); err != nil {
 		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 		if apierrors.IsNotFound(err) {
-			r.clearLastReconciled(rsRef)
 			if _, ok := r.repoSyncs[rsRef]; !ok {
 				r.logger(ctx).Error(err, "Sync object not managed by this reconciler-manager")
 				// return `controllerruntime.Result{}, nil` here to make sure the request will not be requeued.
@@ -132,13 +131,6 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		// Deletion requested.
 		// Cleanup is handled above, after the RepoSync is NotFound.
 		r.logger(ctx).V(3).Info("Sync deletion timestamp detected")
-	}
-
-	// The caching client sometimes returns an old R*Sync, because the watch
-	// hasn't received the update event yet. If so, error and retry.
-	// This is an optimization to avoid unnecessary API calls.
-	if r.isLastReconciled(rsRef, rs.ResourceVersion) {
-		return controllerruntime.Result{}, fmt.Errorf("ResourceVersion already reconciled: %s", rs.ResourceVersion)
 	}
 
 	currentRS := rs.DeepCopy()
@@ -774,15 +766,10 @@ func (r *RepoSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 			"diff", fmt.Sprintf("Diff (- Expected, + Actual):\n%s", cmp.Diff(currentRS.Status, rs.Status)))
 	}
 
-	resourceVersion := rs.ResourceVersion
-
 	err := r.client.Status().Update(ctx, rs)
 	if err != nil {
 		return false, err
 	}
-
-	// Register the latest ResourceVersion as reconciled.
-	r.setLastReconciled(core.ObjectNamespacedName(rs), resourceVersion)
 	return true, nil
 }
 

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -3371,17 +3371,15 @@ func TestRepoSyncReconcileStaleClientCache(t *testing.T) {
 	err = fakeClient.Storage().TestPut(oldRS)
 	require.NoError(t, err)
 
-	// Expect next Reconcile to error since the ResourceVersion hasn't been updated.
-	// This means the client cache hasn't been updated and isn't returning the latest version.
+	// Expect next Reconcile to succeed but NOT update the RepoSync
 	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.Error(t, err, "expected Reconcile to error")
-	require.Equal(t, err.Error(), "ResourceVersion already reconciled: 1", "unexpected Reconcile error")
+	require.NoError(t, err, "unexpected Reconcile error")
 
 	// Simulate cache update from watch event (roll forward to the latest resource version)
 	err = fakeClient.Storage().TestPut(rs)
 	require.NoError(t, err)
 
-	// Reconcile should succeed and NOT update the RepoSync
+	// Reconcile should succeed but NOT update the RepoSync
 	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
 	require.NoError(t, err, "unexpected Reconcile error")
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -118,7 +118,6 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	if err := r.client.Get(ctx, rsRef, rs); err != nil {
 		metrics.RecordReconcileDuration(ctx, metrics.StatusTagKey(err), start)
 		if apierrors.IsNotFound(err) {
-			r.clearLastReconciled(rsRef)
 			r.logger(ctx).Info("Deleting managed objects")
 			return controllerruntime.Result{}, r.deleteClusterRoleBinding(ctx, reconcilerRef)
 		}
@@ -129,13 +128,6 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		// Deletion requested.
 		// Cleanup is handled above, after the RootSync is NotFound.
 		r.logger(ctx).V(3).Info("Sync deletion timestamp detected")
-	}
-
-	// The caching client sometimes returns an old R*Sync, because the watch
-	// hasn't received the update event yet. If so, error and retry.
-	// This is an optimization to avoid unnecessary API calls.
-	if r.isLastReconciled(rsRef, rs.ResourceVersion) {
-		return controllerruntime.Result{}, fmt.Errorf("ResourceVersion already reconciled: %s", rs.ResourceVersion)
 	}
 
 	currentRS := rs.DeepCopy()
@@ -573,15 +565,10 @@ func (r *RootSyncReconciler) updateStatus(ctx context.Context, currentRS, rs *v1
 			"diff", fmt.Sprintf("Diff (- Expected, + Actual):\n%s", cmp.Diff(currentRS.Status, rs.Status)))
 	}
 
-	resourceVersion := rs.ResourceVersion
-
 	err := r.client.Status().Update(ctx, rs)
 	if err != nil {
 		return false, err
 	}
-
-	// Register the latest ResourceVersion as reconciled.
-	r.setLastReconciled(core.ObjectNamespacedName(rs), resourceVersion)
 	return true, nil
 }
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -2875,17 +2875,16 @@ func TestRootSyncReconcileStaleClientCache(t *testing.T) {
 	err = fakeClient.Storage().TestPut(oldRS)
 	require.NoError(t, err)
 
-	// Expect next Reconcile to error since the ResourceVersion hasn't been updated.
+	// Expect next Reconcile to succeed but NOT update the RootSync
 	// This means the client cache hasn't been updated and isn't returning the latest version.
 	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
-	require.Error(t, err, "expected Reconcile to error")
-	require.Equal(t, err.Error(), "ResourceVersion already reconciled: 1", "unexpected Reconcile error")
+	require.NoError(t, err, "unexpected Reconcile error")
 
 	// Simulate cache update from watch event (roll forward to the latest resource version)
 	err = fakeClient.Storage().TestPut(rs)
 	require.NoError(t, err)
 
-	// Reconcile should succeed and NOT update the RootSync
+	// Reconcile should succeed but NOT update the RootSync
 	_, err = testReconciler.Reconcile(ctx, reqNamespacedName)
 	require.NoError(t, err, "unexpected Reconcile error")
 


### PR DESCRIPTION
- The reconciler-manager rurrently skips reconciles if the RootSync or RepoSync ResourceVersion didn't change. This causes it to miss updates to other watched resources, like user Secrets, and drift in other managed objects, like the reconciler Deployment, ServiceAccount, RoleBinding, and Secrets.
- Fix the issue by removing the ResourceVersion cache "optimization" that was originally added to reduce API calls.
- This may moderately increase API calls, but mostly Get & List calls, which are fast due to server-side cache, and don't cause etcd churn.