### PR TITLE
refactor: move the askpass declaration to manifest

### DIFF
--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -598,11 +598,11 @@ func templateForGcpServiceAccountAuthType() testpredicates.Predicate {
 			}
 		}
 		for _, container := range d.Spec.Template.Spec.Containers {
-			if container.Name == controllers.GceNodeAskpassSidecarName {
+			if container.Name == reconcilermanager.GCENodeAskpassSidecar {
 				return nil
 			}
 		}
-		return fmt.Errorf("the %s container has not be created yet", controllers.GceNodeAskpassSidecarName)
+		return fmt.Errorf("the %s container has not be created yet", reconcilermanager.GCENodeAskpassSidecar)
 	}
 }
 
@@ -616,7 +616,7 @@ func templateForSSHAuthType() testpredicates.Predicate {
 			return testpredicates.WrongTypeErr(d, &appsv1.Deployment{})
 		}
 		for _, container := range d.Spec.Template.Spec.Containers {
-			if container.Name == controllers.GceNodeAskpassSidecarName {
+			if container.Name == reconcilermanager.GCENodeAskpassSidecar {
 				return fmt.Errorf("the gcenode-askpass-sidecar container should not exist for `ssh` auth type")
 			}
 		}

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -129,6 +129,18 @@ data:
              requests:
                cpu: "10m"
                memory: "200Mi"
+         - name: gcenode-askpass-sidecar
+           image: gcr.io/config-management-release/gcenode-askpass-sidecar:v1.0.3
+           args: ["--port=9102", "--logtostderr"]
+           imagePullPolicy: IfNotPresent
+           terminationMessagePolicy: File
+           terminationMessagePath: /dev/termination-log
+           securityContext:
+             allowPrivilegeEscalation: false
+             readOnlyRootFilesystem: false
+             capabilities:
+               drop:
+               - NET_RAW
          - name: oci-sync
            image: OCI_SYNC_IMAGE_NAME
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -56,6 +56,9 @@ const (
 	// GitSync is the name of the git-sync container in reconciler pods.
 	GitSync = "git-sync"
 
+	// GCENodeAskpassSidecar is the name of the gcenode-askpass-sidecar container in reconciler pods.
+	GCENodeAskpassSidecar = "gcenode-askpass-sidecar"
+
 	// OciSync is the name of the oci-sync container in reconciler pods.
 	OciSync = "oci-sync"
 

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -886,6 +886,9 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			noSSLVerify:     rs.Spec.Git.NoSSLVerify,
 			caCertSecretRef: v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef),
 		})
+		if enableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
+			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
+		}
 	case v1beta1.OciSource:
 		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriodSecs(rs.Spec.Oci.Period))
 	case v1beta1.HelmSource:
@@ -1131,6 +1134,14 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
 					mutateContainerResource(&container, rs.Spec.Override)
 				}
+			case reconcilermanager.GCENodeAskpassSidecar:
+				if !enableAskpassSidecar(rs.Spec.SourceType, auth) {
+					addContainer = false
+				} else {
+					container.Env = append(container.Env, containerEnvs[container.Name]...)
+					injectFWICredsToContainer(&container, injectFWICreds)
+					// TODO: enable resource/logLevel overrides for gcenode-askpass-sidecar
+				}
 			case metrics.OtelAgentName:
 				// The no-op case to avoid unknown container error after
 				// first-ever reconcile.
@@ -1142,18 +1153,17 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 			}
 		}
 
-		// Add container spec for the "gcenode-askpass-sidecar" (defined as
-		// a constant) to the reconciler Deployment when `.spec.sourceType` is `git`,
-		// and `.spec.git.auth` is either `gcenode` or `gcpserviceaccount`.
-		// The container is added first time when the reconciler deployment is created.
-		if v1beta1.SourceType(rs.Spec.SourceType) == v1beta1.GitSource &&
-			(auth == configsync.AuthGCPServiceAccount || auth == configsync.AuthGCENode) {
-			updatedContainers = append(updatedContainers, gceNodeAskPassSidecar(gcpSAEmail, injectFWICreds))
-		}
-
 		templateSpec.Containers = updatedContainers
 		return nil
 	}
