### PR TITLE
test: enable workload identity for new gke clusters

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -85,7 +85,10 @@ func createGKECluster(t testing.NTB, name string) error {
 	} else {
 		args = append(args, "create")
 	}
-	args = append(args, name, "--project", *e2e.GCPProject)
+	args = append(args, name,
+		"--project", *e2e.GCPProject,
+		"--workload-pool", fmt.Sprintf("%s.svc.id.goog", *e2e.GCPProject),
+	)
 	if *e2e.GCPZone != "" {
 		args = append(args, "--zone", *e2e.GCPZone)
 	}


### PR DESCRIPTION
The cluster creation was missing the workload identity option, causing tests which require workload identity to fail.