### PR TITLE
test: add e2e options for disk size/type

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -167,6 +167,14 @@ var GKEClusterVersion = flag.String("gke-cluster-version", util.EnvString("GKE_C
 var GKEMachineType = flag.String("gke-machine-type", util.EnvString("GKE_MACHINE_TYPE", DefaultGKEMachineType),
 	"GKE machine type to use when creating GKE clusters. Defaults to GKE_MACHINE_TYPE env var.")
 
+// GKEDiskSize is the GKE disk size to use when creating GKE clusters.
+var GKEDiskSize = flag.String("gke-disk-size", util.EnvString("GKE_DISK_SIZE", ""),
+	"GKE disk size to use when creating GKE clusters. Defaults to GKE_DISK_SIZE env var.")
+
+// GKEDiskType is the GKE disk type to use when creating GKE clusters.
+var GKEDiskType = flag.String("gke-disk-type", util.EnvString("GKE_DISK_TYPE", ""),
+	"GKE disk type to use when creating GKE clusters. Defaults to GKE_DISK_TYPE env var.")
+
 // GKENumNodes is the number of nodes to use when creating GKE clusters.
 var GKENumNodes = flag.Int("gke-num-nodes", util.EnvInt("GKE_NUM_NODES", DefaultGKENumNodes),
 	"Number of node to use when creating GKE clusters. Defaults to GKE_NUM_NODES env var.")

--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -217,6 +217,12 @@ func createGKECluster(t testing.NTB, name string) error {
 		if *e2e.GKEMachineType != "" {
 			args = append(args, "--machine-type", *e2e.GKEMachineType)
 		}
+		if *e2e.GKEDiskSize != "" {
+			args = append(args, "--disk-size", *e2e.GKEDiskSize)
+		}
+		if *e2e.GKEDiskType != "" {
+			args = append(args, "--disk-type", *e2e.GKEDiskType)
+		}
 		if *e2e.GKENumNodes > 0 {
 			args = append(args, "--num-nodes", fmt.Sprintf("%d", *e2e.GKENumNodes))
 		}


### PR DESCRIPTION
This adds options to configure the disk size/type for GKE standard clusters. This enables customizing the shape of persistent disks when creating clusters with the test framework.