### PR TITLE
fix: Remove 'type' label from all metrics

### DIFF
--- a/e2e/nomostest/metrics/expectations.go
+++ b/e2e/nomostest/metrics/expectations.go
@@ -190,12 +190,11 @@ func (ae *SyncSetExpectations) ExpectedObjectOperations(syncKind SyncKind, syncN
 		return nil
 	}
 	var ops []ObjectOperation
-	for id, operation := range ae.expectations[syncKind][syncNN] {
+	for _, operation := range ae.expectations[syncKind][syncNN] {
 		if operation == SkipOperation {
 			continue
 		}
 		ops = AppendOperations(ops, ObjectOperation{
-			Kind:      id.Kind,
 			Operation: operation,
 			Count:     1,
 		})

--- a/e2e/nomostest/metrics/validate.go
+++ b/e2e/nomostest/metrics/validate.go
@@ -39,10 +39,8 @@ const (
 )
 
 // ObjectOperation is used for validating count aggregated metrics that have a
-// "type" tag (ex: `api_duration_seconds` & `apply_operations`).
+// "operation" tag (ex: `api_duration_seconds` & `apply_operations`).
 type ObjectOperation struct {
-	// Kind of the object
-	Kind string
 	// Operation performed on the object
 	Operation Operation
 	// Count of the times the operation was performed on objects of the
@@ -56,7 +54,7 @@ func AppendOperations(to []ObjectOperation, from ...ObjectOperation) []ObjectOpe
 loop:
 	for _, fromOp := range from {
 		for j, toOp := range to {
-			if fromOp.Kind == toOp.Kind && fromOp.Operation == toOp.Operation {
+			if fromOp.Operation == toOp.Operation {
 				to[j].Count += fromOp.Count
 				continue loop // stop looking for matches for this operation
 			}

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -199,7 +199,7 @@ func TestPreventDeletionRole(t *testing.T) {
 		// Adjust operations for this edge case.
 		// Deletion is prevented, but management annotations/labels are removed.
 		Operations: []metrics.ObjectOperation{
-			{Kind: "Role", Operation: metrics.UpdateOperation, Count: 1},
+			{Operation: metrics.UpdateOperation, Count: 1}, // Role
 		},
 	})
 	if err != nil {

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -454,7 +454,7 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 		// The abandoned object is NOT in the declared objects but it does get
 		// updated to remove config sync annotations and labels.
 		Operations: []metrics.ObjectOperation{
-			{Kind: "ConfigMap", Operation: metrics.UpdateOperation, Count: 1},
+			{Operation: metrics.UpdateOperation, Count: 1}, // ConfigMap
 		},
 	})
 	if err != nil {
@@ -648,7 +648,7 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 		// The implicit object is NOT in the declared objects but it does get
 		// updated to remove config sync annotations and labels.
 		Operations: []metrics.ObjectOperation{
-			{Kind: "Namespace", Operation: metrics.UpdateOperation, Count: 1},
+			{Operation: metrics.UpdateOperation, Count: 1}, // Namespace
 		},
 	})
 	if err != nil {

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -37,10 +37,9 @@ func record(ctx context.Context, ms ...stats.Measurement) {
 }
 
 // RecordAPICallDuration produces a measurement for the APICallDuration view.
-func RecordAPICallDuration(ctx context.Context, operation, status, kind string, startTime time.Time) {
+func RecordAPICallDuration(ctx context.Context, operation, status string, startTime time.Time) {
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyOperation, operation),
-		tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := APICallDuration.M(time.Since(startTime).Seconds())
 	record(tagCtx, measurement)
@@ -110,12 +109,11 @@ func RecordDeclaredResources(ctx context.Context, commit string, numResources in
 }
 
 // RecordApplyOperation produces a measurement for the ApplyOperations view.
-func RecordApplyOperation(ctx context.Context, controller, operation, status, kind string) {
+func RecordApplyOperation(ctx context.Context, controller, operation, status string) {
 	tagCtx, _ := tag.New(ctx,
 		//tag.Upsert(KeyName, GetResourceLabels()),
 		tag.Upsert(KeyOperation, operation),
 		tag.Upsert(KeyController, controller),
-		tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyStatus, status))
 	measurement := ApplyOperations.M(1)
 	record(tagCtx, measurement)
@@ -138,31 +136,28 @@ func RecordApplyDuration(ctx context.Context, status, commit string, startTime t
 }
 
 // RecordResourceFight produces measurements for the ResourceFights view.
-func RecordResourceFight(ctx context.Context, _, _ string) {
+func RecordResourceFight(ctx context.Context, _ string) {
 	//tagCtx, _ := tag.New(ctx,
 	//tag.Upsert(KeyName, GetResourceLabels()),
 	//tag.Upsert(KeyOperation, operation),
-	//tag.Upsert(KeyType, kind),
 	//)
 	measurement := ResourceFights.M(1)
 	record(ctx, measurement)
 }
 
 // RecordRemediateDuration produces measurements for the RemediateDuration view.
-func RecordRemediateDuration(ctx context.Context, status, kind string, startTime time.Time) {
+func RecordRemediateDuration(ctx context.Context, status string, startTime time.Time) {
 	tagCtx, _ := tag.New(ctx,
 		tag.Upsert(KeyStatus, status),
-		tag.Upsert(KeyType, kind),
 	)
 	measurement := RemediateDuration.M(time.Since(startTime).Seconds())
 	record(tagCtx, measurement)
 }
 
 // RecordResourceConflict produces measurements for the ResourceConflicts view.
-func RecordResourceConflict(ctx context.Context, _, commit string) {
+func RecordResourceConflict(ctx context.Context, commit string) {
 	tagCtx, _ := tag.New(ctx,
 		// tag.Upsert(KeyName, GetResourceLabels()),
-		// tag.Upsert(KeyType, kind),
 		tag.Upsert(KeyCommit, commit),
 	)
 	measurement := ResourceConflicts.M(1)

--- a/pkg/metrics/tagkeys.go
+++ b/pkg/metrics/tagkeys.go
@@ -51,9 +51,6 @@ var (
 	// KeyStatus groups metrics by their status. Possible values: success, error.
 	KeyStatus, _ = tag.NewKey("status")
 
-	// KeyType groups metrics by their resource Kind.
-	KeyType, _ = tag.NewKey("type")
-
 	// KeyInternalErrorSource groups the InternalError metrics by their source. Possible values: parser, differ, remediator.
 	KeyInternalErrorSource, _ = tag.NewKey("source")
 

--- a/pkg/metrics/views.go
+++ b/pkg/metrics/views.go
@@ -31,7 +31,7 @@ var (
 		Name:        APICallDuration.Name(),
 		Measure:     APICallDuration,
 		Description: "The latency distribution of API server calls",
-		TagKeys:     []tag.Key{KeyOperation, KeyType, KeyStatus},
+		TagKeys:     []tag.Key{KeyOperation, KeyStatus},
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 
@@ -97,7 +97,7 @@ var (
 		Name:        ApplyOperations.Name() + "_total",
 		Measure:     ApplyOperations,
 		Description: "The total number of operations that have been performed to sync resources to source of truth",
-		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyType, KeyStatus},
+		TagKeys:     []tag.Key{KeyController, KeyOperation, KeyStatus},
 		Aggregation: view.Count(),
 	}
 
@@ -132,7 +132,7 @@ var (
 		Name:        RemediateDuration.Name(),
 		Measure:     RemediateDuration,
 		Description: "The latency distribution of remediator reconciliation events",
-		TagKeys:     []tag.Key{KeyType, KeyStatus},
+		TagKeys:     []tag.Key{KeyStatus},
 		Aggregation: view.Distribution(distributionBounds...),
 	}
 

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -88,16 +88,16 @@ func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Objec
 	err := r.remediate(ctx, id, objDiff)
 
 	// Record duration, even if there's an error
-	metrics.RecordRemediateDuration(ctx, metrics.StatusTagKey(err), id.Kind, start)
+	metrics.RecordRemediateDuration(ctx, metrics.StatusTagKey(err), start)
 
 	if err != nil {
 		switch err.Code() {
 		case syncerclient.ResourceConflictCode:
 			// Record conflict, if there was one
-			metrics.RecordResourceConflict(ctx, id.Kind, commit)
+			metrics.RecordResourceConflict(ctx, commit)
 		case status.FightErrorCode:
 			operation := objDiff.Operation(r.scope, r.syncName)
-			metrics.RecordResourceFight(ctx, string(operation), id.Kind)
+			metrics.RecordResourceFight(ctx, string(operation))
 			r.fightHandler.AddFightError(id, err)
 		}
 		return err

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -201,7 +201,7 @@ func (w *filteredWatcher) SetManagementConflict(object client.Object, commit str
 		core.GKNN(object), newManager, manager)
 	gvknn := queue.GVKNNOf(object)
 	w.conflictHandler.AddConflictError(gvknn, status.ManagementConflictErrorWrap(object, newManager))
-	metrics.RecordResourceConflict(context.Background(), gvknn.Kind, commit)
+	metrics.RecordResourceConflict(context.Background(), commit)
 }
 
 func (w *filteredWatcher) ClearManagementConflict() {

--- a/pkg/syncer/client/client.go
+++ b/pkg/syncer/client/client.go
@@ -67,8 +67,8 @@ func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.C
 
 	start := time.Now()
 	err := c.Client.Create(ctx, obj, opts...)
-	c.recordLatency(start, "Create", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "create", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
+	c.recordLatency(start, "Create", metrics.StatusLabel(err))
+	m.RecordAPICallDuration(ctx, "create", m.StatusTagKey(err), start)
 
 	switch {
 	case apierrors.IsAlreadyExists(err):
@@ -115,8 +115,8 @@ func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.D
 		err = errors.Wrapf(err, "delete failed for %s", description)
 	}
 
-	c.recordLatency(start, "delete", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "delete", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
+	c.recordLatency(start, "delete", metrics.StatusLabel(err))
+	m.RecordAPICallDuration(ctx, "delete", m.StatusTagKey(err), start)
 
 	if err != nil {
 		return status.ResourceWrap(err, "failed to delete", obj)
@@ -183,8 +183,8 @@ func (c *Client) apply(ctx context.Context, obj client.Object, updateFn update,
 
 		start := time.Now()
 		err = clientUpdateFn(ctx, newObj)
-		c.recordLatency(start, "update", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-		m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
+		c.recordLatency(start, "update", metrics.StatusLabel(err))
+		m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), start)
 
 		if err == nil {
 			newV := resourceVersion(newObj)
@@ -217,8 +217,8 @@ func (c *Client) Update(ctx context.Context, obj client.Object) status.Error {
 	oldV := resourceVersion(obj)
 	start := time.Now()
 	err := c.Client.Update(ctx, obj)
-	c.recordLatency(start, "update", obj.GetObjectKind().GroupVersionKind().Kind, metrics.StatusLabel(err))
-	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), obj.GetObjectKind().GroupVersionKind().Kind, start)
+	c.recordLatency(start, "update", metrics.StatusLabel(err))
+	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), start)
 	switch {
 	case apierrors.IsNotFound(err):
 		return ConflictUpdateDoesNotExist(err, obj)

--- a/pkg/syncer/metrics/metrics.go
+++ b/pkg/syncer/metrics/metrics.go
@@ -30,9 +30,8 @@ var (
 			Buckets:   []float64{.001, .01, .1, 1},
 		},
 		// operation: create, patch, update, delete
-		// type: resource kind
 		// status: success, error
-		[]string{"operation", "type", "status"},
+		[]string{"operation", "status"},
 	)
 	ControllerRestarts = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -52,9 +51,8 @@ var (
 			Name:      "operations_total",
 		},
 		// operation: create, update, delete
-		// type: resource kind
 		// status: success, error
-		[]string{"operation", "type", "status"},
+		[]string{"operation", "status"},
 	)
 	ReconcileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -64,9 +62,8 @@ var (
 			Name:      "reconcile_duration_seconds",
 			Buckets:   []float64{.001, .01, .1, 1, 10, 100},
 		},
-		// type: cluster, crd, namespace, repo, sync
 		// status: success, error
-		[]string{"type", "status"},
+		[]string{"status"},
 	)
 	ReconcileEventTimes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -75,8 +72,7 @@ var (
 			Subsystem: "syncer",
 			Name:      "reconcile_event_timestamps",
 		},
-		// type: cluster, crd, namespace, repo, sync
-		[]string{"type"},
+		[]string{},
 	)
 )
 


### PR DESCRIPTION
The type label was increasing the cardinality of metrics by a significant amount, especially when used with config connector or crossplane, which have hundreds or even thousands of CRDs.

So this removes the type label from all metrics, which should reduce the total number of metrics and the cost, especially when combined with high-commit repositories.