### PR TITLE
Revert "fix: increase default cpuRequest for askpass"

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -55,7 +55,7 @@ func ReconcilerContainerResourceDefaults() map[string]v1beta1.ContainerResources
 		},
 		reconcilermanager.GCENodeAskpassSidecar: {
 			ContainerName: reconcilermanager.GCENodeAskpassSidecar,
-			CPURequest:    resource.MustParse("50m"),
+			CPURequest:    resource.MustParse("10m"),
 			MemoryRequest: resource.MustParse("20Mi"),
 		},
 		metrics.OtelAgentName: {


### PR DESCRIPTION
Reverts GoogleContainerTools/kpt-config-sync#892

These changes have been made for autopilot-only in https://github.com/GoogleContainerTools/kpt-config-sync/pull/872

Reverting the change for non-autopilot clusters which support boosting.