### PR TITLE
Custom ClusterRole for RootSync reconcilers

### DIFF
--- a/docs/design-docs/01-explicit-only-namespace-strategy.md
+++ b/docs/design-docs/01-explicit-only-namespace-strategy.md
@@ -2,7 +2,7 @@
 
 * Author(s): @tomasaschan
 * Approver: @sdowell, @janetkuo
-* Status: provisional
+* Status: approved
 
 ## Summary
 

--- a/docs/design-docs/02-custom-root-reconciler-clusterrole.md
+++ b/docs/design-docs/02-custom-root-reconciler-clusterrole.md
@@ -41,18 +41,25 @@ on `spec.overrides` for a `RootSync`:
 ```yaml
 spec:
   overrides:
-    clusterRole: my-custom-role
+    clusterRole:
+      name: my-custom-role
 ```
 
 This role is defaulted to `cluster-admin` in order to stay backwards compatible.
 
 For the case where a single `ClusterRole` is not expressive enough to configure the
-permissions a user want, we also allow the special sentinel value `%none%`, which
-disables creating the `ClusterRoleBinding` entirely. The value is chosen so that it can
-never coincide with the name of an existing `ClusterRole`, since they [do not allow `%`
-signs in their names].
+permissions a user want, you can instead set `disabled: true` on the override object:
 
-[do not allow `%` signs in their names]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#path-segment-names
+```yaml
+spec:
+  overrides:
+    clusterRole:
+      disabled: true
+```
+This disables creating the `ClusterRoleBinding` entirely.
+
+If both `disabled: true` and a custom name is specified, `disabled` "wins" and no binding
+is created.
 
 ## User Guide
 
@@ -68,7 +75,8 @@ metadata:
   namespace: config-management-system
 spec:
   overrides:
-    clusterRole: my-cluster-role
+    clusterRole:
+      name: my-cluster-role
   # ...
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -79,7 +87,21 @@ rules:
 # ...
 ```
 
-You can also use the special value `%none%` and disable automatic binding to any role.
+You can also disable automatic binding to any role.
+
+```yaml
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  overrides:
+    clusterRole:
+      name: my-cluster-role
+  # ...
+```
+
 The reconciler will then run with effectively no permissions, until you manually create
 some role or cluster role bindings for it.
 

--- a/docs/design-docs/02-custom-root-reconciler-clusterrole.md
+++ b/docs/design-docs/02-custom-root-reconciler-clusterrole.md
@@ -98,7 +98,7 @@ metadata:
 spec:
   overrides:
     clusterRole:
-      name: my-cluster-role
+      disabled: true
   # ...
 ```
 

