### PR TITLE
chore: bump git-sync for security fixes

### DIFF
--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -109,7 +109,7 @@ data:
                - NET_RAW
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.3__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.4__linux_amd64
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
note - this commit is not a cherry pick. The main branch has moved forward a major version which contains breaking changes. This commit upgrades the patch version on the release branch to avoid breaking changes.