### PR TITLE
revert resource increases

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -46,7 +46,7 @@ func ReconcilerContainerResourceDefaults() map[string]v1beta1.ContainerResources
 		reconcilermanager.HelmSync: {
 			ContainerName: reconcilermanager.HelmSync,
 			CPURequest:    resource.MustParse("50m"),
-			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryRequest: resource.MustParse("200Mi"),
 		},
 		reconcilermanager.GitSync: {
 			ContainerName: reconcilermanager.GitSync,

--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -55,7 +55,7 @@ func ReconcilerContainerResourceDefaults() map[string]v1beta1.ContainerResources
 		},
 		reconcilermanager.GCENodeAskpassSidecar: {
 			ContainerName: reconcilermanager.GCENodeAskpassSidecar,
-			CPURequest:    resource.MustParse("50m"),
+			CPURequest:    resource.MustParse("10m"),
 			MemoryRequest: resource.MustParse("20Mi"),
 		},
 		metrics.OtelAgentName: {


### PR DESCRIPTION
Reason for revert: The problems solved by these commits have been fixed
by using autopilot-specific defaults