### PR TITLE
[CHERRY-PICK] fix: persist deployment fields during allowListing (#898)

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -293,13 +293,14 @@ func (r *reconcilerBase) createOrPatchDeployment(ctx context.Context, declared *
 
 // deleteDeploymentFields delete all the fields in allowlist from unstructured object and convert the unstructured object to Deployment object
 func deleteDeploymentFields(allowList []string, unstructuredDeployment *unstructured.Unstructured) (*appsv1.Deployment, error) {
+	deploymentDeepCopy := unstructuredDeployment.DeepCopy()
 	for _, path := range allowList {
-		if err := deleteFields(unstructuredDeployment.Object, path); err != nil {
+		if err := deleteFields(deploymentDeepCopy.Object, path); err != nil {
 			return nil, err
 		}
 	}
 	var resultDeployment appsv1.Deployment
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredDeployment.Object, &resultDeployment); err != nil {
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(deploymentDeepCopy.Object, &resultDeployment); err != nil {
 		return nil, fmt.Errorf("failed to convert from current reconciler unstructured object to deployment object: %w", err)
 	}
 	return &resultDeployment, nil


### PR DESCRIPTION
The deleteDeploymentFields function was mutating the passed in pointer when deleting the allowList fields. This caused the Deployment patch data to be missing any of the allowListed fields if set. The reconciler Deployment does not contain any of the allowListed fields by default, but these fields can be patched in the reconciler-manager-cm ConfigMap by users.

The allow-listed fields are intended to be ignored when comparing the declared to the actual object to allow drift, but we should still apply the Deployment as it is declared.