### PR TITLE
Fix deletion of resources with deleted CRDs

### DIFF
--- a/pkg/reconcilermanager/controllers/errors.go
+++ b/pkg/reconcilermanager/controllers/errors.go
@@ -61,6 +61,12 @@ func (ooe *ObjectOperationError) Error() string {
 		ooe.ID.Kind, ooe.ID.ObjectKey, ooe.Operation, ooe.Cause)
 }
 
+// Unwrap returns the cause of the error, to allow type checking with errors.Is
+// and errors.As.
+func (ooe *ObjectOperationError) Unwrap() error {
+	return ooe.Cause
+}
+
 // NewObjectOperationError constructs a new ObjectOperationError
 func NewObjectOperationError(err error, obj client.Object, op Operation) *ObjectOperationError {
 	id := core.IDOf(obj)
@@ -142,6 +148,12 @@ type ObjectReconcileError struct {
 func (oripe *ObjectReconcileError) Error() string {
 	return fmt.Sprintf("%s (%s) %s: %v",
 		oripe.ID.Kind, oripe.ID.ObjectKey, oripe.Status, oripe.Cause)
+}
+
+// Unwrap returns the cause of the error, to allow type checking with errors.Is
+// and errors.As.
+func (oripe *ObjectReconcileError) Unwrap() error {
+	return oripe.Cause
 }
 
 // NewObjectReconcileError constructs a new ObjectReconcileError

--- a/pkg/util/watch/delete.go
+++ b/pkg/util/watch/delete.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -164,6 +165,13 @@ func DeleteAndWait(ctx context.Context, c client.WithWatch, obj client.Object, r
 					logFieldObjectRef, id.ObjectKey.String(),
 					logFieldObjectKind, id.Kind)
 				// Stop waiting - object already deleted
+				return true, nil
+			}
+			if meta.IsNoMatchError(err) {
+				klog.V(3).Infof("Resource not registered %q=%q, %q=%q",
+					logFieldObjectRef, id.ObjectKey.String(),
+					logFieldObjectKind, id.Kind)
+				// Stop waiting - resource not registered
 				return true, nil
 			}
 			// Stop waiting

--- a/pkg/util/watch/until.go
+++ b/pkg/util/watch/until.go
@@ -62,6 +62,15 @@ func UntilDeletedWithSync(ctx context.Context, c client.WithWatch, obj client.Ob
 	if err != nil {
 		return err
 	}
+	// Validate that the resource API is registered.
+	// If not, error and let the caller deal with whether NoMatchError is
+	// tolerated or not.
+	// Without this check, the informer will retry endlessly waiting for the
+	// ListAndWatch to succeed.
+	_, err = c.RESTMapper().RESTMapping(itemGVK.GroupKind(), itemGVK.Version)
+	if err != nil {
+		return err
+	}
 	var objList client.ObjectList
 	if _, ok := obj.(*unstructured.Unstructured); ok {
 		objList = kinds.NewUnstructuredListForItemGVK(itemGVK)


### PR DESCRIPTION
We don't have any yet, but when VPA is added, the reconciler-manager cleanup will need to work with resources whos CRD may have been removed. Also fix the errors so they can be unwrapped correctly. This will fix error messages to be more clear.