### PR TITLE
test: fix memory request predicate

### DIFF
--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -705,11 +705,11 @@ func firstContainerCPURequestIs(cpuRequest int64) testpredicates.Predicate {
 }
 
 func firstContainerMemoryRequestIs(memoryRequest int64) testpredicates.Predicate {
+	memoryRequest *= memoryMB
 	return func(o client.Object) error {
 		if o == nil {
 			return testpredicates.ErrObjectNotFound
 		}
-		memoryRequest *= memoryMB
 		d, ok := o.(*appsv1.Deployment)
 		if !ok {
 			return testpredicates.WrongTypeErr(d, &appsv1.Deployment{})


### PR DESCRIPTION
Reassigning the value in the nested function causes the value to keep increasing on each invocation of the predicate.