### PR TITLE
refactor: remove uses of deprecated io/ioutil package

### DIFF
--- a/cmd/gen-core-scoper/main.go
+++ b/cmd/gen-core-scoper/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -40,17 +39,17 @@ func CoreScoper() Scoper {
 
 func main() {
 	// Types available on a default-created cluster for both Kubernetes 1.15 and 1.18.
-	apiResources115, err := ioutil.ReadFile("cmd/gen-core-scoper/api_resources_1_15.txt")
+	apiResources115, err := os.ReadFile("cmd/gen-core-scoper/api_resources_1_15.txt")
 	if err != nil {
 		panic(err)
 	}
-	apiResources118, err := ioutil.ReadFile("cmd/gen-core-scoper/api_resources_1_18.txt")
+	apiResources118, err := os.ReadFile("cmd/gen-core-scoper/api_resources_1_18.txt")
 	if err != nil {
 		panic(err)
 	}
 	apiResources := append(apiResources115, apiResources118...)
 	// Read Nomos-specific types which are not available on a default-created cluster.
-	nomosResources, err := ioutil.ReadFile("cmd/gen-core-scoper/nomos_resources.txt")
+	nomosResources, err := os.ReadFile("cmd/gen-core-scoper/nomos_resources.txt")
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +93,7 @@ func main() {
 }
 `)
 
-	err = ioutil.WriteFile("pkg/util/discovery/core_scoper.generated.go", []byte(sb.String()), os.ModePerm)
+	err = os.WriteFile("pkg/util/discovery/core_scoper.generated.go", []byte(sb.String()), os.ModePerm)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/nomos/initialize/init.go
+++ b/cmd/nomos/initialize/init.go
@@ -15,7 +15,6 @@
 package initialize
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,7 +116,7 @@ func Initialize(root string, force bool) error {
 }
 
 func checkEmpty(dir cmpath.Absolute) error {
-	files, err := ioutil.ReadDir(dir.OSPath())
+	files, err := os.ReadDir(dir.OSPath())
 	if err != nil {
 		return errors.Wrapf(err, "error reading %q", dir)
 	}

--- a/cmd/nomos/migrate/migrate.go
+++ b/cmd/nomos/migrate/migrate.go
@@ -17,7 +17,6 @@ package migrate
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -415,7 +414,7 @@ func saveRootSyncYAML(ctx context.Context, cm *util.ConfigManagementClient, cont
 	}
 
 	yamlFile := filepath.Join(dir, rootSyncYamlFile)
-	if err := ioutil.WriteFile(yamlFile, content, 0644); err != nil {
+	if err := os.WriteFile(yamlFile, content, 0644); err != nil {
 		return rs, yamlFile, err
 	}
 	printInfo("A RootSync object is generated and saved in %q", yamlFile)
@@ -437,7 +436,7 @@ func saveConfigManagementYAML(ctx context.Context, cm *util.ConfigManagementClie
 		return cmMulti, "", err
 	}
 	yamlFile := filepath.Join(dir, cmOrigYAMLFile)
-	if err := ioutil.WriteFile(yamlFile, content, 0644); err != nil {
+	if err := os.WriteFile(yamlFile, content, 0644); err != nil {
 		return cmMulti, yamlFile, err
 	}
 	printInfo("The original ConfigManagement object is saved in %q", yamlFile)
@@ -447,7 +446,7 @@ func saveConfigManagementYAML(ctx context.Context, cm *util.ConfigManagementClie
 		return cmMulti, "", err
 	}
 	yamlFile = filepath.Join(dir, cmMultiYAMLFile)
-	if err := ioutil.WriteFile(yamlFile, content, 0644); err != nil {
+	if err := os.WriteFile(yamlFile, content, 0644); err != nil {
 		return cmMulti, yamlFile, err
 	}
 	printInfo("The ConfigManagement object is updated and saved in %q", yamlFile)

--- a/cmd/nomos/parse/find_files_test.go
+++ b/cmd/nomos/parse/find_files_test.go
@@ -15,7 +15,6 @@
 package parse
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sort"
@@ -51,7 +50,7 @@ func TestListPolicyFiles(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			dirP, err := ioutil.TempDir(os.TempDir(), "nomos-git-test")
+			dirP, err := os.MkdirTemp(os.TempDir(), "nomos-git-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/nomos/status/status.go
+++ b/cmd/nomos/status/status.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -63,7 +62,7 @@ func init() {
 // caused by the os.Pipe buffer limit: 64k.
 // This function is only used in `nomos bugreport` for the `nomos status` output.
 func SaveToTempFile(ctx context.Context, contexts []string) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "nomos-status-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "nomos-status-")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a temporary file: %w", err)
 	}

--- a/cmd/nomos/version/version.go
+++ b/cmd/nomos/version/version.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -62,7 +61,7 @@ func GetVersionReadCloser(ctx context.Context, contexts []string) (io.ReadCloser
 		return nil, errors.Wrap(err, "failed to close version file writer with error: %v")
 	}
 
-	return ioutil.NopCloser(r), nil
+	return io.NopCloser(r), nil
 }
 
 var (

--- a/e2e/nomostest/artifactregistry/yaml.go
+++ b/e2e/nomostest/artifactregistry/yaml.go
@@ -15,7 +15,6 @@
 package artifactregistry
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,7 +47,7 @@ func WriteObjectYAMLFile(nt *nomostest.NT, path string, obj client.Object) error
 			return errors.Wrapf(err, "making parent directories: %s", dirPath)
 		}
 	}
-	if err := ioutil.WriteFile(path, bytes, fileMode); err != nil {
+	if err := os.WriteFile(path, bytes, fileMode); err != nil {
 		return errors.Wrapf(err, "writing file: %s", path)
 	}
 	return nil

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -17,7 +17,6 @@ package nomostest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -215,15 +214,15 @@ func convertToTypedObjects(nt *NT, objs []client.Object) ([]client.Object, error
 }
 
 func copyFile(src, dst string) error {
-	bytes, err := ioutil.ReadFile(src)
+	bytes, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, bytes, fileMode)
+	return os.WriteFile(dst, bytes, fileMode)
 }
 
 func copyDirContents(src, dest string) error {
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}
@@ -271,7 +270,7 @@ func parseManifestDir(dirPath string) ([]client.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/nomostest/docker.go
+++ b/e2e/nomostest/docker.go
@@ -16,7 +16,7 @@ package nomostest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -112,7 +112,7 @@ func checkImage(image string) error {
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Errorf("Failed to read response for image %s in registry: %s", image, err)
 	}

--- a/e2e/nomostest/gitproviders/repository.go
+++ b/e2e/nomostest/gitproviders/repository.go
@@ -17,7 +17,6 @@ package gitproviders
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -441,7 +440,7 @@ func (g *Repository) AddFile(path string, bytes []byte) error {
 	}
 
 	// Write bytes to file.
-	if err := ioutil.WriteFile(absPath, bytes, fileMode); err != nil {
+	if err := os.WriteFile(absPath, bytes, fileMode); err != nil {
 		return errors.Wrapf(err, "writing file: %s", absPath)
 	}
 
@@ -463,7 +462,7 @@ func (g *Repository) AddEmptyDir(path string) error {
 func (g *Repository) GetFile(path string) ([]byte, error) {
 	absPath := filepath.Join(g.Root, path)
 
-	bytes, err := ioutil.ReadFile(absPath)
+	bytes, err := os.ReadFile(absPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading file: %s", absPath)
 	}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -16,7 +16,6 @@ package nomostest
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -501,7 +500,7 @@ func TestDir(t nomostesting.NTB) string {
 	if err != nil {
 		t.Fatalf("creating nomos-e2e tmp directory: %v", err)
 	}
-	tmpDir, err := ioutil.TempDir(filepath.Join(os.TempDir(), NomosE2E), name)
+	tmpDir, err := os.MkdirTemp(filepath.Join(os.TempDir(), NomosE2E), name)
 	if err != nil {
 		t.Fatalf("creating nomos-e2e tmp test subdirectory %s: %v", tmpDir, err)
 	}

--- a/e2e/nomostest/ssh.go
+++ b/e2e/nomostest/ssh.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -249,7 +248,7 @@ func downloadSSHKey(nt *NT) string {
 		nt.T.Fatal("downloading SSH key:", err)
 	}
 
-	if err := ioutil.WriteFile(privateKeyPath(nt), []byte(out), 0600); err != nil {
+	if err := os.WriteFile(privateKeyPath(nt), []byte(out), 0600); err != nil {
 		nt.T.Fatal("saving SSH key:", err)
 	}
 

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -15,7 +15,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -98,7 +98,7 @@ metadata:
   name: test-ns
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -125,7 +125,7 @@ metadata:
   name: test-ns
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -161,7 +161,7 @@ metadata:
 		nt.T.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "webhook.yaml"), webhook, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "webhook.yaml"), webhook, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -981,7 +980,7 @@ func TestNomosImage(t *testing.T) {
 // getBugReportZipName find and returns the zip name of bugreport under test dir
 // or error if no bugreport zip found
 func getBugReportZipName(dir string, nt *nomostest.NT) (string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/custom_resource_definitions_schema_test.go
+++ b/e2e/testcases/custom_resource_definitions_schema_test.go
@@ -15,7 +15,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,11 +36,11 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	newCRFile := filepath.Join(".", "..", "testdata", "customresources", "changed_schema_crds", "new_schema_cr.yaml")
 
 	// Add a CRD and CR to the repo
-	crdContent, err := ioutil.ReadFile(oldCRDFile)
+	crdContent, err := os.ReadFile(oldCRDFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	crContent, err := ioutil.ReadFile(oldCRFile)
+	crContent, err := os.ReadFile(oldCRFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -65,11 +65,11 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	}
 
 	// Add the CRD with a new schema and a CR using the new schema to the repo
-	crdContent, err = ioutil.ReadFile(newCRDFile)
+	crdContent, err = os.ReadFile(newCRDFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	crContent, err = ioutil.ReadFile(newCRFile)
+	crContent, err = os.ReadFile(newCRFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -16,7 +16,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -134,7 +134,7 @@ func TestMustRemoveCustomResourceWithDefinitionV1(t *testing.T) {
 
 func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
-	crdContent, err := ioutil.ReadFile(crdFile)
+	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestAddAndRemoveCustomResourceV1Beta1(t *testing.T) {
 
 func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string) {
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
-	crdContent, err := ioutil.ReadFile(crdFile)
+	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestMustRemoveUnManagedCustomResourceV1Beta1(t *testing.T) {
 
 func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
-	crdContent, err := ioutil.ReadFile(crdFile)
+	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 
 	// Update the CRD from version v1 to version v2.
 	crdFile = filepath.Join(".", "..", "testdata", "customresources", dir, "clusteranvil-crd-v2.yaml")
-	crdContent, err = ioutil.ReadFile(crdFile)
+	crdContent, err = os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -395,7 +395,7 @@ func TestAddUpdateRemoveClusterScopedCRDV1Beta1(t *testing.T) {
 
 func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
-	crdContent, err := ioutil.ReadFile(crdFile)
+	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -430,7 +430,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 
 	// Update the CRD from version v1 to version v2.
 	crdFile = filepath.Join(".", "..", "testdata", "customresources", dir, "anvil-crd-v2.yaml")
-	crdContent, err = ioutil.ReadFile(crdFile)
+	crdContent, err = os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 
 	// Update CRD and CR to only support V2
 	crdFile = filepath.Join(".", "..", "testdata", "customresources", dir, "anvil-crd-only-v2.yaml")
-	crdContent, err = ioutil.ReadFile(crdFile)
+	crdContent, err = os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func TestLargeCRD(t *testing.T) {
 
 	for _, file := range []string{"challenges-acme-cert-manager-io.yaml", "solrclouds-solr-apache-org.yaml"} {
 		crdFile := filepath.Join(".", "..", "testdata", "customresources", file)
-		crdContent, err := ioutil.ReadFile(crdFile)
+		crdContent, err := os.ReadFile(crdFile)
 		if err != nil {
 			nt.T.Fatal(err)
 		}
@@ -544,7 +544,7 @@ func TestLargeCRD(t *testing.T) {
 
 	// update one CRD
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", "challenges-acme-cert-manager-io_with_new_label.yaml")
-	crdContent, err := ioutil.ReadFile(crdFile)
+	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -16,7 +16,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -81,7 +81,7 @@ metadata:
     configsync.gke.io/manager: :root
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns1.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns1.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -110,7 +110,7 @@ metadata:
     configsync.gke.io/manager: :abcdef
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns2.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns2.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -145,7 +145,7 @@ metadata:
     configsync.gke.io/resource-id: _namespace_test-ns3
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns3.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns3.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -180,7 +180,7 @@ metadata:
     configsync.gke.io/manager: :root
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-ns4.yaml"), ns, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-ns4.yaml"), ns, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -238,7 +238,7 @@ data:
   weekday: "monday"
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-cm1.yaml"), cm, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-cm1.yaml"), cm, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -269,7 +269,7 @@ data:
   weekday: "monday"
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-cm2.yaml"), cm, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-cm2.yaml"), cm, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -308,7 +308,7 @@ data:
   weekday: "monday"
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-cm3.yaml"), cm, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-cm3.yaml"), cm, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -346,7 +346,7 @@ data:
   weekday: "monday"
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-cm4.yaml"), cm, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-cm4.yaml"), cm, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 
@@ -382,7 +382,7 @@ metadata:
     configsync.gke.io/manager: :root
 `)
 
-	if err := ioutil.WriteFile(filepath.Join(nt.TmpDir, "test-secret.yaml"), cm, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nt.TmpDir, "test-secret.yaml"), cm, 0644); err != nil {
 		nt.T.Fatalf("failed to create a tmp file %v", err)
 	}
 

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -620,7 +620,7 @@ func archiveAndPushOCIImage(imageName string, dir string, options ...remote.Opti
 	}
 
 	// Make new layer
