### PR TITLE
helm: clear cache after getting chart version

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -159,7 +159,7 @@ func (h *Hydrator) getChartVersion(ctx context.Context) error {
 	if err := os.RemoveAll(helmCacheHome); err != nil {
 		// we don't necessarily need to exit on error here, as it is possible that the later rendering
 		// step could still succeed, so we just log the error and continue
-		klog.Infoln("failed to clear helm cache: %w", err)
+		klog.Infof("failed to clear helm cache: %w\n", err)
 	}
 
 	return nil


### PR DESCRIPTION
This seemed to fix the issue for autopilot clusters on my end, hopefully it will fix the issue in the test cluster too. Leaving this as a draft while I do some more experimentation.

b/286152128