### PR TITLE
Update the http-git-server image

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -36,7 +36,7 @@ const testGitNamespace = "config-management-system-test"
 const testGitServer = "test-git-server"
 const testGitServerImage = testing.TestInfraArtifactRegistry + "/git-server:v1.0.0"
 const testGitHTTPServer = "http-git-server"
-const testGitHTTPServerImage = testing.TestInfraArtifactRegistry + "/http-git-server:v1.0.0"
+const testGitHTTPServerImage = testing.TestInfraArtifactRegistry + "/http-git-server:v1.0.0-2b06b183"
 
 func testGitServerSelector() map[string]string {
 	// Note that maps are copied by reference into objects.


### PR DESCRIPTION
This is to pick up the vulnerability fixes addressed in https://github.com/GoogleContainerTools/kpt-config-sync/pull/739.