### PR TITLE
test: enhance cleanup logic for destroy-clusters

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -184,8 +184,12 @@ var CreateClusters = flag.String("create-clusters", util.EnvString("E2E_CREATE_C
 var CreateClustersAllowedValues = []string{CreateClustersEnabled, CreateClustersLazy, CreateClustersDisabled}
 
 // DestroyClusters indicates whether to destroy clusters that were created by the test suite after the tests.
-var DestroyClusters = flag.Bool("destroy-clusters", util.EnvBool("E2E_DESTROY_CLUSTERS", true),
-	"Whether to destroy clusters that were created by the test suite after the tests.")
+var DestroyClusters = flag.String("destroy-clusters", util.EnvString("E2E_DESTROY_CLUSTERS", DestroyClustersAuto),
+	fmt.Sprintf("Whether to destroy clusters that were created by the test suite after the tests. Allowed Values: [%s]",
+		strings.Join(DestroyClustersAllowedValues, ", ")))
+
+// DestroyClustersAllowedValues is a list of allowed values for the destroy-clusters parameter
+var DestroyClustersAllowedValues = []string{DestroyClustersEnabled, DestroyClustersAuto, DestroyClustersDisabled}
 
 const (
 	// Kind indicates creating a Kind cluster for testing.
@@ -208,6 +212,13 @@ const (
 	CreateClustersLazy = "lazy"
 	// CreateClustersDisabled indicates to not create clusters
 	CreateClustersDisabled = "false"
+	// DestroyClustersEnabled indicates to destroy clusters
+	DestroyClustersEnabled = "true"
+	// DestroyClustersAuto indicates to only destroy clusters if they were created
+	// by the test framework
+	DestroyClustersAuto = "auto"
+	// DestroyClustersDisabled indicates to not destroy clusters
+	DestroyClustersDisabled = "false"
 )
 
 const (

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -287,8 +287,8 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		connectToLocalRegistry(nt)
 	}
 	t.Cleanup(func() {
-		if *e2e.DestroyClusters {
-			nt.T.Logf("Skipping cleanup because cluster will be destroyed (--destroy-clusters=true)")
+		if opts.IsEphemeralCluster {
+			nt.T.Logf("Skipping cleanup because cluster will be destroyed (--destroy-clusters=%s)", *e2e.DestroyClusters)
 			return
 		} else if t.Failed() && *e2e.Debug {
 			nt.T.Logf("Skipping cleanup because test failed with --debug")

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -41,6 +41,9 @@ type New struct {
 	// ClusterName is the name of the target cluster used by the test.
 	ClusterName string
 
+	// IsEphemeralCluster indicates whether the cluster will be destroyed.
+	IsEphemeralCluster bool
+
 	// TmpDir is the base temporary directory to use for the test. Overrides the
 	// generated directory based on Name and the OS's main temporary directory.
 	TmpDir string

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -72,6 +72,11 @@ func validateArgs() error {
 			errors.Errorf("Unrecognized value %s for CREATE_CLUSTERS. Allowed values: [%s]",
 				*e2e.CreateClusters, strings.Join(e2e.CreateClustersAllowedValues, ", ")))
 	}
+	if !slices.Contains(e2e.DestroyClustersAllowedValues, *e2e.DestroyClusters) {
+		errs = multierr.Append(errs,
+			errors.Errorf("Unrecognized value %s for DESTROY_CLUSTERS. Allowed values: [%s]",
+				*e2e.DestroyClusters, strings.Join(e2e.DestroyClustersAllowedValues, ", ")))
+	}
 	if *e2e.TestCluster == e2e.GKE { // required vars for GKE
 		if *e2e.GCPProject == "" {
 			errs = multierr.Append(errs, errors.Errorf("Environment variable GCP_PROJECT is required for GKE clusters"))


### PR DESCRIPTION
This adds several options for destroying clusters:
- true always destroys clusters
- auto destroys clusters if created (default)
- false never destroys clusters

This streamlines the logic for destroying clusters and decouples it from
the cluster creation logic, while maintaining backwards compatible
defaults.