### PR TITLE
test: add cluster-prefix parameter

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -116,6 +116,12 @@ var TestFeatures = flag.String("test-features", "",
 var NumClusters = flag.Int("num-clusters", util.EnvInt("E2E_NUM_CLUSTERS", 1),
 	"Number of parallel test threads to run. Also dictates the number of clusters which will be created in parallel. Overrides the -test.parallel flag.")
 
+// ClusterPrefix is the prefix to use when naming clusters. An index is appended
+// to the prefix with the pattern '<prefix>-<index>', starting at 0. If unset, defaults
+// to cs-e2e-<UNIX_TIME>. cluster-names takes precedence, if provided.
+var ClusterPrefix = flag.String("cluster-prefix", util.EnvString("E2E_CLUSTER_PREFIX", ""),
+	"Prefix to use when naming clusters. An index is appended to the prefix with the pattern '<prefix>-<index>', starting at 0. If unset, defaults to cs-e2e-<UNIX_TIME>. cluster-names takes precedence, if provided.")
+
 // ClusterNames is a list of cluster names to use for the tests. If specified without
 // create-clusters, assumes the clusters were pre-provisioned.
 var ClusterNames = newStringListFlag("cluster-names", util.EnvList("E2E_CLUSTER_NAMES", nil),

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -311,12 +311,16 @@ func InitSharedEnvironments() error {
 	mySharedNTs = &sharedNTs{
 		testMap: map[string]*sharedNT{},
 	}
-	timeStamp := time.Now().Unix()
+	prefix := *e2e.ClusterPrefix
+	if prefix == "" {
+		timeStamp := time.Now().Unix()
+		prefix = fmt.Sprintf("cs-e2e-%v", timeStamp)
+	}
 	tg := taskgroup.New()
 	clusters := *e2e.ClusterNames
 	if len(clusters) == 0 { // generate names for ephemeral clusters
 		for x := 0; x < e2e.NumParallel(); x++ {
-			clusters = append(clusters, fmt.Sprintf("cs-e2e-%v-%v", timeStamp, x))
+			clusters = append(clusters, fmt.Sprintf("%s-%d", prefix, x))
 		}
 	}
 	for _, name := range clusters {


### PR DESCRIPTION
This parameter can be used to specify a prefix to use when generating cluster names. The default behavior remains to generate a prefix using cs-e2e-<timestamp>.