### PR TITLE
Improve the retry behavior (#812)

### DIFF
--- a/pkg/parse/cache.go
+++ b/pkg/parse/cache.go
@@ -16,7 +16,6 @@ package parse
 
 import (
 	"sort"
-	"time"
 
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/core"
@@ -66,12 +65,6 @@ type cacheForCommit struct {
 	// needToRetry indicates whether a retry is needed.
 	needToRetry bool
 
-	// reconciliationWithSameErrs tracks the number of reconciliation attempts failed with the same errors.
-	reconciliationWithSameErrs int
-
-	// nextRetryTime tracks when the next retry should happen.
-	nextRetryTime time.Time
-
 	// errs tracks all the errors encounted during the reconciliation.
 	errs status.MultiError
 }
@@ -82,10 +75,6 @@ func (c *cacheForCommit) setParserResult(objs []ast.FileObject, parserErrs statu
 	c.objsToApply = knownScopeObjs
 	c.parserErrs = parserErrs
 	c.hasParserResult = true
-}
-
-func (c *cacheForCommit) readyToRetry() bool {
-	return !time.Now().Before(c.nextRetryTime)
 }
 
 func (c *cacheForCommit) parserResultUpToDate() bool {

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -21,8 +21,10 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
@@ -319,7 +321,11 @@ func TestRun(t *testing.T) {
 				SourceBranch: "main",
 			}
 			parser := newParser(t, fs, tc.renderingEnabled)
-			state := &reconcilerState{}
+			state := &reconcilerState{
+				backoff:     defaultBackoff(),
+				retryTimer:  time.NewTimer(configsync.DefaultReconcilerRetryPeriod),
+				retryPeriod: configsync.DefaultReconcilerRetryPeriod,
+			}
 			run(context.Background(), parser, triggerReimport, state)
 
 			testutil.AssertEqual(t, tc.needRetry, state.cache.needToRetry, "[%s] unexpected state.cache.needToRetry return", tc.name)


### PR DESCRIPTION
Currently, the retry behavior for different triggers are different. When the trigger is managementConflict, it waits 5 seconds between retries. When the trigger is watchUpdate, it retries every second. When the trigger is the fact that the last reconciliation failed, it retries every second for the first 5 retires, and then does exponential backoff retry up to 5 minutes.

This PR unifies the retry behavior for these three triggers with backoff
+ jitter (inital duration: 1s; factor: 2; jitter: 0.1). There can be up to 12 retries for a given commit.

b/289254423