### PR TITLE
test: fix poll override logic in `nomostest`

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +70,9 @@ func main() {
 
 	profiler.Service()
 	ctrl.SetLogger(klogr.New())
+
+	setupLog.Info(fmt.Sprintf("running with flags --cluster-name=%s; --reconciler-polling-period=%s; --hydration-polling-period=%s",
+		*clusterName, *reconcilerPollingPeriod, *hydrationPollingPeriod))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: core.Scheme,

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -90,9 +90,9 @@ var (
 	hydrationPollingPeriod time.Duration
 )
 
-// IsReconcilerManagerCmConfigMap returns true if passed obj is the
+// IsReconcilerTemplateConfigMap returns true if passed obj is the
 // reconciler-manager ConfigMap reconciler-manager-cm in config-management namespace.
-func IsReconcilerManagerCmConfigMap(obj client.Object) bool {
+func IsReconcilerTemplateConfigMap(obj client.Object) bool {
 	return obj.GetName() == "reconciler-manager-cm" &&
 		obj.GetNamespace() == "config-management-system" &&
 		obj.GetObjectKind().GroupVersionKind() == kinds.ConfigMap()
@@ -122,7 +122,7 @@ func ResetReconcilerManagerConfigMap(nt *NT) error {
 		return err
 	}
 	for _, obj := range objs {
-		if !IsReconcilerManagerCmConfigMap(obj) {
+		if !IsReconcilerTemplateConfigMap(obj) {
 			continue
 		}
 		nt.T.Logf("ResetReconcilerManagerConfigMap obj: %v", core.GKNN(obj))
@@ -307,7 +307,7 @@ func multiRepoObjects(objects []client.Object, opts ...func(obj client.Object) e
 		if !isPSPCluster() && obj.GetName() == "acm-psp" {
 			continue
 		}
-		if IsReconcilerManagerCmConfigMap(obj) {
+		if IsReconcilerTemplateConfigMap(obj) {
 			// Mark that we've found the ReconcilerManager ConfigMap.
 			// This way we know we've enabled debug mode.
 			found = true
@@ -532,7 +532,7 @@ func setReconcilerDebugMode(obj client.Object) error {
 	if obj == nil {
 		return testpredicates.ErrObjectNotFound
 	}
-	if !IsReconcilerManagerCmConfigMap(obj) {
+	if !IsReconcilerTemplateConfigMap(obj) {
 		return nil
 	}
 

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -90,9 +90,9 @@ var (
 	hydrationPollingPeriod time.Duration
 )
 
-// IsReconcilerManagerConfigMap returns true if passed obj is the
+// IsReconcilerManagerCmConfigMap returns true if passed obj is the
 // reconciler-manager ConfigMap reconciler-manager-cm in config-management namespace.
-func IsReconcilerManagerConfigMap(obj client.Object) bool {
+func IsReconcilerManagerCmConfigMap(obj client.Object) bool {
 	return obj.GetName() == "reconciler-manager-cm" &&
 		obj.GetNamespace() == "config-management-system" &&
 		obj.GetObjectKind().GroupVersionKind() == kinds.ConfigMap()
@@ -114,7 +114,7 @@ func ResetReconcilerManagerConfigMap(nt *NT) error {
 		return err
 	}
 	for _, obj := range objs {
-		if !IsReconcilerManagerConfigMap(obj) {
+		if !IsReconcilerManagerCmConfigMap(obj) {
 			continue
 		}
 		nt.T.Logf("ResetReconcilerManagerConfigMap obj: %v", core.GKNN(obj))
@@ -299,7 +299,7 @@ func multiRepoObjects(objects []client.Object, opts ...func(obj client.Object) e
 		if !isPSPCluster() && obj.GetName() == "acm-psp" {
 			continue
 		}
-		if IsReconcilerManagerConfigMap(obj) {
+		if IsReconcilerManagerCmConfigMap(obj) {
 			// Mark that we've found the ReconcilerManager ConfigMap.
 			// This way we know we've enabled debug mode.
 			found = true
@@ -524,7 +524,7 @@ func setReconcilerDebugMode(obj client.Object) error {
 	if obj == nil {
 		return testpredicates.ErrObjectNotFound
 	}
-	if !IsReconcilerManagerConfigMap(obj) {
+	if !IsReconcilerManagerCmConfigMap(obj) {
 		return nil
 	}
 
@@ -575,7 +575,7 @@ func setPollingPeriods(obj client.Object) error {
 	if obj == nil {
 		return testpredicates.ErrObjectNotFound
 	}
-	if !IsReconcilerManagerConfigMap(obj) {
+	if !IsReconcilerManagerCmConfigMap(obj) {
 		return nil
 	}
 

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -98,6 +98,14 @@ func IsReconcilerManagerCmConfigMap(obj client.Object) bool {
 		obj.GetObjectKind().GroupVersionKind() == kinds.ConfigMap()
 }
 
+// IsReconcilerManagerConfigMap returns true if passed obj is the
+// reconciler-manager ConfigMap reconciler-manager in config-management namespace.
+func IsReconcilerManagerConfigMap(obj client.Object) bool {
+	return obj.GetName() == "reconciler-manager" &&
+		obj.GetNamespace() == "config-management-system" &&
+		obj.GetObjectKind().GroupVersionKind() == kinds.ConfigMap()
+}
+
 // isOtelCollectorDeployment returns true if passed obj is the
 // otel-collector Deployment in the config-management-monitoring namespace.
 func isOtelCollectorDeployment(obj client.Object) bool {
@@ -575,7 +583,7 @@ func setPollingPeriods(obj client.Object) error {
 	if obj == nil {
 		return testpredicates.ErrObjectNotFound
 	}
-	if !IsReconcilerManagerCmConfigMap(obj) {
+	if !IsReconcilerManagerConfigMap(obj) {
 		return nil
 	}
 

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -249,12 +249,18 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		GitProvider:             gitproviders.NewGitProvider(t, *e2e.GitProvider, logger),
 	}
 
+	// TODO: Try speeding up the reconciler and hydration polling.
+	// It seems that speeding them up too much can cause failures in
+	// our tests, so we will have to experiment and investigate to
+	// see how much we can speed it up.
+	// See original discussion in https://github.com/GoogleContainerTools/kpt-config-sync/pull/707#discussion_r1240911054
+
 	// Speed up the delay between sync attempts to speed up testing
 	// (default: 15s), but leave the remediator (paused while syncing) and retry
 	// code (1s delay) time to execute between sync attempts.
-	nt.ReconcilerPollingPeriod = 2 * time.Second
+	nt.ReconcilerPollingPeriod = 15 * time.Second
 	// Speed up the delay between rendering attempts to speed up testing (default: 5s)
-	nt.HydrationPollingPeriod = 1 * time.Second
+	nt.HydrationPollingPeriod = 5 * time.Second
 
 	// init the Client & WatchClient
 	nt.RenewClient()


### PR DESCRIPTION
Pulled out from https://github.com/GoogleContainerTools/kpt-config-sync/pull/707, see discussion in https://github.com/GoogleContainerTools/kpt-config-sync/pull/707#discussion_r1240911054

I separated the rename and logic fix into separate commits to ease review. 