### PR TITLE
test: Fix the missing KUBECONFIG env variable

### DIFF
--- a/e2e/nomostest/testshell/shell.go
+++ b/e2e/nomostest/testshell/shell.go
@@ -118,7 +118,8 @@ func (tc *TestShell) Helm(args ...string) ([]byte, error) {
 // KUBECONFIG environment variable and debug logging.
 func (tc *TestShell) ExecWithDebug(name string, args ...string) ([]byte, error) {
 	tc.Logger.Debugf("%s %s", name, strings.Join(args, " "))
-	out, err := exec.Command(name, args...).CombinedOutput()
+	cmd := tc.Command(name, args...)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if !tc.Logger.IsDebugEnabled() {
 			tc.Logger.Infof("%s %s", name, strings.Join(args, " "))


### PR DESCRIPTION
The ExecWithDebug function is invoked to run `nomos status`, which requires the KUBECONFIG env variable to be set. Otherwise, `nomos status` will fail with no cluster info, for example, https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-rapid-latest-stress/1709417838403391488.