### PR TITLE
test: fix usage of flag pointers in tests

### DIFF
--- a/e2e/testcases/csr_auth_test.go
+++ b/e2e/testcases/csr_auth_test.go
@@ -43,14 +43,17 @@ const (
 	crossProjectFleetProjectID = "cs-dev-hub"
 )
 
-var (
-	// The CSR repo was built from the directory e2e/testdata/hydration/kustomize-components,
-	// which includes a kustomization.yaml file in the root directory that
-	// references resources for tenant-a, tenant-b, and tenant-c.
-	// Each tenant includes a NetworkPolicy, a Role and a RoleBinding.
-	csrRepo           = fmt.Sprintf("https://source.developers.google.com/p/%s/r/kustomize-components", *e2e.GCPProject)
-	gsaCSRReaderEmail = fmt.Sprintf("e2e-test-csr-reader@%s.iam.gserviceaccount.com", *e2e.GCPProject)
-)
+// The CSR repo was built from the directory e2e/testdata/hydration/kustomize-components,
+// which includes a kustomization.yaml file in the root directory that
+// references resources for tenant-a, tenant-b, and tenant-c.
+// Each tenant includes a NetworkPolicy, a Role and a RoleBinding.
+func csrRepo() string {
+	return fmt.Sprintf("https://source.developers.google.com/p/%s/r/kustomize-components", *e2e.GCPProject)
+}
+
+func gsaCSRReaderEmail() string {
+	return fmt.Sprintf("e2e-test-csr-reader@%s.iam.gserviceaccount.com", *e2e.GCPProject)
+}
 
 // TestGCENode tests the `gcenode` auth type.
 //
@@ -71,7 +74,7 @@ func TestGCENode(t *testing.T) {
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a CSR repo")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"git": {"dir": "%s", "branch": "%s", "repo": "%s", "auth": "gcenode", "secretRef": {"name": ""}}}}`,
-		tenant, syncBranch, csrRepo))
+		tenant, syncBranch, csrRepo()))
 
 	err := nt.WatchForAllSyncs(nomostest.WithRootSha1Func(nomostest.RemoteRootRepoSha1Fn),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: tenant}))
@@ -103,9 +106,9 @@ func TestGKEWorkloadIdentity(t *testing.T) {
 	testWorkloadIdentity(t, workloadIdentityTestSpec{
 		fleetWITest:  false,
 		crossProject: false,
-		sourceRepo:   csrRepo,
+		sourceRepo:   csrRepo(),
 		sourceType:   v1beta1.GitSource,
-		gsaEmail:     gsaCSRReaderEmail,
+		gsaEmail:     gsaCSRReaderEmail(),
 		rootCommitFn: nomostest.RemoteRootRepoSha1Fn,
 	})
 }
@@ -130,9 +133,9 @@ func TestFleetWISameProject(t *testing.T) {
 		workloadIdentityTestSpec{
 			fleetWITest:  true,
 			crossProject: false,
-			sourceRepo:   csrRepo,
+			sourceRepo:   csrRepo(),
 			sourceType:   v1beta1.GitSource,
-			gsaEmail:     gsaCSRReaderEmail,
+			gsaEmail:     gsaCSRReaderEmail(),
 			rootCommitFn: nomostest.RemoteRootRepoSha1Fn,
 		})
 }
