### PR TITLE
Rewrite reconciler-manager error handling

### DIFF
--- a/pkg/reconcilermanager/controllers/create_or_update.go
+++ b/pkg/reconcilermanager/controllers/create_or_update.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// CreateOrUpdate creates or updates the given object in the Kubernetes
+// cluster. The object's desired state must be reconciled with the existing
+// state inside the passed in callback MutateFn.
+//
+// The MutateFn is called regardless of creating or updating an object.
+//
+// Returns the executed operation and an error.
+//
+// Similar to controllerutil.CreateOrUpdate, except it returns
+// ObjectOperationError when possible, with added context for error handling.
+func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	key := client.ObjectKeyFromObject(obj)
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationGet, key)
+		}
+		if err := mutate(f, key, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationCreate, key)
+		}
+		return controllerutil.OperationResultCreated, nil
+	}
+
+	existing := obj.DeepCopyObject() //nolint
+	if err := mutate(f, key, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		return controllerutil.OperationResultNone, nil
+	}
+
+	if err := c.Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationUpdate, key)
+	}
+	return controllerutil.OperationResultUpdated, nil
+}
+
+// mutate wraps a MutateFn and applies validation to its result.
+func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
+		return errors.Errorf("MutateFn cannot mutate object name or namespace (before: %q, after: %q)",
+			key, newKey)
+	}
+	return nil
+}

--- a/pkg/reconcilermanager/controllers/errors.go
+++ b/pkg/reconcilermanager/controllers/errors.go
@@ -1,0 +1,175 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"fmt"
+
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// OperationCreate is the create operation
+	OperationCreate = Operation("create")
+	// OperationUpdate is the update operation
+	OperationUpdate = Operation("update")
+	// OperationPatch is the patch operation
+	OperationPatch = Operation("patch")
+	// OperationDelete is the delete operation
+	OperationDelete = Operation("delete")
+	// OperationGet is the get operation
+	OperationGet = Operation("get")
+	// OperationList is the list operation
+	OperationList = Operation("list")
+	// OperationWatch is the watch operation
+	OperationWatch = Operation("watch")
+)
+
+// Operation performed on a Kubernetes resource or object
+type Operation string
+
+// ObjectOperationError is an error from the reconciler-manager regarding
+// failure to perform an operation on a managed Kubernetes resource or resource
+// object.
+type ObjectOperationError struct {
+	// ID of the managed object
+	ID core.ID
+	// Operation attempted on the managed object
+	Operation Operation
+	// Cause of the operation failure
+	Cause error
+}
+
+// Error returns the error string
+func (ooe *ObjectOperationError) Error() string {
+	return fmt.Sprintf("resource object operation failed (operation: %q, object: %q, objectKind: %q): %v",
+		ooe.Operation, ooe.ID.ObjectKey, ooe.ID.Kind, ooe.Cause)
+}
+
+// NewObjectOperationError constructs a new ObjectOperationError
+func NewObjectOperationError(err error, obj client.Object, op Operation) *ObjectOperationError {
+	id := core.IDOf(obj)
+	if id.GroupKind.Empty() {
+		gvk, lookupErr := kinds.Lookup(obj, core.Scheme)
+		if lookupErr != nil {
+			// Invalid or unregistered resource type - err probably already includes the same message
+			// Fake the kind with the struct type
+			id.Kind = fmt.Sprintf("%T", obj)
+		} else {
+			id.GroupKind = gvk.GroupKind()
+		}
+	}
+	return &ObjectOperationError{
+		ID:        id,
+		Operation: op,
+		Cause:     err,
+	}
+}
+
+// NewObjectOperationErrorWithKey constructs a new ObjectOperationError and
+// overrides the Object's key with the specified ObjectKey.
+// This is useful if you don't know whether the Object's key will be populated.
+func NewObjectOperationErrorWithKey(err error, obj client.Object, op Operation, objKey client.ObjectKey) *ObjectOperationError {
+	ooe := NewObjectOperationError(err, obj, op)
+	ooe.ID.ObjectKey = objKey
+	return ooe
+}
+
+// NewObjectOperationErrorWithID constructs a new ObjectOperationError with a
+// specific ID.
+func NewObjectOperationErrorWithID(err error, id core.ID, op Operation) *ObjectOperationError {
+	return &ObjectOperationError{
+		ID:        id,
+		Operation: op,
+		Cause:     err,
+	}
+}
+
+// NewObjectOperationErrorForList constructs a new ObjectOperationError for a
+// list of objects with the same resource.
+func NewObjectOperationErrorForList(err error, objList client.ObjectList, op Operation) *ObjectOperationError {
+	id := core.ID{}
+	listGVK, lookupErr := kinds.Lookup(objList, core.Scheme)
+	if lookupErr != nil {
+		// Invalid or unregistered resource type - err probably already includes the same message
+		// Fake the kind with the struct type
+		id.Kind = fmt.Sprintf("%T", objList)
+	} else {
+		id.GroupKind = kinds.ItemGVKForListGVK(listGVK).GroupKind()
+	}
+	return &ObjectOperationError{
+		ID:        id,
+		Operation: op,
+		Cause:     err,
+	}
+}
+
+// NewObjectOperationErrorForListWithNamespace constructs a new
+// ObjectOperationError for a list of objects with the same resource and
+// namespace.
+func NewObjectOperationErrorForListWithNamespace(err error, objList client.ObjectList, op Operation, namespace string) *ObjectOperationError {
+	ooe := NewObjectOperationErrorForList(err, objList, op)
+	ooe.ID.ObjectKey = client.ObjectKey{Namespace: namespace}
+	return ooe
+}
+
+// ObjectReconcileError is an error from the status of a managed resource object
+type ObjectReconcileError struct {
+	// ID of the managed object
+	ID core.ID
+	// Status of the managed object
+	Status kstatus.Status
+	// Cause of the operation failure
+	Cause error
+}
+
+// Error returns the error string
+func (oripe *ObjectReconcileError) Error() string {
+	return fmt.Sprintf("%s (%s) %s: %v",
+		oripe.ID.Kind, oripe.ID.ObjectKey, oripe.Status, oripe.Cause)
+}
+
+// NewObjectReconcileError constructs a new ObjectReconcileError
+func NewObjectReconcileError(err error, obj client.Object, status kstatus.Status) *ObjectReconcileError {
+	id := core.IDOf(obj)
+	if id.GroupKind.Empty() {
+		gvk, lookupErr := kinds.Lookup(obj, core.Scheme)
+		if lookupErr != nil {
+			// Invalid or unregistered resource type - err probably already includes the same message
+			// Fake the kind with the struct type
+			id.Kind = fmt.Sprintf("%T", obj)
+		} else {
+			id.GroupKind = gvk.GroupKind()
+		}
+	}
+	return &ObjectReconcileError{
+		ID:     id,
+		Status: status,
+		Cause:  err,
+	}
+}
+
+// NewObjectReconcileErrorWithID constructs a new ObjectReconcileError with the
+// specified ID.
+func NewObjectReconcileErrorWithID(err error, id core.ID, status kstatus.Status) *ObjectReconcileError {
+	return &ObjectReconcileError{
+		ID:     id,
+		Status: status,
+		Cause:  err,
+	}
+}

