### PR TITLE
Add configsync_sync_generation metric resource tag

### DIFF
--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -853,17 +853,15 @@ func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add both cluster selector annotations to a role binding"))
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, selectors.ClusterSelectorAnnotationConflictErrorCode, "")
 
-	rootReconcilerPod, err := nt.KubeClient.GetDeploymentPod(
-		nomostest.DefaultRootReconcilerName, configmanagement.ControllerNamespace,
-		nt.DefaultWaitTimeout)
+	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
+	rootSyncLabels, err := nomostest.MetricLabelsForRootSync(nt, rootSyncNN)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-
 	commitHash := nt.RootRepos[configsync.RootSyncName].MustHash(nt.T)
 
 	err = nomostest.ValidateMetrics(nt,
-		nomostest.ReconcilerErrorMetrics(nt, rootReconcilerPod.Name, commitHash, metrics.ErrorSummary{
+		nomostest.ReconcilerErrorMetrics(nt, rootSyncLabels, commitHash, metrics.ErrorSummary{
 			Source: 1,
 		}))
 	if err != nil {

--- a/manifests/otel-agent-cm.yaml
+++ b/manifests/otel-agent-cm.yaml
@@ -33,7 +33,12 @@ data:
           insecure: true
     processors:
       # Attributes processor adds custom configsync metric labels to applicable
-      # metrics to identify the sync object used to configure this deployment
+      # metrics to identify the sync object used to configure this deployment.
+      #
+      # Note: configsync.sync.generation is explicitly excluded here, because it
+      # is high cardinality. So we don't want to send it as a label, only as a
+      # resource attribute. That way it's only propagated to Prometheus, and not
+      # Monarch or Cloud Monitoring, which ignore custom resource attributes.
       attributes:
         actions:
           - key: configsync.sync.kind

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -48,6 +48,7 @@ data:
            configsync.gke.io/sync-kind: "" # this field will be assigned dynamically by the reconciler-manager
            configsync.gke.io/sync-name: "" # this field will be assigned dynamically by the reconciler-manager
            configsync.gke.io/sync-namespace: "" # this field will be assigned dynamically by the reconciler-manager
+           configsync.gke.io/sync-generation: "" # this field will be assigned dynamically by the reconciler-manager
          annotations:
            cluster-autoscaler.kubernetes.io/safe-to-evict: "true" # this annotation is needed so that pods doesn't block scale down
        spec:
@@ -209,8 +210,13 @@ data:
            imagePullPolicy: IfNotPresent
            # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
            # is used by the otel-agent to populate resource attributes when
-           # emiting metrics to the otel-collector. This is more efficient than
+           # emitting metrics to the otel-collector. This is more efficient than
            # having the otel-collector look them up from the apiserver.
+           #
+           # Unlike the other configsync metric labels,
+           # "configsync.sync.generation" is specified here as a resource
+           # attribute so that it is sent to Prometheus, but not Monarch or
+           # Cloud Monitoring.
            env:
            - name: KUBE_POD_NAME
              valueFrom:
@@ -257,13 +263,19 @@ data:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.labels['configsync.gke.io/sync-namespace']
+           - name: CONFIGSYNC_SYNC_GENERATION
+             valueFrom:
+               fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.labels['configsync.gke.io/sync-generation']
            - name: OTEL_RESOURCE_ATTRIBUTES
              value: "k8s.pod.name=$(KUBE_POD_NAME),\
                k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
                k8s.pod.uid=$(KUBE_POD_UID),\
                k8s.pod.ip=$(KUBE_POD_IP),\
                k8s.node.name=$(KUBE_NODE_NAME),\
-               k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)"
+               k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME),\
+               configsync.sync.generation=$(CONFIGSYNC_SYNC_GENERATION)"
          volumes:
          - name: repo
            emptyDir: {}

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -49,6 +49,9 @@ const (
 	// SyncKindLabel indicates the RSync kind: RootSync or RepoSync.
 	SyncKindLabel = configsync.ConfigSyncPrefix + "sync-kind"
 
+	// SyncGenerationLabel indicates the generation of RootSync or RepoSync.
+	SyncGenerationLabel = configsync.ConfigSyncPrefix + "sync-generation"
+
 	// DeploymentNameLabel indicates the name of the Deployment.
 	// This is used to enable selecting pods by label, primarily for printing logs.
 	// Example: kubectl logs deployment/<deploy-name> <container-name> -n config-management-system

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -159,6 +159,8 @@ processors:
         action: delete
       - key: configsync.sync.namespace
         action: delete
+      - key: configsync.sync.generation
+        action: delete
       # Remove high cardinality configsync metric labels when sending to Monarch.
       # These labels are useful to users, but too noisy for global aggregation.
       - key: commit

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -73,7 +73,7 @@ var (
 	// TODO: replace with k8s.container.name resource attribute
 	KeyContainer, _ = tag.NewKey("container")
 
-	// KeyResourceType groups metris by their resource types. Possible values: cpu, memory.
+	// KeyResourceType groups metrics by their resource types. Possible values: cpu, memory.
 	KeyResourceType, _ = tag.NewKey("resource")
 )
 
@@ -89,6 +89,10 @@ var (
 
 	// ResourceKeySyncNamespace groups metrics by the Sync namespace.
 	ResourceKeySyncNamespace, _ = tag.NewKey("configsync_sync_namespace")
+
+	// ResourceKeySyncGeneration groups metrics by the Sync metadata.generation.
+	// This allows matching metrics to a specific Sync configuration.
+	ResourceKeySyncGeneration, _ = tag.NewKey("configsync_sync_generation")
 
 	// ResourceKeyDeploymentName groups metrics by k8s deployment name.
 	ResourceKeyDeploymentName, _ = tag.NewKey("k8s_deployment_name")

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -37,6 +37,10 @@ const (
 	// the RootSync or RepoSync object.
 	SyncNameKey = "SYNC_NAME"
 
+	// SyncGenerationKey is the OS env variable key for the generation of
+	// the RootSync or RepoSync object.
+	SyncGenerationKey = "SYNC_GENERATION"
+
 	// ReconcilerNameKey is the OS env variable key for the name of
 	// the Reconciler Deployment.
 	ReconcilerNameKey = "RECONCILER_NAME"

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -46,7 +46,7 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "00a85865e19d827bad96615656b05cef"
+	depAnnotationGooglecloud = "7600b36cb5439cb0e5adf961575eacf4"
 	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -372,6 +372,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerResourcesMutator(overrideReconcilerAndGitSyncResourceLimits),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -421,6 +422,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -457,6 +459,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -502,6 +505,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -557,6 +561,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -611,6 +616,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -657,6 +663,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -692,6 +699,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -737,6 +745,7 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -882,7 +891,6 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
 	repoDeployment.ResourceVersion = "3"
-
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
 	}
@@ -915,7 +923,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setUID("1"), setResourceVersion("4"), setGeneration(4),
+		setUID("1"), setResourceVersion("4"), setGeneration(2),
 	)
 	wantDeployments[core.IDOf(updatedRepoDeployment)] = updatedRepoDeployment
 
@@ -1002,6 +1010,22 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 	reposync.ClearCondition(wantRs, v1beta1.RepoSyncReconciling)
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("6"), setGeneration(2),
+	)
+	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
+	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
+		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
 	// Set rs.Spec.NoSSLVerify to false
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
@@ -1021,7 +1045,14 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoDeployment.ResourceVersion = "7"
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("7"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1063,6 +1094,7 @@ func TestRepoSyncCreateWithCACert(t *testing.T) {
 		envVarMutator(gitSyncName, nsSecretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, nsSecretName, GitSecretConfigKeyToken),
 		containerEnvMutator(repoContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1100,6 +1132,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		envVarMutator(gitSyncName, nsSecretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, nsSecretName, GitSecretConfigKeyToken),
 		containerEnvMutator(repoContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1169,7 +1202,16 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoDeployment.ResourceVersion = "3"
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsSecretName),
+		envVarMutator("HTTPS_PROXY", nsSecretName, "https_proxy"),
+		envVarMutator(gitSyncName, nsSecretName, GitSecretConfigKeyTokenUsername),
+		envVarMutator(gitSyncPassword, nsSecretName, GitSecretConfigKeyToken),
+		containerEnvMutator(repoContainerEnvs),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1261,6 +1303,7 @@ func TestRepoSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1382,7 +1425,14 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoDeployment.ResourceVersion = "4"
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
+	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1434,6 +1484,7 @@ func TestRepoSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1523,7 +1574,14 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoDeployment.ResourceVersion = "3"
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1576,6 +1634,7 @@ func TestRepoSyncCreateWithOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
@@ -1605,9 +1664,8 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
-	repoDeployment.ResourceVersion = "1"
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(repoDeployment): repoDeployment}
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1638,9 +1696,8 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(nsReconcilerName),
 		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
 		containerEnvMutator(repoContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
-	updatedRepoDeployment.ResourceVersion = "2"
 	wantDeployments[core.IDOf(repoDeployment)] = updatedRepoDeployment
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1664,7 +1721,14 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	repoDeployment.ResourceVersion = "3"
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1881,8 +1945,15 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 		fmt.Sprintf("Deployment (config-management-system/%s) InProgress: Replicas: 0/1", nsReconcilerName))
 	validateRepoSyncStatus(t, wantRs, fakeClient)
 
-	repoDeployment.ResourceVersion = "3"
-
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
+	repoDeployment = repoSyncDeployment(
+		nsReconcilerName,
+		setServiceAccountName(nsReconcilerName),
+		secretMutator(nsReconcilerName+"-"+reposyncSSHKey),
+		containerEnvMutator(repoContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
+	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
 	}
@@ -2781,6 +2852,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setAnnotations(map[string]string{
@@ -2817,7 +2889,6 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	}
 
 	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
-
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
@@ -2953,13 +3024,14 @@ func TestRepoSyncWithHelm(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	repoContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
 		containerResourcesMutator(overrideHelmSyncResources),
 		containerEnvMutator(repoContainerEnvs),
-		setUID("1"), setResourceVersion("3"), setGeneration(4),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(repoDeployment)] = repoDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -3116,6 +3188,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
 		t.Errorf("ServiceAccount validation failed: %v", err)
 	}
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setAnnotations(map[string]string{
@@ -3159,6 +3232,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	repoContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, nsReconcilerName)
 	repoDeployment = repoSyncDeployment(
 		nsReconcilerName,
 		setAnnotations(map[string]string{
@@ -3460,6 +3534,7 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 			reconcilermanager.ScopeKey:                reposyncNs,
 			reconcilermanager.SyncNameKey:             reposyncName,
 			reconcilermanager.NamespaceNameKey:        reposyncNs,
+			reconcilermanager.SyncGenerationKey:       "1",
 			reconcilermanager.ReconcilerNameKey:       nsReconcilerName,
 			reconcilermanager.SyncDirKey:              reposyncDir,
 			reconcilermanager.SourceRepoKey:           reposyncRepo,
@@ -3651,6 +3726,11 @@ func validateDeployments(wants map[core.ID]*appsv1.Deployment, fakeDynamicClient
 		// Compare Deployment ResourceVersion
 		if diff := cmp.Diff(want.ResourceVersion, got.ResourceVersion); diff != "" {
 			return errors.Errorf("Unexpected Deployment ResourceVersion found for %q. Diff: %v", id, diff)
+		}
+
+		// Compare Deployment Generation
+		if diff := cmp.Diff(want.Generation, got.Generation); diff != "" {
+			return errors.Errorf("Unexpected Deployment Generation found for %q: Diff (- want, + got): %v", id, diff)
 		}
 
 		// Compare Deployment Annotations

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -371,6 +371,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -399,6 +400,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -486,6 +488,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -535,6 +538,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -574,6 +578,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -603,11 +608,12 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
-		setUID("1"), setResourceVersion("5"), setGeneration(4),
+		setUID("1"), setResourceVersion("5"), setGeneration(5),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -639,6 +645,7 @@ func TestRootSyncCreateWithNoSSLVerify(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -666,7 +673,6 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 
 	rootContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
-
 	rootDeployment := rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -746,7 +752,13 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	rootDeployment.ResourceVersion = "3"
+	rootContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerEnvMutator(rootContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -816,7 +828,6 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 
 	rootContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
-
 	rootDeployment := rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(secretName),
@@ -893,7 +904,16 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	rootDeployment.ResourceVersion = "3"
+	rootContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(secretName),
+		envVarMutator("HTTPS_PROXY", secretName, "https_proxy"),
+		envVarMutator(gitSyncName, secretName, GitSecretConfigKeyTokenUsername),
+		envVarMutator(gitSyncPassword, secretName, GitSecretConfigKeyToken),
+		containerEnvMutator(rootContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Fatalf("Deployment validation failed. err: %v", err)
@@ -982,6 +1002,7 @@ func TestRootSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1009,7 +1030,6 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 
 	rootContainerEnv := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
-
 	rootDeployment := rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -1101,7 +1121,13 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	rootDeployment.ResourceVersion = "4"
+	rootContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerEnvMutator(rootContainerEnv),
+		setUID("1"), setResourceVersion("4"), setGeneration(4),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
@@ -1153,6 +1179,7 @@ func TestRootSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1238,7 +1265,13 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	rootDeployment.ResourceVersion = "3"
+	rootContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerEnvMutator(rootContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1290,6 +1323,7 @@ func TestRootSyncCreateWithOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnvs),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1317,7 +1351,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("1"),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 
@@ -1347,10 +1381,8 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv),
-		setResourceVersion("2"),
+		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
-
-	updatedRootDeployment.ResourceVersion = "2"
 	wantDeployments[core.IDOf(updatedRootDeployment)] = updatedRootDeployment
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1373,7 +1405,13 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
-	rootDeployment.ResourceVersion = "3"
+	rootContainerEnv = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerEnvMutator(rootContainerEnv),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1533,8 +1571,8 @@ func TestRootSyncReconcilerRestart(t *testing.T) {
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
-	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 
+	rootContainerEnvs := testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment := rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
@@ -1576,15 +1614,16 @@ func TestRootSyncReconcilerRestart(t *testing.T) {
 		t.Fatalf("failed to reconcile: %v", err)
 	}
 
-	rootDeployment.ResourceVersion = "3"
-	// Verify the Reconciler Deployment is updated to 1 replicas.
-	rootDeployment.Spec.Replicas = pointer.Int32(1)
+	rootDeployment = rootSyncDeployment(rootReconcilerName,
+		setServiceAccountName(rootReconcilerName),
+		secretMutator(rootsyncSSHKey),
+		containerEnvMutator(rootContainerEnvs),
+		setReplicas(1), // Change reverted
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
+	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
-		t.Errorf("Deployment validation failed. err: %v", err)
-	}
-	if t.Failed() {
-		t.FailNow()
+		t.Fatalf("Deployment validation failed. err: %v", err)
 	}
 	t.Log("Deployment successfully updated")
 }
@@ -1662,6 +1701,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName),
 		secretMutator(rootsyncSSHKey),
 		containerEnvMutator(rootContainerEnv1),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment1): rootDeployment1}
 
@@ -1706,6 +1746,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName2),
 		gceNodeMutator(""),
 		containerEnvMutator(rootContainerEnv2),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(rootDeployment2)] = rootDeployment2
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1761,6 +1802,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		setServiceAccountName(rootReconcilerName3),
 		gceNodeMutator(gcpSAEmail),
 		containerEnvMutator(rootContainerEnv3),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(rootDeployment3)] = rootDeployment3
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1821,6 +1863,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		secretMutator(reposyncCookie),
 		envVarMutator("HTTPS_PROXY", reposyncCookie, "https_proxy"),
 		containerEnvMutator(rootContainerEnvs4),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(rootDeployment4)] = rootDeployment4
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1882,6 +1925,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		envVarMutator(gitSyncName, secretName, GitSecretConfigKeyTokenUsername),
 		envVarMutator(gitSyncPassword, secretName, GitSecretConfigKeyToken),
 		containerEnvMutator(rootContainerEnvs5),
+		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
 	wantDeployments[core.IDOf(rootDeployment5)] = rootDeployment5
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2465,12 +2509,13 @@ func TestRootSyncWithHelm(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		containersWithRepoVolumeMutator(noneHelmContainers()),
 		containerResourcesMutator(overrideHelmSyncResources),
 		containerEnvMutator(rootContainerEnvs),
-		setUID("1"), setResourceVersion("3"), setGeneration(4),
+		setUID("1"), setResourceVersion("3"), setGeneration(3),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2666,6 +2711,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error upon request update, got error: %q, want error: nil", err)
 	}
 
+	rootContainerEnvs = testReconciler.populateContainerEnvs(ctx, rs, rootReconcilerName)
 	rootDeployment = rootSyncDeployment(rootReconcilerName,
 		setServiceAccountName(rootReconcilerName),
 		setAnnotations(map[string]string{
@@ -2674,7 +2720,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 		fwiOciMutator(workloadIdentityPool),
 		containerResourcesMutator(overrideOciSyncResources),
 		containerEnvMutator(rootContainerEnvs),
-		setUID("1"), setResourceVersion("5"), setGeneration(4),
+		setUID("1"), setResourceVersion("5"), setGeneration(5),
 	)
 	wantDeployments[core.IDOf(rootDeployment)] = rootDeployment
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -2970,6 +3016,7 @@ func TestPopulateRootContainerEnvs(t *testing.T) {
 			reconcilermanager.ScopeKey:                ":root",
 			reconcilermanager.SyncNameKey:             rootsyncName,
 			reconcilermanager.NamespaceNameKey:        ":root",
+			reconcilermanager.SyncGenerationKey:       "1",
 			reconcilermanager.ReconcilerNameKey:       rootReconcilerName,
 			reconcilermanager.SyncDirKey:              rootsyncDir,
 			reconcilermanager.SourceRepoKey:           rootsyncRepo,
@@ -3099,6 +3146,12 @@ func rootSyncDeployment(reconcilerName string, muts ...depMutator) *appsv1.Deplo
 		mut(dep)
 	}
 	return dep
+}
+
+func setReplicas(replicas int32) depMutator {
+	return func(dep *appsv1.Deployment) {
+		dep.Spec.Replicas = pointer.Int32(replicas)
+	}
 }
 
 func setResourceVersion(rv string) depMutator {

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -85,7 +85,7 @@ func hydrationEnvs(sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1
 }
 
 // reconcilerEnvs returns environment variables for namespace reconciler.
-func reconcilerEnvs(clusterName, syncName, reconcilerName string, reconcilerScope declared.Scope, sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1.Oci, helmConfig *v1beta1.HelmBase, pollPeriod, statusMode string, reconcileTimeout string, apiServerTimeout string, requiresRendering bool) []corev1.EnvVar {
+func reconcilerEnvs(clusterName, syncName string, syncGeneration int64, reconcilerName string, reconcilerScope declared.Scope, sourceType string, gitConfig *v1beta1.Git, ociConfig *v1beta1.Oci, helmConfig *v1beta1.HelmBase, pollPeriod, statusMode string, reconcileTimeout string, apiServerTimeout string, requiresRendering bool) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	if statusMode == "" {
 		statusMode = applier.StatusEnabled
@@ -133,6 +133,10 @@ func reconcilerEnvs(clusterName, syncName, reconcilerName string, reconcilerScop
 		corev1.EnvVar{
 			Name:  reconcilermanager.SyncNameKey,
 			Value: syncName,
+		},
+		corev1.EnvVar{
+			Name:  reconcilermanager.SyncGenerationKey,
+			Value: fmt.Sprint(syncGeneration),
 		},
 		corev1.EnvVar{
 			Name:  reconcilermanager.ReconcilerNameKey,


### PR DESCRIPTION
- Add `configsync.gke.io/sync-generation` reconciler deployment/pod label, populated by the reconciler-manager
- Add `CONFIGSYNC_SYNC_GENERATION` env var on the otel-agent container, populated by the k8s downward API from the pod label
- Add `configsync.sync.generation` metric resource attribute on the otel-agent config, populated from the env var
- Add attribute filter to delete the `configsync.sync.generation` label in the otel-collector config, when sending to Monarch
- Change the e2e tests to use the sync metric labels, instead of the pod name. This allows the metrics validation to tolerate pod replacement due to rescheduling, oomkill, or autoscaling

This PR blocks VPA: https://github.com/GoogleContainerTools/kpt-config-sync/pull/691

### Motivation
The e2e tests have been using pod name + source commit to filter metrics queries. But pod name was really just a proxy for RSync generation, so that we could match expected metrics with the most recent RSync spec and Git/OCI/Helm source changes. However, it turns out using pod name is still occasionally flaky, because the pod might be replaced or rescheduled even when the RSync spec didn't change (e.g. node replacement, rescheduling, oomkill, or autoscaling). Using RSync generation instead of pod name makes the e2e tests less flaky and makes it possible to add VPA and memory limits, which would otherwise cause most e2e tests to fail metrics validation.

Note: `configsync.sync.generation` is a metric resource attribute, NOT a normal metric label. So it will not be sent to either Monarch or Cloud Monitoring, because those providers do not support custom resource attributes without hard-coded support and a custom resource type registered with Google. However, custom resources attributes ARE being sent to Prometheus, because of the `resource_to_telemetry_conversion: { enabled: true }` setting, which converts them to metric labels. So `configsync.sync.generation` becomes `configsync_sync_generation` in Prometheus metrics. This is how the e2e tests use them for query filtering.