### PR TITLE
test: add conditional for invalid autopilot flags

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -86,10 +86,6 @@ func createGKECluster(t testing.NTB, name string) error {
 		args = append(args, "create")
 	}
 	args = append(args, name, "--project", *e2e.GCPProject)
-	// gcenode tests require workload identity to be disabled
-	if !*e2e.GceNode {
-		args = append(args, "--workload-pool", fmt.Sprintf("%s.svc.id.goog", *e2e.GCPProject))
-	}
 	if *e2e.GCPZone != "" {
 		args = append(args, "--zone", *e2e.GCPZone)
 	}
@@ -108,11 +104,18 @@ func createGKECluster(t testing.NTB, name string) error {
 	if *e2e.GKEClusterVersion != "" {
 		args = append(args, "--cluster-version", *e2e.GKEClusterVersion)
 	}
-	if *e2e.GKEMachineType != "" {
-		args = append(args, "--machine-type", *e2e.GKEMachineType)
-	}
-	if *e2e.GKENumNodes > 0 {
-		args = append(args, "--num-nodes", fmt.Sprintf("%d", *e2e.GKENumNodes))
+	// Standard-specific options (cannot specify for autopilot)
+	if !*e2e.GKEAutopilot {
+		if *e2e.GKEMachineType != "" {
+			args = append(args, "--machine-type", *e2e.GKEMachineType)
+		}
+		if *e2e.GKENumNodes > 0 {
+			args = append(args, "--num-nodes", fmt.Sprintf("%d", *e2e.GKENumNodes))
+		}
+		// gcenode tests require workload identity to be disabled
+		if !*e2e.GceNode {
+			args = append(args, "--workload-pool", fmt.Sprintf("%s.svc.id.goog", *e2e.GCPProject))
+		}
 	}
 	t.Logf("gcloud %s", strings.Join(args, " "))
 	cmd := exec.Command("gcloud", args...)

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -60,6 +60,9 @@ func validateArgs() error {
 		if *e2e.GKEAutopilot && *e2e.GCPRegion == "" {
 			return errors.Errorf("Autopilot clusters must be created with a region")
 		}
+		if *e2e.GKEAutopilot && *e2e.GceNode {
+			return errors.Errorf("Cannot run gcenode tests on autopilot clusters")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Some of these flags cannot be provided when creating autopilot clusters, such as machine type.