### PR TITLE
chore: bump git-sync to v3.6.9-gke.5

### DIFF
--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -109,7 +109,7 @@ data:
                - NET_RAW
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.4__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v3.6.9-gke.5__linux_amd64
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
This includes security fixes for the previous version. Note this is not a cherry-pick as the main branch has moved forward to a new major version which includes breaking changes.