### PR TITLE
perf: limit helm-sync polling to every hour when a version range is specified

### DIFF
--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -128,7 +128,7 @@ func main() {
 			Password:        *flPassword,
 		}
 
-		var refreshVersion bool
+		refreshVersion := false
 		if initialSync || time.Now().After(start.Add(duration)) {
 			refreshVersion = true
 			start = time.Now()

--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -67,6 +67,8 @@ var (
 		"the username to use for helm authantication")
 	flPassword = flag.String("password", util.EnvString("HELM_SYNC_PASSWORD", ""),
 		"the password or personal access token to use for helm authantication")
+	flVersionPollPeriod = flag.String("version-poll-period", util.EnvString(reconcilermanager.HelmSyncVersionPollingPeriod, "1h"),
+		"the amount of time between version polling when a version range is specified")
 )
 
 func main() {
@@ -76,7 +78,7 @@ func main() {
 		"--chart", *flChart, "--version", *flVersion, "--root", *flRoot,
 		"--values", *flValues, "--include-crds", *flIncludeCRDs, "--dest", *flDest, "--wait", *flWait,
 		"--error-file", *flErrorFile, "--timeout", *flSyncTimeout,
-		"--one-time", *flOneTime, "--max-sync-failures", *flMaxSyncFailures)
+		"--one-time", *flOneTime, "--max-sync-failures", *flMaxSyncFailures, "--version-poll-period", *flVersionPollPeriod)
 
 	if *flRepo == "" {
 		utillog.HandleError(log, true, "ERROR: --repo must be specified")
@@ -100,8 +102,14 @@ func main() {
 		}
 	}
 
+	duration, err := time.ParseDuration(*flVersionPollPeriod)
+	if err != nil {
+		utillog.HandleError(log, true, "ERROR: --version-poll-period must be a valid duration")
+	}
+
 	initialSync := true
 	failCount := 0
