### PR TITLE
Avoid creating LoadBalancer in wordpress Helm chart

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -408,7 +408,7 @@ image:
 			  "wordpressEmail": "test-user@example.com",
 			  "service": {
 				"type": "ClusterIP"
-			  },
+			  }
 			},
 			"valuesFileRefs": [
 			  {

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -405,7 +405,10 @@ image:
 				  "value": "inline"
 				}
 			  ],
-			  "wordpressEmail": "test-user@example.com"
+			  "wordpressEmail": "test-user@example.com",
+			  "service": {
+				"type": "ClusterIP"
+			  },
 			},
 			"valuesFileRefs": [
 			  {


### PR DESCRIPTION
This removes the need of LoadBalancer and avoids the problem of firewall rules cleanup. 