### PR TITLE
fix: Increase reconciler resources on autopilot

### DIFF
--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -55,7 +55,12 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	// Get the default CPU/memory requests and limits of the reconciler container and the git-sync container
-	defaultResources := controllers.ReconcilerContainerResourceDefaults()
+	var defaultResources map[string]v1beta1.ContainerResourcesSpec
+	if nt.IsGKEAutopilot {
+		defaultResources = controllers.ReconcilerContainerResourceDefaultsForAutopilot()
+	} else {
+		defaultResources = controllers.ReconcilerContainerResourceDefaults()
+	}
 
 	// Verify root-reconciler uses the default resource requests and limits
 	rootReconcilerDeployment := &appsv1.Deployment{}
@@ -418,7 +423,12 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	// Get the default CPU/memory requests and limits of the reconciler container and the git-sync container
-	defaultResources := controllers.ReconcilerContainerResourceDefaults()
+	var defaultResources map[string]v1beta1.ContainerResourcesSpec
+	if nt.IsGKEAutopilot {
+		defaultResources = controllers.ReconcilerContainerResourceDefaultsForAutopilot()
+	} else {
+		defaultResources = controllers.ReconcilerContainerResourceDefaults()
+	}
 
 	// Verify root-reconciler uses the default resource requests and limits
 	rootReconcilerDeployment := &appsv1.Deployment{}

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -734,7 +734,12 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 
 	// default container resource requests defined in code:
 	// pkg/reconcilermanager/controllers/reconciler_container_resources.go
-	expectedResources := controllers.ReconcilerContainerResourceDefaults()
+	var expectedResources map[string]v1beta1.ContainerResourcesSpec
+	if nt.IsGKEAutopilot {
+		expectedResources = controllers.ReconcilerContainerResourceDefaultsForAutopilot()
+	} else {
+		expectedResources = controllers.ReconcilerContainerResourceDefaults()
+	}
 	// Filter container map down to just expected containers
 	expectedResources = filterResourceMap(expectedResources,
 		reconcilermanager.Reconciler,

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -570,7 +572,16 @@ func TestCompareDeploymentsToCreatePatchData(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testDeclared := tc.declared.DeepCopy()
 			testCurrent := tc.current.DeepCopy()
-			dep, err := compareDeploymentsToCreatePatchData(tc.isAutopilot, testDeclared, testCurrent, reconcilerManagerAllowList, core.Scheme)
+			fakeClient := syncerFake.NewClient(t, core.Scheme)
+			if tc.isAutopilot {
+				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject())
+				require.NoError(t, err)
+			}
+			r := &reconcilerBase{
+				scheme: fakeClient.Scheme(),
+				client: fakeClient,
+			}
+			dep, err := r.compareDeploymentsToCreatePatchData(testDeclared, testCurrent, reconcilerManagerAllowList)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSame, dep.same)
 			require.Equal(t, tc.expectedPatch, string(dep.dataToPatch))
@@ -679,7 +690,16 @@ func TestCompareDeploymentsToCreatePatchDataResourceLimits(t *testing.T) {
 			} else {
 				testCurrent = tc.current.DeepCopy()
 			}
-			dep, err := compareDeploymentsToCreatePatchData(tc.isAutopilot, testDeclared, testCurrent, reconcilerManagerAllowList, core.Scheme)
+			fakeClient := syncerFake.NewClient(t, core.Scheme)
+			if tc.isAutopilot {
+				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject())
+				require.NoError(t, err)
+			}
+			r := &reconcilerBase{
+				scheme: fakeClient.Scheme(),
+				client: fakeClient,
+			}
+			dep, err := r.compareDeploymentsToCreatePatchData(testDeclared, testCurrent, reconcilerManagerAllowList)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSame, dep.same)
 		})

--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -68,6 +68,65 @@ func ReconcilerContainerResourceDefaults() map[string]v1beta1.ContainerResources
 	}
 }
 
