### PR TITLE
fix: install/use binaries from local build dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Add binary directories to PATH (prioritize .output/go/bin -> $GOPATH/bin -> $PATH)
+PATH := $(BIN_DIR):$(GOBIN):$(PATH)
+
 ##### SETUP #####
 
 .DEFAULT_GOAL := all

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -45,12 +45,17 @@ image-oss-prow: build/prow/kubekins-kind/Dockerfile
 install-crane:
 	go install github.com/google/go-containerregistry/cmd/crane@latest
 
+.PHONY: clean-helm
+# remove any existing helm directory/binary. The install-helm target was previously
+# creating a directory at this path rather than the binary/file.
+clean-helm:
+	rm -rf $(HELM)
+
 .PHONY: install-helm
 # install helm binary to publish the image
-install-helm:
+install-helm: clean-helm buildenv-dirs
 	wget https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz -O /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 	tar -zxvf /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz -C /tmp
-	mkdir -p $(HELM) || true
 	mv /tmp/linux-amd64/helm $(HELM)
 	rm /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 


### PR DESCRIPTION
The install-helm target was installing helm into a nested subdirectory, causing it to not be discoverable in the PATH. This refactors the target to reuse the buildenv-dirs target, which correctly creates the directory.

Also set the PATH in the makefile so that we use the correct binaries, prioritizing the local build dir, then the go bins, then the parent PATH.