### PR TITLE
test: increase timeout for stress tests

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -282,8 +282,9 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 
 	// Longer default wait timeout for stress tests
 	// Particularly the reset/finalizer takes a long time for the stress tests
+	// Current slowest test is TestStressLargeRequest
 	if *e2e.Stress {
-		nt.DefaultWaitTimeout = nt.DefaultWaitTimeout * 2
+		nt.DefaultWaitTimeout = 30 * time.Minute
 	}
 
 	if *e2e.TestCluster == e2e.Kind {

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -209,6 +209,8 @@ func TestStressFrequentGitCommits(t *testing.T) {
 	}
 }
 
+// This test creates a RootSync pointed at https://github.com/config-sync-examples/crontab-crs
+// This repository contains 13,000+ objects, which takes a long time to reconcile
 func TestStressLargeRequest(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
@@ -253,8 +255,7 @@ func TestStressLargeRequest(t *testing.T) {
 		nomostest.WithRootSha1Func(nomostest.RemoteRootRepoSha1Fn),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
 			nomostest.DefaultRootRepoNamespacedName: "configs",
-		}),
-		nomostest.WithTimeout(30*time.Minute))
+		}))
 	if err != nil {
 		nt.T.Fatal(err)
 	}


### PR DESCRIPTION
All of the stress tests are now passing in CI with the exception of TestStressLargeRequest. It turns out this test takes a much longer time to reconcile, because it is creating 13,000+ resources in a single RootSync. Increasing the default timeout gives the finalizer enough time to cleanup all of the resources.