### PR TITLE
test: migrate ResourceGroup e2e tests to this repo

### DIFF
--- a/e2e/nomostest/testresourcegroup/resourcegroup.go
+++ b/e2e/nomostest/testresourcegroup/resourcegroup.go
@@ -1,0 +1,150 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testresourcegroup
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/resourcegroup/apis/kpt.dev/v1alpha1"
+	"kpt.dev/resourcegroup/controllers/resourcegroup"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// NotOwnedMessage is the status message for a resource which does not have
+	// an inventory id.
+	NotOwnedMessage = "This object is not owned by any inventory object. The status for the current object may not reflect the specification for it in current ResourceGroup."
+)
+
+// New creates a new ResourceGroup object
+func New(nn types.NamespacedName, id string) *v1alpha1.ResourceGroup {
+	rg := &v1alpha1.ResourceGroup{}
+	rg.SetNamespace(nn.Namespace)
+	rg.SetName(nn.Name)
+	if id != "" {
+		rg.SetLabels(map[string]string{
+			common.InventoryLabel: id,
+		})
+	}
+	return rg
+}
+
+// GenerateResourceStatus is a helper function to generate an array of ResourceStatus
+// from ObjMetadata
+func GenerateResourceStatus(resources []v1alpha1.ObjMetadata, s v1alpha1.Status, sourceHash string) []v1alpha1.ResourceStatus {
+	resourceStatus := []v1alpha1.ResourceStatus{}
+	for _, resource := range resources {
+		resourceStatus = append(resourceStatus, v1alpha1.ResourceStatus{
+			ObjMetadata: resource,
+			Status:      s,
+			SourceHash:  sourceHash,
+		})
+	}
+	return resourceStatus
+}
+
+// EmptyStatus returns the initial/default ResourceStatus of a
+// ResourceGroup object. This is the status set by the controller upon a successful
+// reconcile.
+func EmptyStatus() v1alpha1.ResourceGroupStatus {
+	return v1alpha1.ResourceGroupStatus{
+		Conditions: []v1alpha1.Condition{
+			{
+				Type:    v1alpha1.Reconciling,
+				Status:  v1alpha1.FalseConditionStatus,
+				Reason:  resourcegroup.FinishReconciling,
+				Message: "finish reconciling",
+			},
+			{
+				Type:    v1alpha1.Stalled,
+				Status:  v1alpha1.FalseConditionStatus,
+				Reason:  resourcegroup.FinishReconciling,
+				Message: "finish reconciling",
+			},
+		},
+	}
+}
+
+// UpdateResourceGroup modifies a ResourceGroup object on the cluster using
+// the provided mutateFn.
+func UpdateResourceGroup(kubeClient *testkubeclient.KubeClient, nn types.NamespacedName, mutateFn func(group *v1alpha1.ResourceGroup)) error {
+	obj := &v1alpha1.ResourceGroup{}
+	if err := kubeClient.Get(nn.Name, nn.Namespace, obj); err != nil {
+		return err
+	}
+	mutateFn(obj)
+	return kubeClient.Update(obj)
+}
+
+// CreateOrUpdateResources applies the list of resources to the cluster with the provided
+// ResourceGroup inventory ID.
+func CreateOrUpdateResources(kubeClient *testkubeclient.KubeClient, resources []v1alpha1.ObjMetadata, id string) error {
+	for _, r := range resources {
+		u := &unstructured.Unstructured{}
+		u.SetName(r.Name)
+		u.SetNamespace(r.Namespace)
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   r.Group,
+			Version: "v1",
+			Kind:    r.Kind,
+		})
+		u.SetAnnotations(map[string]string{
+			"config.k8s.io/owning-inventory":      id,
+			resourcegroup.SourceHashAnnotationKey: "1234567890",
+		})
+
+		err := kubeClient.Get(r.Name, r.Namespace, u.DeepCopy())
+		if err == nil {
+			if updateErr := kubeClient.Update(u); updateErr != nil {
+				return updateErr
+			}
+		} else if apierrors.IsNotFound(err) {
+			if createErr := kubeClient.Create(u); createErr != nil {
+				return createErr
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateNoControllerPodRestarts checks that no pods have restarted in the ResourceGroup
+// controller namespace.
+func ValidateNoControllerPodRestarts(kubeClient *testkubeclient.KubeClient) error {
+	podList := &v1.PodList{}
+	opts := []client.ListOption{
+		client.InNamespace(configmanagement.RGControllerNamespace),
+	}
+	if err := kubeClient.List(podList, opts...); err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		for _, c := range pod.Status.ContainerStatuses {
+			if c.RestartCount != 0 {
+				return fmt.Errorf("%s has a restart as %d", c.Name, c.RestartCount)
+			}
+		}
+	}
+	return nil
+}

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e"
@@ -25,9 +26,13 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testresourcegroup"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/resourcegroup/apis/kpt.dev/v1alpha1"
 )
 
 // This file includes tests for KCC resources from a cloud source repository.
@@ -126,6 +131,86 @@ func TestKCCResourcesOnCSR(t *testing.T) {
 			testwatcher.WatchUnstructured())
 	})
 	if err := tg.Wait(); err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestResourceGroupKCC(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.ACMController, ntopts.KCCTest)
