### PR TITLE
helm fix: volume names will use the valuesFileRef index rather than ConfigMap name

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -433,7 +433,7 @@ func mountConfigMapValuesFiles(templateSpec *corev1.PodSpec, c *corev1.Container
 		fileName := reconcilermanager.HelmConfigMapRef
 		mountPath := filepath.Join("/etc/config", vf.Name, vf.ValuesFile)
 		valuesFiles = append(valuesFiles, filepath.Join(mountPath, fileName))
-		volumeName := fmt.Sprintf("vol-%d-", i) + strings.ToLower(vf.Name)
+		volumeName := fmt.Sprintf("valuesfile-vol-%d", i)
 
 		if len(volumeName) > volumeNameLengthLimit {
 			// trim the volume name as we only have a length limit of 63, even though

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -114,8 +114,6 @@ type reconcilerBase struct {
 	syncKind string
 }
 
-const volumeNameLengthLimit = 63
-
 func (r *reconcilerBase) serviceAccountSubject(reconcilerRef types.NamespacedName) rbacv1.Subject {
 	return newSubject(reconcilerRef.Name, reconcilerRef.Namespace, kinds.ServiceAccount().Kind)
 }
@@ -434,13 +432,6 @@ func mountConfigMapValuesFiles(templateSpec *corev1.PodSpec, c *corev1.Container
 		mountPath := filepath.Join("/etc/config", vf.Name, vf.ValuesFile)
 		valuesFiles = append(valuesFiles, filepath.Join(mountPath, fileName))
 		volumeName := fmt.Sprintf("valuesfile-vol-%d", i)
-
-		if len(volumeName) > volumeNameLengthLimit {
-			// trim the volume name as we only have a length limit of 63, even though
-			// the ConfigMap name can be much longer.  The prefix
-			// containing the index i should be sufficient to uniquify the value.
-			volumeName = volumeName[:volumeNameLengthLimit]
-		}
 
 		templateSpec.Volumes = append(templateSpec.Volumes, corev1.Volume{
 			Name: volumeName,

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -637,7 +637,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{{
-						Name:      "vol-0-foo",
+						Name:      "valuesfile-vol-0",
 						MountPath: "/etc/config/foo/values.yaml",
 					}},
 					Env: []corev1.EnvVar{{
@@ -647,7 +647,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "vol-0-foo",
+						Name: "valuesfile-vol-0",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -678,11 +678,11 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "vol-0-foo",
+							Name:      "valuesfile-vol-0",
 							MountPath: "/etc/config/foo/values.yaml",
 						},
 						{
-							Name:      "vol-1-bar",
+							Name:      "valuesfile-vol-1",
 							MountPath: "/etc/config/bar/values.yaml",
 						},
 					},
@@ -693,7 +693,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "vol-0-foo",
+						Name: "valuesfile-vol-0",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -707,7 +707,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 						},
 					},
 					{
-						Name: "vol-1-bar",
+						Name: "valuesfile-vol-1",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -738,11 +738,11 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "vol-0-foo",
+							Name:      "valuesfile-vol-0",
 							MountPath: "/etc/config/foo/values-0.yaml",
 						},
 						{
-							Name:      "vol-1-foo",
+							Name:      "valuesfile-vol-1",
 							MountPath: "/etc/config/foo/values-1.yaml",
 						},
 					},
@@ -753,7 +753,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "vol-0-foo",
+						Name: "valuesfile-vol-0",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -767,7 +767,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 						},
 					},
 					{
-						Name: "vol-1-foo",
+						Name: "valuesfile-vol-1",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -783,7 +783,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				},
 			},
 		},
-		"long name gets truncated": {
+		"long configmap names": {
 			input: []v1beta1.ValuesFileSources{
 				{
 					Name:       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0",
@@ -798,11 +798,11 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "vol-0-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+							Name:      "valuesfile-vol-0",
 							MountPath: "/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0/values.yaml",
 						},
 						{
-							Name:      "vol-1-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+							Name:      "valuesfile-vol-1",
 							MountPath: "/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-1/values.yaml",
 						},
 					},
@@ -814,7 +814,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "vol-0-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+						Name: "valuesfile-vol-0",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -828,7 +828,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 						},
 					},
 					{
-						Name: "vol-1-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+						Name: "valuesfile-vol-1",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -636,7 +636,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{{
-						Name:      "configmap-vol-foo-0",
+						Name:      "vol-0-foo",
 						MountPath: "/etc/config/foo/values.yaml",
 					}},
 					Env: []corev1.EnvVar{{
@@ -646,7 +646,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "configmap-vol-foo-0",
+						Name: "vol-0-foo",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -677,11 +677,11 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "configmap-vol-foo-0",
+							Name:      "vol-0-foo",
 							MountPath: "/etc/config/foo/values.yaml",
 						},
 						{
-							Name:      "configmap-vol-bar-1",
+							Name:      "vol-1-bar",
 							MountPath: "/etc/config/bar/values.yaml",
 						},
 					},
