### PR TITLE
fix: add otel-agent to override api

### DIFF
--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -346,7 +346,7 @@ spec:
                             deployment container for which log level will be overridden.
                             Must be one of the following: "reconciler", "git-sync",
                             "hydration-controller", "oci-sync", or "helm-sync".'
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
                           description: logLevel specifies the log level override value
@@ -383,7 +383,7 @@ spec:
                             whose resource requirements will be overridden. Must be
                             "reconciler", "git-sync", "hydration-controller", "oci-sync",
                             or "helm-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:
@@ -1389,7 +1389,7 @@ spec:
                             deployment container for which log level will be overridden.
                             Must be one of the following: "reconciler", "git-sync",
                             "hydration-controller", "oci-sync", or "helm-sync".'
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
                           description: logLevel specifies the log level override value
@@ -1426,7 +1426,7 @@ spec:
                             whose resource requirements will be overridden. Must be
                             "reconciler", "git-sync", "hydration-controller", "oci-sync",
                             or "helm-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -356,7 +356,7 @@ spec:
                             deployment container for which log level will be overridden.
                             Must be one of the following: "reconciler", "git-sync",
                             "hydration-controller", "oci-sync", or "helm-sync".'
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
                           description: logLevel specifies the log level override value
@@ -405,7 +405,7 @@ spec:
                             whose resource requirements will be overridden. Must be
                             "reconciler", "git-sync", "hydration-controller", "oci-sync",
                             or "helm-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:
@@ -1421,7 +1421,7 @@ spec:
                             deployment container for which log level will be overridden.
                             Must be one of the following: "reconciler", "git-sync",
                             "hydration-controller", "oci-sync", or "helm-sync".'
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
                           description: logLevel specifies the log level override value
@@ -1470,7 +1470,7 @@ spec:
                             whose resource requirements will be overridden. Must be
                             "reconciler", "git-sync", "hydration-controller", "oci-sync",
                             or "helm-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:

--- a/pkg/api/configsync/v1alpha1/resource_override.go
+++ b/pkg/api/configsync/v1alpha1/resource_override.go
@@ -103,7 +103,7 @@ type ContainerResourcesSpec struct {
 	// containerName specifies the name of a container whose resource requirements will be overridden.
 	// Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
 	//
-	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	// +optional
 	ContainerName string `json:"containerName,omitempty"`
 	// cpuRequest allows one to override the CPU request of a container
@@ -126,7 +126,7 @@ type ContainerLogLevelOverride struct {
 	// Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	ContainerName string `json:"containerName"`
 
 	// logLevel specifies the log level override value for the container.

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -103,7 +103,7 @@ type ContainerResourcesSpec struct {
 	// containerName specifies the name of a container whose resource requirements will be overridden.
 	// Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
 	//
-	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	// +optional
 	ContainerName string `json:"containerName,omitempty"`
 	// cpuRequest allows one to override the CPU request of a container
@@ -126,7 +126,7 @@ type ContainerLogLevelOverride struct {
 	// Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar)$
+	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	ContainerName string `json:"containerName"`
 
 	// logLevel specifies the log level override value for the container.


### PR DESCRIPTION
The support for otel-agent overrides has already been implemented in code, but was not allowed on the RSync api since it was not enumerated on the CRD.