### PR TITLE
Revert "test: log bugreport output in e2e test (#670)"

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -853,8 +853,8 @@ func TestCLIBugreportNomosRunningCorrectly(t *testing.T) {
 	// TODO(b/280652816): remove this once nomos bugreport WI auth is fixed.
 	cmd.Env = append(cmd.Env, "KUBERNETES_SERVICE_HOST=")
 	out, err := cmd.CombinedOutput()
-	nt.T.Log("nomos bugreport\n%s", string(out))
 	if err != nil {
+		nt.T.Log(string(out))
 		nt.T.Fatal(err)
 	}
 


### PR DESCRIPTION
This reverts commit a4101a0caa571efe82c13d34e17b0b291c652dde.

The output of nomos bugreport includes characters which break the xml parser for the junit output