### PR TITLE
set namespaceStrategy default on CRD

### DIFF
--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1445,6 +1445,7 @@ spec:
                     - containerName
                     x-kubernetes-list-type: map
                   namespaceStrategy:
+                    default: implicit
                     description: 'namespaceStrategy controls how the reconciler handles
                       Namespaces which are used by resources in the source but not
                       declared. Only applies when using the unstructured sourceFormat.

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -90,6 +90,7 @@ type RootSyncOverrideSpec struct {
 	// are not declared in the source.
 	//
 	// +kubebuilder:validation:Enum=implicit;explicit
+	// +kubebuilder:default:=implicit
 	// +optional
 	NamespaceStrategy configsync.NamespaceStrategy `json:"namespaceStrategy,omitempty"`
 }

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -206,9 +206,6 @@ func sourceFormatEnv(format string) corev1.EnvVar {
 
 // namespaceStrategyEnv returns the environment variable for NAMESPACE_STRATEGY in the reconciler container.
 func namespaceStrategyEnv(strategy configsync.NamespaceStrategy) corev1.EnvVar {
-	if strategy == "" {
-		strategy = configsync.NamespaceStrategyImplicit
-	}
 	return corev1.EnvVar{
 		Name:  reconcilermanager.NamespaceStrategy,
 		Value: string(strategy),


### PR DESCRIPTION
This change sets the default value of the namespaceStrategy field explicitly in the CRD.