### PR TITLE
Cherrypick: fix: Handle watcher context cancel (#792)

### DIFF
--- a/pkg/status/internal_error.go
+++ b/pkg/status/internal_error.go
@@ -40,3 +40,8 @@ func InternalErrorf(format string, a ...interface{}) Error {
 func InternalWrap(err error) Error {
 	return InternalErrorBuilder.Wrap(err).Build()
 }
+
+// InternalWrapf wraps an error as an internal error with a formatted message
+func InternalWrapf(err error, format string, a ...interface{}) Error {
+	return InternalErrorBuilder.Wrap(err).Sprintf(format, a...).Build()
+}


### PR DESCRIPTION
Update the remediator's filteredwatcher to handle context cancellation, which is used to shut down the remediator. Previously, the cancel error was treated as any other error and the watcher would restart repeatedly until hitting the retry timeout (~4m). Now it should exit more quickly.

This also avoids logging the confusing watch error, `unable to decode an event from the watch stream`, when the context is cancelled during normal execution.

b/281728670