### PR TITLE
Validate all Config Sync controller Namespaces

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -110,7 +110,7 @@ func IsReconcilerManagerConfigMap(obj client.Object) bool {
 // otel-collector Deployment in the config-management-monitoring namespace.
 func isOtelCollectorDeployment(obj client.Object) bool {
 	return obj.GetName() == ocmetrics.OtelCollectorName &&
-		obj.GetNamespace() == ocmetrics.MonitoringNamespace &&
+		obj.GetNamespace() == configmanagement.MonitoringNamespace &&
 		obj.GetObjectKind().GroupVersionKind() == kinds.Deployment()
 }
 
@@ -346,7 +346,7 @@ func ValidateMultiRepoDeployments(nt *NT) error {
 			predicates = append(predicates, testpredicates.HasGenerationAtLeast(2))
 		}
 		return nt.Watcher.WatchObject(kinds.Deployment(),
-			ocmetrics.OtelCollectorName, ocmetrics.MonitoringNamespace, predicates)
+			ocmetrics.OtelCollectorName, configmanagement.MonitoringNamespace, predicates)
 	})
 	tg.Go(func() error {
 		// The root-reconciler is created after the reconciler-manager is ready.

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -36,7 +36,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kind/pkg/errors"
@@ -343,7 +342,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	if err := nt.KubeClient.Create(fake.NamespaceObject(configmanagement.ControllerNamespace)); err != nil {
 		nt.T.Fatal(err)
 	}
-	if err := nt.KubeClient.Create(fake.NamespaceObject(metrics.MonitoringNamespace)); err != nil {
+	if err := nt.KubeClient.Create(fake.NamespaceObject(configmanagement.MonitoringNamespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 	if *e2e.GitProvider == e2e.Local {

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -206,7 +206,7 @@ func (nt *NT) Must(args ...interface{}) {
 // CSNamespaces is the namespaces of the Config Sync components.
 var CSNamespaces = []string{
 	configmanagement.ControllerNamespace,
-	ocmetrics.MonitoringNamespace,
+	configmanagement.MonitoringNamespace,
 	configmanagement.RGControllerNamespace,
 }
 
@@ -675,12 +675,12 @@ func (nt *NT) portForwardOtelCollector() {
 		nt.T.Fatal("otel collector port forward already initialized")
 	}
 	nt.otelCollectorPortForwarder = nt.newPortForwarder(
-		ocmetrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		ocmetrics.OtelCollectorName,
 		fmt.Sprintf(":%d", testmetrics.OtelCollectorMetricsPort),
 	)
 	nt.startPortForwarder(
-		ocmetrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		ocmetrics.OtelCollectorName,
 		nt.otelCollectorPortForwarder,
 	)

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -36,7 +36,6 @@ import (
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/syncer/differ"
 	"kpt.dev/configsync/pkg/util/log"
@@ -50,7 +49,7 @@ import (
 var sharedTestNamespaces = []string{
 	configsync.ControllerNamespace,
 	configmanagement.RGControllerNamespace,
-	metrics.MonitoringNamespace,
+	configmanagement.MonitoringNamespace,
 	testGitNamespace,
 	prometheusNamespace,
 }

--- a/pkg/api/configmanagement/register.go
+++ b/pkg/api/configmanagement/register.go
@@ -57,12 +57,16 @@ const (
 	// RGControllerNamespace is the namespace used for the resource-group controller
 	RGControllerNamespace = "resource-group-system"
 
+	// MonitoringNamespace is the namespace used for Config Sync monitoring
+	MonitoringNamespace = "config-management-monitoring"
+
 	// RGControllerName is the name used for the resource-group controller
 	RGControllerName = "resource-group-controller-manager"
 )
 
-// IsControllerNamespace returns true if the namespace is the ACM Controller Namespace.
+// IsControllerNamespace returns true if the namespace is one of the Config Sync controller Namespace.
 func IsControllerNamespace(name string) bool {
-	// For now we only forbid syncing the Namespace containing the ACM controllers.
-	return name == ControllerNamespace
+	return name == ControllerNamespace ||
+		name == RGControllerNamespace ||
+		name == MonitoringNamespace
 }

--- a/pkg/bugreport/bugreport.go
+++ b/pkg/bugreport/bugreport.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
-	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/policycontroller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -440,7 +439,7 @@ func (b *BugReporter) FetchCMSystemPods(ctx context.Context) (rd []Readable) {
 		configmanagement.ControllerNamespace,
 		metav1.NamespaceSystem,
 		configmanagement.RGControllerNamespace,
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		policycontroller.NamespaceSystem,
 	}
 

--- a/pkg/bugreport/constants.go
+++ b/pkg/bugreport/constants.go
@@ -16,7 +16,6 @@ package bugreport
 
 import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
-	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/policycontroller"
 )
 
@@ -39,6 +38,6 @@ var (
 		PolicyController:     policycontroller.NamespaceSystem,
 		ConfigSync:           configmanagement.ControllerNamespace,
 		ResourceGroup:        configmanagement.RGControllerNamespace,
-		ConfigSyncMonitoring: metrics.MonitoringNamespace,
+		ConfigSyncMonitoring: configmanagement.MonitoringNamespace,
 	}
 )

--- a/pkg/importer/analyzer/validation/nonhierarchical/illegal_namespace_validator.go
+++ b/pkg/importer/analyzer/validation/nonhierarchical/illegal_namespace_validator.go
@@ -15,7 +15,6 @@
 package nonhierarchical
 
 import (
-	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,9 +24,9 @@ const IllegalNamespaceErrorCode = "1034"
 
 var illegalNamespaceError = status.NewErrorBuilder(IllegalNamespaceErrorCode)
 
-// IllegalNamespace reports that the config-management-system Namespace MUST NOT be declared.
+// IllegalNamespace reports that the controller Namespaces MUST NOT be declared.
 func IllegalNamespace(resource client.Object) status.Error {
 	return illegalNamespaceError.
-		Sprintf("The %q Namespace must not be declared", configmanagement.ControllerNamespace).
+		Sprintf("The %q Namespace must not be declared", resource.GetName()).
 		BuildWithResources(resource)
 }

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -30,9 +30,6 @@ const (
 	// OtelCollectorCustomCM is the name of the custom OpenTelemetry Collector ConfigMap.
 	OtelCollectorCustomCM = "otel-collector-custom"
 
-	// MonitoringNamespace is the Namespace used for OpenTelemetry Collector deployment.
-	MonitoringNamespace = "config-management-monitoring"
-
 	// CollectorConfigGooglecloud is the OpenTelemetry Collector configuration with
 	// the googlecloud exporter.
 	CollectorConfigGooglecloud = `receivers:

--- a/pkg/reconcilermanager/controllers/otel_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
@@ -98,7 +99,7 @@ func (r *OtelReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 func otelCollectorDeploymentRef() client.ObjectKey {
 	return client.ObjectKey{
 		Name:      metrics.OtelCollectorName,
-		Namespace: metrics.MonitoringNamespace,
+		Namespace: configmanagement.MonitoringNamespace,
 	}
 }
 
@@ -143,7 +144,7 @@ func (r *OtelReconciler) configureGooglecloudConfigMap(ctx context.Context) ([]b
 
 	cm := &corev1.ConfigMap{}
 	cm.Name = metrics.OtelCollectorGooglecloud
-	cm.Namespace = metrics.MonitoringNamespace
+	cm.Namespace = configmanagement.MonitoringNamespace
 	op, err := CreateOrUpdate(ctx, r.client, cm, func() error {
 		cm.Labels = map[string]string{
 			"app":                metrics.OpenTelemetry,
@@ -198,13 +199,13 @@ func (r *OtelReconciler) SetupWithManager(mgr controllerruntime.Manager) error {
 	// Process create / update events for resources in the `config-management-monitoring` namespace.
 	p := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetNamespace() == metrics.MonitoringNamespace
+			return e.Object.GetNamespace() == configmanagement.MonitoringNamespace
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetNamespace() == metrics.MonitoringNamespace
+			return e.ObjectNew.GetNamespace() == configmanagement.MonitoringNamespace
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetNamespace() == metrics.MonitoringNamespace
+			return e.Object.GetNamespace() == configmanagement.MonitoringNamespace
 		},
 	}
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/oauth2/google"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
@@ -71,13 +72,13 @@ func setupOtelReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 
 func TestOtelReconciler(t *testing.T) {
 	cm := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorName,
 		map[string]string{"otel-collector-config.yaml": ""},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
-	reqNamespacedName := namespacedName(metrics.OtelCollectorName, metrics.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(metrics.MonitoringNamespace)))
+	reqNamespacedName := namespacedName(metrics.OtelCollectorName, configmanagement.MonitoringNamespace)
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(ctx context.Context) (*google.Credentials, error) {
 		return nil, errors.New("could not find default credentials")
@@ -90,7 +91,7 @@ func TestOtelReconciler(t *testing.T) {
 	}
 
 	wantDeployment := fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
 
@@ -115,13 +116,13 @@ func TestOtelReconciler(t *testing.T) {
 
 func TestOtelReconcilerGooglecloud(t *testing.T) {
 	cm := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorName,
 		map[string]string{"otel-collector-config.yaml": ""},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
-	reqNamespacedName := namespacedName(metrics.OtelCollectorName, metrics.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(metrics.MonitoringNamespace)))
+	reqNamespacedName := namespacedName(metrics.OtelCollectorName, configmanagement.MonitoringNamespace)
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(ctx context.Context) (*google.Credentials, error) {
 		return &google.Credentials{
@@ -138,7 +139,7 @@ func TestOtelReconcilerGooglecloud(t *testing.T) {
 	}
 
 	wantConfigMap := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorGooglecloud,
 		map[string]string{"otel-collector-config.yaml": metrics.CollectorConfigGooglecloud},
 		core.Labels(map[string]string{
@@ -151,7 +152,7 @@ func TestOtelReconcilerGooglecloud(t *testing.T) {
 	)
 
 	wantDeployment := fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
 	core.SetAnnotation(&wantDeployment.Spec.Template, metadata.ConfigMapAnnotationKey, depAnnotationGooglecloud)
@@ -177,19 +178,19 @@ func TestOtelReconcilerGooglecloud(t *testing.T) {
 
 func TestOtelReconcilerCustom(t *testing.T) {
 	cm := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorName,
 		map[string]string{"otel-collector-config.yaml": ""},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	cmCustom := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorCustomCM,
 		map[string]string{"otel-collector-config.yaml": "custom"},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
-	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, metrics.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(metrics.MonitoringNamespace)))
+	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, configmanagement.MonitoringNamespace)
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(ctx context.Context) (*google.Credentials, error) {
 		return nil, nil
@@ -202,7 +203,7 @@ func TestOtelReconcilerCustom(t *testing.T) {
 	}
 
 	wantDeployment := fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -229,19 +230,19 @@ func TestOtelReconcilerCustom(t *testing.T) {
 
 func TestOtelReconcilerDeleteCustom(t *testing.T) {
 	cm := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorName,
 		map[string]string{"otel-collector-config.yaml": ""},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	cmCustom := configMapWithData(
-		metrics.MonitoringNamespace,
+		configmanagement.MonitoringNamespace,
 		metrics.OtelCollectorCustomCM,
 		map[string]string{"otel-collector-config.yaml": "custom"},
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
-	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, metrics.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(metrics.MonitoringNamespace)))
+	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, configmanagement.MonitoringNamespace)
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(ctx context.Context) (*google.Credentials, error) {
 		return nil, nil
@@ -263,7 +264,7 @@ func TestOtelReconcilerDeleteCustom(t *testing.T) {
 	}
 
 	wantDeployment := fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -306,19 +307,19 @@ const test2GSAEmail = "metric-writer@test2.iam.gserviceaccount.com"
 func TestOtelSAReconciler(t *testing.T) {
 	sa := fake.ServiceAccountObject(
 		defaultSAName,
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Annotation(GCPSAAnnotationKey, test1GSAEmail),
 	)
-	reqNamespacedName := namespacedName(defaultSAName, metrics.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelSAReconciler(t, sa, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(metrics.MonitoringNamespace)))
+	reqNamespacedName := namespacedName(defaultSAName, configmanagement.MonitoringNamespace)
+	fakeClient, testReconciler := setupOtelSAReconciler(t, sa, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	// Verify that the otel-collector Deployment does not have the GCPSAAnnotationKey annotation.
 	wantDeployment := fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
 	ctx := context.Background()
-	deployKey := client.ObjectKey{Namespace: metrics.MonitoringNamespace, Name: metrics.OtelCollectorName}
+	deployKey := client.ObjectKey{Namespace: configmanagement.MonitoringNamespace, Name: metrics.OtelCollectorName}
 	gotDeployment := &appsv1.Deployment{}
 	err := fakeClient.Get(ctx, deployKey, gotDeployment)
 	require.NoError(t, err, "Deployment[%s] not found", deployKey)
@@ -332,7 +333,7 @@ func TestOtelSAReconciler(t *testing.T) {
 
 	// Verify that the otel-collector Deployment has the GCPSAAnnotationKey annotation.
 	wantDeployment = fake.DeploymentObject(
-		core.Namespace(metrics.MonitoringNamespace),
+		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
 	wantDeployment.Spec.Template.Annotations = map[string]string{GCPSAAnnotationKey: test1GSAEmail}

--- a/pkg/reconcilermanager/controllers/otel_sa_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_sa_controller.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/status"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,10 +106,10 @@ func (r *OtelSAReconciler) SetupWithManager(mgr controllerruntime.Manager) error
 	// Process create / update events for service accounts in the `config-management-monitoring` namespace.
 	p := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetNamespace() == metrics.MonitoringNamespace
+			return e.Object.GetNamespace() == configmanagement.MonitoringNamespace
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetNamespace() == metrics.MonitoringNamespace
+			return e.ObjectNew.GetNamespace() == configmanagement.MonitoringNamespace
 		},
 	}
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/validate/raw/validate/namespace_validator_test.go
+++ b/pkg/validate/raw/validate/namespace_validator_test.go
@@ -54,9 +54,19 @@ func TestNamespace(t *testing.T) {
 			obj:  fake.Namespace("hello"),
 		},
 		{
-			name:    "Illegal namespace",
+			name:    "Illegal namespace " + configmanagement.ControllerNamespace,
 			obj:     fake.Namespace(configmanagement.ControllerNamespace),
 			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.ControllerNamespace)),
+		},
+		{
+			name:    "Illegal namespace " + configmanagement.RGControllerNamespace,
+			obj:     fake.Namespace(configmanagement.RGControllerNamespace),
+			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.RGControllerNamespace)),
+		},
+		{
+			name:    "Illegal namespace " + configmanagement.MonitoringNamespace,
+			obj:     fake.Namespace(configmanagement.MonitoringNamespace),
+			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.MonitoringNamespace)),
 		},
 	}
 


### PR DESCRIPTION
Config Sync checks and errors out if config-management-system namespace is declared in SoT. 

This PR extends the check to config-management-monitoring namespace and resource-group-controller to avoid accidental modification or removal to the managed namespaces.