### PR TITLE
Tune retryCap used in unit test to fix flakiness

### DIFF
--- a/pkg/hydrate/controller_test.go
+++ b/pkg/hydrate/controller_test.go
@@ -59,8 +59,8 @@ func TestSourceCommitAndDirWithRetry(t *testing.T) {
 		},
 		{
 			name:                 "source root directory created within the retry cap",
-			retryCap:             10 * time.Millisecond,
-			srcRootCreateLatency: time.Millisecond,
+			retryCap:             20 * time.Millisecond,
+			srcRootCreateLatency: 5 * time.Millisecond,
 			expectedSourceCommit: commit,
 		},
 		{
@@ -71,7 +71,7 @@ func TestSourceCommitAndDirWithRetry(t *testing.T) {
 		},
 		{
 			name:                 "symlink created within the retry cap",
-			retryCap:             10 * time.Millisecond,
+			retryCap:             20 * time.Millisecond,
 			symlinkCreateLatency: 5 * time.Millisecond,
 			expectedSourceCommit: commit,
 		},
@@ -174,6 +174,7 @@ func TestSourceCommitAndDirWithRetry(t *testing.T) {
 				}
 			}()
 
+			t.Logf("start calling SourceCommitAndDirWithRetry at %v", time.Now())
 			srcCommit, srcSyncDir, err := SourceCommitAndDirWithRetry(backoff, v1beta1.GitSource, cmpath.Absolute(commitDir), cmpath.RelativeOS(tc.syncDir), "root-reconciler")
 			if tc.expectedErrMsg == "" {
 				assert.Nil(t, err, "got unexpected error %v", err)

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -60,6 +60,7 @@ func newParser(t *testing.T, fs FileSource, renderingEnabled bool) Parser {
 	parser.sourceFormat = filesystem.SourceFormatUnstructured
 	parser.opts = opts{
 		parser:             filesystem.NewParser(&reader.File{}),
+		statusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
 		syncName:           rootSyncName,
 		reconcilerName:     rootReconcilerName,
 		client:             syncerFake.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
@@ -191,8 +192,8 @@ func TestRun(t *testing.T) {
 		{
 			id:                   "1",
 			name:                 "source commit directory created within the retry cap",
-			retryCap:             110 * time.Millisecond,
-			srcRootCreateLatency: 100 * time.Millisecond,
+			retryCap:             20 * time.Millisecond,
+			srcRootCreateLatency: 5 * time.Millisecond,
 			needRetry:            false,
 			expectedMsg:          "Sync Completed",
 		},
@@ -282,7 +283,7 @@ func TestRun(t *testing.T) {
 			util.SourceRetryBackoff = wait.Backoff{
 				Duration: time.Millisecond,
 				Factor:   2,
-				Steps:    20,
+				Steps:    10,
 				Cap:      tc.retryCap,
 				Jitter:   0.1,
 			}

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -164,7 +164,7 @@ func TestReadHydratedDirWithRetry(t *testing.T) {
 		{
 			name:                 "symlink created within the retry cap",
 			commit:               originCommit,
-			retryCap:             10 * time.Millisecond,
+			retryCap:             20 * time.Millisecond,
 			symlinkCreateLatency: 5 * time.Millisecond,
 			expectedCommit:       originCommit,
 		},
@@ -281,6 +281,7 @@ func TestReadHydratedDirWithRetry(t *testing.T) {
 				syncDir: cmpath.Absolute(filepath.Join(parserCommitDir, syncDir)),
 			}
 
+			t.Logf("start calling readHydratedDirWithRetry at %v", time.Now())
 			hydrationState, hydrationErr := parser.readHydratedDirWithRetry(backoff,
 				cmpath.Absolute(hydratedRoot), parser.reconcilerName, *srcState)
 


### PR DESCRIPTION
Some unit tests failed intermittently because the test directory wasn't created in the retryCap. This commit increases the cap. It also makes the backoff step consistent.