### PR TITLE
Override the resource requests for helm-sync to address the flakiness of TestPublicHelm

### DIFF
--- a/e2e/testdata/root-sync-helm-chart-cr.yaml
+++ b/e2e/testdata/root-sync-helm-chart-cr.yaml
@@ -18,6 +18,13 @@ metadata:
   name: root-sync
   namespace: config-management-system
 spec:
+  # This is to fix the test flakiness on the v1.16 branch.
+  # The main branch does not have the flakiness.
+  override:
+    resources:
+    - containerName: helm-sync
+      cpuRequest: "200m"
+      memoryRequest: "600Mi"
   sourceFormat: unstructured
   sourceType: helm
   helm:


### PR DESCRIPTION

The override setting is borrowed from
https://github.com/GoogleContainerTools/kpt-config-sync/pull/665/files#diff-d79a2bfd62bc74a4236bb679fd53f68e6e7618a1e04fb3b7788add5e36a64243.

 This is to fix the test flakiness on the v1.16 branch.  The main branch  does not have the flakiness.