@@ -692,7 +692,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "configmap-vol-foo-0",
+						Name: "vol-0-foo",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -706,7 +706,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 						},
 					},
 					{
-						Name: "configmap-vol-bar-1",
+						Name: "vol-1-bar",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -737,11 +737,11 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "configmap-vol-foo-0",
+							Name:      "vol-0-foo",
 							MountPath: "/etc/config/foo/values-0.yaml",
 						},
 						{
-							Name:      "configmap-vol-foo-1",
+							Name:      "vol-1-foo",
 							MountPath: "/etc/config/foo/values-1.yaml",
 						},
 					},
@@ -752,7 +752,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{
 					{
-						Name: "configmap-vol-foo-0",
+						Name: "vol-0-foo",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -766,7 +766,7 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 						},
 					},
 					{
-						Name: "configmap-vol-foo-1",
+						Name: "vol-1-foo",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
@@ -774,6 +774,42 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 								},
 								Items: []corev1.KeyToPath{{
 									Key:  "values-1.yaml",
+									Path: reconcilermanager.HelmConfigMapRef,
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"long name gets truncated": {
+			input: []v1beta1.ValuesFileSources{
+				{
+					Name:       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx",
+					ValuesFile: "values.yaml",
+				},
+			},
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "vol-0-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+						MountPath: "/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx/values.yaml",
+					}},
+					Env: []corev1.EnvVar{{
+						Name:  reconcilermanager.HelmValuesFileSources,
+						Value: filepath.Join("/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx/values.yaml", reconcilermanager.HelmConfigMapRef),
+					}},
+				}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "vol-0-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghi",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx",
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  "values.yaml",
 									Path: reconcilermanager.HelmConfigMapRef,
 								}},
 							},

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -775,67 +774,6 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 								},
 								Items: []corev1.KeyToPath{{
 									Key:  "values-1.yaml",
-									Path: reconcilermanager.HelmConfigMapRef,
-								}},
-							},
-						},
-					},
-				},
-			},
-		},
-		"long configmap names": {
-			input: []v1beta1.ValuesFileSources{
-				{
-					Name:       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0",
-					ValuesFile: "values.yaml",
-				},
-				{
-					Name:       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-1",
-					ValuesFile: "values.yaml",
-				},
-			},
-			expected: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "valuesfile-vol-0",
-							MountPath: "/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0/values.yaml",
-						},
-						{
-							Name:      "valuesfile-vol-1",
-							MountPath: "/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-1/values.yaml",
-						},
-					},
-					Env: []corev1.EnvVar{{
-						Name: reconcilermanager.HelmValuesFileSources,
-						Value: strings.Join([]string{filepath.Join("/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0/values.yaml", reconcilermanager.HelmConfigMapRef),
-							filepath.Join("/etc/config/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-1/values.yaml", reconcilermanager.HelmConfigMapRef)}, ","),
-					}},
-				}},
-				Volumes: []corev1.Volume{
-					{
-						Name: "valuesfile-vol-0",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-0",
-								},
-								Items: []corev1.KeyToPath{{
-									Key:  "values.yaml",
-									Path: reconcilermanager.HelmConfigMapRef,
-								}},
-							},
-						},
-					},
-					{
-						Name: "valuesfile-vol-1",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvabcdefghijklmnopqrstuvwx-1",
-								},
-								Items: []corev1.KeyToPath{{
-									Key:  "values.yaml",
 									Path: reconcilermanager.HelmConfigMapRef,
 								}},
 							},


### PR DESCRIPTION
Volume names have a length limit of 63 or we get an error, this fixes it so that we just use the valuesFileRef index rather than the ConifgMap name

b/289378438