--- a/pkg/reconcilermanager/controllers/otel_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_controller.go
@@ -144,7 +144,7 @@ func (r *OtelReconciler) configureGooglecloudConfigMap(ctx context.Context) ([]b
 	cm := &corev1.ConfigMap{}
 	cm.Name = metrics.OtelCollectorGooglecloud
 	cm.Namespace = metrics.MonitoringNamespace
-	op, err := controllerruntime.CreateOrUpdate(ctx, r.client, cm, func() error {
+	op, err := CreateOrUpdate(ctx, r.client, cm, func() error {
 		cm.Labels = map[string]string{
 			"app":                metrics.OpenTelemetry,
 			"component":          metrics.OtelCollectorName,

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -338,7 +338,8 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -393,7 +394,8 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -428,7 +430,8 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -465,7 +468,8 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -525,7 +529,8 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -578,7 +583,8 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -623,7 +629,8 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -657,7 +664,8 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	}
 
 	wantRs.Spec = rs.Spec
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment = repoSyncDeployment(
@@ -694,7 +702,8 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -732,7 +741,8 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -786,7 +796,8 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 
 	// RepoSync should still be reconciling because the Deployment is not yet available
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// Simulate Deployment becoming Available
@@ -868,7 +879,8 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -923,7 +935,8 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 
 	// RepoSync should still be reconciling because the Deployment is not yet available
-	reposync.SetReconciling(wantRs, "Deployment", "Updated: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Updated: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// Simulate Deployment becoming Available
@@ -978,7 +991,8 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 
 	// RepoSync should still be reconciling because the Deployment is not yet available
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment.ResourceVersion = "7"
@@ -1565,12 +1579,16 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setResourceVersion("1"),
 	)
 	repoDeployment.ResourceVersion = "1"
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("Deployment successfully created")
 
@@ -1594,12 +1612,16 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setResourceVersion("2"),
 	)
 	updatedRepoDeployment.ResourceVersion = "2"
 	wantDeployments[core.IDOf(repoDeployment)] = updatedRepoDeployment
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("Deployment successfully updated")
 
@@ -1621,6 +1643,9 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
 	}
+	if t.Failed() {
+		t.FailNow()
+	}
 	t.Log("Deployment successfully updated")
 
 	// Clear rs.Spec.Override
@@ -1638,6 +1663,9 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("No need to update Deployment.")
 }
@@ -1776,7 +1804,8 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 	wantRs := fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
@@ -1821,7 +1850,8 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment.ResourceVersion = "3"
@@ -1880,7 +1910,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs1 := fake.RepoSyncObjectV1Beta1(rs1.Namespace, rs1.Name)
 	wantRs1.Spec = rs1.Spec
 	wantRs1.Status.Reconciler = nsReconcilerName
-	reposync.SetReconciling(wantRs1, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs1, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
@@ -1938,7 +1969,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs2 := fake.RepoSyncObjectV1Beta1(rs2.Namespace, rs2.Name)
 	wantRs2.Spec = rs2.Spec
 	wantRs2.Status.Reconciler = nsReconcilerName2
-	reposync.SetReconciling(wantRs2, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs2, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName2))
 	validateRepoSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
@@ -1995,7 +2027,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs3 := fake.RepoSyncObjectV1Beta1(rs3.Namespace, rs3.Name)
 	wantRs3.Spec = rs3.Spec
 	wantRs3.Status.Reconciler = nsReconcilerName3
-	reposync.SetReconciling(wantRs3, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs3, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName3))
 	validateRepoSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
@@ -2051,7 +2084,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs4 := fake.RepoSyncObjectV1Beta1(rs4.Namespace, rs4.Name)
 	wantRs4.Spec = rs4.Spec
 	wantRs4.Status.Reconciler = nsReconcilerName4
-	reposync.SetReconciling(wantRs4, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs4, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName4))
 	validateRepoSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
@@ -2107,7 +2141,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	wantRs5 := fake.RepoSyncObjectV1Beta1(rs5.Namespace, rs5.Name)
 	wantRs5.Spec = rs5.Spec
 	wantRs5.Status.Reconciler = nsReconcilerName5
-	reposync.SetReconciling(wantRs5, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs5, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName5))
 	validateRepoSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{
@@ -2163,7 +2198,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	reposync.SetReconciling(wantRs1, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs1, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs1, fakeClient)
 
 	repoContainerEnv1 = testReconciler.populateContainerEnvs(ctx, rs1, nsReconcilerName)
@@ -2197,7 +2233,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	reposync.SetReconciling(wantRs2, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs2, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName2))
 	validateRepoSyncStatus(t, wantRs2, fakeClient)
 
 	repoContainerEnv2 = testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