+// ReconcilerContainerResourceDefaultsForAutopilot are the default resources to
+// use on GKE Autopilot clusters for the reconciler deployment.
+// On Autopilot, limits are set to requests and bursting is not allowed,
+// so requests need to be high enough to work for most users our of the box,
+// with a moderately high number of resource objects (e.g. 1k).
+func ReconcilerContainerResourceDefaultsForAutopilot() map[string]v1beta1.ContainerResourcesSpec {
+	return map[string]v1beta1.ContainerResourcesSpec{
+		reconcilermanager.Reconciler: {
+			ContainerName: reconcilermanager.Reconciler,
+			CPURequest:    resource.MustParse("700m"),
+			CPULimit:      resource.MustParse("700m"),
+			MemoryRequest: resource.MustParse("512Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+		reconcilermanager.HydrationController: {
+			ContainerName: reconcilermanager.HydrationController,
+			CPURequest:    resource.MustParse("200m"),
+			CPULimit:      resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("256Mi"),
+		},
+		reconcilermanager.OciSync: {
+			ContainerName: reconcilermanager.OciSync,
+			CPURequest:    resource.MustParse("100m"),
+			CPULimit:      resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("256Mi"),
+		},
+		reconcilermanager.HelmSync: {
+			ContainerName: reconcilermanager.HelmSync,
+			CPURequest:    resource.MustParse("100m"),
+			CPULimit:      resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("256Mi"),
+		},
+		reconcilermanager.GitSync: {
+			ContainerName: reconcilermanager.GitSync,
+			CPURequest:    resource.MustParse("20m"),
+			CPULimit:      resource.MustParse("20m"),
+			MemoryRequest: resource.MustParse("32Mi"),
+			MemoryLimit:   resource.MustParse("32Mi"),
+		},
+		reconcilermanager.GCENodeAskpassSidecar: {
+			ContainerName: reconcilermanager.GCENodeAskpassSidecar,
+			CPURequest:    resource.MustParse("50m"),
+			CPULimit:      resource.MustParse("50m"),
+			MemoryRequest: resource.MustParse("64Mi"),
+			MemoryLimit:   resource.MustParse("64Mi"),
+		},
+		metrics.OtelAgentName: {
+			ContainerName: metrics.OtelAgentName,
+			CPURequest:    resource.MustParse("10m"),
+			CPULimit:      resource.MustParse("10m"),
+			MemoryRequest: resource.MustParse("32Mi"),
+			MemoryLimit:   resource.MustParse("32Mi"),
+		},
+	}
+}
+
 // setContainerResourceDefaults sets the defaults when not specified in the
 // overrides.
 func setContainerResourceDefaults(overrides []v1beta1.ContainerResourcesSpec, defaultsMap map[string]v1beta1.ContainerResourcesSpec) []v1beta1.ContainerResourcesSpec {

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -1061,9 +1061,19 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 		}
 		templateSpec.Volumes = filterVolumes(templateSpec.Volumes, auth, secretName, caCertSecretRefName, rs.Spec.SourceType, r.membership)
 
+		autopilot, err := r.isAutopilot()
+		if err != nil {
+			return err
+		}
+		var containerResourceDefaults map[string]v1beta1.ContainerResourcesSpec
+		if autopilot {
+			containerResourceDefaults = ReconcilerContainerResourceDefaultsForAutopilot()
+		} else {
+			containerResourceDefaults = ReconcilerContainerResourceDefaults()
+		}
 		overrides := rs.Spec.SafeOverride()
 		containerResources := setContainerResourceDefaults(overrides.Resources,
-			ReconcilerContainerResourceDefaults())
+			containerResourceDefaults)
 
 		var updatedContainers []corev1.Container
 		// Mutate spec.Containers to update name, configmap references and volumemounts.

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -923,9 +923,19 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 		// in the RootSync CR.
 		templateSpec.Volumes = filterVolumes(templateSpec.Volumes, auth, secretRefName, caCertSecretRefName, rs.Spec.SourceType, r.membership)
 
+		autopilot, err := r.isAutopilot()
+		if err != nil {
+			return err
+		}
+		var containerResourceDefaults map[string]v1beta1.ContainerResourcesSpec
+		if autopilot {
+			containerResourceDefaults = ReconcilerContainerResourceDefaultsForAutopilot()
+		} else {
+			containerResourceDefaults = ReconcilerContainerResourceDefaults()
+		}
 		overrides := rs.Spec.SafeOverride()
 		containerResources := setContainerResourceDefaults(overrides.Resources,
-			ReconcilerContainerResourceDefaults())
+			containerResourceDefaults)
 
 		var updatedContainers []corev1.Container
 		for _, container := range templateSpec.Containers {

--- a/pkg/util/autopilot.go
+++ b/pkg/util/autopilot.go
@@ -132,3 +132,11 @@ func AutopilotResourceMutation(annotation string) (map[string]corev1.ResourceReq
 	}
 	return input, output, nil
 }
+
+// FakeAutopilotWebhookObject returns a fake empty MutatingWebhookConfiguration
+// that satisfies IsGKEAutopilotCluster, for testing.
+func FakeAutopilotWebhookObject() client.Object {
+	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	webhook.Name = autopilotWebhooks[0]
+	return webhook
+}


### PR DESCRIPTION
- Increase requests & limits on autopilot to avoid OOMKill and
  CPU throttling. Leave standard defaults alone, to continue
  using boosting above the minimal requests.
- Clean up createOrPatchDeployment impl
- Use a fake autopilot webhook to test autopilot enablement
- Add TestStressMemoryUsage to test maximum number of supported objects with 100 CRDs and 50 objects each

Depends On:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/876
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/882
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/910

Proposal: [go/config-sync-reconciler-profiling](http://goto.google.com/config-sync-reconciler-profiling)

b/300294367