### PR TITLE
Fixes the bitbucket API failures

### DIFF
--- a/e2e/nomostest/gitproviders/bitbucket.go
+++ b/e2e/nomostest/gitproviders/bitbucket.go
@@ -212,8 +212,8 @@ func FetchCloudSecret(name string) (string, error) {
 func (b *BitbucketClient) deleteObsoleteReposByPage(accessToken string, page int) (int, error) {
 	out, err := exec.Command("curl", "-sX", "GET",
 		"-H", fmt.Sprintf("Authorization:Bearer %s", accessToken),
-		fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s?page=%d",
-			GitUser, page)).CombinedOutput()
+		fmt.Sprintf(`https://api.bitbucket.org/2.0/repositories/%s?q=project.key="%s"&page=%d`,
+			GitUser, bitbucketProject, page)).CombinedOutput()
 	if err != nil {
 		return -1, errors.Wrap(err, string(out))
 	}


### PR DESCRIPTION
Bitbucket now has three types of access tokens, repository access token, project access token and workspace access token:
https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens.

The config-sync-ci-bot account only has access to the repository access token. The other two requires upgrading to premium plan.

The repository access token only allows listing repositories with the project filter. Hence this commit as a query to the list call.

b/308221985
b/308219656