### PR TITLE
fix: use GroupName for RootSyncPermissionPrefix

### DIFF
--- a/pkg/core/names.go
+++ b/pkg/core/names.go
@@ -28,7 +28,7 @@ const (
 	// RootReconcilerPrefix is the prefix usef for all Root reconcilers.
 	RootReconcilerPrefix = "root-reconciler"
 	// RootSyncPermissionsPrefix is the prefix used for all ClusterRoleBindings granting access to Root Reconcilers
-	RootSyncPermissionsPrefix = configsync.RootSyncKind + ":" + RootReconcilerPrefix
+	RootSyncPermissionsPrefix = configsync.GroupName + ":" + RootReconcilerPrefix
 )
 
 // RootReconcilerName returns the root reconciler's name in the format root-reconciler-<name>.


### PR DESCRIPTION
This prefix was unintentionally changed to the wrong value in https://github.com/GoogleContainerTools/kpt-config-sync/pull/938