### PR TITLE
test: fix for reconcile timeout test on autopilot

### DIFF
--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -56,10 +56,10 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 	// (common on Autopilot clusters, which are optimized for utilization),
 	// this low priority workload will be evicted to make room for the new normal priority workload.
 	if nt.IsGKEAutopilot {
-		nt.MustKubectl("apply", "-f", "../testdata/low-priority-pause-deployment.yaml")
 		nt.T.Cleanup(func() {
 			nt.MustKubectl("delete", "-f", "../testdata/low-priority-pause-deployment.yaml", "--ignore-not-found")
 		})
+		nt.MustKubectl("apply", "-f", "../testdata/low-priority-pause-deployment.yaml")
 		require.NoError(nt.T,
 			nt.Watcher.WatchObject(kinds.Deployment(), "pause-deployment", "default", []testpredicates.Predicate{
 				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),

--- a/e2e/testdata/low-priority-pause-deployment.yaml
+++ b/e2e/testdata/low-priority-pause-deployment.yaml
@@ -16,6 +16,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: low-priority
+  labels:
+    nomos-test: enabled
 value: -1
 globalDefault: false
 ---
@@ -23,8 +25,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pause-deployment
+  namespace: default
   labels:
     app: pause
+    nomos-test: enabled
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Explicitly set the namespace for the pause-deployment object. When running this in a Pod the applied object defaults to the namespace of the Pod.

Also move the cleanup instantiation to before the apply, so the cleanup runs in the case that the apply errors.