+
+	namespace := "resourcegroup-e2e"
+	nt.T.Cleanup(func() {
+		// all test resources are created in this namespace
+		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+		nt.T.Fatal(err)
+	}
+	rgNN := types.NamespacedName{
+		Name:      "group-kcc",
+		Namespace: namespace,
+	}
+	resourceID := rgNN.Name
+	rg := testresourcegroup.New(rgNN, resourceID)
+	if err := nt.KubeClient.Create(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Create a KCC object and verify the ResourceGroup status")
+	kccObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "serviceusage.cnrm.cloud.google.com/v1beta1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "pubsub.googleapis.com",
+				"namespace": namespace,
+				"annotations": map[string]interface{}{
+					"config.k8s.io/owning-inventory": resourceID,
+				},
+			},
+		},
+	}
+	resource := v1alpha1.ObjMetadata{
+		GroupKind: v1alpha1.GroupKind{
+			Group: kccObj.GroupVersionKind().Group,
+			Kind:  kccObj.GroupVersionKind().Kind,
+		},
+		Namespace: kccObj.GetNamespace(),
+		Name:      kccObj.GetName(),
+	}
+	if err := nt.KubeClient.Create(kccObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.T.Log("Add the KCC object to the ResourceGroup")
+	err := testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Spec.Resources = []v1alpha1.ObjMetadata{resource}
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.T.Log("Verifying the resourcegroup status: It can surface the kcc resource status.conditions")
+	expectedStatus := testresourcegroup.EmptyStatus()
+	expectedStatus.ObservedGeneration = 2
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resource,
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:    "Ready",
+					Status:  "False",
+					Reason:  "UpdateFailed",
+					Message: "Update call failed",
+				},
+			},
+			Status: v1alpha1.InProgress,
+		},
+	}
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
 		nt.T.Fatal(err)
 	}
 }

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -15,18 +15,26 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/retry"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testresourcegroup"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/resourcegroup"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/resourcegroup/apis/kpt.dev/v1alpha1"
 )
 
 func TestResourceGroupController(t *testing.T) {
@@ -59,6 +67,477 @@ func TestResourceGroupController(t *testing.T) {
 		return nil
 	})
 	if err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestResourceGroupControllerInKptGroup(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.ACMController)
