### PR TITLE
Avoid resetting the retryTimer to re-enable the smart retry logic

### DIFF
--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -130,7 +130,6 @@ func Run(ctx context.Context, p Parser) {
 			}
 			run(ctx, p, trigger, state)
 
-			retryTimer.Reset(opts.retryPeriod)               // Schedule retry attempt
 			statusUpdateTimer.Reset(opts.statusUpdatePeriod) // Schedule status update attempt
 
 		// Update the sync status to report management conflicts (from the remediator).


### PR DESCRIPTION
The smart-retry logic was added in http://tg/983432, but was disabled in https://github.com/GoogleContainerTools/kpt-config-sync/pull/279.

The retry behaves in the following way:
 * For the first 5 retries for reconciling a git change which fail with
   the same errors, the reconciler waits 1 second before retrying;
 * For the remaining retries for reconciling a git change which fail
   with the same errors, the reconciler does exponential backoff retry
   up to 5 minutes (i.e., 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 5m, 5m, ...).