+}
+
+func enableAskpassSidecar(sourceType string, auth configsync.AuthType) bool {
+	if v1beta1.SourceType(sourceType) == v1beta1.GitSource &&
+		(auth == configsync.AuthGCPServiceAccount || auth == configsync.AuthGCENode) {
+		return true
+	}
+	return false
 }
 
 func (r *RepoSyncReconciler) setDefaultHelmDataKey(rs *v1beta1.RepoSync) {

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -1792,7 +1792,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
-		gceNodeMutator(gcpSAEmail),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv),
 		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
@@ -2083,7 +2083,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	repoDeployment2 := repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
-		gceNodeMutator(""),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv2),
 		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
@@ -2142,7 +2142,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	repoDeployment3 := repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
-		gceNodeMutator(gcpSAEmail),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv3),
 		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
@@ -2344,7 +2344,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	repoDeployment2 = repoSyncDeployment(
 		nsReconcilerName2,
 		setServiceAccountName(nsReconcilerName2),
-		gceNodeMutator(""),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv2),
 		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
@@ -2379,7 +2379,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	repoDeployment3 = repoSyncDeployment(
 		nsReconcilerName3,
 		setServiceAccountName(nsReconcilerName3),
-		gceNodeMutator(gcpSAEmail),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv3),
 		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)
@@ -2825,7 +2825,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	repoDeployment := repoSyncDeployment(
 		nsReconcilerName,
 		setServiceAccountName(nsReconcilerName),
-		gceNodeMutator(gcpSAEmail),
+		gceNodeMutator(),
 		containerEnvMutator(repoContainerEnv),
 		setUID("1"), setResourceVersion("1"), setGeneration(1),
 	)
@@ -2859,7 +2859,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 			metadata.FleetWorkloadIdentityCredentials: `{"audience":"identitynamespace:test-gke-dev.svc.id.goog:https://container.googleapis.com/v1/projects/test-gke-dev/locations/us-central1-c/clusters/fleet-workload-identity-test-cluster","credential_source":{"file":"/var/run/secrets/tokens/gcp-ksa/token"},"service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/config-sync@cs-project.iam.gserviceaccount.com:generateAccessToken","subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"https://sts.googleapis.com/v1/token","type":"external_account"}`,
 		}),
 		setServiceAccountName(nsReconcilerName),
-		fleetWorkloadIdentityMutator(workloadIdentityPool, gcpSAEmail),
+		fleetWorkloadIdentityMutator(workloadIdentityPool),
 		containerEnvMutator(repoContainerEnv),
 		setUID("1"), setResourceVersion("2"), setGeneration(2),
 	)

--- a/scripts/lib/manifests.sh
+++ b/scripts/lib/manifests.sh
@@ -15,13 +15,6 @@
 
 set -euo pipefail
 
-# find the tag for the gcenode-askpass-sidecar image by reading it from a Go constant.
-# This sidecar is injected at runtime. So it's not in any local manifest files.
-find_askpass_image_tag() {
-  grep -ohE --color=never 'gceNodeAskpassImageTag\s*=.*' pkg/reconcilermanager/controllers/gcenode_askpass_sidecar.go |
-    sed -E 's/gceNodeAskpassImageTag\s*=\s*"(\S+)"/\1/'
-}
-
 # find the "name:tag" of images in the manifests directory.
 find_manifest_images() {
   grep -rohE --color=never "image:\s+\S+:\S+" .output/staging/oss/*.yaml |
@@ -30,10 +23,7 @@ find_manifest_images() {
 
 config_sync_images() {
   # Build a full list of images with tags
-  gcenode_askpass_tag=$(find_askpass_image_tag)
-  images=(
-    "gcr.io/config-management-release/gcenode-askpass-sidecar:${gcenode_askpass_tag}"
-  )
+  images=()
 
   echo "++++ Parsing image tags from rendered manifests at: .output/staging" >&2
 


### PR DESCRIPTION
The askpass sidecar is a container in the reconciler Pod akin to the other containers, but is treated differently and declared in code rather than the manifests. This inconsistency can be a gotcha and requires our other tooling to have special exceptions for parsing the image tag from code. This change makes the askpass sidecar consistent with the other reconciler containers.

Note this is intended as a non-functional refactor, so the overall behavior should be unchanged.