### PR TITLE
feat: dynamically disable hydration-controller

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -32,6 +32,7 @@ import (
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util"
 	"kpt.dev/configsync/pkg/util/log"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -93,6 +94,8 @@ var (
 	debug = flag.Bool("debug", false,
 		"Enable debug mode, panicking in many scenarios where normally an InternalError would be logged. "+
 			"Do not use in production.")
+
+	renderingEnabled = flag.Bool("rendering-enabled", util.EnvBool(reconcilermanager.RenderingEnabled, false), "")
 )
 
 var flags = struct {
@@ -183,6 +186,7 @@ func main() {
 		StatusMode:              *statusMode,
 		ReconcileTimeout:        *reconcileTimeout,
 		APIServerTimeout:        *apiServerTimeout,
+		RenderingEnabled:        *renderingEnabled,
 	}
 
 	if declared.Scope(*scope) == declared.RootReconciler {

--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -428,6 +428,48 @@ func DeploymentMissingEnvVar(containerName, key string) Predicate {
 	}
 }
 
+// DeploymentHasContainer check whether the deployment has the
+// container with the specified name.
+func DeploymentHasContainer(containerName string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		d, ok := o.(*appsv1.Deployment)
+		if !ok {
+			return WrongTypeErr(o, d)
+		}
+		nn := core.ObjectNamespacedName(o)
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				return nil
+			}
+		}
+		return errors.Errorf("Deployment %s should have container %s", nn, containerName)
+	}
+}
+
+// DeploymentMissingContainer check whether the deployment does not have the
+// container with the specified name.
+func DeploymentMissingContainer(containerName string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		d, ok := o.(*appsv1.Deployment)
+		if !ok {
+			return WrongTypeErr(o, d)
+		}
+		nn := core.ObjectNamespacedName(o)
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				return errors.Errorf("Deployment %s should not have container %s", nn, containerName)
+			}
+		}
+		return nil
+	}
+}
+
 // IsManagedBy checks that the object is managed by configsync, has the expected
 // resource manager, and has a valid resource-id.
 // Use diff.IsManager if you just need a boolean without errors.

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -903,7 +903,6 @@ func TestCLIBugreportNomosRunningCorrectly(t *testing.T) {
 		"namespaces/config-management-system/RootSync-root-sync.txt",
 		"namespaces/config-management-system/RootSync-root-sync_yaml.txt",
 		"namespaces/config-management-system/root-reconciler.*/git-sync.txt",
-		"namespaces/config-management-system/root-reconciler.*/hydration-controller.txt",
 		"namespaces/config-management-system/root-reconciler.*/otel-agent.txt",
 		"namespaces/config-management-system/root-reconciler.*/reconciler.txt",
 		"namespaces/config-management-monitoring/pods.txt",

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -66,15 +66,15 @@ func needsKustomize(dir string) (bool, error) {
 		return false, errors.Wrapf(err, "unable to traverse the directory: %s", dir)
 	}
 	for _, f := range files {
-		if hasKustomization(filepath.Base(f.Name())) {
+		if HasKustomization(filepath.Base(f.Name())) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-// hasKustomization checks if the file is a Kustomize configuration file.
-func hasKustomization(filename string) bool {
+// HasKustomization checks if the file is a Kustomize configuration file.
+func HasKustomization(filename string) bool {
 	for _, kustomization := range validKustomizationFiles {
 		if filename == kustomization {
 			return true
@@ -98,7 +98,7 @@ func hasKustomizeSubdir(dir string) (bool, error) {
 			if fi.IsDir() {
 				return nil
 			}
-			if hasKustomization(fi.Name()) {
+			if HasKustomization(fi.Name()) {
 				found = true
 			}
 			return nil

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -137,6 +137,14 @@ const (
 	// RootSync/RepoSync objects to indicate what do do with the managed
 	// resources when the RootSync/RepoSync object is deleted.
 	DeletionPropagationPolicyAnnotationKey = configsync.ConfigSyncPrefix + "deletion-propagation-policy"
+
+	// RequiresRenderingAnnotationKey is the annotation key set on
+	// RootSync/RepoSync objects to indicate whether the source of truth
+	// requires last mile hydration. The reconciler writes the value of this
+	// annotation and the reconciler-manager reads it. If set to true, the
+	// reconciler-manager will create the reconciler with the hydration-controller
+	// sidecar container.
+	RequiresRenderingAnnotationKey = configsync.ConfigSyncPrefix + "requires-rendering"
 )
 
 // Lifecycle annotations

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -71,6 +71,10 @@ type opts struct {
 	// mux prevents status update conflicts.
 	mux *sync.Mutex
 
+	// renderingEnabled indicates whether the hydration-controller is currently
+	// running for this reconciler.
+	renderingEnabled bool
+
 	files
 	updater
 }
@@ -89,6 +93,8 @@ type Parser interface {
 	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
+	// setRequiresRendering sets the requires-rendering annotation on the RSync
+	setRequiresRendering(ctx context.Context, renderingRequired bool) error
 }
 
 func (o *opts) k8sClient() client.Client {

--- a/pkg/parse/source.go
+++ b/pkg/parse/source.go
@@ -74,8 +74,8 @@ type sourceState struct {
 }
 
 // readConfigFiles reads all the files under state.syncDir and sets state.files.
-// - if rendered is true, state.syncDir contains the hydrated files.
-// - if rendered is false, state.syncDir contains the source files.
+// - if rendering is enabled, state.syncDir contains the hydrated files.
+// - if rendered is disabled, state.syncDir contains the source files.
 // readConfigFiles should be called after sourceState is populated.
 func (o *files) readConfigFiles(state *sourceState) status.Error {
 	if state == nil || state.commit == "" || state.syncDir.OSPath() == "" {

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -43,6 +43,9 @@ type renderingStatus struct {
 	message    string
 	errs       status.MultiError
 	lastUpdate metav1.Time
+	// requiresRendering indicates whether the sync source has dry configs
+	// only used internally (not surfaced on RSync status)
+	requiresRendering bool
 }
 
 func (rs renderingStatus) equal(other renderingStatus) bool {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -106,6 +106,9 @@ type Options struct {
 	ReconcileTimeout string
 	// APIServerTimeout is the client-side timeout used for talking to the API server
 	APIServerTimeout string
+	// RenderingEnabled indicates whether the reconciler Pod is currently running
+	// with the hydration-controller.
+	RenderingEnabled bool
 	// RootOptions is the set of options to fill in if this is configuring the
 	// Root reconciler.
 	// Unset for Namespace repositories.
@@ -214,13 +217,13 @@ func Run(opts Options) {
 	}
 	if opts.ReconcilerScope == declared.RootReconciler {
 		parser, err = parse.NewRootRunner(opts.ClusterName, opts.SyncName, opts.ReconcilerName, opts.SourceFormat, &reader.File{}, cl,
-			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, opts.StatusUpdatePeriod, fs, discoveryClient, decls, supervisor, rem)
+			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, opts.StatusUpdatePeriod, fs, discoveryClient, decls, supervisor, rem, opts.RenderingEnabled)
 		if err != nil {
 			klog.Fatalf("Instantiating Root Repository Parser: %v", err)
 		}
 	} else {
 		parser, err = parse.NewNamespaceRunner(opts.ClusterName, opts.SyncName, opts.ReconcilerName, opts.ReconcilerScope, &reader.File{}, cl,
-			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, opts.StatusUpdatePeriod, fs, discoveryClient, decls, supervisor, rem)
+			opts.PollingPeriod, opts.ResyncPeriod, opts.RetryPeriod, opts.StatusUpdatePeriod, fs, discoveryClient, decls, supervisor, rem, opts.RenderingEnabled)
 		if err != nil {
 			klog.Fatalf("Instantiating Namespace Repository Parser: %v", err)
 		}

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -77,6 +77,10 @@ const (
 	// StatusMode is to control if the kpt applier needs to inject the actuation data
 	// into the ResourceGroup object.
 	StatusMode = "STATUS_MODE"
+
+	// RenderingEnabled tells the reconciler container whether the hydration-controller
+	// container is running in the Pod.
+	RenderingEnabled = "RENDERING_ENABLED"
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/util_test.go
+++ b/pkg/reconcilermanager/controllers/util_test.go
@@ -105,3 +105,61 @@ func TestHelmSyncEnvs(t *testing.T) {
 		})
 	}
 }
+
+func boolPointer(val bool) *bool {
+	return &val
+}
+
+func TestUpdateHydrationControllerImage(t *testing.T) {
+	testCases := []struct {
+		name          string
+		image         string
+		overrideSpec  v1beta1.OverrideSpec
+		expectedImage string
+	}{
+		{
+			name:          "update hydration-controller with enableShellInRendering: true",
+			image:         "gcr.io/example/hydration-controller:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: boolPointer(true)},
+			expectedImage: "gcr.io/example/hydration-controller-with-shell:v1.2.3",
+		},
+		{
+			name:          "update hydration-controller-with-shell with enableShellInRendering: true",
+			image:         "gcr.io/example/hydration-controller-with-shell:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: boolPointer(true)},
+			expectedImage: "gcr.io/example/hydration-controller-with-shell:v1.2.3",
+		},
+		{
+			name:          "update hydration-controller-with-shell with enableShellInRendering: false",
+			image:         "gcr.io/example/hydration-controller-with-shell:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: boolPointer(false)},
+			expectedImage: "gcr.io/example/hydration-controller:v1.2.3",
+		},
+		{
+			name:          "update hydration-controller with enableShellInRendering: false",
+			image:         "gcr.io/example/hydration-controller:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: boolPointer(false)},
+			expectedImage: "gcr.io/example/hydration-controller:v1.2.3",
+		},
+		{
+			name:          "update hydration-controller-with-shell with enableShellInRendering: nil",
+			image:         "gcr.io/example/hydration-controller-with-shell:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: nil},
+			expectedImage: "gcr.io/example/hydration-controller:v1.2.3",
+		},
+		{
+			name:          "update hydration-controller with enableShellInRendering: nil",
+			image:         "gcr.io/example/hydration-controller:v1.2.3",
+			overrideSpec:  v1beta1.OverrideSpec{EnableShellInRendering: nil},
+			expectedImage: "gcr.io/example/hydration-controller:v1.2.3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := updateHydrationControllerImage(tc.image, tc.overrideSpec)
+			assert.Equal(t, tc.expectedImage, actual)
+		})
+	}
+
+}


### PR DESCRIPTION
The hydration-controller is used for last mile hydration when the source of truth contains kustomization files, and is a no-op otherwise. This change optimizes the resource footprint of reconciler Pods by dynamically detecting whether the source of truth requires hydration, and only enabling the hydration-controller container if it does.

This is accomplished by setting an annotation with the reconciler, and having the reconciler-manager read that annotation to determine whether to include hydration-controller in the Deployment.