### PR TITLE
test: install kind at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ GO_DIR := $(OUTPUT_DIR)/go
 BIN_DIR := $(GO_DIR)/bin
 KUSTOMIZE_VERSION := v5.1.0
 HELM_VERSION := v3.12.2
+# Keep KIND_VERSION in sync with the version defined in go.mod
+# When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
+KIND_VERSION := v0.14.0
 
 # Directory used for staging Docker contexts.
 STAGING_DIR := $(OUTPUT_DIR)/staging
@@ -300,6 +303,15 @@ lint-license: pull-buildenv buildenv-dirs
 
 .PHONY: install-kustomize
 install-kustomize: "$(BIN_DIR)/kustomize"
+
+"$(GOBIN)/kind":
+	go install sigs.k8s.io/kind@$(KIND_VERSION)
+
+"$(BIN_DIR)/kind": "$(GOBIN)/kind" buildenv-dirs
+	cp $(GOBIN)/kind $(BIN_DIR)/kind
+
+.PHONY: install-kind
+install-kind: "$(BIN_DIR)/kind"
 
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"

--- a/Makefile.build
+++ b/Makefile.build
@@ -247,8 +247,8 @@ config-sync-manifest: config-sync-manifest-no-push push-images
 # config-sync-manifest-local builds config sync for local testing in kind.
 # starts local docker registry and pushes images to the local registry
 .PHONY: config-sync-manifest-local
-config-sync-manifest-local:
-	@bash scripts/docker-registry.sh
+config-sync-manifest-local: install-kind
+	@KIND_VERSION=$(KIND_VERSION) bash scripts/docker-registry.sh
 	$(MAKE) config-sync-manifest \
 		REGISTRY=localhost:5000 \
 		IMAGE_TAG=$(IMAGE_TAG)

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -9,6 +9,8 @@ GOTOPT2_BINARY := docker run -i -u $(UID):$(GID) $(BUILDENV_IMAGE) /bin/gotopt2
 
 GCP_ZONE ?= us-central1-a
 GKE_E2E_TIMEOUT ?= 6h
+KIND_E2E_TIMEOUT ?= 60m
+
 E2E_CREATE_CLUSTERS ?= "true"
 E2E_DESTROY_CLUSTERS ?= "true"
 
@@ -58,12 +60,13 @@ test-e2e-gke-nobuild:
 test-e2e-gke: config-sync-manifest test-e2e-gke-nobuild
 
 # This target runs all the e2e tests with the multi-repo mode.
+# This is the target used by the presubmits.
 .PHONY: test-e2e-kind-multi-repo
 test-e2e-kind-multi-repo: config-sync-manifest-local
 	kind delete clusters --all
-	GCP_PROJECT=$(GCP_PROJECT) ./scripts/e2e-kind.sh \
+	GCP_PROJECT=$(GCP_PROJECT) KIND_VERSION=$(KIND_VERSION) ./scripts/e2e-kind.sh \
 		--share-test-env \
-		--timeout 60m \
+		--timeout $(KIND_E2E_TIMEOUT) \
 		--test.v -v \
 		--num-clusters 15 \
 		$(E2E_ARGS)

--- a/build/prow/kubekins-e2e/Dockerfile
+++ b/build/prow/kubekins-e2e/Dockerfile
@@ -23,10 +23,3 @@
 # actually being used.
 
 FROM gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
-
-# TODO: using a pre-installed kind binary makes it very painful to upgrade the
-# kind version. Update the e2e tests to either:
-# - install kind binary at runtime
-# - consolidate kind usage to Go dependency rather than mixing usage with binary
-RUN wget -q -O /bin/kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
-RUN chmod +x /bin/kind

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -58,7 +58,7 @@ FROM kpt-config-sync-e2e
 # We're running tests within kind clusters.
 # If you upgrade the version, you also need to update the special kubekins-with-Kind
 # images we use in the test-infra repository. See Makefile.prow.
-ARG KIND_VERSION=v0.14.0
+ARG KIND_VERSION
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 
 # Steps after here can't be cached since they touch the local filesystem.

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,8 +66,7 @@ This section provides instructions on how to run the e2e tests on [kind].
 
 Install [kind]
 ```shell
-# install the kind version specified in https://github.com/GoogleContainerTools/kpt-config-sync/blob/main/scripts/docker-registry.sh#L50
-go install sigs.k8s.io/kind@v0.14.0
+make install-kind
 ```
 
 - This will put kind in `$(go env GOPATH)/bin`. This directory will need to be added to `$PATH` if it isn't already.

--- a/scripts/docker-registry.sh
+++ b/scripts/docker-registry.sh
@@ -21,6 +21,11 @@ set -euxo pipefail
 #
 # Installs kind if it is not already installed. If you already have kind
 # installed but this does not work, make sure you're on version 0.10.0 or later.
+KIND_VERSION="${KIND_VERSION:-"unset"}"
+if [[ "${KIND_VERSION}" == "unset" ]]; then
+  echo "KIND_VERSION not specified"
+  exit 1
+fi
 
 # create registry container unless it already exists
 reg_name='kind-registry'
@@ -36,19 +41,21 @@ docker inspect "${reg_name}" &>/dev/null || (
 # It's safe to run this even if the container is already running.
 docker start "${reg_name}"
 
-# Ensure kind v0.14.0 is installed.
+# Ensure kind is installed with the expected version.
 # Dear future people: Feel free to upgrade this as new versions are released.
 # Note that upgrading the kind version will require updating the image versions:
 # https://github.com/kubernetes-sigs/kind/releases
 kind &>/dev/null || (
-  echo "Kind is not installed. Install v0.14.0."
+  echo "Kind is not installed. Install ${KIND_VERSION}."
   echo "https://kind.sigs.k8s.io/docs/user/quick-start/"
+  echo "    make install-kind"
   exit 1
 )
 
-kind version | grep v0.14.0 || (
-  echo "Using unsupported kind version. Install v0.14.0."
+kind version | grep "${KIND_VERSION}" || (
+  echo "Using unsupported kind version. Install ${KIND_VERSION}."
   echo "https://kind.sigs.k8s.io/docs/user/quick-start/"
+  echo "    make install-kind"
   exit 1
 )
 

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 echo "+++ Building build/test-e2e-go/kind/Dockerfile prow-image"
-docker buildx build . -f build/test-e2e-go/kind/Dockerfile -t prow-image
+docker buildx build . \
+  -f build/test-e2e-go/kind/Dockerfile \
+  --build-arg KIND_VERSION="${KIND_VERSION}" \
+  -t prow-image
 # The .sock volume allows you to connect to the Docker daemon of the host.
 # Part of the docker-in-docker pattern.
 


### PR DESCRIPTION
Assuming that kind is pre-installed on the prow image makes it very difficult to upgrade the kind version, because the kind version of the binary must be the same as the go import. Installing it at runtime makes it easier to change the version.