@@ -157,9 +160,9 @@ func TestFleetWIDifferentProject(t *testing.T) {
 	testWorkloadIdentity(t, workloadIdentityTestSpec{
 		fleetWITest:  true,
 		crossProject: true,
-		sourceRepo:   csrRepo,
+		sourceRepo:   csrRepo(),
 		sourceType:   v1beta1.GitSource,
-		gsaEmail:     gsaCSRReaderEmail,
+		gsaEmail:     gsaCSRReaderEmail(),
 		rootCommitFn: nomostest.RemoteRootRepoSha1Fn,
 	})
 }

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -157,7 +157,7 @@ func TestHelmDefaultNamespace(t *testing.T) {
 
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "version": "%s", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "namespace": "", "deployNamespace": ""}}}`,
-		v1beta1.HelmSource, helm.PrivateARHelmRegistry(), remoteHelmChart.ChartName, privateSimpleHelmChartVersion, gsaARReaderEmail))
+		v1beta1.HelmSource, helm.PrivateARHelmRegistry(), remoteHelmChart.ChartName, privateSimpleHelmChartVersion, gsaARReaderEmail()))
 	err = nt.WatchForAllSyncs(nomostest.WithRootSha1Func(helmChartVersion(remoteHelmChart.ChartName+":"+privateSimpleHelmChartVersion)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: remoteHelmChart.ChartName}))
 	if err != nil {
@@ -202,7 +202,7 @@ func TestHelmLatestVersion(t *testing.T) {
 
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"chart": "%s", "repo": "%s", "version": "", "auth": "gcpserviceaccount", "gcpServiceAccountEmail": "%s", "deployNamespace": "simple"}, "git": null}}`,
-		v1beta1.HelmSource, remoteHelmChart.ChartName, helm.PrivateARHelmRegistry(), gsaARReaderEmail))
+		v1beta1.HelmSource, remoteHelmChart.ChartName, helm.PrivateARHelmRegistry(), gsaARReaderEmail()))
 	if err = nt.Watcher.WatchObject(kinds.Deployment(), "deploy-default", "simple",
 		[]testpredicates.Predicate{testpredicates.HasLabel("version", privateSimpleHelmChartVersion)}); err != nil {
 		nt.T.Error(err)
@@ -274,7 +274,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 		Repo:                   helm.PrivateARHelmRegistry(),
 		Chart:                  remoteHelmChart.ChartName,
 		Auth:                   configsync.AuthGCPServiceAccount,
-		GCPServiceAccountEmail: gsaARReaderEmail,
+		GCPServiceAccountEmail: gsaARReaderEmail(),
 		Version:                privateNSHelmChartVersion,
 		ReleaseName:            "test",
 	}}
@@ -311,7 +311,7 @@ func TestHelmARFleetWISameProject(t *testing.T) {
 		sourceVersion: privateCoreDNSHelmChartVersion,
 		sourceChart:   privateCoreDNSHelmChart,
 		sourceType:    v1beta1.HelmSource,
-		gsaEmail:      gsaARReaderEmail,
+		gsaEmail:      gsaARReaderEmail(),
 		rootCommitFn:  helmChartVersion(privateCoreDNSHelmChart + ":" + privateCoreDNSHelmChartVersion),
 	})
 }
@@ -339,7 +339,7 @@ func TestHelmARFleetWIDifferentProject(t *testing.T) {
 		sourceVersion: privateCoreDNSHelmChartVersion,
 		sourceChart:   privateCoreDNSHelmChart,
 		sourceType:    v1beta1.HelmSource,
-		gsaEmail:      gsaARReaderEmail,
+		gsaEmail:      gsaARReaderEmail(),
 		rootCommitFn:  helmChartVersion(privateCoreDNSHelmChart + ":" + privateCoreDNSHelmChartVersion),
 	})
 }
@@ -366,7 +366,7 @@ func TestHelmARGKEWorkloadIdentity(t *testing.T) {
 		sourceVersion: privateCoreDNSHelmChartVersion,
 		sourceChart:   privateCoreDNSHelmChart,
 		sourceType:    v1beta1.HelmSource,
-		gsaEmail:      gsaARReaderEmail,
+		gsaEmail:      gsaARReaderEmail(),
 		rootCommitFn:  helmChartVersion(privateCoreDNSHelmChart + ":" + privateCoreDNSHelmChartVersion),
 	})
 }


### PR DESCRIPTION
The flag pointers are updated after module initialization, causing these string to be evaluated with the default value instead of the parsed value. This works when the desired value is the default or and environment variable, but not when the desired value is the command line flag. Update the variables to functions so that the pointer value is evaluated after the flag has been parsed.