### PR TITLE
fix: reconciler fail/timeout as error for destroy

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -280,6 +280,12 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		nt.DefaultWaitTimeout = 6 * time.Minute
 	}
 
+	// Longer default wait timeout for stress tests
+	// Particularly the reset/finalizer takes a long time for the stress tests
+	if *e2e.Stress {
+		nt.DefaultWaitTimeout = nt.DefaultWaitTimeout * 2
+	}
+
 	if *e2e.TestCluster == e2e.Kind {
 		// We're using an ephemeral Kind cluster, so connect to the local Docker
 		// repository. No need to clean before/after as these tests only exist for

--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -51,6 +51,12 @@ func DeleteErrorForResource(err error, id core.ID) status.Error {
 	return applierErrorBuilder.Wrap(fmt.Errorf("failed to delete %v: %w", id, err)).Build()
 }
 
+// WaitErrorForResource indicates that the applier failed to wait for
+// the given resource.
+func WaitErrorForResource(err error, id core.ID) status.Error {
+	return applierErrorBuilder.Wrap(fmt.Errorf("failed to wait for %v: %w", id, err)).Build()
+}
+
 // SkipErrorForResource indicates that the applier skipped apply or delete of
 // the given resource.
 func SkipErrorForResource(err error, id core.ID, strategy actuation.ActuationStrategy) status.Error {


### PR DESCRIPTION
This change updates the WaitEvent processing to treat a reconcile failure or timeout as an error for Destroyer. This ensures that the finalizer waits until all objects are NotFound before exiting.

The behavior is left unchanged for the Applier.