### PR TITLE
ci: fix junit test output parsing

### DIFF
--- a/build/test-e2e-go/e2e.sh
+++ b/build/test-e2e-go/e2e.sh
@@ -34,6 +34,11 @@ echo "Tests took $(( end_time - start_time )) seconds"
 # enables running this script more flexibly, e.g. without docker in docker.
 if [[ -n "${ARTIFACTS}" && -d "${ARTIFACTS}" ]]; then
   echo "Creating junit xml report"
+  # Go 1.20 started using "=== NAME" when tests resume instead of "=== CONT".
+  # go-junit-report does not yet properly parse "=== NAME", so this hack enables
+  # proper parsing.
+  # TODO: revert when fixed https://github.com/jstemmer/go-junit-report/issues/169
+  sed -i -e 's/=== NAME/=== CONT/g' test_results.txt
   cat test_results.txt | go-junit-report --subtest-mode=exclude-parents > "${ARTIFACTS}/junit_report.xml"
   if [ "$exit_code" -eq 0 ]; then
     junit-report reset-failure --path="${ARTIFACTS}/junit_report.xml"


### PR DESCRIPTION
After upgrading to Go 1.20 there was a breaking change in the test output, in which resuming tests print NAME instead of CONT.

https://go-review.git.corp.google.com/c/go/+/443596

The go-junit-report utility does not properly parse NAME, so this hack replaces the output to look how it did before. The upstream go-junit-report should be fixed to properly parse the new gotest output format.