### PR TITLE
helm api: better handling of copying referenced configmaps to c-m-s (and other cleanup)

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -346,11 +346,11 @@ image:
 			"valuesFileRefs": [
 			  {
 				"name": "helm-config-map-override",
-				"valuesFile": "first"
+				"dataKey": "first"
 			  },
 			  {
 				"name": "helm-config-map-override",
-				"valuesFile": "second"
+				"dataKey": "second"
 			  }
 			]
 		  }
@@ -565,7 +565,7 @@ func TestHelmConfigMapNamespaceRepo(t *testing.T) {
 		GCPServiceAccountEmail: gsaARReaderEmail(),
 		Version:                privateNSHelmChartVersion,
 		ReleaseName:            "test",
-		ValuesFileRefs:         []v1beta1.ValuesFileRef{{Name: cmName, ValuesFile: "foo.yaml"}},
+		ValuesFileRefs:         []v1beta1.ValuesFileRef{{Name: cmName, DataKey: "foo.yaml"}},
 	}}
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(repoSyncNN.Namespace, repoSyncNN.Name), rs))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update RepoSync to sync from a private Helm Chart without cluster scoped resources"))

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -1205,13 +1205,12 @@ spec:
                         contains a values file to use for helm rendering. The ConfigMap
                         must be in the same namespace as the RootSync/RepoSync.
                       properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the value from. Default: `values.yaml`'
+                          type: string
                         name:
                           description: name represents the Object name. Required.
-                          type: string
-                        valuesFile:
-                          default: values.yaml
-                          description: valuesFile represents the object data key to
-                            read the value from.
                           type: string
                       type: object
                     type: array

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -1207,7 +1207,7 @@ spec:
                       properties:
                         dataKey:
                           description: 'dataKey represents the object data key to
-                            read the value from. Default: `values.yaml`'
+                            read the values from. Default: `values.yaml`'
                           type: string
                         name:
                           description: name represents the Object name. Required.

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1220,13 +1220,12 @@ spec:
                         contains a values file to use for helm rendering. The ConfigMap
                         must be in the same namespace as the RootSync/RepoSync.
                       properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the value from. Default: `values.yaml`'
+                          type: string
                         name:
                           description: name represents the Object name. Required.
-                          type: string
-                        valuesFile:
-                          default: values.yaml
-                          description: valuesFile represents the object data key to
-                            read the value from.
                           type: string
                       type: object
                     type: array

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1222,7 +1222,7 @@ spec:
                       properties:
                         dataKey:
                           description: 'dataKey represents the object data key to
-                            read the value from. Default: `values.yaml`'
+                            read the values from. Default: `values.yaml`'
                           type: string
                         name:
                           description: name represents the Object name. Required.

