### PR TITLE
ci: use share-test-env for kind presubmits

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -55,6 +55,7 @@ test-e2e-gke: config-sync-manifest test-e2e-gke-nobuild
 test-e2e-kind-multi-repo: config-sync-manifest-local
 	kind delete clusters --all
 	GCP_PROJECT=$(GCP_PROJECT) ./scripts/e2e-kind.sh \
+		--share-test-env \
 		--timeout 60m \
 		--test.v -v \
 		--num-clusters 15 \


### PR DESCRIPTION
This change updates the kind e2e target which is used by the presubmits to enable shared test env. This makes the presubmits behave more similarly to the periodics, so that we can discover cleanup related issues before they are submitted.