### PR TITLE
test: use new logger for each sharedNT

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -139,6 +139,9 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	t.Helper()
 
 	sharedNt := SharedNT(t)
+	// Set t on the logger to ensure proper interleaving of logs
+	sharedNt.Logger.SetNTBForTest(t)
+
 	nt := &NT{
 		Context:                 sharedNt.Context,
 		T:                       t,

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -329,7 +329,7 @@ func newSharedNT(name string) error {
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return errors.Wrap(err, "failed to remove the shared test directory")
 	}
-	fakeNTB := &testing.FakeNTB{}
+	fakeNTB := testing.NewFakeNTB(name)
 	// Register a new SharedNT immediately with the fakeNTB. This way in the case
 	// of an error (e.g. during cluster creation) the cleanup can still run.
 	newSNT := mySharedNTs.newNT(fakeNTB)

--- a/e2e/nomostest/testing/ntb.go
+++ b/e2e/nomostest/testing/ntb.go
@@ -46,6 +46,14 @@ type FakeNTB struct {
 	mu       sync.RWMutex
 	failed   bool
 	cleanups []func()
+	name     string
+}
+
+// NewFakeNTB returns a new FakeNTB
+func NewFakeNTB(name string) *FakeNTB {
+	return &FakeNTB{
+		name: name,
+	}
 }
 
 // Error is equivalent to Log followed by Fail.
@@ -94,7 +102,7 @@ func (t *FakeNTB) Fatalf(format string, args ...interface{}) {
 
 // Name returns an empty string.
 func (t *FakeNTB) Name() string {
-	return ""
+	return t.name
 }
 
 // Helper is a no-op function.
@@ -168,12 +176,11 @@ func (t *FakeNTB) Skipped() bool {
 
 // Log generates the output. It's always at the same stack depth.
 func (t *FakeNTB) Log(args ...interface{}) {
-	fmt.Println(args...)
+	fmt.Println(fmt.Sprintf("[%s]", t.name), fmt.Sprint(args...))
 }
 
 // Logf formats its arguments according to the format, analogous to Printf, and
 // records the text in the error log.
 func (t *FakeNTB) Logf(format string, args ...interface{}) {
-	fmt.Printf(format, args...)
-	fmt.Println()
+	fmt.Println(fmt.Sprintf("[%s]", t.name), fmt.Sprintf(format, args...))
 }

--- a/e2e/nomostest/testlogger/testlogger.go
+++ b/e2e/nomostest/testlogger/testlogger.go
@@ -33,6 +33,18 @@ func New(t testing.NTB, debugEnabled bool) *TestLogger {
 	}
 }
 
+// SetNTBForTest sets the loggers NTB for the scope of a test. This ensures that
+// for shared test environments, the actual test's logger is used for the scope
+// of the test. This ensures proper interleaving of logs when running tests in
+// parallel. Reset to the original logger after the test for post-test logging.
+func (tl *TestLogger) SetNTBForTest(t testing.NTB) {
+	originalNTB := tl.t
+	t.Cleanup(func() {
+		tl.t = originalNTB
+	})
+	tl.t = t
+}
+
 // IsDebugEnabled returns true if debug is enabled for this test
 func (tl *TestLogger) IsDebugEnabled() bool {
 	return tl.debugEnabled


### PR DESCRIPTION
Using the logger from the testing.T ensures proper interleaving of logs. Without this change shared test environments used the logger from the original FreshTestEnv.