### PR TITLE
ci: fix permissions for gcenode tests

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -85,10 +85,11 @@ func createGKECluster(t testing.NTB, name string) error {
 	} else {
 		args = append(args, "create")
 	}
-	args = append(args, name,
-		"--project", *e2e.GCPProject,
-		"--workload-pool", fmt.Sprintf("%s.svc.id.goog", *e2e.GCPProject),
-	)
+	args = append(args, name, "--project", *e2e.GCPProject)
+	// gcenode tests require workload identity to be disabled
+	if !*e2e.GceNode {
+		args = append(args, "--workload-pool", fmt.Sprintf("%s.svc.id.goog", *e2e.GCPProject))
+	}
 	if *e2e.GCPZone != "" {
 		args = append(args, "--zone", *e2e.GCPZone)
 	}

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -118,6 +118,12 @@ func TestGCENodeOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest)
 
+	if workloadPool, err := getWorkloadPool(nt); err != nil {
+		nt.T.Fatal(err)
+	} else if workloadPool != "" {
+		nt.T.Fatal("expected workload identity to be disabled")
+	}
+
 	tenant := "tenant-a"
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)

--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -49,6 +49,8 @@ data "google_compute_default_service_account" "default" {
 
 resource "google_project_iam_member" "gce-default-sa-iam" {
   for_each = toset([
+    "roles/source.reader",
+    "roles/artifactregistry.reader",
     "roles/storage.objectViewer",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",


### PR DESCRIPTION
The gcenode tests require the compute GSA to have reader permissions for AR and CSR. Having this permission on the default compute SA can lead to false positives with the workload identity tests, so this change adds assertions for workload identity on the target cluster.