-	tarFile, err := ioutil.TempFile("", "tar")
+	tarFile, err := os.CreateTemp("", "tar")
 	if err != nil {
 		return "", err
 	}

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -16,7 +16,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -83,7 +83,7 @@ func TestStressCRD(t *testing.T) {
 	nt.T.Logf("Delete the %q CRD if needed", crdName)
 	nt.MustKubectl("delete", "crd", crdName, "--ignore-not-found")
 
-	crdContent, err := ioutil.ReadFile("../testdata/customresources/changed_schema_crds/old_schema_crd.yaml")
+	crdContent, err := os.ReadFile("../testdata/customresources/changed_schema_crds/old_schema_crd.yaml")
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/pkg/bugreport/bugreport.go
+++ b/pkg/bugreport/bugreport.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -610,7 +609,7 @@ func (b *BugReporter) appendPrettyJSON(rd []Readable, pathName string, object in
 		b.ErrorList = append(b.ErrorList, fmt.Errorf("invalid json response from resources %s: %v", pathName, err))
 	} else {
 		rd = append(rd, Readable{
-			ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+			ReadCloser: io.NopCloser(bytes.NewReader(data)),
 			Name:       fmt.Sprintf("%s.json", pathName),
 		})
 	}
@@ -619,7 +618,7 @@ func (b *BugReporter) appendPrettyJSON(rd []Readable, pathName string, object in
 		b.ErrorList = append(b.ErrorList, fmt.Errorf("invalid yaml response from resources %s: %v", pathName, err))
 	} else {
 		rd = append(rd, Readable{
-			ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+			ReadCloser: io.NopCloser(bytes.NewReader(data)),
 			Name:       fmt.Sprintf("%s.yaml", pathName),
 		})
 	}

--- a/pkg/hydrate/controller.go
+++ b/pkg/hydrate/controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -271,7 +270,7 @@ func (h *Hydrator) complete(commit string, hydrationErr HydrationError) error {
 // and wait for the next hydration loop to retry the hydration.
 func DoneCommit(donePath string) string {
 	if _, err := os.Stat(donePath); err == nil {
-		commit, err := ioutil.ReadFile(donePath)
+		commit, err := os.ReadFile(donePath)
 		if err != nil {
 			klog.Warningf("unable to read the done file %s: %v", donePath, err)
 			return ""
@@ -293,7 +292,7 @@ func exportError(commit, root, errorFile string, hydrationError HydrationError) 
 		}
 	}
 
-	tmpFile, err := ioutil.TempFile(root, "tmp-err-")
+	tmpFile, err := os.CreateTemp(root, "tmp-err-")
 	if err != nil {
 		return errors.Wrapf(err, "unable to create temporary error-file under directory %s", root)
 	}

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -17,7 +17,6 @@ package hydrate
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,7 +60,7 @@ var (
 
 // needsKustomize checks if there is a Kustomization config file under the directory.
 func needsKustomize(dir string) (bool, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to traverse the directory: %s", dir)
 	}
@@ -233,7 +232,7 @@ func ValidateAndRunKustomize(sourcePath string) (cmpath.Absolute, error) {
 
 	// Save the 'kustomize build' output to a temp directory for further
 	// parsing or validation.
-	tmpHydratedDir, err := ioutil.TempDir(os.TempDir(), "hydrated-")
+	tmpHydratedDir, err := os.MkdirTemp(os.TempDir(), "hydrated-")
 	if err != nil {
 		return output, err
 	}

--- a/pkg/importer/filesystem/filesystemtest/test_dir.go
+++ b/pkg/importer/filesystem/filesystemtest/test_dir.go
@@ -15,7 +15,6 @@
 package filesystemtest
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -44,7 +43,7 @@ type TestDir struct {
 // The test directory is automatically cleaned at the end of the test.
 func NewTestDir(t *testing.T, opts ...TestDirOpt) *TestDir {
 	t.Helper()
-	tmp, err := ioutil.TempDir("", "nomos-test-")
+	tmp, err := os.MkdirTemp("", "nomos-test-")
 	if err != nil {
 		t.Fatalf("Failed to create test directory %v", err)
 	}
@@ -104,7 +103,7 @@ func FileContents(file string, contents string) TestDirOpt {
 	return func(t *testing.T, testDir cmpath.Absolute) {
 		Dir(path.Dir(file))(t, testDir)
 		p := testDir.Join(cmpath.RelativeSlash(file))
-		if err := ioutil.WriteFile(p.OSPath(), []byte(contents), os.ModePerm); err != nil {
+		if err := os.WriteFile(p.OSPath(), []byte(contents), os.ModePerm); err != nil {
 			t.Fatalf("writing contents to file %q: %v", p.OSPath(), err)
 		}
 	}

--- a/pkg/importer/reader/parse_file.go
+++ b/pkg/importer/reader/parse_file.go
@@ -17,7 +17,7 @@ package reader
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -38,7 +38,7 @@ func parseFile(path string) ([]*unstructured.Unstructured, error) {
 
 	switch filepath.Ext(path) {
 	case ".yml", ".yaml":
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			klog.Errorf("Failed to read file declared in git from mounted filesystem: %s", path)
 			importer.Metrics.Violations.Inc()
@@ -46,7 +46,7 @@ func parseFile(path string) ([]*unstructured.Unstructured, error) {
 		}
 		return parseYAMLFile(contents)
 	case ".json":
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			klog.Errorf("Failed to read file declared in git from mounted filesystem: %s", path)
 			importer.Metrics.Violations.Inc()

--- a/pkg/reconcilermanager/controllers/parse.go
+++ b/pkg/reconcilermanager/controllers/parse.go
@@ -15,7 +15,7 @@
 package controllers
 
 import (
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 
@@ -41,7 +41,7 @@ var parseDeployment = func(de *appsv1.Deployment) error {
 }
 
 func parseFromDeploymentConfig(config string, obj *appsv1.Deployment) error {
-	yamlDep, err := ioutil.ReadFile(config)
+	yamlDep, err := os.ReadFile(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/testing/openapitest/doc.go
+++ b/pkg/testing/openapitest/doc.go
@@ -16,7 +16,7 @@ package openapitest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -36,7 +36,7 @@ func Doc() (*openapiv2.Document, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/log/logging.go
+++ b/pkg/util/log/logging.go
@@ -17,7 +17,6 @@ package log
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -102,7 +101,7 @@ func (l *Logger) writeContent(content []byte) {
 			return
 		}
 	}
-	tmpFile, err := ioutil.TempFile(l.root, "tmp-err-")
+	tmpFile, err := os.CreateTemp(l.root, "tmp-err-")
 	if err != nil {
 		l.Logger.Error(err, "can't create temporary error-file", "directory", l.root, "prefix", "tmp-err-")
 		return

--- a/pkg/vet/api_resources.go
+++ b/pkg/vet/api_resources.go
@@ -16,7 +16,6 @@ package vet
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -40,7 +39,7 @@ var APIResourcesCommand = fmt.Sprintf("kubectl api-resources > %s", APIResources
 // file is the file to read API Resources from.
 func AddCachedAPIResources(file cmpath.Absolute) discovery.AddResourcesFunc {
 	return func(scoper *discovery.Scoper) status.MultiError {
-		data, err := ioutil.ReadFile(file.OSPath())
+		data, err := os.ReadFile(file.OSPath())
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil


### PR DESCRIPTION
This change removes uses of the deprecated [io/ioutil](https://pkg.go.dev/io/ioutil) package, moving any uses to the [io](https://pkg.go.dev/io) and [os](https://pkg.go.dev/os) packages.