### PR TITLE
ci: remove upx from CLI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-inf
 
 # Docker image used for build and test. This image does not support CGO.
 # When upgrading this tag, publish the image after the change is submitted.
-BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.2.14
+BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.2.15
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -72,7 +72,6 @@ RUN apt-get update \
   gcc \
   git \
   musl-dev \
-  upx \
   wget
 
 # Starting from go 1.10, build and test results are cached, which speeds up

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,10 +61,4 @@ for PLATFORM in "${PLATFORMS[@]}"; do
   if [[ "${GOOS}" == "windows" ]]; then
     bin="$bin.exe"
   fi
-  # Use upx to reduce binary size.
-  if [[ "${GOOS}" != "darwin" ]]; then
-    # upx doesn't play nice with Darwin 16 for Go Binaries.
-    # We don't care to debug this since the file size difference is ~20MB.
-    upx "${GOPATH}/bin/${PLATFORM}/${bin}"
-  fi
 done


### PR DESCRIPTION
The upx package was being used to compress the nomos binary as part of the build process. upx poses a few problems:
- Compressed binaries cannot be scanned for packages (SBOM)
- The upx package is not available on bookworm package manager