### PR TITLE
test: stricter regex for gke operation filter

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -71,7 +71,7 @@ func listOperations(ctx context.Context, t testing.NTB, name string) ([]string, 
 	args := []string{
 		"container", "operations", "list",
 		"--project", *e2e.GCPProject,
-		"--filter", fmt.Sprintf("status = RUNNING AND targetLink ~ %s", name),
+		"--filter", fmt.Sprintf("status = RUNNING AND targetLink ~ ^.*/%s$", name),
 		"--format", "value(name)",
 	}
 	if *e2e.GCPZone != "" {


### PR DESCRIPTION
Since we were not matching the end of the string, this filter could return operations for multiple clusters. The stricter regex should result in operations for a unique cluster name.