### PR TITLE
ci: add make targets for parallel gke e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,9 @@ lint-license: pull-buildenv buildenv-dirs
 "$(BIN_DIR)/kustomize": "$(GOBIN)/kustomize"
 	cp $(GOBIN)/kustomize $(BIN_DIR)/kustomize
 
+.PHONY: install-kustomize
+install-kustomize: "$(BIN_DIR)/kustomize"
+
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"
 	GOBIN=$(GOBIN) ./scripts/license-headers.sh add

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -28,13 +28,27 @@ __install-nomos-local:
 # Run the Go e2e tests after building images/manifests.
 # Useful for when you're actively modifying code between runs.
 .PHONY: test-e2e-go
-test-e2e-go: config-sync-manifest-local __install-nomos-local test-e2e-go-nobuild
+test-e2e: config-sync-manifest-local __install-nomos-local test-e2e-nobuild
 
 # Run the Go e2e tests without building images/manifests.
 # Useful for modifying test code and rerunning tests without rebuilding images.
 .PHONY: test-e2e-go-nobuild
-test-e2e-go-nobuild:
-	@GO111MODULE=on go test ./e2e/... --e2e $(E2E_ARGS)
+test-e2e-nobuild: install-kustomize install-helm
+	./build/test-e2e-go/e2e.sh $(E2E_ARGS)
+
+# Run the Go e2e tests on GKE without building images/manifests.
+# The test framework will create/teardown the GKE clusters.
+.PHONY: test-e2e-gke-nobuild
+test-e2e-gke-nobuild:
+	$(MAKE) test-e2e-nobuild \
+		E2E_ARGS="$(E2E_ARGS) --timeout=$(GKE_E2E_TIMEOUT) --share-test-env --create-clusters --test-cluster=gke" \
+		GCP_PROJECT=$(GCP_PROJECT) \
+		GCP_ZONE=$(GCP_ZONE) \
+		GCP_REGION=$(GCP_REGION)
+
+# Build Config Sync and run e2e tests on GKE
+.PHONY: test-e2e-gke
+test-e2e-gke: config-sync-manifest test-e2e-gke-nobuild
 
 # This target runs all the e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo
@@ -44,7 +58,6 @@ test-e2e-kind-multi-repo: config-sync-manifest-local
 		--timeout 60m \
 		--test.v -v \
 		--num-clusters 15 \
-		--p 1 \
 		$(E2E_ARGS)
 
 # This target runs the first group of e2e tests with the multi-repo mode.

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -27,6 +27,7 @@ __docker-run-e2e-go-gke: config-sync-manifest __build-e2e-go-container
 	@docker run \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ARTIFACTS):/logs/artifacts \
+		--env ARTIFACTS="/logs/artifacts" \
 		--env GCP_PROJECT=$(GCP_PROJECT) \
 		--env GCP_CLUSTER=$(GCP_CLUSTER) \
 		--env GCP_ZONE=$(GCP_ZONE) \
@@ -37,7 +38,6 @@ __docker-run-e2e-go-gke: config-sync-manifest __build-e2e-go-container
 			--timeout $(GKE_E2E_TIMEOUT) \
 			--test.v -v \
 			--num-clusters 1 \
-			--p 1 \
 			--test-cluster=gke \
 			$(E2E_ARGS)
 
@@ -94,6 +94,13 @@ test-e2e-gke-multi-repo-test-group7:
 test-e2e-gke-multi-repo-test-group8:
 	$(MAKE) E2E_ARGS="$(E2E_ARGS) --share-test-env --test-features=workload-identity" \
 		test-e2e-go-gke-ci
+
+# New CI target for running the entire e2e test suite on GKE.
+# - Reuses build artifacts from postsubmit job
+# - Creates N target clusters and runs the tests in parallel
+# - Does not build any images or require docker-in-docker
+.PHONY: test-e2e-gke-ci
+test-e2e-gke-ci: pull-postsubmit-retry test-e2e-gke-nobuild
 
 POSTSUBMIT_GCS_PREFIX ?= gs://kpt-config-sync-ci-postsubmit
 POSTSUBMIT_REGISTRY ?= us-docker.pkg.dev/kpt-config-sync-ci-artifacts/postsubmit

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -13,28 +13,46 @@
 # limitations under the License.
 
 # special prow related things
+# Images are tagged with an arbitrary semver and git SHA. The git SHA ensures
+# unique tags and makes the images traceable back to a commit. The semver should
+# be revved upon any major changes to the image.
 
-# This is the image that our prow nomos-presubmit-e2e job runs so that it can
-# use KIND instead of setting up a GKE cluster per test run.
+# This is the image that our prow kind/e2e presubmit job runs so that it can
+# use KIND instead of setting up a GKE cluster per test run. Based on kubekins-e2e
+# for docker-in-docker support to build docker images and run kind.
 
 # Note: nothing builds this, if you update the version, you will need to rebuild manually.
