### PR TITLE
fix: remove policy-controller-psp from operator

### DIFF
--- a/manifests/operator/kustomization.yaml
+++ b/manifests/operator/kustomization.yaml
@@ -15,5 +15,4 @@
 resources:
 - ../base
 - ../hierarchyconfig-crd.yaml
-- ../policy-controller-psp.yaml
 - ../templates/admission-webhook.yaml


### PR DESCRIPTION
The policy-controller-psp was removed by a separate commit, but the inclusion in this kustomization file was overlooked.

The manifest was removed in https://github.com/GoogleContainerTools/kpt-config-sync/pull/909