### PR TITLE
ci: skip cleanup of ConfigConnector resource

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -810,11 +810,14 @@ func (nt *NT) setupConfigConnector() {
 			},
 		},
 	}
-	nt.T.Cleanup(func() {
-		if err := nt.KubeClient.Delete(kccObj); err != nil {
-			nt.T.Error(err)
-		}
-	})
+	// TODO(sdowell): there are currently issues with cleanup, most likely related to a
+	// known issue in cli-utils. This currently only runs on a dedicated KCC cluster,
+	// so it shouldn't be too disruptive to skip cleanup of the ConfigConnector CR.
+	//nt.T.Cleanup(func() {
+	//	if err := nt.KubeClient.Delete(kccObj); err != nil {
+	//		nt.T.Error(err)
+	//	}
+	//})
 	if err := nt.KubeClient.Apply(kccObj); err != nil {
 		nt.T.Fatal(err)
 	}


### PR DESCRIPTION
There is currently an issue with cleaning up the ConfigConnector resource in CI that is wedging the cluster. A known issue with cleanup is currently being worked on in cli-utils, so this may be fixed with that change. Prior to a recent change the ConfigConnector resource was created with a one-off provisioning script, so this essentially reverts to that behavior. The KCC tests run on a dedicated KCC cluster, so this should not be too disruptive.