### PR TITLE
Aggregate commit label for GCM metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/net v0.8.0
 	golang.org/x/oauth2 v0.6.0
 	google.golang.org/api v0.108.0
+	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.7
 	k8s.io/apiextensions-apiserver v0.26.7
@@ -136,7 +137,6 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 // indirect
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -46,7 +46,7 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "4d0a24156f2d3d1bdc6a01ef41a3f625"
+	depAnnotationGooglecloud = "c3b8f7c8647aa20b219d141081ed7f6f"
 	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.


### PR DESCRIPTION
This should reduce the number of unique metrics recorded and the cost of using Config Sync with Google Cloud Monitoring. Prometheus metrics still include the commit, to facilitate metrics validation.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/827