### PR TITLE
Fix reconciler-manager cmd to accept log flags

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -33,6 +33,7 @@ import (
 	"kpt.dev/configsync/pkg/profiler"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+	"kpt.dev/configsync/pkg/util/log"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
@@ -57,12 +58,6 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-func init() {
-	// klogr flags
-	_ = flag.Set("v", "1")
-	_ = flag.Set("logtostderr", "true")
-}
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -70,8 +65,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.Parse()
 
+	log.Setup()
 	profiler.Service()
 	ctrl.SetLogger(klogr.New())
 

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -41,6 +41,7 @@ spec:
         - /reconciler-manager
         args:
         - --enable-leader-election
+        - "-v=1"
         image: RECONCILER_MANAGER_IMAGE_NAME
         name: reconciler-manager
         securityContext:


### PR DESCRIPTION
Previously, -v=# and other log flags were not being registered. Not it sets up log flags the sam as other component binaries.