### PR TITLE
Migrate to git-sync v4

### DIFF
--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -87,7 +87,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: branch is the git branch to checkout. The field is
+                      deprecated. Use `revision` instead. If both `branch` and `revision`
+                      are defined, `revision` takes precedence over `branch`.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -144,8 +146,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit)
-                      to fetch. Default: "HEAD".'
+                    description: 'revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Default: "HEAD".'
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git
@@ -1130,7 +1132,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: branch is the git branch to checkout. The field is
+                      deprecated. Use `revision` instead. If both `branch` and `revision`
+                      are defined, `revision` takes precedence over `branch`.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -1186,8 +1190,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit)
-                      to fetch. Default: "HEAD".'
+                    description: 'revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Default: "HEAD".'
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -87,7 +87,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: branch is the git branch to checkout. The field is
+                      deprecated. Use `revision` instead. If both `branch` and `revision`
+                      are defined, `revision` takes precedence over `branch`.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -144,8 +146,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit)
-                      to fetch. Default: "HEAD".'
+                    description: 'revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Default: "HEAD".'
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git
@@ -1152,7 +1154,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: branch is the git branch to checkout. The field is
+                      deprecated. Use `revision` instead. If both `branch` and `revision`
+                      are defined, `revision` takes precedence over `branch`.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -1208,8 +1212,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit)
-                      to fetch. Default: "HEAD".'
+                    description: 'revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Default: "HEAD".'
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -101,8 +101,8 @@ data:
                - NET_RAW
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.2__linux_amd64
-           args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
+           image: gcr.io/config-management-release/git-sync:v4.0.0-gke.1__linux_amd64
+           args: ["--root=/repo/source", "--link=rev", "--max-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo
              mountPath: /repo

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -52,17 +52,13 @@ const (
 	// TODO: replace with retry-backoff strategy
 	DefaultHydrationRetryPeriod = 30 * time.Minute
 
-	// DefaultReconcilerPollingPeriodSeconds is time delay between polling the
-	// filesystem for source updates to sync, in seconds.
-	DefaultReconcilerPollingPeriodSeconds = 15
-
 	// DefaultHelmSyncVersionPollingPeriod is time delay between polling for
 	// helm chart version updates in helm-sync.
 	DefaultHelmSyncVersionPollingPeriod = 1 * time.Hour
 
 	// DefaultReconcilerPollingPeriod is the time delay between polling the
 	// filesystem for source updates to sync.
-	DefaultReconcilerPollingPeriod = DefaultReconcilerPollingPeriodSeconds * time.Second
+	DefaultReconcilerPollingPeriod = 15 * time.Second
 
 	// DefaultReconcilerResyncPeriod is the time delay between forced re-syncs
 	// from source (even without a new commit).

--- a/pkg/api/configsync/v1alpha1/getters.go
+++ b/pkg/api/configsync/v1alpha1/getters.go
@@ -14,19 +14,6 @@
 
 package v1alpha1
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"kpt.dev/configsync/pkg/api/configsync"
-)
-
-// GetPeriodSecs returns the sync period defaulting to 15 if empty.
-func GetPeriodSecs(g *Git) float64 {
-	if g.Period.Duration == 0 {
-		return configsync.DefaultReconcilerPollingPeriodSeconds
-	}
-	return g.Period.Duration.Seconds()
-}
-
 // SafeOverride creates an override or returns an existing one
 // use it if you need to ensure that you are assigning
 // to an object, but not to test for nil (current existence)
@@ -45,12 +32,4 @@ func (rs *RootSyncSpec) SafeOverride() *RootSyncOverrideSpec {
 		rs.Override = &RootSyncOverrideSpec{}
 	}
 	return rs.Override
-}
-
-// GetReconcileTimeout returns reconcile timeout in string, defaulting to 5m if empty
-func GetReconcileTimeout(d *metav1.Duration) string {
-	if d == nil || d.Duration == 0 {
-		return configsync.DefaultReconcileTimeout.String()
-	}
-	return d.Duration.String()
 }

--- a/pkg/api/configsync/v1alpha1/gitconfig.go
+++ b/pkg/api/configsync/v1alpha1/gitconfig.go
@@ -25,11 +25,13 @@ type Git struct {
 	// repo is the git repository URL to sync from. Required.
 	Repo string `json:"repo"`
 
-	// branch is the git branch to checkout. Default: "master".
+	// branch is the git branch to checkout.
+	// The field is deprecated. Use `revision` instead.
+	// If both `branch` and `revision` are defined, `revision` takes precedence over `branch`.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 
-	// revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".
+	// revision is the git revision (branch, tag, ref or commit) to fetch. Default: "HEAD".
 	// +optional
 	Revision string `json:"revision,omitempty"`
 

--- a/pkg/api/configsync/v1beta1/getters.go
+++ b/pkg/api/configsync/v1beta1/getters.go
@@ -15,17 +15,19 @@
 package v1beta1
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/client/restconfig"
 )
 
