### PR TITLE
ci: publish buildenv in postsubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,9 @@ TEST_INFRA_PROJECT ?= kpt-config-sync-ci-artifacts
 TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-infra
 
 # Docker image used for build and test. This image does not support CGO.
-# When upgrading this tag, publish the image after the change is submitted.
+# When upgrading this tag, the image will be rebuilt locally during presubmits.
+# After the change is submitted, a postsubmit job will publish the new tag.
+# There is no need to manually publish this image.
 BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.3.1
 
 # Nomos docker images containing all binaries.

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -14,6 +14,13 @@ POSTSUBMIT_REGISTRY ?= us-docker.pkg.dev/kpt-config-sync-ci-artifacts/postsubmit
 postsubmit: build-cli
 	$(MAKE) config-sync-manifest REGISTRY=$(POSTSUBMIT_REGISTRY)
 	$(MAKE) publish-gcs GCS_PREFIX=$(POSTSUBMIT_GCS_PREFIX)
+	$(MAKE) publish-buildenv
+
+# publish-buildenv checks if the buildenv image tag exists in the remote registry.
+# if it does not exist, the image will be built and published.
+.PHONY: publish-buildenv
+publish-buildenv:
+	docker manifest inspect $(BUILDENV_IMAGE) &> /dev/null || $(MAKE) build-buildenv push-buildenv
 
 .PHONY: publish-gcs
 publish-gcs:


### PR DESCRIPTION
This change publishes the buildenv image in the postsubmit target if the image tag does not already exist. This removes any need for manual steps to publish a new buildenv image.