### PR TITLE
test: fix name pattern of kcc and stress test

### DIFF
--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -135,7 +135,7 @@ func TestKCCResourcesOnCSR(t *testing.T) {
 	}
 }
 
-func TestResourceGroupKCC(t *testing.T) {
+func TestKCCResourceGroup(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController, ntopts.KCCTest)
 
 	namespace := "resourcegroup-e2e"

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -685,7 +685,7 @@ func TestStressMemoryUsageHelm(t *testing.T) {
 	}
 }
 
-func TestResourceGroupStress(t *testing.T) {
+func TestStressResourceGroup(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController, ntopts.StressTest)
 
 	namespace := "resourcegroup-e2e"


### PR DESCRIPTION
These recently added test cases for ResourceGroup do not match the expected pattern for KCC and stress tests. This change will make it so that the periodic jobs properly run these tests.