### PR TITLE
fix: use k8s yaml parser to unmarshal

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -41,6 +40,7 @@ import (
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // fileMode is the file mode to use for all operations.
@@ -392,7 +392,6 @@ func applyAutoPilotKeepAlive(nt *NT) error {
 	if err := yaml.Unmarshal(yamlBytes, uObj); err != nil {
 		return errors.Wrapf(err, "failed to decode %q as yaml", yamlPath)
 	}
-	uObj.SetGroupVersionKind(kinds.Deployment())
 	// Apply with nt.KubeClient.Client directly, not nt.KubeClient.Apply
 	// to avoid adding the test label, to avoid deletion during cleanup
 	nt.Logger.Infof("applying %s", yamlPath)

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	golang.org/x/oauth2 v0.6.0
 	google.golang.org/api v0.108.0
 	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.7
 	k8s.io/apiextensions-apiserver v0.26.7
@@ -142,6 +141,7 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.26.7 // indirect
 	k8s.io/component-base v0.26.7 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect


### PR DESCRIPTION
The keepalive deployment was not being parsed since it was using the wrong yaml parser. This changes the import to use the k8s parser.