### PR TITLE
Add the scope marker to ConfigManagement CRDs

### DIFF
--- a/pkg/api/configmanagement/v1/types.go
+++ b/pkg/api/configmanagement/v1/types.go
@@ -28,6 +28,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // ClusterConfig is the top-level object for the config data definition.
 //
@@ -105,6 +106,7 @@ type ClusterConfigList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // NamespaceConfig is the top-level object for the config data definition.
 //
@@ -209,6 +211,7 @@ type GenericVersionResources struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // ClusterSelector specifies a LabelSelector applied to clusters that exist within a
 // cluster registry.
@@ -248,6 +251,7 @@ type ClusterSelectorList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // NamespaceSelector specifies a LabelSelector applied to namespaces that exist within a
 // NamespaceConfig hierarchy.
@@ -287,6 +291,7 @@ type NamespaceSelectorList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // Sync is used for configuring sync of generic resources.
 type Sync struct {
@@ -369,6 +374,7 @@ type SyncList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // Repo holds configuration and status about the Nomos source of truth.
 type Repo struct {
@@ -542,6 +548,7 @@ type RepoList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 
 // HierarchyConfig is used for configuring the HierarchyModeType for managed resources.
 type HierarchyConfig struct {


### PR DESCRIPTION
This commit configures the scope and the apiVersion of those CRDs. If the scope is not set, the scope of those CRD manifests will be set to Namespaced after regeneration.
Setting the apiVersion is for preparation of moving some types into a separate package.