### PR TITLE
ci: fix workload identity for reposync

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -247,7 +247,7 @@ func TestHelmVersionRange(t *testing.T) {
 // This test will work only with following pre-requisites:
 // Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
 func TestHelmNamespaceRepo(t *testing.T) {
-	repoSyncNN := nomostest.RepoSyncNN(testNs, "rs-test")
+	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireGKE(t),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))

--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -49,8 +49,6 @@ data "google_compute_default_service_account" "default" {
 
 resource "google_project_iam_member" "gce-default-sa-iam" {
   for_each = toset([
-    "roles/source.reader",
-    "roles/artifactregistry.reader",
     "roles/storage.objectViewer",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",

--- a/e2e/testinfra/terraform/modules/service_account/service_account.tf
+++ b/e2e/testinfra/terraform/modules/service_account/service_account.tf
@@ -29,6 +29,12 @@ resource "google_service_account_iam_member" "k8s_sa_binding" {
   member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler]"
 }
 
+resource "google_service_account_iam_member" "k8s_sa_ns_binding" {
+  service_account_id = google_service_account.gcp_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns]"
+}
+
 resource "google_project_iam_member" "gcp_sa_role" {
   role    = var.role
   member  = "serviceAccount:${google_service_account.gcp_sa.email}"


### PR DESCRIPTION
There is no workload identity binding for ns reconcilers, which was causing this test to fail. This change adds a workload identity binding for repo-sync and updates the test to create the correctly named RepoSync.

Also removes the AR/CSR reader permissions from the default compute SA, as this was causing false positives when testing with a cluster that did not have workload identity enabled.