### PR TITLE
refactor: consolidate rsync helper functions

### DIFF
--- a/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
@@ -43,7 +43,7 @@ func TestRepoSyncReconcilerDeploymentLifecycle(t *testing.T) {
 	parseDeployment = parsedDeployment
 
 	t.Log("building RepoSyncReconciler")
-	rs := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
+	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
@@ -298,7 +298,7 @@ func TestRepoSyncReconcilerAuthSecretDriftProtection(t *testing.T) {
 
 func testRepoSyncDriftProtection(t *testing.T, exampleObj client.Object, objKeyFunc func(client.ObjectKey) client.ObjectKey, modify, validate func(client.Object) error) {
 	t.Log("building RepoSyncReconciler")
-	syncObj := repoSync(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
+	syncObj := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(syncObj.Namespace))
 	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
 	testDriftProtection(t, fakeClient, testReconciler, syncObj, exampleObj, objKeyFunc, modify, validate)

--- a/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
@@ -55,7 +55,7 @@ func TestRootSyncReconcilerDeploymentLifecycle(t *testing.T) {
 	parseDeployment = parsedDeployment
 
 	t.Log("building root-reconciler-controller")
-	rs := rootSync(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
+	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupRootReconciler(t, secretObj)
@@ -259,7 +259,7 @@ func TestRootSyncReconcilerClusterRoleBindingDriftProtection(t *testing.T) {
 
 func testRootSyncDriftProtection(t *testing.T, exampleObj client.Object, objKeyFunc func(client.ObjectKey) client.ObjectKey, modify, validate func(client.Object) error) {
 	t.Log("building RootSyncReconciler")
-	syncObj := rootSync(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
+	syncObj := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(syncObj.Namespace))
 	fakeClient, _, testReconciler := setupRootReconciler(t, secretObj)
 	testDriftProtection(t, fakeClient, testReconciler, syncObj, exampleObj, objKeyFunc, modify, validate)


### PR DESCRIPTION
Declare a common rootSync/repoSync helper that is reused by the various source types, so that it is easier to define common logic.