### PR TITLE
ci: run all of test-presubmit in a single container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .idea/
+.vscode/

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update \
   gcc \
   git \
   musl-dev \
+  shellcheck \
   wget
 
 # Starting from go 1.10, build and test results are cached, which speeds up

--- a/scripts/generate-clientset.sh
+++ b/scripts/generate-clientset.sh
@@ -109,7 +109,7 @@ done
 
 echo "informer"
 "${GOBASE}/bin/informer-gen" \
-  ${LOGGING_FLAGS} \
+  "${LOGGING_FLAGS}" \
   --input-dirs="${informer_inputs}" \
   --versioned-clientset-package="${OUTPUT_CLIENT}/apis" \
   --listers-package="${OUTPUT_CLIENT}/listers" \
@@ -121,7 +121,7 @@ echo "informer"
 echo "deepcopy"
 # Creates types.generated.go
 "${GOBASE}/bin/deepcopy-gen" \
-  ${LOGGING_FLAGS} \
+  "${LOGGING_FLAGS}" \
   --input-dirs="${informer_inputs}" \
   --output-file-base zz_generated.deepcopy \
   --output-base="${OUTPUT_BASE}" \
@@ -129,7 +129,7 @@ echo "deepcopy"
 
 echo "lister"
 "${GOBASE}/bin/lister-gen" \
-  ${LOGGING_FLAGS} \
+  "${LOGGING_FLAGS}" \
   --input-dirs="${informer_inputs}" \
   --output-base="$GOWORK/src" \
   --output-package="${OUTPUT_CLIENT}/listers" \
@@ -137,7 +137,7 @@ echo "lister"
 
 echo "conversion"
 "${GOBASE}/bin/conversion-gen" \
-  ${LOGGING_FLAGS} \
+  "${LOGGING_FLAGS}" \
   --input-dirs="${informer_inputs}" \
   --output-base="$GOWORK/src" \
   --output-file-base zz_generated.conversion \

--- a/scripts/license-headers.sh
+++ b/scripts/license-headers.sh
@@ -25,6 +25,8 @@ ignores=(
   "-ignore=e2e/testdata/helm-charts/**"
   "-ignore=.output/**"
   "-ignore=e2e/testdata/*.xml"
+  "-ignore=.idea/**"
+  "-ignore=.vscode/**"
 )
 
 case "$1" in

--- a/scripts/lint-bash.sh
+++ b/scripts/lint-bash.sh
@@ -26,28 +26,6 @@ mapfile -t check_files < <(
     uniq -u
 )
 
-# Handle bats tests
-bats_tmp="$(mktemp -d lint-bash-XXXXXX)"
-function cleanup() {
-  rm -rf "${bats_tmp}"
-}
-trap cleanup EXIT
-
-readonly linter=koalaman/shellcheck:v0.6.0
-
-if ! docker image inspect "$linter" &>/dev/null; then
-  docker pull "$linter"
-fi
-
-cmd=(docker run -v "$(pwd):/mnt")
-if [ -t 1 ]; then
-  cmd+=(--tty)
-fi
-cmd+=(
-  --rm
-  "$linter" "${check_files[@]}"
-)
-
 echo "Linting scripts..."
-"${cmd[@]}"
+shellcheck "${check_files[@]}"
 echo "PASS"


### PR DESCRIPTION
This refactors the test-presubmit entrypoint to wrap the entrypoint and all nested targets in a single container. This ensures that all of the presubmit targets run inside the same nested container. Before this change, some targets such as tidy/vendor ran on the host machine. This also has the benefit on minimizing the number of extra containers that need to be pulled and/or created.