### PR TITLE
Set default log level value and configure at runtime

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_container_log_level.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_log_level.go
@@ -1,0 +1,101 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+)
+
+// ReconcilerContainerLogLevelDefaults are the default log level to use for the
+// reconciler deployment containers.
+// All containers default value are 0 except git-sync which default value is 5
+func ReconcilerContainerLogLevelDefaults() map[string]v1beta1.ContainerLogLevelOverride {
+	return map[string]v1beta1.ContainerLogLevelOverride{
+		reconcilermanager.Reconciler: {
+			ContainerName: reconcilermanager.Reconciler,
+			LogLevel:      0,
+		},
+		reconcilermanager.HydrationController: {
+			ContainerName: reconcilermanager.HydrationController,
+			LogLevel:      0,
+		},
+		reconcilermanager.OciSync: {
+			ContainerName: reconcilermanager.OciSync,
+			LogLevel:      0,
+		},
+		reconcilermanager.HelmSync: {
+			ContainerName: reconcilermanager.HelmSync,
+			LogLevel:      0,
+		},
+		reconcilermanager.GitSync: {
+			ContainerName: reconcilermanager.GitSync,
+			LogLevel:      5, // git-sync default is 5 so the logs will store git commands ran
+		},
+		reconcilermanager.GCENodeAskpassSidecar: {
+			ContainerName: reconcilermanager.GCENodeAskpassSidecar,
+			LogLevel:      0,
+		},
+		metrics.OtelAgentName: {
+			ContainerName: metrics.OtelAgentName,
+			LogLevel:      0,
+		},
+	}
+}
+
+// setContainerLogLevelDefaults will compile the default and override value of container log level
+func setContainerLogLevelDefaults(overrides []v1beta1.ContainerLogLevelOverride, defaultsMap map[string]v1beta1.ContainerLogLevelOverride) []v1beta1.ContainerLogLevelOverride {
+
+	// replace defaultsMap value with values from overrides
+	for _, override := range overrides {
+		defaultsMap[override.ContainerName] = v1beta1.ContainerLogLevelOverride{
+			ContainerName: override.ContainerName,
+			LogLevel:      override.LogLevel,
+		}
+	}
+
+	// convert defaultsMap back to list
+	overrideList := make([]v1beta1.ContainerLogLevelOverride, 0, len(defaultsMap))
+	for _, override := range defaultsMap {
+		overrideList = append(overrideList, override)
+	}
+
+	return overrideList
+}
+
+// mutateContainerLogLevel will add log level to container args as specified in the override
+func mutateContainerLogLevel(c *corev1.Container, override []v1beta1.ContainerLogLevelOverride) {
+	if len(override) == 0 {
+		return
+	}
+	for i, arg := range c.Args {
+		if strings.HasPrefix(arg, "-v=") {
+			c.Args = removeArg(c.Args, i)
+			break
+		}
+	}
+
+	for _, logLevel := range override {
+		if logLevel.ContainerName == c.Name {
+			c.Args = append(c.Args, fmt.Sprintf("-v=%d", logLevel.LogLevel))
+			break
+		}
+	}
+}

