### PR TITLE
Use foreground delete on RootSyncs

### DIFF
--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -187,13 +186,8 @@ func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
 		defer cancel()
 		go TailReconcilerLogs(ctx, nt, RootReconcilerObjectKey(rsNN.Name))
 
-		// DeletePropagationBackground is required when deleting RSyncs with
-		// dependencies that have owners references. Otherwise the reconciler
-		// and dependenencies will be garbage collected before the finalizer
-		// can delete the managed resources.
-		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
 		nt.T.Logf("[RESET] Deleting RootSync %s", rsNN)
-		if err := nt.KubeClient.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+		if err := nt.KubeClient.Delete(rs); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return err
 			}
@@ -270,13 +264,8 @@ func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
 		defer cancel()
 		go TailReconcilerLogs(ctx, nt, NsReconcilerObjectKey(rsNN.Namespace, rsNN.Name))
 
-		// DeletePropagationBackground is required when deleting RSyncs with
-		// dependencies that have owners references. Otherwise the reconciler
-		// and dependenencies will be garbage collected before the finalizer
-		// can delete the managed resources.
-		// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
 		nt.T.Logf("[RESET] Deleting RepoSync %s", rsNN)
-		if err := nt.KubeClient.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+		if err := nt.KubeClient.Delete(rs); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return err
 			}

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -109,11 +109,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 		}))
 
 	// Delete the RootSync
-	// DeletePropagationBackground is required when deleting RootSync, to
-	// avoid causing the reconciler Deployment to be deleted before the RootSync
-	// finishes finalizing.
-	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
-	err = nt.KubeClient.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	err = nt.KubeClient.Delete(rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -197,11 +193,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 		}))
 
 	// Delete the RootSync
-	// DeletePropagationBackground is required when deleting RootSync, to
-	// avoid causing the reconciler Deployment to be deleted before the RootSync
-	// finishes finalizing.
-	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
-	err = nt.KubeClient.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	err = nt.KubeClient.Delete(rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -320,11 +312,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 		}))
 
 	// Delete the RootSync
-	// DeletePropagationBackground is required when deleting RootSync, to
-	// avoid causing the reconciler Deployment to be deleted before the RootSync
-	// finishes finalizing.
-	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
-	err = nt.KubeClient.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	err = nt.KubeClient.Delete(rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -456,11 +444,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	}
 
 	// Delete the RootSync
-	// DeletePropagationBackground is required when deleting RootSync, to
-	// avoid causing the reconciler Deployment to be deleted before the RootSync
-	// finishes finalizing.
-	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
-	err = nt.KubeClient.Delete(rootSync, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	err = nt.KubeClient.Delete(rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -607,8 +591,7 @@ func deleteSyncWithOrphanPolicy(nt *nomostest.NT, obj client.Object) error {
 	}
 
 	nt.T.Logf("Deleting %s %s", gvk.Kind, key)
-	// TODO: Remove explicit Background policy after the reconciler-manager finalizer is added.
-	err = nt.KubeClient.Delete(obj, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	err = nt.KubeClient.Delete(obj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
Now that the reconciler-manager uses a finalizer to delete managed resources, it's safe to delete RootSyncs with foreground deletion propagation.