### PR TITLE
fetch kustomize from patched GKE version

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -54,7 +54,7 @@ build-junit-report-cli: pull-buildenv buildenv-dirs
 
 # Build Config Sync docker images
 .PHONY: build-images
-build-images: install-helm
+build-images: install-helm install-kustomize
 	@echo "+++ Building the Reconciler image: $(RECONCILER_TAG)"
 	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_IMAGE) \
@@ -180,7 +180,7 @@ build-manifests: build-manifests-operator build-manifests-oss
 
 # Build Config Sync manifests for OSS installations
 .PHONY: build-manifests-oss
-build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
+build-manifests-oss: "$(GOBIN)/addlicense" "$(BIN_DIR)/kustomize" $(OUTPUT_DIR)
 	@ echo "+++ Generating manifests in $(OSS_MANIFEST_STAGING_DIR)"
 	@ echo "    Using these tags:"
 	@ echo "    $(RECONCILER_MANAGER_IMAGE): $(RECONCILER_MANAGER_TAG)"
@@ -191,7 +191,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
 	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
 	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
 	@ rm -f $(OSS_MANIFEST_STAGING_DIR)/*
-	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/oss \
+	@ "$(BIN_DIR)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/oss \
 		| sed \
 			-e "s|RECONCILER_IMAGE_NAME|$(RECONCILER_TAG)|g" \
 			-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_SYNC_TAG)|g" \
@@ -212,7 +212,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
 
 # Build Config Sync manifests for ACM operator
 .PHONY: build-manifests-operator
-build-manifests-operator: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DIR)
+build-manifests-operator: "$(GOBIN)/addlicense" "$(BIN_DIR)/kustomize" $(OUTPUT_DIR)
 	@ echo "+++ Generating manifests in $(NOMOS_MANIFEST_STAGING_DIR)"
 	@ echo "    Using these tags:"
 	@ echo "    $(RECONCILER_MANAGER_IMAGE): $(RECONCILER_MANAGER_TAG)"
@@ -223,7 +223,7 @@ build-manifests-operator: "$(GOBIN)/addlicense" "$(GOBIN)/kustomize" $(OUTPUT_DI
 	@ echo "    $(OCI_SYNC_IMAGE): $(OCI_SYNC_TAG)"
 	@ echo "    $(HELM_SYNC_IMAGE): $(HELM_SYNC_TAG)"
 	@ rm -f $(NOMOS_MANIFEST_STAGING_DIR)/*
-	@ "$(GOBIN)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/operator \
+	@ "$(BIN_DIR)/kustomize" build --load-restrictor=LoadRestrictionsNone manifests/operator \
 		| sed \
 			-e "s|RECONCILER_IMAGE_NAME|$(RECONCILER_TAG)|g" \
 			-e "s|OCI_SYNC_IMAGE_NAME|$(OCI_SYNC_TAG)|g" \

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -68,8 +68,8 @@ install-crane:
 # remove any existing helm directory/binary. The install-helm target was previously
 # creating a directory at this path rather than the binary/file.
 clean-helm:
-	rm -rf $(HELM_STAGING_DIR)
-	rm -rf $(HELM)
+	@rm -rf $(HELM_STAGING_DIR)
+	@rm -rf $(HELM)
 
 HELM_URL := gs://config-management-release/config-sync/helm/tag/$(HELM_VERSION)/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
@@ -78,14 +78,14 @@ HELM_TARBALL := /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 .PHONY: install-helm
 # install helm binary to publish the image
 install-helm: clean-helm buildenv-dirs
-	gsutil cp $(HELM_URL).sha256 $(HELM_TARBALL).sha256
-	gsutil cp $(HELM_URL) $(HELM_TARBALL)
-	echo "$$(cat $(HELM_TARBALL).sha256)  $(HELM_TARBALL)" | sha256sum -c
-	mkdir -p $(HELM_STAGING_DIR)
-	tar -zxvf $(HELM_TARBALL) -C $(HELM_STAGING_DIR)
-	cp $(HELM_STAGING_DIR)/helm $(HELM)
-	rm $(HELM_TARBALL)
-	rm $(HELM_TARBALL).sha256
+	@gsutil cp $(HELM_URL).sha256 $(HELM_TARBALL).sha256
+	@gsutil cp $(HELM_URL) $(HELM_TARBALL)
+	@echo "$$(cat $(HELM_TARBALL).sha256)  $(HELM_TARBALL)" | sha256sum -c
+	@mkdir -p $(HELM_STAGING_DIR)
+	@tar -zxvf $(HELM_TARBALL) -C $(HELM_STAGING_DIR)
+	@cp $(HELM_STAGING_DIR)/helm $(HELM)
+	@rm $(HELM_TARBALL)
+	@rm $(HELM_TARBALL).sha256
 
 ###################################
 # Prow environment provisioning

--- a/Makefile.reconcilermanager
+++ b/Makefile.reconcilermanager
@@ -13,7 +13,7 @@ generate: install-controller-gen
 
 .PHONY: configsync-crds
 # Generate configsync CRDs
-configsync-crds: install-controller-gen "$(GOBIN)/kustomize" "$(GOBIN)/addlicense"
+configsync-crds: install-controller-gen "$(BIN_DIR)/kustomize" "$(GOBIN)/addlicense"
 	$(CONTROLLER_GEN) \
 		crd \
 		paths="./pkg/api/configsync/v1alpha1" \
@@ -21,7 +21,7 @@ configsync-crds: install-controller-gen "$(GOBIN)/kustomize" "$(GOBIN)/addlicens
 		output:artifacts:config=manifests \
 		&& mv manifests/configsync.gke.io_reposyncs.yaml manifests/patch/reposync-crd.yaml \
 		&& mv manifests/configsync.gke.io_rootsyncs.yaml manifests/patch/rootsync-crd.yaml; \
-	"$(GOBIN)/kustomize" build ./manifests/patch -o ./manifests;  \
+	"$(BIN_DIR)/kustomize" build ./manifests/patch -o ./manifests;  \
 	mv ./manifests/*customresourcedefinition_rootsyncs* ./manifests/rootsync-crd.yaml; \
 	mv ./manifests/*customresourcedefinition_reposyncs* ./manifests/reposync-crd.yaml; \
 	rm ./manifests/patch/reposync-crd.yaml; \

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -22,20 +22,6 @@ COPY . .
 # Version string to embed in built binary.
 ARG VERSION
 
-ARG KUSTOMIZE_VERSION=v5.1.1
-
-# Install Kustomize with license
-RUN URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" && \
-  URL_PREFIX="$(dirname "${URL}")" && FILENAME="$(basename "${URL}")" && \
-  wget "${URL}" -O "/tmp/${FILENAME}" && \
-  wget "${URL_PREFIX}/checksums.txt" -O /tmp/kustomize_checksums.txt && \
-  echo "$(grep "${FILENAME}" /tmp/kustomize_checksums.txt | cut -d ' ' -f 1)  /tmp/${FILENAME}" | sha256sum --check && \
-  tar -zxvf "/tmp/${FILENAME}" -C /tmp && \
-  mv /tmp/kustomize /usr/local/bin/kustomize && \
-  rm "/tmp/${FILENAME}" /tmp/kustomize_checksums.txt && \
-  mkdir -p ./vendor/sigs.k8s.io/kustomize && \
-  wget "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/${KUSTOMIZE_VERSION}/LICENSE" -O ./vendor/sigs.k8s.io/kustomize/LICENSE
-
 # Build all our stuff.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
   go install \
@@ -70,7 +56,8 @@ WORKDIR /
 COPY --from=bins /go/bin/hydration-controller .
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
 COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
-COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 USER nonroot:nonroot
@@ -107,7 +94,8 @@ USER root
 COPY --from=bins /go/bin/hydration-controller .
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
 COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
-COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 RUN apt-get update && apt-get install -y git
@@ -156,7 +144,8 @@ WORKDIR /opt/nomos/bin
 COPY --from=bins /go/bin/nomos nomos
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
 COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
-COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
+COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -29,14 +29,6 @@ ENV CGO_ENABLED=0
 RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
-ARG KUSTOMIZE_VERSION=v5.1.1
-
-# Install Kustomize
-RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -O /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
-  tar -zxvf /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /tmp && \
-  mv /tmp/kustomize /usr/local/bin/kustomize && \
-  rm /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
-
 # Copy installed gcloud and kubectl into image
 COPY --from=gcloud-install /usr/lib/google-cloud-sdk /opt/gcloud/google-cloud-sdk
 COPY --from=gcloud-install /usr/bin/kubectl /opt/gcloud/google-cloud-sdk/bin/kubectl
@@ -60,6 +52,7 @@ RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 COPY . .
 
 COPY .output/go/bin/helm /usr/local/bin/helm
+COPY .output/go/bin/kustomize /usr/local/bin/kustomize
 
 # Make sure the nomos command is available for tests.
 RUN go install kpt.dev/configsync/cmd/nomos

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -45,7 +45,7 @@ const (
 	// HelmVersion is the recommended version of Helm for hydration.
 	HelmVersion = "v3.12.3-gke.1"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
-	KustomizeVersion = "v5.1.1"
+	KustomizeVersion = "v5.1.1-gke.0"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.


### PR DESCRIPTION
This version is similar to the upstream release, but with several CVE fixes.