+	start := time.Now()
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*flSyncTimeout))
 		hydrator := &helm.Hydrator{
@@ -119,7 +127,14 @@ func main() {
 			UserName:        *flUsername,
 			Password:        *flPassword,
 		}
-		if err := hydrator.HelmTemplate(ctx); err != nil {
+
+		var refreshVersion bool
+		if initialSync || time.Now().After(start.Add(duration)) {
+			refreshVersion = true
+			start = time.Now()
+		}
+
+		if err := hydrator.HelmTemplate(ctx, refreshVersion); err != nil {
 			if *flMaxSyncFailures != -1 && failCount >= *flMaxSyncFailures {
 				// Exit after too many retries, maybe the error is not recoverable.
 				log.Error(err, "too many failures, aborting", "failCount", failCount)

--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -50,6 +50,10 @@ var (
 		controllers.PollingPeriod(reconcilermanager.HydrationPollingPeriod, configsync.DefaultHydrationPollingPeriod),
 		"Period of time between checking the filesystem for source updates to render.")
 
+	helmSyncVersionPollingPeriod = flag.Duration("helm-sync-version-polling-period",
+		controllers.PollingPeriod(reconcilermanager.HelmSyncVersionPollingPeriod, configsync.DefaultHelmSyncVersionPollingPeriod),
+		"Period of time between checking the the latest version of a helm chart in helm-sync.")
+
 	setupLog = ctrl.Log.WithName("setup")
 )
 
@@ -100,7 +104,7 @@ func main() {
 	}
 	watchFleetMembership := fleetMembershipCRDExists(dynamicClient, mgr.GetRESTMapper())
 
-	repoSync := controllers.NewRepoSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod,
+	repoSync := controllers.NewRepoSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, *helmSyncVersionPollingPeriod,
 		mgr.GetClient(), watcher, dynamicClient,
 		ctrl.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		mgr.GetScheme())
@@ -109,7 +113,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	rootSync := controllers.NewRootSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod,
+	rootSync := controllers.NewRootSyncReconciler(*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, *helmSyncVersionPollingPeriod,
 		mgr.GetClient(), watcher, dynamicClient,
 		ctrl.Log.WithName("controllers").WithName(configsync.RootSyncKind),
 		mgr.GetScheme())

--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -75,8 +75,8 @@ func main() {
 	profiler.Service()
 	ctrl.SetLogger(klogr.New())
 
-	setupLog.Info(fmt.Sprintf("running with flags --cluster-name=%s; --reconciler-polling-period=%s; --hydration-polling-period=%s",
-		*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod))
+	setupLog.Info(fmt.Sprintf("running with flags --cluster-name=%s; --reconciler-polling-period=%s; --hydration-polling-period=%s; --helm-sync-version-polling-period=%s",
+		*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod, *helmSyncVersionPollingPeriod))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: core.Scheme,

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -88,6 +88,8 @@ var (
 	reconcilerPollingPeriod time.Duration
 	// hydrationPollingPeriod specifies hydration-controller polling period as time.Duration
 	hydrationPollingPeriod time.Duration
+	// helmSyncVersionPollingPeriod specifies the helm-sync version polling period as time.Duration.
+	helmSyncVersionPollingPeriod time.Duration
 )
 
 // IsReconcilerTemplateConfigMap returns true if passed obj is the
@@ -147,6 +149,8 @@ func parseConfigSyncManifests(nt *NT) ([]client.Object, error) {
 	}
 	reconcilerPollingPeriod = nt.ReconcilerPollingPeriod
 	hydrationPollingPeriod = nt.HydrationPollingPeriod
+	helmSyncVersionPollingPeriod = nt.HelmSyncVersionPollingPeriod
+
 	objs, err = multiRepoObjects(objs,
 		setReconcilerDebugMode,
 		setPollingPeriods,
@@ -594,6 +598,7 @@ func setPollingPeriods(obj client.Object) error {
 
 	cm.Data[reconcilermanager.ReconcilerPollingPeriod] = reconcilerPollingPeriod.String()
 	cm.Data[reconcilermanager.HydrationPollingPeriod] = hydrationPollingPeriod.String()
+	cm.Data[reconcilermanager.HelmSyncVersionPollingPeriod] = helmSyncVersionPollingPeriod.String()
 	return nil
 }
 

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -143,32 +143,33 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	sharedNt.Logger.SetNTBForTest(t)
 
 	nt := &NT{
-		Context:                 sharedNt.Context,
-		T:                       t,
-		Logger:                  sharedNt.Logger,
-		Shell:                   sharedNt.Shell,
-		ClusterName:             sharedNt.ClusterName,
-		TmpDir:                  opts.TmpDir,
-		Config:                  opts.RESTConfig,
-		repoSyncPermissions:     opts.RepoSyncPermissions,
-		KubeClient:              sharedNt.KubeClient,
-		Watcher:                 sharedNt.Watcher,
-		WatchClient:             sharedNt.WatchClient,
-		IsGKEAutopilot:          sharedNt.IsGKEAutopilot,
-		DefaultWaitTimeout:      sharedNt.DefaultWaitTimeout,
-		DefaultReconcileTimeout: sharedNt.DefaultReconcileTimeout,
-		kubeconfigPath:          sharedNt.kubeconfigPath,
-		ReconcilerPollingPeriod: sharedNt.ReconcilerPollingPeriod,
-		HydrationPollingPeriod:  sharedNt.HydrationPollingPeriod,
-		RootRepos:               sharedNt.RootRepos,
-		NonRootRepos:            sharedNt.NonRootRepos,
-		MetricsExpectations:     sharedNt.MetricsExpectations,
-		gitPrivateKeyPath:       sharedNt.gitPrivateKeyPath,
-		caCertPath:              sharedNt.caCertPath,
-		Scheme:                  sharedNt.Scheme,
-		RemoteRepositories:      sharedNt.RemoteRepositories,
-		WebhookDisabled:         sharedNt.WebhookDisabled,
-		GitProvider:             sharedNt.GitProvider,
+		Context:                      sharedNt.Context,
+		T:                            t,
+		Logger:                       sharedNt.Logger,
+		Shell:                        sharedNt.Shell,
+		ClusterName:                  sharedNt.ClusterName,
+		TmpDir:                       opts.TmpDir,
+		Config:                       opts.RESTConfig,
+		repoSyncPermissions:          opts.RepoSyncPermissions,
+		KubeClient:                   sharedNt.KubeClient,
+		Watcher:                      sharedNt.Watcher,
+		WatchClient:                  sharedNt.WatchClient,
+		IsGKEAutopilot:               sharedNt.IsGKEAutopilot,
+		DefaultWaitTimeout:           sharedNt.DefaultWaitTimeout,
+		DefaultReconcileTimeout:      sharedNt.DefaultReconcileTimeout,
+		kubeconfigPath:               sharedNt.kubeconfigPath,
+		ReconcilerPollingPeriod:      sharedNt.ReconcilerPollingPeriod,
+		HydrationPollingPeriod:       sharedNt.HydrationPollingPeriod,
+		HelmSyncVersionPollingPeriod: sharedNt.HelmSyncVersionPollingPeriod,
+		RootRepos:                    sharedNt.RootRepos,
+		NonRootRepos:                 sharedNt.NonRootRepos,
+		MetricsExpectations:          sharedNt.MetricsExpectations,
+		gitPrivateKeyPath:            sharedNt.gitPrivateKeyPath,
+		caCertPath:                   sharedNt.caCertPath,
+		Scheme:                       sharedNt.Scheme,
+		RemoteRepositories:           sharedNt.RemoteRepositories,
+		WebhookDisabled:              sharedNt.WebhookDisabled,
+		GitProvider:                  sharedNt.GitProvider,
 	}
 
 	if opts.SkipConfigSyncInstall {
@@ -261,6 +262,8 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	nt.ReconcilerPollingPeriod = 15 * time.Second
 	// Speed up the delay between rendering attempts to speed up testing (default: 5s)
 	nt.HydrationPollingPeriod = 5 * time.Second
+	// Speed up the delay between helm version polling to speed up testing (default: 1h)
+	nt.HelmSyncVersionPollingPeriod = 1 * time.Minute
 
 	// init the Client & WatchClient
 	nt.RenewClient()

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -138,6 +138,10 @@ type NT struct {
 	// poll the filesystem for rendering the DRY configs.
 	HydrationPollingPeriod time.Duration
 
+	// HelmSyncVersionPeriod defines how often helm-sync polls for a new chart
+	// verison.
+	HelmSyncVersionPollingPeriod time.Duration
+
 	// gitPrivateKeyPath is the path to the private key used for communicating with the Git server.
 	gitPrivateKeyPath string
 

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -220,6 +220,18 @@ func TestHelmLatestVersion(t *testing.T) {
 		[]testpredicates.Predicate{testpredicates.HasLabel("version", newVersion)}); err != nil {
 		nt.T.Error(err)
 	}
+
+	newVersion = "3.0.0"
+	if err := remoteHelmChart.UpdateVersion(newVersion); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := remoteHelmChart.Push(); err != nil {
+		nt.T.Fatal("failed to push helm chart update: %v", err)
+	}
+	if err = nt.Watcher.WatchObject(kinds.Deployment(), "deploy-default", "simple",
+		[]testpredicates.Predicate{testpredicates.HasLabel("version", newVersion)}); err != nil {
+		nt.T.Error(err)
+	}
 }
 
 // TestHelmVersionRange verifies the Config Sync behavior for helm charts when helm.spec.version is specified as a range.

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -56,6 +56,10 @@ const (
 	// filesystem for source updates to sync, in seconds.
 	DefaultReconcilerPollingPeriodSeconds = 15
 
+	// DefaultHelmSyncVersionPollingPeriod is time delay between polling for
+	// helm chart version updates in helm-sync.
+	DefaultHelmSyncVersionPollingPeriod = 1 * time.Hour
+
 	// DefaultReconcilerPollingPeriod is the time delay between polling the
 	// filesystem for source updates to sync.
 	DefaultReconcilerPollingPeriod = DefaultReconcilerPollingPeriodSeconds * time.Second

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -240,18 +240,23 @@ func (h *Hydrator) registryLogin(ctx context.Context) error {
 }
 
 // HelmTemplate runs helm template with args
-func (h *Hydrator) HelmTemplate(ctx context.Context) error {
+func (h *Hydrator) HelmTemplate(ctx context.Context, refreshVersion bool) error {
 	var loggedIn bool
 
 	if isRange(h.Version) {
-		klog.Infof("version range %s detected, fetching chart version\n", h.Version)
-		if err := h.registryLogin(ctx); err != nil {
-			return err
-		}
-		loggedIn = true
+		if refreshVersion {
+			klog.Infof("version range %s detected, fetching chart version\n", h.Version)
+			if err := h.registryLogin(ctx); err != nil {
+				return err
+			}
+			loggedIn = true
 
-		if err := h.getChartVersion(ctx); err != nil {
-			return err
+			if err := h.getChartVersion(ctx); err != nil {
+				return err
+			}
+		} else {
+			klog.Infof("version range %s detected, waiting to refresh\n", h.Version)
+			return nil
 		}
 	}
 

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -101,6 +101,10 @@ const (
 	// HydrationPollingPeriod defines how often the hydration controller should
 	// poll the filesystem for rendering the DRY configs.
 	HydrationPollingPeriod = "HYDRATION_POLLING_PERIOD"
+
+	// HelmSyncVersionPollingPeriod defines how often the hydration controller should
+	// poll the filesystem for rendering the DRY configs.
+	HelmSyncVersionPollingPeriod = "HELM_SYNC_VERSION_POLLING_PERIOD"
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -97,15 +97,16 @@ var reconcilerManagerAllowList = []string{
 type reconcilerBase struct {
 	loggingController
 
-	clusterName             string
-	client                  client.Client    // caching
-	watcher                 client.WithWatch // non-caching
-	dynamicClient           dynamic.Interface
-	scheme                  *runtime.Scheme
-	isAutopilotCluster      *bool
-	reconcilerPollingPeriod time.Duration
-	hydrationPollingPeriod  time.Duration
-	membership              *hubv1.Membership
+	clusterName                  string
+	client                       client.Client    // caching
+	watcher                      client.WithWatch // non-caching
+	dynamicClient                dynamic.Interface
+	scheme                       *runtime.Scheme
+	isAutopilotCluster           *bool
+	reconcilerPollingPeriod      time.Duration
+	hydrationPollingPeriod       time.Duration
+	helmSyncVersionPollingPeriod time.Duration
+	membership                   *hubv1.Membership
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -69,20 +69,21 @@ type RepoSyncReconciler struct {
 }
 
 // NewRepoSyncReconciler returns a new RepoSyncReconciler.
-func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, watcher client.WithWatch, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
+func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod, helmSyncVersionPollingPeriod time.Duration, client client.Client, watcher client.WithWatch, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RepoSyncReconciler {
 	return &RepoSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			loggingController: loggingController{
 				log: log,
 			},
-			clusterName:             clusterName,
-			client:                  client,
-			dynamicClient:           dynamicClient,
-			watcher:                 watcher,
-			scheme:                  scheme,
-			reconcilerPollingPeriod: reconcilerPollingPeriod,
-			hydrationPollingPeriod:  hydrationPollingPeriod,
-			syncKind:                configsync.RepoSyncKind,
+			clusterName:                  clusterName,
+			client:                       client,
+			dynamicClient:                dynamicClient,
+			watcher:                      watcher,
+			scheme:                       scheme,
+			reconcilerPollingPeriod:      reconcilerPollingPeriod,
+			hydrationPollingPeriod:       hydrationPollingPeriod,
+			helmSyncVersionPollingPeriod: helmSyncVersionPollingPeriod,
+			syncKind:                     configsync.RepoSyncKind,
 		},
 	}
 }
@@ -706,7 +707,7 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 	case v1beta1.OciSource:
 		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriodSecs(rs.Spec.Oci.Period))
 	case v1beta1.HelmSource:
-		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Namespace, "")
+		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Namespace, "", r.helmSyncVersionPollingPeriod.String())
 	}
 	return result
 }

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -79,6 +79,7 @@ const (
 
 var filesystemPollingPeriod time.Duration
 var hydrationPollingPeriod time.Duration
+var helmSyncVersionPollingPeriod time.Duration
 var nsReconcilerName = core.NsReconcilerName(reposyncNs, reposyncName)
 var reconcilerDeploymentReplicaCount int32 = 1
 
@@ -127,6 +128,7 @@ func init() {
 		klog.Exitf("failed to parse polling period: %q, got error: %v, want error: nil", pollingPeriod, err)
 	}
 	hydrationPollingPeriod = filesystemPollingPeriod
+	helmSyncVersionPollingPeriod = filesystemPollingPeriod
 }
 
 func reposyncSourceType(sourceType string) func(*v1beta1.RepoSync) {
@@ -296,6 +298,7 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 		testCluster,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
+		helmSyncVersionPollingPeriod,
 		cs.Client,
 		cs.Client,
 		cs.DynamicClient,

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -78,20 +78,21 @@ type RootSyncReconciler struct {
 }
 
 // NewRootSyncReconciler returns a new RootSyncReconciler.
-func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod time.Duration, client client.Client, watcher client.WithWatch, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
+func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydrationPollingPeriod, helmSyncVersionPollingPeriod time.Duration, client client.Client, watcher client.WithWatch, dynamicClient dynamic.Interface, log logr.Logger, scheme *runtime.Scheme) *RootSyncReconciler {
 	return &RootSyncReconciler{
 		reconcilerBase: reconcilerBase{
 			loggingController: loggingController{
 				log: log,
 			},
-			clusterName:             clusterName,
-			client:                  client,
-			watcher:                 watcher,
-			dynamicClient:           dynamicClient,
-			scheme:                  scheme,
-			reconcilerPollingPeriod: reconcilerPollingPeriod,
-			hydrationPollingPeriod:  hydrationPollingPeriod,
-			syncKind:                configsync.RootSyncKind,
+			clusterName:                  clusterName,
+			client:                       client,
+			watcher:                      watcher,
+			dynamicClient:                dynamicClient,
+			scheme:                       scheme,
+			reconcilerPollingPeriod:      reconcilerPollingPeriod,
+			hydrationPollingPeriod:       hydrationPollingPeriod,
+			helmSyncVersionPollingPeriod: helmSyncVersionPollingPeriod,
+			syncKind:                     configsync.RootSyncKind,
 		},
 	}
 }
@@ -643,7 +644,7 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 	case v1beta1.OciSource:
 		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriodSecs(rs.Spec.Oci.Period))
 	case v1beta1.HelmSource:
-		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Spec.Helm.Namespace, rs.Spec.Helm.DeployNamespace)
+		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Spec.Helm.Namespace, rs.Spec.Helm.DeployNamespace, r.helmSyncVersionPollingPeriod.String())
 	}
 	return result
 }

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -132,6 +132,7 @@ func setupRootReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 		testCluster,
 		filesystemPollingPeriod,
 		hydrationPollingPeriod,
