### PR TITLE
Remove client-side throttling from nomos status

### DIFF
--- a/pkg/client/restconfig/config.go
+++ b/pkg/client/restconfig/config.go
@@ -107,6 +107,8 @@ func AllKubectlConfigs(timeout time.Duration) (map[string]*rest.Config, error) {
 			continue
 		}
 
+		UpdateQPS(restCfg)
+
 		if timeout > 0 {
 			restCfg.Timeout = timeout
 		}


### PR DESCRIPTION
Based on demand by a few customers, we will remove client-side throttling from nomos status