### PR TITLE
test: unique ConfigMap names for tests

### DIFF
--- a/pkg/validate/raw/validate/source_spec_validator.go
+++ b/pkg/validate/raw/validate/source_spec_validator.go
@@ -425,10 +425,10 @@ func MissingConfigMap(o client.Object, err error) status.Error {
 		BuildWithResources(o)
 }
 
-// MissingConfigMapKey reports that an RSync is missing spec.helm.valuesFileSources.name
+// MissingConfigMapKey reports that an RSync is missing spec.helm.valuesFileSources.valuesFile
 func MissingConfigMapKey(o client.Object) status.Error {
 	kind := o.GetObjectKind().GroupVersionKind().Kind
 	return invalidSyncBuilder.
-		Sprintf("%ss must reference ConfigMaps with valid spec.helm.valuesFileSources.key", kind).
+		Sprintf("%ss must reference ConfigMaps with valid spec.helm.valuesFileSources.valuesFile", kind).
 		BuildWithResources(o)
 }


### PR DESCRIPTION
Temporary fix for CI so that it is not continuously failing while I'm gone.

This makes the config map names unique in tests. I will use `nt.Cleanup` to remove them in a followup after I resolve another issue that this revealed. 

TL;DR the root sync cannot be deleted after the ConfigMap is deleted, so I'll investigate and fix this after my vacation. 