+		helmSyncVersionPollingPeriod,
 		cs.Client,
 		cs.Client,
 		cs.DynamicClient,

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -208,7 +208,7 @@ const (
 )
 
 // helmSyncEnvs returns the environment variables for the helm-sync container.
-func helmSyncEnvs(helmBase *v1beta1.HelmBase, releaseNamespace, deployNamespace string) []corev1.EnvVar {
+func helmSyncEnvs(helmBase *v1beta1.HelmBase, releaseNamespace, deployNamespace, versionPollPeriod string) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	helmValues := ""
 	if helmBase.Values != nil {
@@ -244,6 +244,9 @@ func helmSyncEnvs(helmBase *v1beta1.HelmBase, releaseNamespace, deployNamespace 
 	}, corev1.EnvVar{
 		Name:  reconcilermanager.HelmSyncWait,
 		Value: fmt.Sprintf("%f", v1beta1.GetPeriodSecs(helmBase.Period)),
+	}, corev1.EnvVar{
+		Name:  reconcilermanager.HelmSyncVersionPollingPeriod,
+		Value: versionPollPeriod,
 	})
 	return result
 }

--- a/pkg/reconcilermanager/controllers/util_test.go
+++ b/pkg/reconcilermanager/controllers/util_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+)
+
+func TestHelmSyncEnvs(t *testing.T) {
+	duration, _ := time.ParseDuration("15s")
+	testCases := map[string]struct {
+		base              v1beta1.HelmBase
+		releaseNamespace  string
+		deployNamespace   string
+		versionPollPeriod string
+
+		expected []corev1.EnvVar
+	}{
+		"with inline values": {
+			base: v1beta1.HelmBase{
+				Repo:        "example.com/repo",
+				Chart:       "my-chart",
+				Version:     "1.0.0",
+				ReleaseName: "release-name",
+				Values: &apiextensionsv1.JSON{
+					Raw: []byte("foo: bar"),
+				},
+				Period: metav1.Duration{Duration: duration},
+				Auth:   "none",
+			},
+			releaseNamespace:  "releaseNamespace",
+			deployNamespace:   "deployNamespace",
+			versionPollPeriod: "1h",
+
+			expected: []corev1.EnvVar{
+				{Name: reconcilermanager.HelmRepo, Value: "example.com/repo"},
+				{Name: reconcilermanager.HelmChart, Value: "my-chart"},
+				{Name: reconcilermanager.HelmChartVersion, Value: "1.0.0"},
+				{Name: reconcilermanager.HelmReleaseName, Value: "release-name"},
+				{Name: reconcilermanager.HelmReleaseNamespace, Value: "releaseNamespace"},
+				{Name: reconcilermanager.HelmDeployNamespace, Value: "deployNamespace"},
+				{Name: reconcilermanager.HelmValues, Value: "foo: bar"},
+				{Name: reconcilermanager.HelmIncludeCRDs, Value: "false"},
+				{Name: reconcilermanager.HelmAuthType, Value: "none"},
+				{Name: reconcilermanager.HelmSyncWait, Value: "15.000000"},
+				{Name: reconcilermanager.HelmSyncVersionPollingPeriod, Value: "1h"},
+			},
+		},
+		"without inline values": {
+			base: v1beta1.HelmBase{
+				Repo:        "example.com/repo",
+				Chart:       "my-chart",
+				Version:     "1.0.0",
+				ReleaseName: "release-name",
+				Period:      metav1.Duration{Duration: duration},
+				Auth:        "none",
+			},
+			releaseNamespace:  "releaseNamespace",
+			deployNamespace:   "deployNamespace",
+			versionPollPeriod: "1h",
+
+			expected: []corev1.EnvVar{
+				{Name: reconcilermanager.HelmRepo, Value: "example.com/repo"},
+				{Name: reconcilermanager.HelmChart, Value: "my-chart"},
+				{Name: reconcilermanager.HelmChartVersion, Value: "1.0.0"},
+				{Name: reconcilermanager.HelmReleaseName, Value: "release-name"},
+				{Name: reconcilermanager.HelmReleaseNamespace, Value: "releaseNamespace"},
+				{Name: reconcilermanager.HelmDeployNamespace, Value: "deployNamespace"},
+				{Name: reconcilermanager.HelmValues, Value: ""},
+				{Name: reconcilermanager.HelmIncludeCRDs, Value: "false"},
+				{Name: reconcilermanager.HelmAuthType, Value: "none"},
+				{Name: reconcilermanager.HelmSyncWait, Value: "15.000000"},
+				{Name: reconcilermanager.HelmSyncVersionPollingPeriod, Value: "1h"},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, helmSyncEnvs(&tc.base, tc.releaseNamespace, tc.deployNamespace, tc.versionPollPeriod))
+		})
+	}
+}


### PR DESCRIPTION
When a version range is detected in the RSync `spec.helm.version`, we currently continuously poll to get the latest version from that range, causing performance degradation. 

This PR does the following:
- by default, we poll every hour for the latest version
- make the poll configurable in helm-sync for testing purposes, but we don't make it configurable through the RSync API
- use 1m as the poll period in tests

b/288478227

