### PR TITLE
fetch helm from patched GKE version (#806)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
 KUSTOMIZE_VERSION := v5.1.1
-HELM_VERSION := v3.12.2
+HELM_VERSION := v3.12.3-gke.1
 # Keep KIND_VERSION in sync with the version defined in go.mod
 # When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
 KIND_VERSION := v0.14.0

--- a/Makefile.build
+++ b/Makefile.build
@@ -54,7 +54,7 @@ build-junit-report-cli: pull-buildenv buildenv-dirs
 
 # Build Config Sync docker images
 .PHONY: build-images
-build-images:
+build-images: install-helm
 	@echo "+++ Building the Reconciler image: $(RECONCILER_TAG)"
 	@docker buildx build $(DOCKER_BUILD_QUIET) \
 		--target $(RECONCILER_IMAGE) \

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -68,15 +68,24 @@ install-crane:
 # remove any existing helm directory/binary. The install-helm target was previously
 # creating a directory at this path rather than the binary/file.
 clean-helm:
+	rm -rf $(HELM_STAGING_DIR)
 	rm -rf $(HELM)
+
+HELM_URL := gs://config-management-release/config-sync/helm/tag/$(HELM_VERSION)/helm-$(HELM_VERSION)-linux-amd64.tar.gz
+HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
+HELM_TARBALL := /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 
 .PHONY: install-helm
 # install helm binary to publish the image
 install-helm: clean-helm buildenv-dirs
-	wget https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz -O /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
-	tar -zxvf /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz -C /tmp
-	mv /tmp/linux-amd64/helm $(HELM)
-	rm /tmp/helm-$(HELM_VERSION)-linux-amd64.tar.gz
+	gsutil cp $(HELM_URL).sha256 $(HELM_TARBALL).sha256
+	gsutil cp $(HELM_URL) $(HELM_TARBALL)
+	echo "$$(cat $(HELM_TARBALL).sha256)  $(HELM_TARBALL)" | sha256sum --check
+	mkdir -p $(HELM_STAGING_DIR)
+	tar -zxvf $(HELM_TARBALL) -C $(HELM_STAGING_DIR)
+	cp $(HELM_STAGING_DIR)/helm $(HELM)
+	rm $(HELM_TARBALL)
+	rm $(HELM_TARBALL).sha256
 
 ###################################
 # Prow environment provisioning

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -22,20 +22,7 @@ COPY . .
 # Version string to embed in built binary.
 ARG VERSION
 
-ARG HELM_VERSION=v3.12.2
 ARG KUSTOMIZE_VERSION=v5.1.1
-
-# Install Helm with license
-RUN URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
-  URL_PREFIX="$(dirname "${URL}")" && FILENAME="$(basename "${URL}")" && \
-  wget "${URL}" -O "/tmp/${FILENAME}" && \
-  wget "${URL}.sha256" -O /tmp/helm_checksum.txt && \
-  echo "$(cat /tmp/helm_checksum.txt)  /tmp/${FILENAME}" | sha256sum --check && \
-  tar -zxvf "/tmp/${FILENAME}" -C /tmp && \
-  mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
-  mkdir -p ./vendor/helm.sh/helm/v3 && \
-  mv /tmp/linux-amd64/LICENSE ./vendor/helm.sh/helm/v3/LICENSE && \
-  rm -rf /tmp/linux-amd64 "/tmp/${FILENAME}" /tmp/helm_checksum.txt
 
 # Install Kustomize with license
 RUN URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" && \
@@ -81,7 +68,8 @@ USER nonroot:nonroot
 FROM gcr.io/distroless/static:nonroot as hydration-controller
 WORKDIR /
 COPY --from=bins /go/bin/hydration-controller .
-COPY --from=bins /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
@@ -105,7 +93,8 @@ FROM gcr.io/distroless/static:latest as helm-sync
 ENV HOME=/tmp
 WORKDIR /
 COPY --from=bins /go/bin/helm-sync .
-COPY --from=bins /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 USER nonroot:nonroot
@@ -116,7 +105,8 @@ FROM debian-nonroot as hydration-controller-with-shell
 WORKDIR /
 USER root
 COPY --from=bins /go/bin/hydration-controller .
-COPY --from=bins /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
@@ -164,7 +154,8 @@ RUN apt-get update && apt-get install -y bash git
 RUN mkdir -p /opt/nomos/bin
 WORKDIR /opt/nomos/bin
 COPY --from=bins /go/bin/nomos nomos
-COPY --from=bins /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
+COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -29,14 +29,7 @@ ENV CGO_ENABLED=0
 RUN apk add --no-cache \
   bash curl docker gcc git jq make openssh-client python3 diffutils
 
-ARG HELM_VERSION=v3.12.2
 ARG KUSTOMIZE_VERSION=v5.1.1
-
-# Install Helm
-RUN wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O /tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
-  tar -zxvf /tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz -C /tmp && \
-  mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
-  rm -rf /tmp/linux-amd64 /tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz
 
 # Install Kustomize
 RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -O /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
@@ -65,6 +58,8 @@ RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 
 # Just copy everything in the nomos repository so we have whatever we might need.
 COPY . .
+
+COPY .output/go/bin/helm /usr/local/bin/helm
 
 # Make sure the nomos command is available for tests.
 RUN go install kpt.dev/configsync/cmd/nomos

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.12.2"
+	HelmVersion = "v3.12.3-gke.1"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.1.1"
 	// Helm is the binary name of the installed Helm.


### PR DESCRIPTION
This version is similar to the upstream release, but with several CVE fixes.