--- a/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
@@ -473,6 +473,7 @@ func autoConvert_v1beta1_HelmBase_To_v1alpha1_HelmBase(in *v1beta1.HelmBase, out
 	out.Version = in.Version
 	out.ReleaseName = in.ReleaseName
 	out.Values = (*v1.JSON)(unsafe.Pointer(in.Values))
+	// WARNING: in.ValuesFileRefs requires manual conversion: does not exist in peer-type
 	out.IncludeCRDs = in.IncludeCRDs
 	out.Period = in.Period
 	out.Auth = configsync.AuthType(in.Auth)
@@ -787,7 +788,15 @@ func autoConvert_v1alpha1_RepoSyncSpec_To_v1beta1_RepoSyncSpec(in *RepoSyncSpec,
 	out.SourceType = in.SourceType
 	out.Git = (*v1beta1.Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*v1beta1.Oci)(unsafe.Pointer(in.Oci))
-	out.Helm = (*v1beta1.HelmRepoSync)(unsafe.Pointer(in.Helm))
+	if in.Helm != nil {
+		in, out := &in.Helm, &out.Helm
+		*out = new(v1beta1.HelmRepoSync)
+		if err := Convert_v1alpha1_HelmRepoSync_To_v1beta1_HelmRepoSync(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Helm = nil
+	}
 	out.Override = (*v1beta1.OverrideSpec)(unsafe.Pointer(in.Override))
 	return nil
 }
@@ -802,7 +811,15 @@ func autoConvert_v1beta1_RepoSyncSpec_To_v1alpha1_RepoSyncSpec(in *v1beta1.RepoS
 	out.SourceType = in.SourceType
 	out.Git = (*Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*Oci)(unsafe.Pointer(in.Oci))
-	out.Helm = (*HelmRepoSync)(unsafe.Pointer(in.Helm))
+	if in.Helm != nil {
+		in, out := &in.Helm, &out.Helm
+		*out = new(HelmRepoSync)
+		if err := Convert_v1beta1_HelmRepoSync_To_v1alpha1_HelmRepoSync(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Helm = nil
+	}
 	out.Override = (*OverrideSpec)(unsafe.Pointer(in.Override))
 	return nil
 }

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -112,7 +112,7 @@ type ValuesFileRef struct {
 	// name represents the Object name. Required.
 	Name string `json:"name,omitempty"`
 
-	// dataKey represents the object data key to read the value from. Default: `values.yaml`
+	// dataKey represents the object data key to read the values from. Default: `values.yaml`
 	// +optional
 	DataKey string `json:"dataKey,omitempty"`
 }

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -112,8 +112,7 @@ type ValuesFileRef struct {
 	// name represents the Object name. Required.
 	Name string `json:"name,omitempty"`
 
-	// valuesFile represents the object data key to read the value from.
-	// +kubebuilder:default:=values.yaml
+	// dataKey represents the object data key to read the value from. Default: `values.yaml`
 	// +optional
-	ValuesFile string `json:"valuesFile,omitempty"`
+	DataKey string `json:"dataKey,omitempty"`
 }

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -177,14 +177,16 @@ func (r *RepoSyncReconciler) deleteHelmValuesFileRefCopies(ctx context.Context, 
 	}
 
 	for _, vf := range rs.Spec.Helm.ValuesFileRefs {
-		sourceConfigMapCopy := createSourceConfigMapCopy(rs, corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		sourceConfigMapCopy, err := createSourceConfigMapCopy(rs, corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Name:      vf.Name,
 			Namespace: rs.Namespace,
 		}})
+		if err != nil {
+			return fmt.Errorf("failed to create source ConfigMap copy: %w", err)
+		}
 
 		var existingConfigMapCopy corev1.ConfigMap
-		err := r.client.Get(ctx, types.NamespacedName{Name: sourceConfigMapCopy.Name, Namespace: sourceConfigMapCopy.Namespace}, &existingConfigMapCopy)
-		if err != nil {
+		if err = r.client.Get(ctx, types.NamespacedName{Name: sourceConfigMapCopy.Name, Namespace: sourceConfigMapCopy.Namespace}, &existingConfigMapCopy); err != nil {
 			if apierrors.IsNotFound(err) {
 				// the copied ConfigMap doesn't exist, so we don't need to do anything
 				continue

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -630,8 +630,8 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 		"one valuesFileRefs": {
 			input: []v1beta1.ValuesFileRef{
 				{
-					Name:       "foo",
-					ValuesFile: "values.yaml",
+					Name:    "foo",
+					DataKey: "values.yaml",
 				},
 			},
 			expected: corev1.PodSpec{
@@ -667,12 +667,12 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 		"two valuesFileRefs, different ConfigMaps": {
 			input: []v1beta1.ValuesFileRef{
 				{
-					Name:       "foo",
-					ValuesFile: "values.yaml",
+					Name:    "foo",
+					DataKey: "values.yaml",
 				},
 				{
-					Name:       "bar",
-					ValuesFile: "values.yaml",
+					Name:    "bar",
+					DataKey: "values.yaml",
 				},
 			},
 			expected: corev1.PodSpec{
@@ -729,12 +729,12 @@ func TestMountConfigMapValuesFiles(t *testing.T) {
 		"two valuesFileRefs, same ConfigMap, same key": {
 			input: []v1beta1.ValuesFileRef{
 				{
-					Name:       "foo",
-					ValuesFile: "values.yaml",
+					Name:    "foo",
+					DataKey: "values.yaml",
 				},
 				{
-					Name:       "foo",
-					ValuesFile: "values.yaml",
+					Name:    "foo",
+					DataKey: "values.yaml",
 				},
 			},
 			expected: corev1.PodSpec{

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -182,6 +182,7 @@ func (r *RootSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 		return controllerruntime.Result{}, updateErr
 	}
 
+	r.setDefaultHelmDataKey(rs)
 	if err := r.validateValuesFileSourcesRefs(ctx, rs); err != nil {
 		r.logger(ctx).Error(err, "Sync spec invalid")
 		rootsync.SetStalled(rs, "Validation", err)
@@ -994,5 +995,16 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 
 		templateSpec.Containers = updatedContainers
 		return nil
+	}
+}
+
+func (r *RootSyncReconciler) setDefaultHelmDataKey(rs *v1beta1.RootSync) {
+	if rs.Spec.SourceType != string(v1beta1.HelmSource) || rs.Spec.Helm == nil || len(rs.Spec.Helm.ValuesFileRefs) == 0 {
+		return
+	}
+	for i := range rs.Spec.Helm.ValuesFileRefs {
+		if rs.Spec.Helm.ValuesFileRefs[i].DataKey == "" {
+			rs.Spec.Helm.ValuesFileRefs[i].DataKey = helmValuesDefaultDataKey
+		}
 	}
 }

--- a/pkg/validate/raw/validate/source_spec_validator.go
+++ b/pkg/validate/raw/validate/source_spec_validator.go
@@ -28,15 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// gcpSASuffix specifies the default suffix used with gcp ServiceAccount email.
-	// https://cloud.google.com/iam/docs/service-accounts#user-managed
-	gcpSASuffix = ".iam.gserviceaccount.com"
-
-	// HelmValuesDefaultDataKey is the default data key to use when spec.helm.valuesFileRefs.dataKey
-	// is not specified.
-	HelmValuesDefaultDataKey = "values.yaml"
-)
+// gcpSASuffix specifies the default suffix used with gcp ServiceAccount email.
+// https://cloud.google.com/iam/docs/service-accounts#user-managed
+const gcpSASuffix = ".iam.gserviceaccount.com"
 
 // RepoSyncSpec validates the Repo Sync source specification for any obvious problems.
 func RepoSyncSpec(sourceType string, git *v1beta1.Git, oci *v1beta1.Oci, helm *v1beta1.HelmRepoSync, rs client.Object) status.Error {
@@ -213,12 +207,8 @@ func ValuesFileRefs(ctx context.Context, cl client.Client, rs client.Object, val
 		if cm.Immutable == nil || !(*cm.Immutable) {
 			return HelmValuesConfigMapMustBeImmutable(rs, objRef.Name)
 		}
-		key := vf.DataKey
-		if key == "" {
-			key = HelmValuesDefaultDataKey
-		}
-		if _, found := cm.Data[key]; !found {
-			return HelmValuesMissingConfigMapKey(rs, objRef.Name, key)
+		if _, found := cm.Data[vf.DataKey]; !found {
+			return HelmValuesMissingConfigMapKey(rs, objRef.Name, vf.DataKey)
 		}
 	}
 	return nil

--- a/pkg/validate/raw/validate/source_spec_validator.go
+++ b/pkg/validate/raw/validate/source_spec_validator.go
@@ -28,9 +28,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// gcpSASuffix specifies the default suffix used with gcp ServiceAccount email.
-// https://cloud.google.com/iam/docs/service-accounts#user-managed
-const gcpSASuffix = ".iam.gserviceaccount.com"
+const (
+	// gcpSASuffix specifies the default suffix used with gcp ServiceAccount email.
+	// https://cloud.google.com/iam/docs/service-accounts#user-managed
+	gcpSASuffix = ".iam.gserviceaccount.com"
+
+	// HelmValuesDefaultDataKey is the default data key to use when spec.helm.valuesFileRefs.dataKey
+	// is not specified.
+	HelmValuesDefaultDataKey = "values.yaml"
+)
 
 // RepoSyncSpec validates the Repo Sync source specification for any obvious problems.
 func RepoSyncSpec(sourceType string, git *v1beta1.Git, oci *v1beta1.Oci, helm *v1beta1.HelmRepoSync, rs client.Object) status.Error {
@@ -207,8 +213,12 @@ func ValuesFileRefs(ctx context.Context, cl client.Client, rs client.Object, val
 		if cm.Immutable == nil || !(*cm.Immutable) {
 			return HelmValuesConfigMapMustBeImmutable(rs, objRef.Name)
 		}
-		if _, found := cm.Data[vf.ValuesFile]; !found {
-			return HelmValuesMissingConfigMapKey(rs, objRef.Name, vf.ValuesFile)
+		key := vf.DataKey
+		if key == "" {
+			key = HelmValuesDefaultDataKey
+		}
+		if _, found := cm.Data[key]; !found {
+			return HelmValuesMissingConfigMapKey(rs, objRef.Name, key)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Errors from `copyConfigMapsToCms` should cause stalled errors
- ConfigMaps that have been copied to the c-m-s namespace should get deleted if the original source ConfigMap was deleted, the RepoSync object is deleted, or the RepoSync no longer references them.
- Remove extra debug logs.
- Regenerate version conversion code.
- Rename `spec.helm.valuesFileRefs.valuesFile` to `spec.helm.valuesFileRefs.dataKey`
- Remove the default values from the CRDs (if any) and encode them in the controller.