### PR TITLE
Modify the otel_collector_test error condition

### DIFF
--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -56,7 +56,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 	})
 
 	nt.T.Cleanup(func() {
-		nt.MustKubectl("delete", "-f", "../testdata/otel-collector/otel-cm-duplicate-timeseries.yaml", "--ignore-not-found")
+		nt.MustKubectl("delete", "-f", "../testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml", "--ignore-not-found")
 		nt.T.Log("Restart otel-collector pod to reset the ConfigMap and log")
 		nomostest.DeletePodByLabel(nt, "app", ocmetrics.OpenTelemetry, false)
 		if err := nt.Watcher.WatchForCurrentStatus(kinds.Deployment(), ocmetrics.OtelCollectorName, ocmetrics.MonitoringNamespace); err != nil {
@@ -128,7 +128,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 	// will take precedence over 'otel-collector-googlecloud' that was deployed
 	// by the test.
 	nt.T.Log("Apply custom otel-collector ConfigMap that could cause duplicate time series error")
-	nt.MustKubectl("apply", "-f", "../testdata/otel-collector/otel-cm-duplicate-timeseries.yaml")
+	nt.MustKubectl("apply", "-f", "../testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml")
 	nt.T.Log("Restart otel-collector pod to refresh the ConfigMap and log")
 	nomostest.DeletePodByLabel(nt, "app", ocmetrics.OpenTelemetry, false)
 	if err := nt.Watcher.WatchForCurrentStatus(kinds.Deployment(), ocmetrics.OtelCollectorName, ocmetrics.MonitoringNamespace); err != nil {

--- a/e2e/testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml
+++ b/e2e/testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This test file removes the attribute processor that was in place for removing
+# labels that are not allowed in Cloud Monarch, in order to create
+# `failed to export` error in the otel-collector Deployment log.
+
 apiVersion: v1
 data:
   otel-collector-config.yaml: |-
@@ -127,24 +131,6 @@ data:
             - no_ssl_verify_count_total
             - kcc_resource_count
             - last_sync_timestamp
-      # Remove custom configsync metric labels that are not registered with Monarch
-      # This action applies to all metrics that are sent through the pipeline that
-      # is using this processor
-      attributes/kubernetes:
-        actions:
-        # Remove custom configsync metric labels that are not registered with Monarch
-        - key: configsync.sync.kind
-          action: delete
-        - key: configsync.sync.name
-          action: delete
-        - key: configsync.sync.namespace
-          action: delete
-        # Remove high cardinality configsync metric labels when sending to Monarch.
-        # These labels are useful to users, but too noisy for global aggregation.
-        - key: commit
-          action: delete
-        - key: type
-          action: delete
       metricstransform/kubernetes:
         transforms:
         - include: declared_resources
@@ -198,7 +184,7 @@ data:
           exporters: [prometheus]
         metrics/kubernetes:
           receivers: [opencensus]
-          processors: [batch, filter/kubernetes, attributes/kubernetes, metricstransform/kubernetes, resourcedetection]
+          processors: [batch, filter/kubernetes, metricstransform/kubernetes, resourcedetection]
           exporters: [googlecloud/kubernetes]
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
This is a cleanup after https://github.com/GoogleContainerTools/kpt-config-sync/pull/817.

With `type` label removed from the original metrics, the attribute processor that force removes the tag will no longer create the error thus checking for the error condition is not needed.

Changed the error case to metrics fail to export due to the rejected labels by the Cloud Monarch.