@@ -2231,7 +2268,8 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	reposync.SetReconciling(wantRs3, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs3, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName3))
 	validateRepoSyncStatus(t, wantRs3, fakeClient)
 
 	repoContainerEnv3 = testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
@@ -3272,7 +3310,8 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
 	wantRs.Status.Conditions = nil // clear the stalled condition
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid Helm spec
@@ -3297,7 +3336,8 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = nsReconcilerName
 	wantRs.Status.Conditions = nil // clear the stalled condition
-	reposync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	reposync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 }
 
@@ -3558,6 +3598,11 @@ func validateDeployments(wants map[core.ID]*appsv1.Deployment, fakeDynamicClient
 			return errors.Errorf("Deployment[%s] conversion failed", id.ObjectKey)
 		}
 		got := gotCoreObject.(*appsv1.Deployment)
+
+		// Compare Deployment ResourceVersion
+		if diff := cmp.Diff(want.ResourceVersion, got.ResourceVersion); diff != "" {
+			return errors.Errorf("Unexpected Deployment ResourceVersion found for %q. Diff: %v", id, diff)
+		}
 
 		// Compare Deployment Annotations
 		if diff := cmp.Diff(want.Annotations, got.Annotations); diff != "" {

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1298,11 +1298,15 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
+		setResourceVersion("1"),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("ServiceAccount, ClusterRoleBinding and Deployment successfully created")
 
@@ -1324,6 +1328,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
+		setResourceVersion("2"),
 	)
 
 	updatedRootDeployment.ResourceVersion = "2"
@@ -1331,6 +1336,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("Deployment successfully updated")
 
@@ -1352,6 +1360,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
 	}
+	if t.Failed() {
+		t.FailNow()
+	}
 	t.Log("Deployment successfully updated")
 
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
@@ -1368,6 +1379,9 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
 	}
 	t.Log("No need to update Deployment.")
 }
