### PR TITLE
Fix reconciler-manager skipping cleanup

### DIFF
--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,11 +37,6 @@ import (
 // NOTE: Update this method when resources created by namespace controller changes.
 func (r *RepoSyncReconciler) cleanupNSControllerResources(ctx context.Context, rsKey, reconcilerRef types.NamespacedName) error {
 	r.logger(ctx).Info("Deleting managed objects")
-
-	rsList := &v1beta1.RepoSyncList{}
-	if err := r.client.List(ctx, rsList, client.InNamespace(rsKey.Namespace)); err != nil {
-		return errors.Wrapf(err, "failed to list RepoSync managed objects in namespace %q", rsKey.Namespace)
-	}
 
 	// Delete namespace controller resources and return to reconcile loop in case
 	// of errors to try cleaning up resources again.
@@ -64,12 +58,7 @@ func (r *RepoSyncReconciler) cleanupNSControllerResources(ctx context.Context, r
 		return err
 	}
 	// secret
-	if err := r.deleteSecrets(ctx, reconcilerRef); err != nil {
-		return err
-	}
-
-	delete(r.repoSyncs, rsKey)
-	return nil
+	return r.deleteSecrets(ctx, reconcilerRef)
 }
 
 func (r *reconcilerBase) cleanup(ctx context.Context, objRef types.NamespacedName, gvk schema.GroupVersionKind) error {

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -1656,14 +1656,6 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantRepoSyncs := map[types.NamespacedName]struct{}{
-		{Namespace: rs.Namespace, Name: rs.Name}: {},
-	}
-	// compare repoSyncs.
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
-	}
-
 	label := map[string]string{
 		metadata.SyncNamespaceLabel: rs.Namespace,
 		metadata.SyncNameLabel:      rs.Name,
@@ -1885,14 +1877,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantRepoSyncs := map[types.NamespacedName]struct{}{
-		{Namespace: rs1.Namespace, Name: rs1.Name}: {},
-	}
-	// compare repoSyncs.
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
-	}
-
 	wantRs1 := fake.RepoSyncObjectV1Beta1(rs1.Namespace, rs1.Name)
 	wantRs1.Spec = rs1.Spec
 	wantRs1.Status.Reconciler = nsReconcilerName
@@ -1951,12 +1935,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantRepoSyncs[types.NamespacedName{Namespace: rs2.Namespace, Name: rs2.Name}] = struct{}{}
-	// compare repoSyncs.
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
-	}
-
 	wantRs2 := fake.RepoSyncObjectV1Beta1(rs2.Namespace, rs2.Name)
 	wantRs2.Spec = rs2.Spec
 	wantRs2.Status.Reconciler = nsReconcilerName2
@@ -2012,11 +1990,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName3); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
-	}
-	// compare repoSyncs.
-	wantRepoSyncs[types.NamespacedName{Namespace: rs3.Namespace, Name: rs3.Name}] = struct{}{}
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
 	}
 
 	wantRs3 := fake.RepoSyncObjectV1Beta1(rs3.Namespace, rs3.Name)
@@ -2075,12 +2048,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	// compare repoSyncs.
-	wantRepoSyncs[types.NamespacedName{Namespace: rs4.Namespace, Name: rs4.Name}] = struct{}{}
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
-	}
-
 	wantRs4 := fake.RepoSyncObjectV1Beta1(rs4.Namespace, rs4.Name)
 	wantRs4.Spec = rs4.Spec
 	wantRs4.Status.Reconciler = nsReconcilerName4
@@ -2135,12 +2102,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName5); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
-	}
-
-	// compare repoSyncs.
-	wantRepoSyncs[types.NamespacedName{Namespace: rs5.Namespace, Name: rs5.Name}] = struct{}{}
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
 	}
 
 	wantRs5 := fake.RepoSyncObjectV1Beta1(rs5.Namespace, rs5.Name)
@@ -2297,12 +2258,6 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName1); err != nil {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
-	}
-
-	// compare syncs.
-	delete(wantRepoSyncs, types.NamespacedName{Namespace: rs1.Namespace, Name: rs1.Name})
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("syncs diff %s", diff)
 	}
 
 	if err := validateResourceDeleted(core.IDOf(rs1), fakeClient); err != nil {
@@ -2958,15 +2913,6 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	ctx := context.Background()
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
-	}
-
-	wantRepoSyncs := map[types.NamespacedName]struct{}{
-		{Namespace: rs.Namespace, Name: rs.Name}: {},
-	}
-
-	// compare repoSyncs.
-	if diff := cmp.Diff(wantRepoSyncs, testReconciler.repoSyncs, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("repoSyncs diff %s", diff)
 	}
 
 	label := map[string]string{


### PR DESCRIPTION
- Remove the RepoSync cache "optimization", because it was causing the reconciler-manager to skip cleanup of managed objects in some edge cases, like restart/reschedule that would reset the cache.
- The optimization was originally added to reduce the number of API calls, but since Reconcile is only triggered by objects that map to the specific RepoSync, we do actually need to handle each change, especially if it happens to a managed object after its RepoSync was deleted. It probably needs deleting.