### PR TITLE
tweak memory request for some helm sync tests

### DIFF
--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -21,8 +21,7 @@ spec:
   override:
     resources:
     - containerName: helm-sync
-      cpuRequest: "200m"
-      memoryRequest: "600Mi"
+      memoryRequest: "300Mi"
   sourceFormat: unstructured
   sourceType: helm
   helm:

--- a/e2e/testdata/root-sync-helm-chart-version-range-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-version-range-cr.yaml
@@ -18,6 +18,10 @@ metadata:
   name: root-sync
   namespace: config-management-system
 spec:
+  override:
+    resources:
+    - containerName: helm-sync
+      memoryRequest: "300Mi"
   sourceFormat: unstructured
   sourceType: helm
   helm:


### PR DESCRIPTION
follow up experimentation https://github.com/GoogleContainerTools/kpt-config-sync/pull/662 - trying to find the minimum resource request we can make and still have these tests pass in CI