### PR TITLE
test: Wait for Current + Synced

### DIFF
--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -187,11 +187,11 @@ func (nt *NT) WatchForSync(
 	}
 
 	predicates := []testpredicates.Predicate{
-		// Status reflects latest spec changes
+		// Wait until status.observedGeneration matches metadata.generation
 		testpredicates.HasObservedLatestGeneration(nt.Scheme),
-		// Not Terminating, Reconciling, or Stalled
+		// Wait until metadata.deletionTimestamp is missing, and conditions do not iniclude Reconciling=True or Stalled=True
 		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-		// Expected commit/version is parsed, rendered, and synced
+		// Wait until expected commit/version is parsed, rendered, and synced
 		syncSha1(sha1),
 	}
 	if syncDirPair != nil {

--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -36,6 +36,7 @@ import (
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/repo"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
 type watchForAllSyncsOptions struct {
@@ -186,7 +187,11 @@ func (nt *NT) WatchForSync(
 	}
 
 	predicates := []testpredicates.Predicate{
+		// Status reflects latest spec changes
 		testpredicates.HasObservedLatestGeneration(nt.Scheme),
+		// Not Terminating, Reconciling, or Stalled
+		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+		// Expected commit/version is parsed, rendered, and synced
 		syncSha1(sha1),
 	}
 	if syncDirPair != nil {


### PR DESCRIPTION
WatchForSync now also waits for Current kstatus, meaning the reconciler-manager is done Reconciling the reconciler and is not Failed/Stalled.