-// GetPeriodSecs returns the sync period defaulting to the provided defaultPeriod if empty.
-func GetPeriodSecs(period metav1.Duration, defaultPeriod float64) float64 {
+// GetPeriod returns the sync period defaulting to the provided defaultPeriod if empty.
+func GetPeriod(period metav1.Duration, defaultPeriod time.Duration) time.Duration {
 	if period.Duration == 0 {
 		return defaultPeriod
 	}
-	return period.Duration.Seconds()
+	return period.Duration
 }
 
 // GetSecretName will return an empty string if the secretRef.name is

--- a/pkg/api/configsync/v1beta1/gitconfig.go
+++ b/pkg/api/configsync/v1beta1/gitconfig.go
@@ -25,11 +25,13 @@ type Git struct {
 	// repo is the git repository URL to sync from. Required.
 	Repo string `json:"repo"`
 
-	// branch is the git branch to checkout. Default: "master".
+	// branch is the git branch to checkout.
+	// The field is deprecated. Use `revision` instead.
+	// If both `branch` and `revision` are defined, `revision` takes precedence over `branch`.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 
-	// revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".
+	// revision is the git revision (branch, tag, ref or commit) to fetch. Default: "HEAD".
 	// +optional
 	Revision string `json:"revision,omitempty"`
 

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -835,7 +835,7 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			branch:          rs.Spec.Git.Branch,
 			repo:            rs.Spec.Git.Repo,
 			secretType:      rs.Spec.Git.Auth,
-			period:          v1beta1.GetPeriodSecs(rs.Spec.Git.Period, configsync.DefaultReconcilerPollingPeriodSeconds),
+			period:          v1beta1.GetPeriod(rs.Spec.Git.Period, configsync.DefaultReconcilerPollingPeriod),
 			proxy:           rs.Spec.Proxy,
 			depth:           rs.Spec.SafeOverride().GitSyncDepth,
 			noSSLVerify:     rs.Spec.Git.NoSSLVerify,
@@ -845,7 +845,7 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
 		}
 	case v1beta1.OciSource:
-		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriodSecs(rs.Spec.Oci.Period, configsync.DefaultReconcilerPollingPeriodSeconds))
+		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriod(rs.Spec.Oci.Period, configsync.DefaultReconcilerPollingPeriod).Seconds())
 	case v1beta1.HelmSource:
 		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Namespace, "")
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -3667,7 +3667,7 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 			gitSyncKnownHosts: "false",
 			GitSyncRepo:       reposyncRepo,
 			GitSyncDepth:      "1",
-			gitSyncPeriod:     "15.000000",
+			gitSyncPeriod:     "15s",
 		},
 	}
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -683,7 +683,7 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			branch:          rs.Spec.Git.Branch,
 			repo:            rs.Spec.Git.Repo,
 			secretType:      rs.Spec.Git.Auth,
-			period:          v1beta1.GetPeriodSecs(rs.Spec.Git.Period, configsync.DefaultReconcilerPollingPeriodSeconds),
+			period:          v1beta1.GetPeriod(rs.Spec.Git.Period, configsync.DefaultReconcilerPollingPeriod),
 			proxy:           rs.Spec.Proxy,
 			depth:           rs.Spec.SafeOverride().GitSyncDepth,
 			noSSLVerify:     rs.Spec.Git.NoSSLVerify,
@@ -693,7 +693,7 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
 		}
 	case v1beta1.OciSource:
-		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriodSecs(rs.Spec.Oci.Period, configsync.DefaultReconcilerPollingPeriodSeconds))
+		result[reconcilermanager.OciSync] = ociSyncEnvs(rs.Spec.Oci.Image, rs.Spec.Oci.Auth, v1beta1.GetPeriod(rs.Spec.Oci.Period, configsync.DefaultReconcilerPollingPeriod).Seconds())
 	case v1beta1.HelmSource:
 		result[reconcilermanager.HelmSync] = helmSyncEnvs(&rs.Spec.Helm.HelmBase, rs.Spec.Helm.Namespace, rs.Spec.Helm.DeployNamespace)
 	}

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -3125,7 +3125,7 @@ func TestPopulateRootContainerEnvs(t *testing.T) {
 			gitSyncKnownHosts: "false",
 			GitSyncRepo:       rootsyncRepo,
 			GitSyncDepth:      "1",
-			gitSyncPeriod:     "15.000000",
+			gitSyncPeriod:     "15s",
 		},
 	}
 

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -273,7 +273,7 @@ func helmSyncEnvs(helmBase *v1beta1.HelmBase, releaseNamespace, deployNamespace 
 		Value: string(helmBase.Auth),
 	}, corev1.EnvVar{
 		Name:  reconcilermanager.HelmSyncWait,
-		Value: fmt.Sprintf("%f", v1beta1.GetPeriodSecs(helmBase.Period, configsync.DefaultHelmSyncVersionPollingPeriod.Seconds())),
+		Value: fmt.Sprintf("%f", v1beta1.GetPeriod(helmBase.Period, configsync.DefaultHelmSyncVersionPollingPeriod).Seconds()),
 	})
 	return result
 }


### PR DESCRIPTION
`git-sync` v4 has a bunch of improvement, such as efficiency, and closing the race condition where a symbolic name can change after `git ls-remote` but before `git fetch`. It also addresses the missing error file when `git clone` is slow.

Most of the env variables are backward compatible, but this commit updates the env variable names to avoid jamming the git-sync logs.