### PR TITLE
Store last hydration error in-memory for rehydrate

### DIFF
--- a/pkg/hydrate/controller_test.go
+++ b/pkg/hydrate/controller_test.go
@@ -110,7 +110,7 @@ func TestRunHydrate(t *testing.T) {
 				t.Fatal(fmt.Errorf("failed to get commit and sync directory from the source directory %s: %v", commitDir, err))
 			}
 
-			err = hydrator.runHydrate(originCommit, syncDir.OSPath())
+			err = hydrator.runHydrate(originCommit, syncDir)
 			testutil.AssertEqual(t, tc.wantedErr, err)
 		})
 	}


### PR DESCRIPTION
This PR adds commit SHA and syncDir to the hydration error payload, so that the rehydrateOnError function can get them directly without invoking hydrate.SourceCommitAndSyncDir.