### PR TITLE
test: Prevent autopilot scale-to-zero

### DIFF
--- a/e2e/testdata/autopilot-keepalive/deployment.yaml
+++ b/e2e/testdata/autopilot-keepalive/deployment.yaml
@@ -1,0 +1,43 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autopilot-keepalive
+  namespace: default
+  labels:
+    app: autopilot-keepalive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autopilot-keepalive
+  template:
+    metadata:
+      labels:
+        app: autopilot-keepalive
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.7
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 250m
+            memory: 256Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/oauth2 v0.6.0
 	google.golang.org/api v0.108.0
 	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.7
 	k8s.io/apiextensions-apiserver v0.26.7
@@ -141,7 +142,6 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.26.7 // indirect
 	k8s.io/component-base v0.26.7 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect


### PR DESCRIPTION
- Add a persistent Deployment on GKE Autopilot clusters to prevent scale-to-zero. This prevents metric-server from becoming unhealthy and breaking API discovery. b/209800496