### PR TITLE
Nomos CLI: replace APIGROUP with APIVERSION

### DIFF
--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -301,7 +301,7 @@ func Generate() AllExamples {
 	p, _ := cmpath.AbsoluteSlash("/api-resources.txt")
 	result.add(vet.InvalidScopeValue(p, "rbac      other     Role", "other"))
 	result.add(vet.UnableToReadAPIResources(p, errors.New("missing file permissions")))
-	result.add(vet.MissingAPIGroup(p))
+	result.add(vet.MissingAPIVersion(p))
 
 	// 1065
 	result.add(clusterconfig.MalformedCRDError(

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
@@ -1216,13 +1217,10 @@ func TestApiResourceFormatting(t *testing.T) {
 
 	header := strings.Fields(strings.Split(string(out), "\n")[0])
 
-	if len(header) != len(columnName) {
-		nt.T.Fatalf("Number of column titles doesn't match expected result")
-	}
+	assert.Equal(t, len(columnName), len(header))
 
 	for i, column := range header {
-		if column != columnName[i] {
-			nt.T.Fatalf("%s not found in the column titles", column)
-		}
+		assert.Equal(t, columnName[i], column)
+
 	}
 }

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1200,3 +1200,29 @@ func TestNomosStatusNameFilter(t *testing.T) {
 		nt.T.Fatalf("Expected to not find bookinfo:crontab-sync component in output:\n%s\n", string(out4))
 	}
 }
+
+func TestApiResourceFormatting(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.NomosCLI)
+
+	// expected column name
+	var columnName = []string{"NAME", "SHORTNAMES", "APIVERSION", "NAMESPACED", "KIND"}
+
+	cmd := nt.Shell.Command("kubectl", "api-resources")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		nt.T.Log(string(out))
+		nt.T.Fatal(err)
+	}
+
+	header := strings.Fields(strings.Split(string(out), "\n")[0])
+
+	if len(header) != len(columnName) {
+		nt.T.Fatalf("Number of column titles doesn't match expected result")
+	}
+
+	for i, column := range header {
+		if column != columnName[i] {
+			nt.T.Fatalf("%s not found in the column titles", column)
+		}
+	}
+}

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1217,10 +1217,5 @@ func TestApiResourceFormatting(t *testing.T) {
 
 	header := strings.Fields(strings.Split(string(out), "\n")[0])
 
-	assert.Equal(t, len(columnName), len(header))
-
-	for i, column := range header {
-		assert.Equal(t, columnName[i], column)
-
-	}
+	assert.Equal(t, columnName, header)
 }


### PR DESCRIPTION
`APIGROUP` column name has been [replaced](https://github.com/kubernetes/kubernetes/pull/95253) from Kubernetes v1.20 onwards with `APIVERSION`. This has broken the usage of `api-resources.txt` with Nomos command for users using Kubernetes v1.20 or newer. 

[b/299337751](http://b/299337751)