### PR TITLE
Update go version in the test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-inf
 
 # Docker image used for build and test. This image does not support CGO.
 # When upgrading this tag, publish the image after the change is submitted.
-BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.2.12
+BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.2.13
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler

--- a/Makefile.build
+++ b/Makefile.build
@@ -11,8 +11,8 @@ HELM := $(BIN_DIR)/helm
 # Builds the image if it does not exist to enable testing with a new image
 # version before publishing.
 pull-buildenv:
-	@docker image inspect $(BUILDENV_IMAGE) &> /dev/null \
-	|| (docker pull $(BUILDENV_IMAGE) || $(MAKE) build-buildenv)
+	@docker image inspect $(BUILDENV_IMAGE) \
+	|| docker pull $(BUILDENV_IMAGE) || $(MAKE) build-buildenv
 
 build-buildenv: build/buildenv/Dockerfile
 	@echo "+++ Creating the docker container for $(BUILDENV_IMAGE)"

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -27,7 +27,7 @@
 # when the go1.17 image is released in it.
 # Note that we shouldn't use the -alpine image here
 # since it is not allowed due to busybox for licensing.
-ARG GOLANG_CONTAINER=golang:1.19-buster
+ARG GOLANG_CONTAINER=golang:1.20-buster
 
 # Environment to build the helper binaries from.
 FROM ${GOLANG_CONTAINER} AS tools-base

--- a/build/prow/gke-e2e/Dockerfile
+++ b/build/prow/gke-e2e/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:425.0.0-slim as gcloud-install
 RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 WORKDIR /workspace
 
@@ -33,7 +33,7 @@ RUN go install ./cmd/junit-report
 RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
 
 # Build e2e image
-FROM golang:1.19-alpine as kpt-config-sync-e2e
+FROM golang:1.20-alpine as kpt-config-sync-e2e
 
 # Since go modules isn't enabled by default.
 ENV GO111MODULE=on

--- a/build/test-e2e-go/kind/Dockerfile
+++ b/build/test-e2e-go/kind/Dockerfile
@@ -17,7 +17,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:425.0.0-slim as gcloud-install
 RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Build e2e image
-FROM golang:1.19-alpine as kpt-config-sync-e2e
+FROM golang:1.20-alpine as kpt-config-sync-e2e
 
 WORKDIR /repo
 

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 export CGO_ENABLED=0
 
 echo "Running go tests:"
-go test -i -installsuffix "static" "$@"
 go test -installsuffix "static" "$@"
 
 # "none" is just a dummy value so nomoserrors doesn't actually print out errors.


### PR DESCRIPTION
We need to update the go version to fix CVEs.
This commit updates the test images first, so that we can build and push the gke-e2e image from a commit on the main branch.

We'll have a following commit to update go versions used by Config Sync components.