### PR TITLE
test: set GKE cidr range when creating clusters

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -193,6 +193,7 @@ func createGKECluster(t testing.NTB, name string) error {
 	args = append(args, name,
 		"--project", *e2e.GCPProject,
 		"--async",
+		"--cluster-ipv4-cidr", "/19", // use smaller than default CIDR
 	)
 	if *e2e.GCPZone != "" {
 		args = append(args, "--zone", *e2e.GCPZone)


### PR DESCRIPTION
The default value is larger than what is required. This sets the default CIDR range to a more reasonable value. This helps fit a greater number of clusters into a network, particularly for CI use cases.