### PR TITLE
test: fix cleanup ordering of kcc resources (#799)

### DIFF
--- a/e2e/testdata/configsync-kcc/kcc/policy-member.yaml
+++ b/e2e/testdata/configsync-kcc/kcc/policy-member.yaml
@@ -17,6 +17,8 @@ kind: IAMPolicyMember
 metadata:
   name: policy-member-binding
   namespace: foo
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/foo/IAMServiceAccount/pubsub-app
 spec:
   member: serviceAccount:pubsub-app@KCC-MANAGED-PROJECT.iam.gserviceaccount.com
   role: roles/pubsub.subscriber


### PR DESCRIPTION
The IAMPolicyMember must be deleted before the IAMServiceAccount in order to ensure proper cleanup.

See https://cloud.google.com/config-connector/docs/troubleshooting#update_error_with_iampolicy_iampartialpolicy_and_iampolicymember