-# For the version tag, concatenate the kubekins version and KIND version
-E2E_TEST_IMAGE_OSS_PROW_KUBEKINS_REGISTRY := k8s-staging-test-infra
-E2E_TEST_IMAGE_OSS_PROW_KUBEKINS := v20230309-9a6b1b3121-1.23
-E2E_TEST_IMAGE_OSS_PROW_KIND := v0.14.0
-E2E_TEST_IMAGE_OSS_PROW_TAG := kubekins-e2e-$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS)-kind-$(E2E_TEST_IMAGE_OSS_PROW_KIND)
-E2E_TEST_IMAGE_OSS_PROW := gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:$(E2E_TEST_IMAGE_OSS_PROW_TAG)
-image-oss-prow: build/prow/kubekins-kind/Dockerfile
-	@echo "+++ Building the image for the oss-prow presubmit run"
+# TODO: setup postsubmit job to build this image
+KUBEKINS_E2E_TAG := v1.0.0-$(shell git rev-parse --short HEAD)
+KUBEKINS_E2E_IMAGE := $(TEST_INFRA_REGISTRY)/kubekins-e2e:$(KUBEKINS_E2E_TAG)
+.PHONY: build-kubekins-e2e
+build-kubekins-e2e: build/prow/kubekins-e2e/Dockerfile
+	@echo "+++ Building $(KUBEKINS_E2E_IMAGE)"
 	docker buildx build \
-		-t $(E2E_TEST_IMAGE_OSS_PROW) \
-		--build-arg KUBEKINS_REGISTRY=$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS_REGISTRY) \
-		--build-arg KUBEKINS=$(E2E_TEST_IMAGE_OSS_PROW_KUBEKINS) \
-		--build-arg KIND_RELEASE=$(E2E_TEST_IMAGE_OSS_PROW_KIND) \
+		-t $(KUBEKINS_E2E_IMAGE) \
 		-f $< \
 		$(dir $<).
-	@docker push $(E2E_TEST_IMAGE_OSS_PROW)
 
+.PHONY: push-kubekins-e2e
+push-kubekins-e2e:
+	@docker push $(KUBEKINS_E2E_IMAGE)
+
+# This is the image used by the new GKE e2e jobs. This job type runs against GKE
+# clusters rather than kind, so we don't need docker in docker.
+# Note: nothing builds this, if you update the version, you will need to rebuild manually.
+# TODO: setup postsubmit job to build this image
+GKE_E2E_TAG := v1.0.0-$(shell git rev-parse --short HEAD)
+GKE_E2E_IMAGE := $(TEST_INFRA_REGISTRY)/gke-e2e:$(GKE_E2E_TAG)
+.PHONY: build-gke-e2e
+build-gke-e2e:
+	@echo "+++ Building $(GKE_E2E_IMAGE)"
+	docker buildx build \
+		-t $(GKE_E2E_IMAGE) \
+		-f build/prow/gke-e2e/Dockerfile
+
+.PHONY: push-gke-e2e
+push-gke-e2e:
+	@docker push $(GKE_E2E_IMAGE)
 
 ###################################
 # Helpers

--- a/build/prow/gke-e2e/Dockerfile
+++ b/build/prow/gke-e2e/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build intermediate image for gcloud / kubectl
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:425.0.0-slim as gcloud-install
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+
+# Build e2e image
+FROM golang:1.19-alpine as kpt-config-sync-e2e
+
+# Since go modules isn't enabled by default.
+ENV GO111MODULE=on
+# Build static binaries; otherwise go test complains.
+ENV CGO_ENABLED=0
+
+RUN apk add --no-cache \
+  bash curl docker gcc git jq make openssh-client python3 diffutils
+
+# Copy installed gcloud and kubectl into image
+COPY --from=gcloud-install /usr/lib/google-cloud-sdk /opt/gcloud/google-cloud-sdk
+COPY --from=gcloud-install /usr/bin/kubectl /opt/gcloud/google-cloud-sdk/bin/kubectl
+ENV PATH /opt/gcloud/google-cloud-sdk/bin:$PATH
+
+# Get go-junit-report
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0

--- a/build/prow/kubekins-e2e/Dockerfile
+++ b/build/prow/kubekins-e2e/Dockerfile
@@ -22,11 +22,11 @@
 # between these two files will eliminate any confusion on what versions are
 # actually being used.
 
-ARG KUBEKINS_REGISTRY="gke-test-infra"
-ARG KUBEKINS="v20220204-29ea0e1be-1.22"
+FROM gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
 
-FROM gcr.io/${KUBEKINS_REGISTRY}/kubekins-e2e:${KUBEKINS}
-
-ARG KIND_RELEASE="v0.14.0"
-RUN wget -q -O /bin/kind https://kind.sigs.k8s.io/dl/${KIND_RELEASE}/kind-linux-amd64
+# TODO: using a pre-installed kind binary makes it very painful to upgrade the
+# kind version. Update the e2e tests to either:
+# - install kind binary at runtime
+# - consolidate kind usage to Go dependency rather than mixing usage with binary
+RUN wget -q -O /bin/kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
 RUN chmod +x /bin/kind


### PR DESCRIPTION
Adds a series of make targets to support running the newly added parallel gke e2e tests in CI.

Add Dockerfile for gke-e2e image. This is based on and intended to replace the test-e2e-go/gke image. The latter image is rebuilt on every CI test execution and invoked using docker-in-docker inside the prowjob. The new prowjob is intended to not require docker-in-docker, and will use this new image which is built once and used many times. This is intended to simplify and reduce the runtime of the prowjob. Versioned dependencies such as kustomize and helm are still installed at runtime.

This change adds some make targets which are similar to existing targets - this is intentional. New prowjobs will be defined which use the new targets, and the old targets will be cleaned up once the existing prowjobs are retired.