### PR TITLE
Sync from the branch if git.rev is empty or HEAD

### DIFF
--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -87,9 +87,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: branch is the git branch to checkout. The field is
-                      deprecated. Use `revision` instead. If both `branch` and `revision`
-                      are defined, `revision` takes precedence over `branch`.
+                    description: branch is the git branch to sync from. Branch defaults
+                      to 'master', but if 'revision' is set and is not 'HEAD', 'revision'
+                      takes precedence over 'branch'.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -146,8 +146,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (branch, tag, ref or
-                      commit) to fetch. Default: "HEAD".'
+                    description: revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Revision defaults to 'branch'.
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git
@@ -1132,9 +1132,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: branch is the git branch to checkout. The field is
-                      deprecated. Use `revision` instead. If both `branch` and `revision`
-                      are defined, `revision` takes precedence over `branch`.
+                    description: branch is the git branch to sync from. Branch defaults
+                      to 'master', but if 'revision' is set and is not 'HEAD', 'revision'
+                      takes precedence over 'branch'.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -1190,8 +1190,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (branch, tag, ref or
-                      commit) to fetch. Default: "HEAD".'
+                    description: revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Revision defaults to 'branch'.
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -87,9 +87,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: branch is the git branch to checkout. The field is
-                      deprecated. Use `revision` instead. If both `branch` and `revision`
-                      are defined, `revision` takes precedence over `branch`.
+                    description: branch is the git branch to sync from. Branch defaults
+                      to 'master', but if 'revision' is set and is not 'HEAD', 'revision'
+                      takes precedence over 'branch'.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -146,8 +146,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (branch, tag, ref or
-                      commit) to fetch. Default: "HEAD".'
+                    description: revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Revision defaults to 'branch'.
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git
@@ -1155,9 +1155,9 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: branch is the git branch to checkout. The field is
-                      deprecated. Use `revision` instead. If both `branch` and `revision`
-                      are defined, `revision` takes precedence over `branch`.
+                    description: branch is the git branch to sync from. Branch defaults
+                      to 'master', but if 'revision' is set and is not 'HEAD', 'revision'
+                      takes precedence over 'branch'.
                     type: string
                   caCertSecretRef:
                     description: caCertSecretRef specifies the name of the secret
@@ -1213,8 +1213,8 @@ spec:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (branch, tag, ref or
-                      commit) to fetch. Default: "HEAD".'
+                    description: revision is the git revision (branch, tag, ref or
+                      commit) to fetch. Revision defaults to 'branch'.
                     type: string
                   secretRef:
                     description: secretRef is the secret used to connect to the Git

--- a/pkg/api/configsync/v1alpha1/gitconfig.go
+++ b/pkg/api/configsync/v1alpha1/gitconfig.go
@@ -25,13 +25,14 @@ type Git struct {
 	// repo is the git repository URL to sync from. Required.
 	Repo string `json:"repo"`
 
-	// branch is the git branch to checkout.
-	// The field is deprecated. Use `revision` instead.
-	// If both `branch` and `revision` are defined, `revision` takes precedence over `branch`.
+	// branch is the git branch to sync from.
+	// Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+	// 'revision' takes precedence over 'branch'.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 
-	// revision is the git revision (branch, tag, ref or commit) to fetch. Default: "HEAD".
+	// revision is the git revision (branch, tag, ref or commit) to fetch.
+	// Revision defaults to 'branch'.
 	// +optional
 	Revision string `json:"revision,omitempty"`
 

--- a/pkg/api/configsync/v1beta1/gitconfig.go
+++ b/pkg/api/configsync/v1beta1/gitconfig.go
@@ -25,13 +25,14 @@ type Git struct {
 	// repo is the git repository URL to sync from. Required.
 	Repo string `json:"repo"`
 
-	// branch is the git branch to checkout.
-	// The field is deprecated. Use `revision` instead.
-	// If both `branch` and `revision` are defined, `revision` takes precedence over `branch`.
+	// branch is the git branch to sync from.
+	// Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+	// 'revision' takes precedence over 'branch'.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 
-	// revision is the git revision (branch, tag, ref or commit) to fetch. Default: "HEAD".
+	// revision is the git revision (branch, tag, ref or commit) to fetch.
+	// Revision defaults to 'branch'.
 	// +optional
 	Revision string `json:"revision,omitempty"`
 

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -3661,6 +3661,7 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 		reconcilermanager.GitSync: {
 			gitSyncKnownHosts: "false",
 			GitSyncRepo:       reposyncRepo,
+			gitSyncRef:        "master",
 			GitSyncDepth:      "1",
 			gitSyncPeriod:     "15s",
 		},

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -3260,6 +3260,7 @@ func TestPopulateRootContainerEnvs(t *testing.T) {
 		reconcilermanager.GitSync: {
 			gitSyncKnownHosts: "false",
 			GitSyncRepo:       rootsyncRepo,
+			gitSyncRef:        "master",
 			GitSyncDepth:      "1",
 			gitSyncPeriod:     "15s",
 		},


### PR DESCRIPTION
`spec.git.branch` is not technically deprecated. Users can still use it for backward compatibility. It is not recommended.

This commit clarifies the description.