### PR TITLE
ci: add crane binary to e2e environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ HELM_VERSION := v3.13.1-gke.0
 # Keep KIND_VERSION in sync with the version defined in go.mod
 # When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
 KIND_VERSION := v0.20.0
+# crane cli version used for publishing OCI images
+# used by tests or local make targets
+CRANE_VERSION := v0.16.1
 
 # Directory used for staging Docker contexts.
 STAGING_DIR := $(OUTPUT_DIR)/staging
@@ -345,6 +348,16 @@ install-kustomize: "$(BIN_DIR)/kustomize"
 
 .PHONY: install-kind
 install-kind: "$(BIN_DIR)/kind"
+
+"$(GOBIN)/crane":
+	go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)
+
+"$(BIN_DIR)/crane": "$(GOBIN)/crane" buildenv-dirs
+	cp $(GOBIN)/crane $(BIN_DIR)/crane
+
+.PHONY: install-crane
+# install crane binary to publish OCI images
+install-crane: "$(BIN_DIR)/crane"
 
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -40,7 +40,7 @@ test-e2e: config-sync-manifest-local __install-nomos-local test-e2e-nobuild
 # Run the Go e2e tests without building images/manifests.
 # Useful for modifying test code and rerunning tests without rebuilding images.
 .PHONY: test-e2e-go-nobuild
-test-e2e-nobuild: install-kustomize install-helm
+test-e2e-nobuild: install-kustomize install-helm install-crane
 	./scripts/e2e.sh $(E2E_ARGS)
 
 # Run the Go e2e tests on GKE without building images/manifests.
@@ -62,7 +62,7 @@ test-e2e-gke: config-sync-manifest test-e2e-gke-nobuild
 KIND_IMAGE := "kind-image"
 
 .PHONY: build-kind-e2e
-build-kind-e2e: install-kind install-kustomize install-helm
+build-kind-e2e: install-kind install-kustomize install-helm install-crane
 	@echo "+++ Building $(KIND_IMAGE)"
 	docker buildx build . \
 		--target kind-e2e \

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -41,11 +41,6 @@ push-gke-e2e:
 # Helpers
 ###################################
 
-.PHONY: install-crane
-# install crane binary to publish the image
-install-crane:
-	go install github.com/google/go-containerregistry/cmd/crane@latest
-
 .PHONY: clean-helm
 # remove any existing helm directory/binary. The install-helm target was previously
 # creating a directory at this path rather than the binary/file.


### PR DESCRIPTION
This change adds the crane binary to the execution environments for e2e tests. The crane binary is intended to be used by the test framework to push OCI images during test execution.