### PR TITLE
fix: Increase otel-agent CPU request to 20m

### DIFF
--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -51,7 +51,7 @@ import (
 const (
 	initialFirstCPU                    = 10
 	initialFirstMemory                 = 100
-	initialTotalCPU                    = 80
+	initialTotalCPU                    = 90
 	initialAdjustedTotalCPU            = 250
 	initialTotalMemory                 = 600
 	autopilotCPUIncrements             = 250

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -179,7 +179,7 @@ data:
                cpu: 1
                memory: 1Gi
              requests:
-               cpu: 10m
+               cpu: 20m
                memory: 100Mi
            securityContext:
              allowPrivilegeEscalation: false


### PR DESCRIPTION
The limits are being set to request values on autopilot, which has been causing the otel-agent to fail liveness probes and get restarted. This increase should help prevent that.