@@ -1600,7 +1614,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs1 := fake.RootSyncObjectV1Beta1(rs1.Name)
 	wantRs1.Spec = rs1.Spec
 	wantRs1.Status.Reconciler = rootReconcilerName
-	rootsync.SetReconciling(wantRs1, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs1, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName))
 	validateRootSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
@@ -1655,7 +1670,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs2 := fake.RootSyncObjectV1Beta1(rs2.Name)
 	wantRs2.Spec = rs2.Spec
 	wantRs2.Status.Reconciler = rootReconcilerName2
-	rootsync.SetReconciling(wantRs2, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs2, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName2))
 	validateRootSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
@@ -1708,7 +1724,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs3 := fake.RootSyncObjectV1Beta1(rs3.Name)
 	wantRs3.Spec = rs3.Spec
 	wantRs3.Status.Reconciler = rootReconcilerName3
-	rootsync.SetReconciling(wantRs3, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs3, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName3))
 	validateRootSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
@@ -1765,7 +1782,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs4 := fake.RootSyncObjectV1Beta1(rs4.Name)
 	wantRs4.Spec = rs4.Spec
 	wantRs4.Status.Reconciler = rootReconcilerName4
-	rootsync.SetReconciling(wantRs4, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs4, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName4))
 	validateRootSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
@@ -1822,7 +1840,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 	wantRs5 := fake.RootSyncObjectV1Beta1(rs5.Name)
 	wantRs5.Spec = rs5.Spec
 	wantRs5.Status.Reconciler = rootReconcilerName5
-	rootsync.SetReconciling(wantRs5, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs5, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName5))
 	validateRootSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{
@@ -1884,7 +1903,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	rootsync.SetReconciling(wantRs1, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs1, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName))
 	validateRootSyncStatus(t, wantRs1, fakeClient)
 
 	rootContainerEnv1 = testReconciler.populateContainerEnvs(ctx, rs1, rootReconcilerName)
@@ -1920,7 +1940,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	rootsync.SetReconciling(wantRs2, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs2, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName2))
 	validateRootSyncStatus(t, wantRs2, fakeClient)
 
 	rootContainerEnv2 = testReconciler.populateContainerEnvs(ctx, rs2, rootReconcilerName2)
@@ -1957,7 +1978,8 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	rootsync.SetReconciling(wantRs3, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs3, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName3))
 	validateRootSyncStatus(t, wantRs3, fakeClient)
 
 	rootContainerEnv3 = testReconciler.populateContainerEnvs(ctx, rs3, rootReconcilerName3)
@@ -2805,7 +2827,8 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = rootReconcilerName
 	wantRs.Status.Conditions = nil // clear the stalled condition
-	rootsync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName))
 	validateRootSyncStatus(t, wantRs, fakeClient)
 
 	// verify valid Helm spec
@@ -2830,7 +2853,8 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	wantRs.Spec = rs.Spec
 	wantRs.Status.Reconciler = rootReconcilerName
 	wantRs.Status.Conditions = nil // clear the stalled condition
-	rootsync.SetReconciling(wantRs, "Deployment", "Replicas: 0/1")
+	rootsync.SetReconciling(wantRs, "Deployment",
+		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", rootReconcilerName))
 	validateRootSyncStatus(t, wantRs, fakeClient)
 }
 

--- a/pkg/reconcilermanager/controllers/secret.go
+++ b/pkg/reconcilermanager/controllers/secret.go
@@ -25,7 +25,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -139,7 +138,7 @@ func (r *reconcilerBase) upsertSecret(ctx context.Context, cmsSecretRef, rsRef t
 	cmsSecret.Name = cmsSecretRef.Name
 	cmsSecret.Namespace = cmsSecretRef.Namespace
 
-	op, err := controllerruntime.CreateOrUpdate(ctx, r.client, cmsSecret, func() error {
+	op, err := CreateOrUpdate(ctx, r.client, cmsSecret, func() error {
 		r.addLabels(cmsSecret, map[string]string{
 			metadata.SyncNamespaceLabel: rsRef.Namespace,
 			metadata.SyncNameLabel:      rsRef.Name,


### PR DESCRIPTION
- Extract setup method to wrap upsertManagedObjects and handle updating the sync object status conditions.
- Add ObjectOperationError & ObjectReconcileError to pass more context about errors between abstraction layers.
- Update upsert and delete methods to return these new errors.
- Add CreateOrUpdate func that returns ObjectOperationErrors where applicable.
- Avoid updating RoleBinding and ClusterRoleBinding when noting changed.