+
+	namespace := "resourcegroup-e2e"
+	nt.T.Cleanup(func() {
+		// all test resources are created in this namespace
+		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+		nt.T.Fatal(err)
+	}
+	rgNN := types.NamespacedName{
+		Name:      "group-a",
+		Namespace: namespace,
+	}
+	resourceID := rgNN.Name
+	rg := testresourcegroup.New(rgNN, resourceID)
+	if err := nt.KubeClient.Create(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	expectedStatus := testresourcegroup.EmptyStatus()
+	expectedStatus.ObservedGeneration = 1
+	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	resources := []v1alpha1.ObjMetadata{
+		{
+			Name:      "example",
+			Namespace: rgNN.Namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+	}
+	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Spec.Resources = resources
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	subRGNN := types.NamespacedName{
+		Name:      "group-b",
+		Namespace: rgNN.Namespace,
+	}
+	subRG := testresourcegroup.New(subRGNN, subRGNN.Name)
+	if err := nt.KubeClient.Create(subRG); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Spec.Subgroups = []v1alpha1.GroupMetadata{
+			{
+				Name:      subRGNN.Name,
+				Namespace: subRGNN.Namespace,
+			},
+		}
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	expectedStatus.ObservedGeneration = 3
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.NotFound,
+		},
+	}
+	expectedStatus.SubgroupStatuses = []v1alpha1.GroupStatus{
+		{
+			GroupMetadata: v1alpha1.GroupMetadata{
+				Namespace: subRGNN.Namespace,
+				Name:      subRGNN.Name,
+			},
+			Status: v1alpha1.Current,
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:    v1alpha1.Ownership,
+					Status:  v1alpha1.UnknownConditionStatus,
+					Reason:  v1alpha1.OwnershipEmpty,
+					Message: testresourcegroup.NotOwnedMessage,
+				},
+			},
+		},
+	}
+
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	}, testwatcher.WatchTimeout(time.Minute))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, resourceID); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	expectedStatus.ObservedGeneration = 3
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+	}
+
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	}, testwatcher.WatchTimeout(time.Minute))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, "another"); err != nil {
+		nt.T.Fatal(err)
+	}
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:    v1alpha1.Ownership,
+					Status:  v1alpha1.TrueConditionStatus,
+					Reason:  v1alpha1.OwnershipUnmatch,
+					Message: "This resource is owned by another ResourceGroup another. The status only reflects the specification for the current object in ResourceGroup another.",
+				},
+			},
+		},
+	}
+
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	}, testwatcher.WatchTimeout(time.Minute))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	if err := nt.KubeClient.Delete(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.KubeClient.Delete(subRG); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	if err := testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient); err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestResourceGroupCustomResource(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.ACMController)
+
+	namespace := "resourcegroup-e2e"
+	nt.T.Cleanup(func() {
+		// all test resources are created in this namespace
+		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+		nt.T.Fatal(err)
+	}
+	rgNN := types.NamespacedName{
+		Name:      "group-d",
+		Namespace: namespace,
+	}
+	resourceID := rgNN.Name
+	rg := testresourcegroup.New(rgNN, resourceID)
+	if err := nt.KubeClient.Create(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	expectedStatus := testresourcegroup.EmptyStatus()
+	expectedStatus.ObservedGeneration = 1
+	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	crdObj := anvilV1CRD()
+	crdGVK := anvilGVK("v1")
+	resources := []v1alpha1.ObjMetadata{
+		{
+			Name:      "example",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: crdGVK.Group,
+				Kind:  crdGVK.Kind,
+			},
+		},
+	}
+	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Spec.Resources = resources
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	expectedStatus.ObservedGeneration = 2
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.NotFound,
+		},
+	}
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// Create CRD and CR
+	nt.T.Cleanup(func() {
+		crdObj := anvilV1CRD()
+		if err := nt.KubeClient.Delete(crdObj); err != nil && !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(crdObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.Watcher.WatchForCurrentStatus(kinds.CustomResourceDefinitionV1(), crdObj.Name, ""); err != nil {
+		nt.T.Fatal(err)
+	}
+	anvilObj := anvilCR("v1", resources[0].Name, 10)
+	anvilObj.SetNamespace(resources[0].Namespace)
+	nt.T.Cleanup(func() {
+		anvilObj := anvilCR("v1", resources[0].Name, 10)
+		anvilObj.SetNamespace(resources[0].Namespace)
+		if err := nt.KubeClient.Delete(anvilObj); err != nil && !apierrors.IsNotFound(err) {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(anvilObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	// assert status is updated
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.Current,
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:    v1alpha1.Ownership,
+					Status:  v1alpha1.UnknownConditionStatus,
+					Reason:  "Unknown",
+					Message: testresourcegroup.NotOwnedMessage,
+				},
+			},
+		},
+	}
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.KubeClient.Delete(crdObj); err != nil {
+		nt.T.Fatal(err)
+	}
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.NotFound,
+		},
+	}
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestResourceGroupApplyStatus(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.ACMController)
+
+	namespace := "resourcegroup-e2e"
+	nt.T.Cleanup(func() {
+		// all test resources are created in this namespace
+		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+			nt.T.Error(err)
+		}
+	})
+	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+		nt.T.Fatal(err)
+	}
+	rgNN := types.NamespacedName{
+		Name:      "group-e",
+		Namespace: namespace,
+	}
+	resourceID := rgNN.Name
+	rg := testresourcegroup.New(rgNN, resourceID)
+	if err := nt.KubeClient.Create(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	expectedStatus := testresourcegroup.EmptyStatus()
+	expectedStatus.ObservedGeneration = 1
+	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Create and apply ConfigMaps")
+	resources := []v1alpha1.ObjMetadata{
+		{
+			Name:      "test-status-0",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-1",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-2",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-3",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-4",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-5",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+		{
+			Name:      "test-status-6",
+			Namespace: namespace,
+			GroupKind: v1alpha1.GroupKind{
+				Group: "",
+				Kind:  "ConfigMap",
+			},
+		},
+	}
+	nt.T.Log("Apply all but the last ConfigMap to test NotFound error")
+	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources[:len(resources)-1], resourceID); err != nil {
+		nt.T.Fatal(err)
+	}
+	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Spec.Resources = resources
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	expectedStatus.ObservedGeneration = 2
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[1],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[2],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[3],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[4],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[5],
+			Status:      v1alpha1.Current,
+			SourceHash:  "1234567",
+		},
+		{
+			ObjMetadata: resources[6],
+			Status:      v1alpha1.NotFound,
+		},
+	}
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("inject resource status to verify reconcile behavior")
+	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+		rg.Status.ResourceStatuses = nil
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.T.Log("verify that the controller reconciles to the original status")
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceGroupStatusEquals(expectedStatus),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	actualRG := &v1alpha1.ResourceGroup{}
+	if err := nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, actualRG); err != nil {
+		nt.T.Fatal(err)
+	}
+	resourceVersion := actualRG.ResourceVersion
+	nt.T.Log("Wait and check to see we don't cause an infinite/recursive reconcile loop by ensuring the resourceVersion doesn't change.")
+	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
+		testpredicates.ResourceVersionNotEquals(nt.Scheme, resourceVersion),
+	}, testwatcher.WatchTimeout(60*time.Second))
+	if err == nil {
+		nt.T.Fatal("expected ResourceGroup ResourceVersion to not change")
+	}
+	// happy path is a watch timeout, other errors are fatal
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Delete the ResourceGroup")
+	if err := nt.KubeClient.Delete(rg); err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.T.Log("Assert that the controller pods did not restart")
+	if err := testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient); err != nil {
 		nt.T.Fatal(err)
 	}
 }


### PR DESCRIPTION
This implements the e2e test cases as they are defined in the upstream ResourceGroup repository. Implementing these tests here will enable migrating the remaining controller logic and API definitions to this repository.