### PR TITLE
copy only needed files to docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
-.idea/
-.vscode/
+/**
+!/.output/third_party
+!/LICENSE
+!/go.*
+!/cmd
+!/clientgen
+!/pkg
+!/vendor
+!/scripts

--- a/build/prow/e2e/Dockerfile.dockerignore
+++ b/build/prow/e2e/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+# The e2e image has a custom dockerignore to copy e2e test files
+/**
+!/.output/go/bin
+!/.output/staging/oss
+!/LICENSE
+!/go.*
+!/cmd
+!/clientgen
+!/pkg
+!/vendor
+!/scripts
+!/e2e
+!/examples


### PR DESCRIPTION
This is intended to reduce the time to build the core docker images by only copying needed files into the docker context.