### PR TITLE
Implement known_host ssh support

### DIFF
--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -57,6 +57,10 @@ func secretDataPatch(key, value string) string {
 	return fmt.Sprintf(`{"data": {"%s": "%s"}}`, key, value64)
 }
 
+func secretDataDeletePatch(key string) string {
+	return fmt.Sprintf(`{"data": {"%s": null}}`, key)
+}
+
 func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -1,0 +1,221 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	"kpt.dev/configsync/e2e/nomostest/policy"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/testing/fake"
+)
+
+func TestRootSyncSSHKnownHost(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider, ntopts.Unstructured)
+	var err error
+	rootSecret := &corev1.Secret{}
+	nt.T.Cleanup(func() {
+		nt.MustMergePatch(rootSecret, secretDataDeletePatch(controllers.KnownHostsKey))
+		err = nt.Watcher.WatchObject(kinds.Deployment(),
+			core.RootReconcilerPrefix, configsync.ControllerNamespace,
+			[]testpredicates.Predicate{
+				testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
+			},
+		)
+		if err != nil {
+			nt.T.Error(err)
+		}
+	})
+
+	// validate secret and deployment initial stage
+	err = nt.Validate(nomostest.RootAuthSecretName, configsync.ControllerNamespace, rootSecret)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		core.RootReconcilerPrefix, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// get known host key value
+	knownHostValue, err := nomostest.GetKnownHosts(nt)
+	if err != nil {
+		nt.T.Fatalf("error: %s", err)
+	}
+
+	// apply known host key and validate
+	nt.MustMergePatch(rootSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		core.RootReconcilerPrefix, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// try syncing resource and validate
+	cmName := "configmap-test"
+	cmPath := "acme/configmap.yaml"
+	cm := fake.ConfigMapObject(core.Name(cmName))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding test ConfigMap"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Validate(cmName, "default", &corev1.ConfigMap{})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove(cmPath))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing test ConfigMap"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.ValidateNotFound(cmName, "default", &corev1.ConfigMap{}); err != nil {
+		nt.T.Fatalf("error: %s", err)
+	}
+
+	// validate root sync error using invalid known host value
+	knownHostValue = "invalid value"
+	nt.MustMergePatch(rootSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		core.RootReconcilerPrefix, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []testpredicates.Predicate{
+		testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestRepoSyncSSHKnownHost(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider, ntopts.Unstructured,
+		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName), ntopts.WithDelegatedControl,
+		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
+	var err error
+	repoSecret := &corev1.Secret{}
+	repoReconcilerName := core.NsReconcilerName(backendNamespace, configsync.RepoSyncName)
+	repoSyncNN := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
+	nt.T.Cleanup(func() {
+		nt.MustMergePatch(repoSecret, secretDataDeletePatch(controllers.KnownHostsKey))
+		err = nt.Watcher.WatchObject(kinds.Deployment(),
+			repoReconcilerName, configsync.ControllerNamespace,
+			[]testpredicates.Predicate{
+				testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
+			},
+		)
+		if err != nil {
+			nt.T.Error(err)
+		}
+	})
+
+	// validate secret and deployment initial stage
+	err = nt.Validate(nomostest.NamespaceAuthSecretName, backendNamespace, repoSecret)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		repoReconcilerName, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// get known host key value
+	knownHostValue, err := nomostest.GetKnownHosts(nt)
+	if err != nil {
+		nt.T.Fatalf("error: %s", err)
+	}
+
+	// apply known host key and validate
+	nt.MustMergePatch(repoSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		repoReconcilerName, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// try syncing resource and validate
+	cmName := "configmap-test"
+	cmPath := "acme/configmap.yaml"
+	cm := fake.ConfigMapObject(core.Name(cmName))
+	nt.Must(nt.NonRootRepos[repoSyncNN].Add(cmPath, cm))
+	nt.Must(nt.NonRootRepos[repoSyncNN].CommitAndPush("Adding test ConfigMap"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Validate(cmName, backendNamespace, &corev1.ConfigMap{})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	nt.Must(nt.NonRootRepos[repoSyncNN].Remove(cmPath))
+	nt.Must(nt.NonRootRepos[repoSyncNN].CommitAndPush("Removing test ConfigMap"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.ValidateNotFound(cmName, backendNamespace, &corev1.ConfigMap{}); err != nil {
+		nt.T.Fatalf("error: %s", err)
+	}
+
+	// validate repo sync error using invalid known host value
+	knownHostValue = "invalid value"
+	nt.MustMergePatch(repoSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
+	err = nt.Watcher.WatchObject(kinds.Deployment(),
+		repoReconcilerName, configsync.ControllerNamespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	err = nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), configsync.RepoSyncName, backendNamespace, []testpredicates.Predicate{
+		testpredicates.RepoSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+}

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -109,6 +109,7 @@ type reconcilerBase struct {
 	reconcilerPollingPeriod time.Duration
 	hydrationPollingPeriod  time.Duration
 	membership              *hubv1.Membership
+	knownHostExist          bool
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string
@@ -670,4 +671,11 @@ func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef ty
 		logFieldObjectRef, bindingNN.String(),
 		logFieldObjectKind, binding.GetObjectKind().GroupVersionKind().Kind)
 	return nil
+}
+
+func (r *reconcilerBase) isKnownHostsEnabled(auth configsync.AuthType) bool {
+	if auth == configsync.AuthSSH && r.knownHostExist {
+		return true
+	}
+	return false
 }

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -102,6 +102,7 @@ func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			reconcilerPollingPeriod: reconcilerPollingPeriod,
 			hydrationPollingPeriod:  hydrationPollingPeriod,
 			syncKind:                configsync.RepoSyncKind,
+			knownHostExist:          false,
 		},
 		configMapWatches: make(map[string]bool),
 	}
@@ -843,6 +844,7 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			depth:           rs.Spec.SafeOverride().GitSyncDepth,
 			noSSLVerify:     rs.Spec.Git.NoSSLVerify,
 			caCertSecretRef: v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef),
+			knownHost:       r.isKnownHostsEnabled(rs.Spec.Git.Auth),
 		})
 		if enableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
 			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
@@ -934,6 +936,9 @@ func (r *RepoSyncReconciler) validateNamespaceSecret(ctx context.Context, repoSy
 		}
 		return errors.Wrapf(err, "Secret %s get failed", namespaceSecretName)
 	}
+
+	_, r.knownHostExist = secret.Data[KnownHostsKey]
+
 	return validateSecretData(authType, secret)
 }
 


### PR DESCRIPTION
Currently config sync is not supporting known_host configuration for git connection over ssh. With this PR, we are updating the controller logic to check for `known_host` key in the secret. Also added e2e test for Root and Repo sync that demonstrates the end to end process of this feature.

go/cs-known-hosts

b/309005641