### PR TITLE
test: Clean up ReconcileTimeout config

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -119,8 +119,8 @@ type NT struct {
 	DefaultWaitTimeout time.Duration
 
 	// DefaultReconcileTimeout is the default timeout for the applier to wait
-	// for object reconcilition.
-	DefaultReconcileTimeout time.Duration
+	// for object reconciliation.
+	DefaultReconcileTimeout *time.Duration
 
 	// RootRepos is the root repositories the cluster is syncing to.
 	// The key is the RootSync name and the value points to the corresponding Repository object.

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -101,12 +101,18 @@ const (
 )
 
 // WithReconcileTimeout tells the test case to override the default reconcile
-// timeout on all RootSyncs and RepoSyncs.
+// timeout on all RootSyncs and RepoSyncs by default.
 func WithReconcileTimeout(timeout time.Duration) func(opt *New) {
 	return func(opt *New) {
 		timeoutCopy := timeout
 		opt.ReconcileTimeout = &timeoutCopy
 	}
+}
+
+// WithoutReconcileTimeout tells the test case not to override the default
+// reconcile timeout on all RootSyncs and RepoSyncs by default.
+func WithoutReconcileTimeout(opt *New) {
+	opt.ReconcileTimeout = nil
 }
 
 // RepoSyncPermissions specifies PolicyRule(s) to grant NS reconcilers


### PR DESCRIPTION
- Add WithoutReconcileTimeout to remove the setting, if needed.
- Move default ReconcileTimeout into the options constructor, so it can be overridden by test options.