### PR TITLE
fix: increase default memoryRequest for helm-sync

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -46,7 +46,7 @@ func ReconcilerContainerResourceDefaults() map[string]v1beta1.ContainerResources
 		reconcilermanager.HelmSync: {
 			ContainerName: reconcilermanager.HelmSync,
 			CPURequest:    resource.MustParse("50m"),
-			MemoryRequest: resource.MustParse("200Mi"),
+			MemoryRequest: resource.MustParse("256Mi"),
 		},
 		reconcilermanager.GitSync: {
 			ContainerName: reconcilermanager.GitSync,


### PR DESCRIPTION
The helm-sync container is failing regularly on autopilot due to OOMKill. Autopilot sets the limits equal to the requests, and the current value is too low for all of the e2e tests to pass. Standard allows bursting while autopilot does not. We may be able to revert this increase after an upcoming change which will allow separate defaults for standard and autopilot.