### PR TITLE
[Terraform] Add e2e-metric-writer-sa to test infra

### DIFF
--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -60,3 +60,21 @@ resource "google_project_iam_member" "gce-default-sa-iam" {
   member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
   project = data.google_project.project.id
 }
+
+resource "google_service_account" "e2e_metric_writer_sa" {
+  account_id = "e2e-test-metric-writer"
+  display_name = "Test Metric Writer"
+  description = "Service account used to write to Google Cloud Monitoring"
+}
+
+resource "google_project_iam_member" "e2e_metric_writer_gcp_role" {
+  role = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${google_service_account.e2e_metric_writer_sa.email}"
+  project = data.google_project.project.id
+}
+
+resource "google_service_account_iam_member" "e2e_metric_writer_gke_binding" {
+  service_account_id = google_service_account.e2e_metric_writer_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-monitoring/default]"
+}

--- a/e2e/testinfra/terraform/common/services.tf
+++ b/e2e/testinfra/terraform/common/services.tf
@@ -23,6 +23,7 @@ resource "google_project_service" "services" {
     "secretmanager.googleapis.com",
     "container.googleapis.com",
     "compute.googleapis.com",
+    "monitoring.googleapis.com"
   ])
   service = each.value
   disable_on_destroy = false


### PR DESCRIPTION
Otel Collector e2e test requires IAM permission on WI enabled clusters.

This change sets up a Google Service Account with metricWriter role and binds it with the default Kubernetes Service Account under config-management-monitoring namespace.

b/255608560