--- a/docs/design-docs/02-custom-root-reconciler-clusterrole.md
+++ b/docs/design-docs/02-custom-root-reconciler-clusterrole.md
@@ -1,0 +1,111 @@
+# Custom `ClusterRole` assignments for `RootSync`s
+
+* Author(s): @tomasaschan
+* Approver: @sdowell, @janetkuo
+* Status: approved
+
+## Summary
+
+When creating a reconciler deployment for a `RootSync`, Config Sync currently [creates a
+`ClusterRoleBinding`] for the generated `ServiceAccount` granting it `cluster-admin`.
+
+This proposal introduces a mechanism to customize this behavior.
+
+[creates a `ClusterRoleBinding`]: https://github.com/GoogleContainerTools/kpt-config-sync/blob/199db6dbfa0b9eb1824925c8c687574de095a294/pkg/reconcilermanager/controllers/rootsync_controller.go#L789
+
+## Motivation
+
+If one wants to allow deploying resources from a source where one doesn't have full
+control of the contents of the upstream config source, and want to limit what another
+team or third party can accomplish in the cluster, one can imagine limiting what
+permissions are granted to the `ServiceAccount` running the reconciler.
+
+However, as Config Sync is currently granting `cluster-admin`, any custom role bindings
+are effectively ignored; the reconciler will, due to the binding added by Config Sync,
+have access to do _anything_ regardless.
+
+To follow the [principle of least privilege], one should ensure the reconciler only has
+access to deploy the expected resources.
+
+See also [#935].
+
+[principle of least privilege]: https://en.wikipedia.org/wiki/Principle_of_least_privilege
+[#935]: https://github.com/GoogleContainerTools/kpt-config-sync/issues/935
+
+## Design Overview
+
+By providing the name of a user-defined `ClusterRole` for a `RootSync`, a user can
+override which role Config Sync binds to. This configuration is exposed as a new field
+on `spec.overrides` for a `RootSync`:
+
+```yaml
+spec:
+  overrides:
+    clusterRole: my-custom-role
+```
+
+This role is defaulted to `cluster-admin` in order to stay backwards compatible.
+
+For the case where a single `ClusterRole` is not expressive enough to configure the
+permissions a user want, we also allow the special sentinel value `%none%`, which
+disables creating the `ClusterRoleBinding` entirely. The value is chosen so that it can
+never coincide with the name of an existing `ClusterRole`, since they [do not allow `%`
+signs in their names].
+
+[do not allow `%` signs in their names]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#path-segment-names
+
+## User Guide
+
+To take advantage of this new feature, set `spec.overrides.clusterRole` to the name of a
+`ClusterRole` you wish this `RootSync` to be reconciled under; you must create this role
+yourself, but Config Sync will create the `ClusterRoleBinding` for you.
+
+```yaml
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  overrides:
+    clusterRole: my-cluster-role
+  # ...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-cluster-role
+rules:
+# ...
+```
+
+You can also use the special value `%none%` and disable automatic binding to any role.
+The reconciler will then run with effectively no permissions, until you manually create
+some role or cluster role bindings for it.
+
+**Note** that while the name of the relevant service account will _often_ be predictable
+as `root-reconciler-<root-reconciler-name>`, this is not guaranteed by Config Sync. You
+can always find the service account by its labels; in particular, the labels
+`configsync.gke.io/sync-kind` and `configsync.gke.io/sync-name` should be useful.
+
+## Risks and Mitigations
+
+This feature is entirely backwards-compatible, by means of being opt-in.
+
+## Test Plan
+
+Implementation of this feature can includes automated tests that verify the behavior.
+
+## Open Issues/Questions
+
+N/A
+
+## Alternatives Considered
+
+One could imagine exposing settings with slightly different semantics - e.g. a simple
+boolean for turning the `ClusterRoleBinding` off, or a setting to change what service
+account the reconciler is running with. However, these both put a bigger burden on the
+user in order to utilize them even for the simple use cases, which is why changing which
+role to bind to is probably the most user-friendly knob to expose. With the inclusion of
+a sentinel value to create no binding, the first of these alternatives is effectively
+supported, if through a slightly worse API. 

--- a/docs/design-docs/02-custom-root-reconciler-clusterrole.md
+++ b/docs/design-docs/02-custom-root-reconciler-clusterrole.md
@@ -129,5 +129,5 @@ boolean for turning the `ClusterRoleBinding` off, or a setting to change what se
 account the reconciler is running with. However, these both put a bigger burden on the
 user in order to utilize them even for the simple use cases, which is why changing which
 role to bind to is probably the most user-friendly knob to expose. With the inclusion of
-a sentinel value to create no binding, the first of these alternatives is effectively
-supported, if through a slightly worse API. 
+a switch to turn off creating the binding entirely, the first of these alternatives is effectively
+supported as well, and the API supports extending for other use cases in the future. 

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -208,7 +208,7 @@ func validateRootSyncDependencies(nt *nomostest.NT, rsName string) []client.Obje
 	// only happens when upgrading from a very old unsupported version.
 
 	rootSyncCRB := &rbacv1.ClusterRoleBinding{}
-	setNN(rootSyncCRB, client.ObjectKey{Name: controllers.RootSyncPermissionsName()})
+	setNN(rootSyncCRB, client.ObjectKey{Name: controllers.RootSyncPermissionsName(rootSyncReconciler.Name)})
 	rootSyncDependencies = append(rootSyncDependencies, rootSyncCRB)
 
 	rootSyncSA := &corev1.ServiceAccount{}

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -70,7 +70,7 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 		saName := core.RootReconcilerName(rs.Name)
 		errs = multierr.Append(errs, nt.ValidateNotFound(saName, v1.NSConfigManagementSystem, fake.ServiceAccountObject(saName)))
 		// validate Root Reconciler ClusterRoleBinding is no longer present.
-		errs = multierr.Append(errs, nt.ValidateNotFound(controllers.RootSyncPermissionsName(), v1.NSConfigManagementSystem, fake.ClusterRoleBindingObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound(controllers.RootSyncPermissionsName(nomostest.DefaultRootReconcilerName), v1.NSConfigManagementSystem, fake.ClusterRoleBindingObject()))
 		return errs
 	})
 	if err != nil {

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1397,13 +1397,20 @@ spec:
                       apiServerTimeout range is from "3s" to "1m".'
                     type: string
                   clusterRole:
-                    description: "ClusterRole controls which role to bind the service
-                      account for this RootSync's reconciler to. Defaults to 'cluster-admin'.
-                      \n The specified ClusterRole needs to be created manually. \n
-                      You can use the special sentinel value '%none%' to disable binding
-                      to a ClusterRole entirely; it is then your responsibility to
-                      bind any roles to the relevant service account."
-                    type: string
+                    description: clusterRole controls which role to bind the service
+                      account for this RootSync's reconciler to.
+                    properties:
+                      disabled:
+                        description: "disabled turns off binding to a ClusterRole
+                          entirely. \n It is then your responsibility to bind any
+                          roles to the relevant service account."
+                        type: boolean
+                      name:
+                        description: "name is the name of the ClusterRole to bind
+                          to; defaults to \"cluster-admin\". \n If you specify a different
+                          name, the ClusterRole needs to be created manually."
+                        type: string
+                    type: object
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1396,6 +1396,14 @@ spec:
                       about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended
                       apiServerTimeout range is from "3s" to "1m".'
                     type: string
+                  clusterRole:
+                    description: "ClusterRole controls which role to bind the service
+                      account for this RootSync's reconciler to. Defaults to 'cluster-admin'.
+                      \n The specified ClusterRole needs to be created manually. \n
+                      You can use the special sentinel value '%none%' to disable binding
+                      to a ClusterRole entirely; it is then your responsibility to
+                      bind any roles to the relevant service account."
+                    type: string
                   enableShellInRendering:
                     description: 'enableShellInRendering specifies whether to enable
                       or disable the shell access in rendering process. Default: false.

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -92,6 +92,18 @@ type RootSyncOverrideSpec struct {
 	// +kubebuilder:validation:Enum=implicit;explicit
 	// +optional
 	NamespaceStrategy configsync.NamespaceStrategy `json:"namespaceStrategy,omitempty"`
+
+	// ClusterRole controls which role to bind the service account for this RootSync's
+	// reconciler to. Defaults to 'cluster-admin'.
+	//
+	// The specified ClusterRole needs to be created manually.
+	//
+	// You can use the special sentinel value '%none%' to disable binding to a ClusterRole
+	// entirely; it is then your responsibility to bind any roles to the relevant service
+	// account.
+	//
+	// +optional
+	ClusterRole string `json:"clusterRole,omitempty"`
 }
 
 // RepoSyncOverrideSpec allows to override the settings for a RepoSync reconciler pod

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -93,17 +93,29 @@ type RootSyncOverrideSpec struct {
 	// +optional
 	NamespaceStrategy configsync.NamespaceStrategy `json:"namespaceStrategy,omitempty"`
 
-	// ClusterRole controls which role to bind the service account for this RootSync's
-	// reconciler to. Defaults to 'cluster-admin'.
+	// clusterRole controls which role to bind the service account for this RootSync's
+	// reconciler to.
 	//
-	// The specified ClusterRole needs to be created manually.
+	// +optional
+	ClusterRole ClusterRoleOverrideSpec `json:"clusterRole,omitempty"`
+}
+
+// ClusterRoleOverrideSpec allows to override settings for the root reconciler permissions
+type ClusterRoleOverrideSpec struct {
+	// name is the name of the ClusterRole to bind to; defaults to "cluster-admin".
 	//
-	// You can use the special sentinel value '%none%' to disable binding to a ClusterRole
-	// entirely; it is then your responsibility to bind any roles to the relevant service
+	// If you specify a different name, the ClusterRole needs to be created manually.
+	//
+	// +optional
+	Name string `json:"name,omitempty"`
+
+	// disabled turns off binding to a ClusterRole entirely.
+	//
+	// It is then your responsibility to bind any roles to the relevant service
 	// account.
 	//
 	// +optional
-	ClusterRole string `json:"clusterRole,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // RepoSyncOverrideSpec allows to override the settings for a RepoSync reconciler pod

--- a/pkg/core/names.go
+++ b/pkg/core/names.go
@@ -27,11 +27,8 @@ const (
 	NsReconcilerPrefix = "ns-reconciler"
 	// RootReconcilerPrefix is the prefix usef for all Root reconcilers.
 	RootReconcilerPrefix = "root-reconciler"
-)
-
-var (
 	// RootSyncPermissionsPrefix is the prefix used for all ClusterRoleBindings granting access to Root Reconcilers
-	RootSyncPermissionsPrefix = fmt.Sprintf("%s:%s", configsync.RootSyncKind, RootReconcilerPrefix)
+	RootSyncPermissionsPrefix = configsync.RootSyncKind + ":" + RootReconcilerPrefix
 )
 
 // RootReconcilerName returns the root reconciler's name in the format root-reconciler-<name>.

--- a/pkg/core/names.go
+++ b/pkg/core/names.go
@@ -29,6 +29,11 @@ const (
 	RootReconcilerPrefix = "root-reconciler"
 )
 
+var (
+	// RootSyncPermissionsPrefix is the prefix used for all ClusterRoleBindings granting access to Root Reconcilers
+	RootSyncPermissionsPrefix = fmt.Sprintf("%s:%s", configsync.RootSyncKind, RootReconcilerPrefix)
+)
+
 // RootReconcilerName returns the root reconciler's name in the format root-reconciler-<name>.
 // If the RootSync name is "root-sync", it returns "root-reconciler" for backward compatibility.
 func RootReconcilerName(name string) string {

--- a/pkg/core/names.go
+++ b/pkg/core/names.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 
 	"kpt.dev/configsync/pkg/api/configsync"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +36,17 @@ func RootReconcilerName(name string) string {
 		return RootReconcilerPrefix
 	}
 	return fmt.Sprintf("%s-%s", RootReconcilerPrefix, name)
+}
+
+// RootSyncName returns the RootSync's name given the name of its reconciler.
+// It is the inverse of RootReconcilerName
+func RootSyncName(reconcilerName string) string {
+	if reconcilerName == RootReconcilerPrefix {
+		return configsync.RootSyncName
+	}
+
+	syncName, _ := strings.CutPrefix(reconcilerName, fmt.Sprintf("%s-", RootReconcilerPrefix))
+	return syncName
 }
 
 // NsReconcilerName returns the namespace reconciler's name in the format:

--- a/pkg/reconcilermanager/controllers/build_names.go
+++ b/pkg/reconcilermanager/controllers/build_names.go
@@ -35,8 +35,5 @@ func RepoSyncPermissionsName() string {
 // RootSyncPermissionsName returns root reconciler ClusterRoleBinding name.
 // e.g. configsync.gke.io:root-reconciler:my-root-sync
 func RootSyncPermissionsName(reconcilerName string) string {
-	if reconcilerName == core.RootReconcilerPrefix {
-		return fmt.Sprintf("%s:%s", configsync.GroupName, core.RootReconcilerPrefix)
-	}
-	return fmt.Sprintf("%s:%s:%s", configsync.GroupName, core.RootReconcilerPrefix, core.RootSyncName(reconcilerName))
+	return fmt.Sprintf("%s:%s", core.RootSyncPermissionsPrefix, core.RootSyncName(reconcilerName))
 }

--- a/pkg/reconcilermanager/controllers/build_names.go
+++ b/pkg/reconcilermanager/controllers/build_names.go
@@ -32,8 +32,11 @@ func RepoSyncPermissionsName() string {
 	return fmt.Sprintf("%s:%s", configsync.GroupName, core.NsReconcilerPrefix)
 }
 
-// RootSyncPermissionsName returns root reconciler permissions name.
-// e.g. configsync.gke.io:root-reconciler
-func RootSyncPermissionsName() string {
-	return fmt.Sprintf("%s:%s", configsync.GroupName, core.RootReconcilerPrefix)
+// RootSyncPermissionsName returns root reconciler ClusterRoleBinding name.
+// e.g. configsync.gke.io:root-reconciler:my-root-sync
+func RootSyncPermissionsName(reconcilerName string) string {
+	if reconcilerName == core.RootReconcilerPrefix {
+		return fmt.Sprintf("%s:%s", configsync.GroupName, core.RootReconcilerPrefix)
+	}
+	return fmt.Sprintf("%s:%s:%s", configsync.GroupName, core.RootReconcilerPrefix, core.RootSyncName(reconcilerName))
 }

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -233,7 +233,7 @@ func (r *reconcilerBase) deleteDeployment(ctx context.Context, reconcilerRef typ
 }
 
 func (r *RootSyncReconciler) deleteClusterRoleBinding(ctx context.Context, reconcilerRef types.NamespacedName) error {
-	crbKey := client.ObjectKey{Name: RootSyncPermissionsName()}
+	crbKey := client.ObjectKey{Name: RootSyncPermissionsName(reconcilerRef.Name)}
 	// Update the CRB to delete the subject for the deleted RootSync's reconciler
 	crb := &rbacv1.ClusterRoleBinding{}
 	if err := r.client.Get(ctx, crbKey, crb); err != nil {

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -557,7 +557,7 @@ func (r *RootSyncReconciler) mapObjectToRootSync(obj client.Object) []reconcile.
 	// Ignore changes from resources without the root-reconciler prefix or configsync.gke.io:root-reconciler
 	// because all the generated resources have the prefix.
 	if !strings.HasPrefix(objRef.Name, core.RootReconcilerPrefix) &&
-		!strings.HasPrefix(objRef.Name, fmt.Sprintf("%s:%s", configsync.GroupName, core.RootReconcilerPrefix)) {
+		!strings.HasPrefix(objRef.Name, RootSyncPermissionsName(core.RootReconcilerPrefix)) {
 		return nil
 	}
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -810,7 +810,7 @@ func (r *RootSyncReconciler) upsertClusterRoleBinding(ctx context.Context, recon
 	op, err := CreateOrUpdate(ctx, r.client, childCRB, func() error {
 		childCRB.OwnerReferences = nil
 		childCRB.RoleRef = rolereference(clusterRole, "ClusterRole")
-		childCRB.Subjects = addSubject(childCRB.Subjects, r.serviceAccountSubject(reconcilerRef))
+		childCRB.Subjects = []rbacv1.Subject{r.serviceAccountSubject(reconcilerRef)}
 		// Remove existing OwnerReferences, now that we're using finalizers.
 		childCRB.OwnerReferences = nil
 		return nil

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -544,8 +544,8 @@ func (r *RootSyncReconciler) mapObjectToRootSync(obj client.Object) []reconcile.
 
 	// Ignore changes from resources without the root-reconciler prefix or configsync.gke.io:root-reconciler
 	// because all the generated resources have the prefix.
-	roleBindingName := RootSyncPermissionsName()
-	if !strings.HasPrefix(objRef.Name, core.RootReconcilerPrefix) && objRef.Name != roleBindingName {
+	if !strings.HasPrefix(objRef.Name, core.RootReconcilerPrefix) &&
+		!strings.HasPrefix(objRef.Name, fmt.Sprintf("%s:%s", configsync.GroupName, core.RootReconcilerPrefix)) {
 		return nil
 	}
 
@@ -571,7 +571,7 @@ func (r *RootSyncReconciler) mapObjectToRootSync(obj client.Object) []reconcile.
 		reconcilerName := core.RootReconcilerName(rs.GetName())
 		switch obj.(type) {
 		case *rbacv1.ClusterRoleBinding:
-			if objRef.Name == roleBindingName {
+			if objRef.Name == RootSyncPermissionsName(reconcilerName) {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: client.ObjectKeyFromObject(&rs)})
 				attachedRSNames = append(attachedRSNames, rs.GetName())
@@ -780,7 +780,7 @@ func (r *RootSyncReconciler) validateRootSecret(ctx context.Context, rootSync *v
 }
 
 func (r *RootSyncReconciler) upsertClusterRoleBinding(ctx context.Context, reconcilerRef types.NamespacedName) (client.ObjectKey, error) {
-	crbRef := client.ObjectKey{Name: RootSyncPermissionsName()}
+	crbRef := client.ObjectKey{Name: RootSyncPermissionsName(reconcilerRef.Name)}
 	childCRB := &rbacv1.ClusterRoleBinding{}
 	childCRB.Name = crbRef.Name
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
@@ -406,9 +406,9 @@ func TestRootSyncReconcilerServiceAccountDriftProtection(t *testing.T) {
 // reverted if changed by another client.
 func TestRootSyncReconcilerClusterRoleBindingDriftProtection(t *testing.T) {
 	exampleObj := &rbacv1.ClusterRoleBinding{}
-	objKeyFunc := func(_ client.ObjectKey) client.ObjectKey {
+	objKeyFunc := func(rsKey client.ObjectKey) client.ObjectKey {
 		// reconciler-manager managed cluster role binding
-		return client.ObjectKey{Name: RootSyncPermissionsName()}
+		return client.ObjectKey{Name: RootSyncPermissionsName(core.RootReconcilerName(rsKey.Name))}
 	}
 	var oldObj *rbacv1.ClusterRoleBinding
 	var oldValue string

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1748,11 +1748,12 @@ func TestMultipleRootSyncs(t *testing.T) {
 	)
 	wantServiceAccounts := map[core.ID]*corev1.ServiceAccount{core.IDOf(serviceAccount1): serviceAccount1}
 
-	crb := clusterrolebinding(
-		RootSyncPermissionsName(),
+	crb1 := clusterrolebinding(
+		RootSyncPermissionsName(rootReconcilerName),
+		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
-	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName)
+	crb1.Subjects = addSubjectByName(nil, rootReconcilerName)
 	rootContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, rootReconcilerName)
 	resourceOverrides := setContainerResourceDefaults(nil, ReconcilerContainerResourceDefaults())
 	rootDeployment1 := rootSyncDeployment(rootReconcilerName,
@@ -1767,7 +1768,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	if err := validateServiceAccounts(wantServiceAccounts, fakeClient); err != nil {
 		t.Error(err)
 	}
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateClusterRoleBinding(crb1, fakeClient); err != nil {
 		t.Error(err)
 	}
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
@@ -1824,10 +1825,13 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName2)
-	crb.ResourceVersion = "2"
-	crb.Generation = 2
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	crb2 := clusterrolebinding(
+		RootSyncPermissionsName(rootReconcilerName2),
+		"cluster-admin",
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+	)
+	crb2.Subjects = addSubjectByName(nil, rootReconcilerName2)
+	if err := validateClusterRoleBinding(crb2, fakeClient); err != nil {
 		t.Error(err)
 	}
 	if t.Failed() {
@@ -1882,10 +1886,13 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName3)
-	crb.ResourceVersion = "3"
-	crb.Generation = 3
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	crb3 := clusterrolebinding(
+		RootSyncPermissionsName(rootReconcilerName3),
+		"cluster-admin",
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+	)
+	crb3.Subjects = addSubjectByName(nil, rootReconcilerName2)
+	if err := validateClusterRoleBinding(crb3, fakeClient); err != nil {
 		t.Error(err)
 	}
 	if t.Failed() {
@@ -1943,10 +1950,13 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName4)
-	crb.ResourceVersion = "4"
-	crb.Generation = 4
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	crb4 := clusterrolebinding(
+		RootSyncPermissionsName(rootReconcilerName4),
+		"cluster-admin",
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+	)
+	crb4.Subjects = addSubjectByName(nil, rootReconcilerName2)
+	if err := validateClusterRoleBinding(crb4, fakeClient); err != nil {
 		t.Error(err)
 	}
 	if t.Failed() {
@@ -2005,10 +2015,13 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName5)
-	crb.ResourceVersion = "5"
-	crb.Generation = 5
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	crb5 := clusterrolebinding(
+		RootSyncPermissionsName(rootReconcilerName5),
+		"cluster-admin",
+		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+	)
+	crb5.Subjects = addSubjectByName(nil, rootReconcilerName2)
+	if err := validateClusterRoleBinding(crb5, fakeClient); err != nil {
 		t.Error(err)
 	}
 	if t.Failed() {
@@ -2030,7 +2043,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// No changes to the CRB
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateClusterRoleBinding(crb1, fakeClient); err != nil {
 		t.Error(err)
 	}
 
@@ -2068,7 +2081,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// No changes to the CRB
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateClusterRoleBinding(crb2, fakeClient); err != nil {
 		t.Error(err)
 	}
 
@@ -2107,7 +2120,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 
 	// No changes to the CRB
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateClusterRoleBinding(crb3, fakeClient); err != nil {
 		t.Error(err)
 	}
 
@@ -2145,11 +2158,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Subject for rs1 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName)
-	crb.ResourceVersion = "6"
-	crb.Generation = 6
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateResourceDeleted(core.IDOf(crb1), fakeClient); err != nil {
 		t.Error(err)
 	}
 	validateRootGeneratedResourcesDeleted(t, fakeClient, rootReconcilerName)
@@ -2170,11 +2179,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Subject for rs2 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName2)
-	crb.ResourceVersion = "7"
-	crb.Generation = 7
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateResourceDeleted(core.IDOf(crb2), fakeClient); err != nil {
 		t.Error(err)
 	}
 	validateRootGeneratedResourcesDeleted(t, fakeClient, rootReconcilerName2)
@@ -2195,11 +2200,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Subject for rs3 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName3)
-	crb.ResourceVersion = "8"
-	crb.Generation = 8
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateResourceDeleted(core.IDOf(crb3), fakeClient); err != nil {
 		t.Error(err)
 	}
 	validateRootGeneratedResourcesDeleted(t, fakeClient, rootReconcilerName3)
@@ -2220,11 +2221,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Subject for rs4 is removed from ClusterRoleBinding.Subjects
-	crb.Subjects = deleteSubjectByName(crb.Subjects, rootReconcilerName4)
-	crb.ResourceVersion = "9"
-	crb.Generation = 9
-	if err := validateClusterRoleBinding(crb, fakeClient); err != nil {
+	if err := validateResourceDeleted(core.IDOf(crb4), fakeClient); err != nil {
 		t.Error(err)
 	}
 	validateRootGeneratedResourcesDeleted(t, fakeClient, rootReconcilerName4)
@@ -2245,8 +2242,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Verify the ClusterRoleBinding of the root-reconciler is deleted
-	if err := validateResourceDeleted(core.IDOf(crb), fakeClient); err != nil {
+	if err := validateResourceDeleted(core.IDOf(crb5), fakeClient); err != nil {
 		t.Error(err)
 	}
 	validateRootGeneratedResourcesDeleted(t, fakeClient, rootReconcilerName5)

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -229,7 +229,7 @@ func rootsyncOverrideAPIServerTimeout(apiServerTimout metav1.Duration) func(*v1b
 
 func rootsyncOverrideClusterRole(clusterRole string) func(*v1beta1.RootSync) {
 	return func(rs *v1beta1.RootSync) {
-		rs.Spec.SafeOverride().ClusterRole = clusterRole
+		rs.Spec.SafeOverride().ClusterRole.Name = clusterRole
 	}
 }
 
@@ -1544,7 +1544,7 @@ func TestRootSyncCreateWithOverrideClusterRole(t *testing.T) {
 		t.Fatalf("Failed to get RootSync: %q", err)
 	}
 
-	rs.Spec.SafeOverride().ClusterRole = ""
+	rs.Spec.SafeOverride().ClusterRole.Name = ""
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("Failed to update RootSync: %q", err)
 	}
@@ -1568,7 +1568,7 @@ func TestRootSyncCreateWithOverrideClusterRole(t *testing.T) {
 		t.Fatalf("Failed to get RootSync: %q", err)
 	}
 
-	rs.Spec.SafeOverride().ClusterRole = "%none%"
+	rs.Spec.SafeOverride().ClusterRole.Disabled = true
 	if err := fakeClient.Update(ctx, rs); err != nil {
 		t.Fatalf("Failed to update RootSync: %q", err)
 	}


### PR DESCRIPTION
Closes #935.

This introduces a new override for `RootSync`s, which allows customization of which `ClusterRole` to bind the reconciler's service account to. The default is `cluster-admin`, which is the same as what was done before this change. For more details, see the included design document.