### PR TITLE
Update git-sync version for CVE fixes

### DIFF
--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -109,7 +109,7 @@ data:
                - NET_RAW
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.2__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.3__linux_amd64
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
This is not a cherrypick commit from the main branch because the git-sync version diverges from the main branch.