### PR TITLE
[WIP] fix: Allow finalizers to be set from source

### DIFF
--- a/pkg/syncer/reconcile/as_unstructured.go
+++ b/pkg/syncer/reconcile/as_unstructured.go
@@ -35,7 +35,6 @@ func AsUnstructured(o client.Object) (*unstructured.Unstructured, status.Error) 
 // AsUnstructuredSanitized converts o to an Unstructured and removes problematic
 // fields:
 // - metadata.creationTimestamp
-// - metadata.finalizers
 // - status
 //
 // These fields must not be set in the source, so we can safely drop them from
@@ -56,7 +55,6 @@ func AsUnstructuredSanitized(o client.Object) (*unstructured.Unstructured, statu
 	}
 
 	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(u.Object, "metadata", "finalizers")
 	unstructured.RemoveNestedField(u.Object, "status")
 	return u, nil
 }


### PR DESCRIPTION
Finalizers generally should NOT be set from source, because it will cause Config Sync to error when the finalizer is removed by a controller durring deletion: "no new finalizers can be added if the object is being deleted". BUT some users may want to manually manage finalizers simply to stop deletion of an object until manually removed.

NOTE: I'm not actually sure if this is safe or not. I explicitly removed this capability in https://github.com/GoogleContainerTools/kpt-config-sync/pull/242/files#diff-1f337ad11272c3e7579c8c68abebd2e872b60d378cb62634a1192d9599d46f7aR75 but I don't rembember why exactly. It's possible this will cause test failures when using composition. It might also have broken the kubevirt test, which has a lot of complex finalizer behaviors (e.g. to delete the VM when the VM object is deleted, which depended on some RBAC still existing, requiring deletion ordering).