### PR TITLE
ci: enable presubmits on new buildenv before publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ TEST_INFRA_PROJECT ?= kpt-config-sync-ci-artifacts
 TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-infra
 
 # Docker image used for build and test. This image does not support CGO.
+# When upgrading this tag, publish the image after the change is submitted.
 BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.2.12
 
 # Nomos docker images containing all binaries.

--- a/Makefile.build
+++ b/Makefile.build
@@ -7,10 +7,12 @@ HELM := $(BIN_DIR)/helm
 # Build environment
 ###################################
 
-# Pulls the cached builenv docker image from gcrio.
+# Pulls the cached buildenv docker image from GCR.
+# Builds the image if it does not exist to enable testing with a new image
+# version before publishing.
 pull-buildenv:
 	@docker image inspect $(BUILDENV_IMAGE) &> /dev/null \
-	|| docker pull $(BUILDENV_IMAGE)
+	|| (docker pull $(BUILDENV_IMAGE) || $(MAKE) build-buildenv)
 
 build-buildenv: build/buildenv/Dockerfile
 	@echo "+++ Creating the docker container for $(BUILDENV_IMAGE)"


### PR DESCRIPTION
The buildenv image is used for several presubmit targets, which means that this image needed to be published before the change is approved/submitted. This is a bit of an anti-pattern, as the change should be reviewed/approved before the image is published. This change enables the presubmits to run on a new image version before it is published, so that the image can be published after submission.