### PR TITLE
test: remove test finalizer in cleanup

### DIFF
--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -49,6 +49,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// ConfigSyncE2EFinalizer is a contrived finalizer to block deletion of
+	// objects created by the e2e tests.
+	ConfigSyncE2EFinalizer = "config-sync/e2e-test"
+)
+
 // Clean removes all objects of types registered in the Scheme, with the above
 // caveats. It should be run before and after a test is run against any
 // non-ephemeral cluster.

--- a/e2e/nomostest/testutils/validate.go
+++ b/e2e/nomostest/testutils/validate.go
@@ -49,7 +49,19 @@ func AppendFinalizer(obj client.Object, finalizer string) {
 	obj.SetFinalizers(finalizers)
 }
 
-// RemoveFinalizers removes all finalizers from the object
-func RemoveFinalizers(obj client.Object) {
-	obj.SetFinalizers(nil)
+// RemoveFinalizer removes a finalizer from the object.
+// Returns whether the finalizer was removed.
+func RemoveFinalizer(obj client.Object, removeFinalizer string) bool {
+	finalizers := obj.GetFinalizers()
+	var newFinalizers []string
+	found := false
+	for _, finalizer := range finalizers {
+		if finalizer == removeFinalizer {
+			found = true
+		} else {
+			newFinalizers = append(newFinalizers, finalizer)
+		}
+	}
+	obj.SetFinalizers(newFinalizers)
+	return found
 }


### PR DESCRIPTION
If an error occurs mid-test, it is possible that the finalizer removal is not reached and the object cannot be deleted. This adds a test-specific cleanup and generic suite cleanup for removing the test finalizer.