### PR TITLE
test: treat reset git repos error as non-fatal

### DIFF
--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -120,7 +120,9 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	newRepos = append(newRepos, nn5)
 
 	if nt.GitProvider.Type() == e2e.Local {
-		nomostest.InitGitRepos(nt, newRepos...)
+		if err := nomostest.InitGitRepos(nt, newRepos...); err != nil {
+			nt.T.Fatal(err)
+		}
 	}
 	rr2Repo := nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr2), filesystem.SourceFormatUnstructured)
 	rr3Repo := nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr3), filesystem.SourceFormatUnstructured)


### PR DESCRIPTION
Errors can occur during this callback, e.g. if the Pod gets replaced while the callback is running. This happens occasionally on autopilot, which causes the test to fail. Treating this as a non-fatal error will allow the callback to re-run once the port forwarder discovers the error and attempts to recover (e.g. Pod not found).