### PR TITLE
ci: copy nomos binary into path

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -39,6 +39,11 @@ build-cli: pull-buildenv buildenv-dirs
 		--version $(VERSION) \
 		$(PLATFORMS)
 
+.PHONY: copy-cli
+copy-cli: buildenv-dirs
+	@cp $(OUTPUT_DIR)/go/bin/$(shell go env GOOS)_$(shell go env GOARCH)/nomos $(OUTPUT_DIR)/go/bin/nomos
+	@chmod 755 $(OUTPUT_DIR)/go/bin/nomos
+
 # NOTE: this rule depends on OUTPUT_DIR because buildenv needs those dirs to
 # exist in order to work.
 build-junit-report-cli: pull-buildenv buildenv-dirs

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -125,6 +125,7 @@ pull-gcs: clean $(OUTPUT_DIR)
 	gsutil cp $(GCS_BUCKET)/darwin_arm64/nomos $(BIN_DIR)/darwin_arm64/nomos
 	gsutil cp $(GCS_BUCKET)/linux_amd64/nomos $(BIN_DIR)/linux_amd64/nomos
 	gsutil cp $(GCS_BUCKET)/linux_arm64/nomos $(BIN_DIR)/linux_arm64/nomos
+	$(MAKE) copy-cli
 
 .PHONY: pull-gcs-postsubmit
 pull-gcs-postsubmit:


### PR DESCRIPTION
This change adds a copy-cli target which copies the nomos binary from the os/arch subdirectory into the top level bin directory. This enables it to be in the PATH for subsequent commands. Call copy-cli after pulling postsubmit artifacts so that the binary can be used. This enables the periodic CI jobs to use the binary that is pulled from the postsubmit artifacts.