### PR TITLE
Use a patch go version

### DIFF
--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build all Config Sync go binaries
-FROM golang:1.19 as bins
+FROM golang:1.19.11 as bins
 
 WORKDIR /workspace
 

--- a/build/prow/vulnerability-scanner/Dockerfile
+++ b/build/prow/vulnerability-scanner/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:431.0.0 as gcloud-install
 
-FROM golang:1.19
+FROM golang:1.19.11
 
 RUN apt-get update && apt-get install -y \
     jq \


### PR DESCRIPTION
Using a minor go version, different builds may generate different images.