### PR TITLE
test: shift left e2e check images

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -276,7 +276,6 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		// repository. No need to clean before/after as these tests only exist for
 		// a single test.
 		connectToLocalRegistry(nt)
-		checkImages(nt.T)
 	}
 	if !opts.IsEphemeralCluster {
 		// We aren't using an ephemeral cluster, so make sure the cluster is

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -94,6 +94,11 @@ func main(m *testing.M) int {
 		return 1
 	}
 
+	if err := nomostest.CheckImages(); err != nil {
+		fmt.Println(err)
+		return 1
+	}
+
 	if *e2e.ShareTestEnv {
 		defer nomostest.CleanSharedNTs()
 		if err := nomostest.InitSharedEnvironments(); err != nil {


### PR DESCRIPTION
This accomplishes a few things:
- run check images before clusters are created
- allow running tests on kind with images not in the local registry
- check images before running tests on GKE