### PR TITLE
fix: explicitly set makefile shell to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@
 
 REPO := kpt.dev/configsync
 
+# Some of our recipes use bash syntax, so explicitly set the shell to bash.
+SHELL := /bin/bash
+
 # List of dirs containing go code owned by Nomos
 NOMOS_CODE_DIRS := pkg cmd e2e
 NOMOS_GO_PKG := $(foreach dir,$(NOMOS_CODE_DIRS),./$(dir)/...)

--- a/Makefile.build
+++ b/Makefile.build
@@ -11,7 +11,7 @@ HELM := $(BIN_DIR)/helm
 # Builds the image if it does not exist to enable testing with a new image
 # version before publishing.
 pull-buildenv:
-	@docker image inspect $(BUILDENV_IMAGE) \
+	@docker image inspect $(BUILDENV_IMAGE) &> /dev/null \
 	|| docker pull $(BUILDENV_IMAGE) || $(MAKE) build-buildenv
 
 build-buildenv: build/buildenv/Dockerfile


### PR DESCRIPTION
Some of our make targets use bash syntax, which requires for the shell used by make to be bash. Make uses sh by default, so the shell should be set explicitly here. This was a gotcha before, because some systems replace sh with bash. Explicitly setting the shell should help avoid future gotchas.