--- a/pkg/reconcilermanager/controllers/reconciler_container_log_level.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_log_level.go
@@ -63,17 +63,26 @@ func ReconcilerContainerLogLevelDefaults() map[string]v1beta1.ContainerLogLevelO
 // setContainerLogLevelDefaults will compile the default and override value of container log level
 func setContainerLogLevelDefaults(overrides []v1beta1.ContainerLogLevelOverride, defaultsMap map[string]v1beta1.ContainerLogLevelOverride) []v1beta1.ContainerLogLevelOverride {
 
-	// replace defaultsMap value with values from overrides
+	// copy defaultsMap to local overrideMap
+	overrideMap := make(map[string]v1beta1.ContainerLogLevelOverride)
+	for containerName, logLevelOverride := range defaultsMap {
+		overrideMap[containerName] = v1beta1.ContainerLogLevelOverride{
+			ContainerName: logLevelOverride.ContainerName,
+			LogLevel:      logLevelOverride.LogLevel,
+		}
+	}
+
+	// replace overrideMap value with values from overrides
 	for _, override := range overrides {
-		defaultsMap[override.ContainerName] = v1beta1.ContainerLogLevelOverride{
+		overrideMap[override.ContainerName] = v1beta1.ContainerLogLevelOverride{
 			ContainerName: override.ContainerName,
 			LogLevel:      override.LogLevel,
 		}
 	}
 
-	// convert defaultsMap back to list
-	overrideList := make([]v1beta1.ContainerLogLevelOverride, 0, len(defaultsMap))
-	for _, override := range defaultsMap {
+	// convert overrideMap back to list
+	overrideList := make([]v1beta1.ContainerLogLevelOverride, 0, len(overrideMap))
+	for _, override := range overrideMap {
 		overrideList = append(overrideList, override)
 	}
 

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -1071,9 +1071,12 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 		} else {
 			containerResourceDefaults = ReconcilerContainerResourceDefaults()
 		}
+		var containerLogLevelDefaults = ReconcilerContainerLogLevelDefaults()
+
 		overrides := rs.Spec.SafeOverride()
 		containerResources := setContainerResourceDefaults(overrides.Resources,
 			containerResourceDefaults)
+		containerLogLevels := setContainerLogLevelDefaults(overrides.LogLevels, containerLogLevelDefaults)
 
 		var updatedContainers []corev1.Container
 		// Mutate spec.Containers to update name, configmap references and volumemounts.
@@ -1145,7 +1148,7 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 			if addContainer {
 				// Common mutations for all added containers
 				mutateContainerResource(&container, containerResources)
-				mutateContainerLogLevel(&container, overrides.LogLevels)
+				mutateContainerLogLevel(&container, containerLogLevels)
 				updatedContainers = append(updatedContainers, container)
 			}
 		}

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -956,9 +956,12 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 		} else {
 			containerResourceDefaults = ReconcilerContainerResourceDefaults()
 		}
+		var containerLogLevelDefaults = ReconcilerContainerLogLevelDefaults()
+
 		overrides := rs.Spec.SafeOverride()
 		containerResources := setContainerResourceDefaults(overrides.Resources,
 			containerResourceDefaults)
+		containerLogLevels := setContainerLogLevelDefaults(overrides.LogLevels, containerLogLevelDefaults)
 
 		var updatedContainers []corev1.Container
 		for _, container := range templateSpec.Containers {
@@ -1030,7 +1033,7 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 			if addContainer {
 				// Common mutations for all containers
 				mutateContainerResource(&container, containerResources)
-				mutateContainerLogLevel(&container, overrides.LogLevels)
+				mutateContainerLogLevel(&container, containerLogLevels)
 				updatedContainers = append(updatedContainers, container)
 			}
 		}

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -3733,6 +3733,7 @@ func fleetWorkloadIdentityContainers() []corev1.Container {
 			ReadOnly:  true,
 			MountPath: gcpKSATokenDir,
 		}},
+		Args: defaultArgs(),
 	})
 	return containers
 }
@@ -3871,6 +3872,7 @@ func defaultContainers() []corev1.Container {
 		},
 		{
 			Name: reconcilermanager.GCENodeAskpassSidecar,
+			Args: defaultArgs(),
 		},
 		{
 			Name: reconcilermanager.OciSync,
@@ -4000,6 +4002,7 @@ func gceNodeContainers() []corev1.Container {
 	containers := noneGitContainers()
 	containers = append(containers, corev1.Container{
 		Name: reconcilermanager.GCENodeAskpassSidecar,
+		Args: defaultArgs(),
 	})
 	return containers
 }


### PR DESCRIPTION
After the refactor in https://github.com/GoogleContainerTools/kpt-config-sync/pull/876, reconciler container log level will only be configured after override is specified. To mitigate this, the default log level value will be set earlier alongside the container resource.

Also in this PR, removed some hardcoded log level value and updated unit test data.