### PR TITLE
fix: Retry status updates

### DIFF
--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -258,7 +258,7 @@ func HasCorrectResourceRequestsLimits(containerName string, cpuRequest, cpuLimit
 		}
 		dep, ok := o.(*appsv1.Deployment)
 		if !ok {
-			return WrongTypeErr(dep, &appsv1.Deployment{})
+			return WrongTypeErr(o, &appsv1.Deployment{})
 		}
 		container := ContainerByName(dep, containerName)
 		if container == nil {
@@ -596,6 +596,19 @@ func ResourceVersionNotEquals(scheme *runtime.Scheme, unexpected string) Predica
 		return errors.Errorf("expected %s %s to NOT have resourceVersion %q, but got %q",
 			gvk.Kind, core.ObjectNamespacedName(obj),
 			unexpected, resourceVersion)
+	}
+}
+
+// GenerationEquals checks that the object's generation equals the specified value.
+func GenerationEquals(generation int64) Predicate {
+	return func(obj client.Object) error {
+		if obj == nil {
+			return ErrObjectNotFound
+		}
+		if obj.GetGeneration() != generation {
+			return fmt.Errorf("expected generation: %d, got: %d", generation, obj.GetGeneration())
+		}
+		return nil
 	}
 }
 

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -155,7 +155,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("800m"), resource.MustParse("400Mi"), resource.MustParse("411Mi")),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -166,7 +166,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -175,7 +175,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -233,7 +233,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource requests and limits of root-reconciler are not affected by the resource changes of ns-reconciler-backend and ns-reconciler-fronend
 	err = nt.Validate(rootReconcilerNN.Name, rootReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(rootReconcilerDeploymentGeneration),
+		testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("800m"), resource.MustParse("400Mi"), resource.MustParse("411Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -242,7 +242,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the new resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -251,7 +251,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the new resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -266,7 +266,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, resource.MustParse("333m"), defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -277,7 +277,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -286,7 +286,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource limits of ns-reconciler-frontend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -301,7 +301,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -312,7 +312,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -321,7 +321,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-frontend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -329,7 +329,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	// Clear `spec.override` from repoSyncBackend
-	repoSyncBackend.Spec.Override = &v1alpha1.OverrideSpec{}
+	repoSyncBackend.Spec.Override = nil
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -339,7 +339,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -348,7 +348,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify root-reconciler uses the default resource requests and limits
 	err = nt.Validate(rootReconcilerNN.Name, rootReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(rootReconcilerDeploymentGeneration),
+		testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -357,7 +357,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-frontend are not affected by the resource limit change of ns-reconciler-backend
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -365,7 +365,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	// Clear `spec.override` from repoSyncFrontend
-	repoSyncFrontend.Spec.Override = &v1alpha1.OverrideSpec{}
+	repoSyncFrontend.Spec.Override = nil
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -375,7 +375,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -458,7 +458,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("800m"), resource.MustParse("400Mi"), resource.MustParse("411Mi")),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -469,7 +469,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -478,7 +478,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -536,7 +536,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource requests and limits of root-reconciler are not affected by the resource changes of ns-reconciler-backend and ns-reconciler-fronend
 	err = nt.Validate(rootReconcilerNN.Name, rootReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(rootReconcilerDeploymentGeneration),
+		testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("800m"), resource.MustParse("400Mi"), resource.MustParse("411Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -545,7 +545,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the new resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -554,7 +554,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the new resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -569,7 +569,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, resource.MustParse("333m"), defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -580,7 +580,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -589,7 +589,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource limits of ns-reconciler-frontend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -604,7 +604,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	err = nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
 		[]testpredicates.Predicate{
-			hasGeneration(rootReconcilerDeploymentGeneration),
+			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 			testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits),
 		},
@@ -615,7 +615,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("500m"), resource.MustParse("1000m"), resource.MustParse("500Mi"), resource.MustParse("555Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("600m"), resource.MustParse("1"), resource.MustParse("600Mi"), resource.MustParse("666Mi")))
 	if err != nil {
@@ -624,7 +624,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-frontend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -632,7 +632,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	// Clear `spec.override` from repoSyncBackend
-	repoSyncBackend.Spec.Override = &v1beta1.OverrideSpec{}
+	repoSyncBackend.Spec.Override = nil
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -642,7 +642,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerBackendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -651,7 +651,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify root-reconciler uses the default resource requests and limits
 	err = nt.Validate(rootReconcilerNN.Name, rootReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(rootReconcilerDeploymentGeneration),
+		testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {
@@ -660,7 +660,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify the resource requests and limits of ns-reconciler-frontend are not affected by the resource limit change of ns-reconciler-backend
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, resource.MustParse("511m"), resource.MustParse("2000m"), resource.MustParse("511Mi"), resource.MustParse("544Mi")),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, resource.MustParse("611m"), resource.MustParse("2"), resource.MustParse("611Mi"), resource.MustParse("644Mi")))
 	if err != nil {
@@ -668,7 +668,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	// Clear `spec.override` from repoSyncFrontend
-	repoSyncFrontend.Spec.Override = &v1beta1.OverrideSpec{}
+	repoSyncFrontend.Spec.Override = nil
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -678,7 +678,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Verify ns-reconciler-frontend uses the default resource requests and limits
 	err = nt.Validate(frontendReconcilerNN.Name, frontendReconcilerNN.Namespace, &appsv1.Deployment{},
-		hasGeneration(nsReconcilerFrontendDeploymentGeneration),
+		testpredicates.GenerationEquals(nsReconcilerFrontendDeploymentGeneration),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.Reconciler, defaultReconcilerCPURequest, defaultReconcilerCPULimits, defaultReconcilerMemRequest, defaultReconcilerMemLimits),
 		testpredicates.HasCorrectResourceRequestsLimits(reconcilermanager.GitSync, defaultGitSyncCPURequest, defaultGitSyncCPULimits, defaultGitSyncMemRequest, defaultGitSyncMemLimits))
 	if err != nil {

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -524,21 +524,6 @@ func resetReconcilerDeploymentManifests(nt *nomostest.NT, containerName string, 
 	}
 }
 
-func hasGeneration(generation int64) testpredicates.Predicate {
-	return func(o client.Object) error {
-		if o == nil {
-			return testpredicates.ErrObjectNotFound
-		}
-		d, ok := o.(*appsv1.Deployment)
-		if !ok {
-			return testpredicates.WrongTypeErr(d, &appsv1.Deployment{})
-		}
-		if d.Generation != generation {
-			return fmt.Errorf("expected generation: %d, got: %d", generation, d.Generation)
-		}
-		return nil
-	}
-}
 func firstContainerTerminationMessagePathIs(terminationMessagePath string) testpredicates.Predicate {
 	return func(o client.Object) error {
 		if o == nil {

--- a/pkg/reconciler/finalizer/reposync_finalizer.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer.go
@@ -90,7 +90,7 @@ func (f *RepoSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object)
 //
 // The specified syncObj must be of type `*v1beta1.RepoSync`.
 func (f *RepoSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+	updated, err := mutate.Spec(ctx, f.Client, syncObj, func() error {
 		if !addFinalizer(syncObj) {
 			// Already added. No change necessary.
 			return &mutate.NoUpdateError{}
@@ -113,7 +113,7 @@ func (f *RepoSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Obj
 //
 // The specified syncObj must be of type `*v1beta1.RepoSync`.
 func (f *RepoSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+	updated, err := mutate.Spec(ctx, f.Client, syncObj, func() error {
 		if !removeFinalizer(syncObj) {
 			// Already removed. No change necessary.
 			return &mutate.NoUpdateError{}

--- a/pkg/reconciler/finalizer/reposync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
@@ -251,11 +252,13 @@ func TestRepoSyncFinalize(t *testing.T) {
 			},
 			expectedError: errors.Wrapf(
 				errors.Wrapf(
-					status.APIServerError(
-						apierrors.NewNotFound(
-							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
-							"example/repo-sync-1"),
-						"failed to update object status",
+					status.APIServerErrorWrap(
+						errors.Wrapf(
+							apierrors.NewNotFound(
+								schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+								"example/repo-sync-1"),
+							"failed to update object status: %s",
+							kinds.ObjectSummary(repoSync1)),
 						repoSync1.DeepCopy()),
 					"failed to set ReconcilerFinalizing condition"),
 				"setting Finalizing condition"),
@@ -406,11 +409,13 @@ func TestRepoSyncAddFinalizer(t *testing.T) {
 				return fakeClient.Delete(ctx, rs)
 			},
 			expectedError: errors.Wrapf(
-				status.APIServerError(
-					apierrors.NewNotFound(
-						schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
-						"example/repo-sync-1"),
-					"failed to update object",
+				status.APIServerErrorWrap(
+					errors.Wrapf(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+							"example/repo-sync-1"),
+						"failed to update object: %s",
+						kinds.ObjectSummary(repoSync1)),
 					repoSync1.DeepCopy()),
 				"failed to add finalizer"),
 			expectedUpdated: false,
@@ -548,11 +553,13 @@ func TestRepoSyncRemoveFinalizer(t *testing.T) {
 				return fakeClient.Delete(ctx, rs)
 			},
 			expectedError: errors.Wrapf(
-				status.APIServerError(
-					apierrors.NewNotFound(
-						schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
-						"example/repo-sync-1"),
-					"failed to update object",
+				status.APIServerErrorWrap(
+					errors.Wrapf(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
+							"example/repo-sync-1"),
+						"failed to update object: %s",
+						kinds.ObjectSummary(repoSync1)),
 					repoSync1.DeepCopy()),
 				"failed to remove finalizer"),
 			expectedUpdated: false,

--- a/pkg/reconciler/finalizer/rootsync_finalizer.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer.go
@@ -90,7 +90,7 @@ func (f *RootSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object)
 //
 // The specified syncObj must be of type `*v1beta1.RootSync`.
 func (f *RootSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+	updated, err := mutate.Spec(ctx, f.Client, syncObj, func() error {
 		if !addFinalizer(syncObj) {
 			// Already added. No change necessary.
 			return &mutate.NoUpdateError{}
@@ -113,7 +113,7 @@ func (f *RootSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Obj
 //
 // The specified syncObj must be of type `*v1beta1.RootSync`.
 func (f *RootSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.Object) (bool, error) {
-	updated, err := mutate.WithRetry(ctx, f.Client, syncObj, func() error {
+	updated, err := mutate.Spec(ctx, f.Client, syncObj, func() error {
 		if !removeFinalizer(syncObj) {
 			// Already removed. No change necessary.
 			return &mutate.NoUpdateError{}

--- a/pkg/reconciler/finalizer/rootsync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer_test.go
@@ -260,11 +260,13 @@ func TestRootSyncFinalize(t *testing.T) {
 			},
 			expectedError: errors.Wrapf(
 				errors.Wrapf(
-					status.APIServerError(
-						apierrors.NewNotFound(
-							schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
-							"config-management-system/root-sync"),
-						"failed to update object status",
+					status.APIServerErrorWrap(
+						errors.Wrapf(
+							apierrors.NewNotFound(
+								schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+								"config-management-system/root-sync"),
+							"failed to update object status: %s",
+							kinds.ObjectSummary(rootSync1)),
 						rootSync1.DeepCopy()),
 					"failed to set ReconcilerFinalizing condition"),
 				"setting Finalizing condition"),
@@ -415,11 +417,13 @@ func TestRootSyncAddFinalizer(t *testing.T) {
 				return fakeClient.Delete(ctx, rs)
 			},
 			expectedError: errors.Wrapf(
-				status.APIServerError(
-					apierrors.NewNotFound(
-						schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
-						"config-management-system/root-sync"),
-					"failed to update object",
+				status.APIServerErrorWrap(
+					errors.Wrapf(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+							"config-management-system/root-sync"),
+						"failed to update object: %s",
+						kinds.ObjectSummary(rootSync1)),
 					rootSync1.DeepCopy()),
 				"failed to add finalizer"),
 			expectedUpdated: false,
@@ -557,11 +561,13 @@ func TestRootSyncRemoveFinalizer(t *testing.T) {
 				return fakeClient.Delete(ctx, rs)
 			},
 			expectedError: errors.Wrapf(
-				status.APIServerError(
-					apierrors.NewNotFound(
-						schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
-						"config-management-system/root-sync"),
-					"failed to update object",
+				status.APIServerErrorWrap(
+					errors.Wrapf(
+						apierrors.NewNotFound(
+							schema.GroupResource{Group: "configsync.gke.io", Resource: "RootSync"},
+							"config-management-system/root-sync"),
+						"failed to update object: %s",
+						kinds.ObjectSummary(rootSync1)),
 					rootSync1.DeepCopy()),
 				"failed to remove finalizer"),
 			expectedUpdated: false,

--- a/pkg/reconcilermanager/controllers/create_or_update.go
+++ b/pkg/reconcilermanager/controllers/create_or_update.go
@@ -40,7 +40,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 		if !apierrors.IsNotFound(err) {
 			return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationGet, key)
 		}
-		if err := mutate(f, key, obj); err != nil {
+		if err := mutateWrapper(f, key, obj); err != nil {
 			return controllerutil.OperationResultNone, err
 		}
 		if err := c.Create(ctx, obj); err != nil {
@@ -50,7 +50,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 	}
 
 	existing := obj.DeepCopyObject() //nolint
-	if err := mutate(f, key, obj); err != nil {
+	if err := mutateWrapper(f, key, obj); err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 
@@ -64,8 +64,8 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 	return controllerutil.OperationResultUpdated, nil
 }
 
-// mutate wraps a MutateFn and applies validation to its result.
-func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
+// mutateWrapper wraps a MutateFn and applies validation to its result.
+func mutateWrapper(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
 	if err := f(); err != nil {
 		return err
 	}

--- a/pkg/status/api_server_error.go
+++ b/pkg/status/api_server_error.go
@@ -54,3 +54,17 @@ func APIServerErrorf(err error, format string, a ...interface{}) Error {
 	}
 	return apiServerErrorBuilder.Sprintf(format, a...).Wrap(err).Build()
 }
+
+// APIServerErrorWrap wraps an error returned by the APIServer with resource objects.
+func APIServerErrorWrap(err error, resources ...client.Object) Error {
+	var errorBuilder ErrorBuilder
+	if apierrors.IsForbidden(err) {
+		errorBuilder = InsufficientPermissionErrorBuilder.Wrap(err)
+	} else {
+		errorBuilder = apiServerErrorBuilder.Wrap(err)
+	}
+	if len(resources) == 0 {
+		return errorBuilder.Build()
+	}
+	return errorBuilder.BuildWithResources(resources...)
+}


### PR DESCRIPTION
Status updates should retry if the error is recoverable, especially if it's just a ResourceVersion conflict, as long as the generation hasn't changed. This should reduce unnecessary reconcile loops and API calls in the reconciler-manager and reconciler finalizer.