### PR TITLE
Remove a redefined constant

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -32,7 +32,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/workloadidentity"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -785,12 +784,12 @@ func TestHelmARTokenAuth(t *testing.T) {
 	}
 
 	nt.T.Log("Create secret for authentication")
-	_, err = nt.Shell.Kubectl("create", "secret", "generic", "foo", fmt.Sprintf("--namespace=%s", v1.NSConfigManagementSystem), "--from-literal=username=_json_key", fmt.Sprintf("--from-literal=password=%s", key))
+	_, err = nt.Shell.Kubectl("create", "secret", "generic", "foo", fmt.Sprintf("--namespace=%s", configsync.ControllerNamespace), "--from-literal=username=_json_key", fmt.Sprintf("--from-literal=password=%s", key))
 	if err != nil {
 		nt.T.Fatalf("failed to create secret, err: %v", err)
 	}
 	nt.T.Cleanup(func() {
-		nt.MustKubectl("delete", "secret", "foo", "-n", v1.NSConfigManagementSystem, "--ignore-not-found")
+		nt.MustKubectl("delete", "secret", "foo", "-n", configsync.ControllerNamespace, "--ignore-not-found")
 	})
 
 	chart, err := artifactregistry.PushHelmChart(nt, privateCoreDNSHelmChart, privateCoreDNSHelmChartVersion)

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -32,7 +32,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -344,7 +343,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	// hydration-controller disabled by default, check for existing of container
 	// after sync source contains DRY configs
 	nt.T.Log("Check hydration controller default image name")
-	err := nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
+	err := nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{},
 		testpredicates.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -356,7 +355,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{},
 		testpredicates.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationControllerWithShell, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -403,7 +402,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.T.Log("Update RootSync to sync from the remote-base directory when disable shell in hydration controller")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "remote-base"}}}`)
 	nt.WaitForRootSyncRenderingError(configsync.RootSyncName, status.ActionableHydrationErrorCode, "")
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{},
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{},
 		testpredicates.HasExactlyImage(reconcilermanager.HydrationController, reconcilermanager.HydrationController, "", ""))
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -31,7 +31,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -314,7 +313,7 @@ func checkRepoSyncResourcesNotPresent(nt *nomostest.NT, namespace string, secret
 		return nt.Watcher.WatchForNotFound(kinds.RepoSyncV1Beta1(), configsync.RepoSyncName, namespace)
 	})
 	tg.Go(func() error {
-		return nt.Watcher.WatchForNotFound(kinds.Deployment(), core.NsReconcilerName(namespace, configsync.RepoSyncName), v1.NSConfigManagementSystem)
+		return nt.Watcher.WatchForNotFound(kinds.Deployment(), core.NsReconcilerName(namespace, configsync.RepoSyncName), configsync.ControllerNamespace)
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchForNotFound(kinds.ConfigMap(), "ns-reconciler-bookstore-git-sync", configsync.ControllerNamespace)

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -24,7 +24,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
@@ -43,11 +42,11 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	key := controllers.GitSSLNoVerify
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
 		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 
 	// verify the reconciler deployments don't have the key yet
@@ -122,11 +121,11 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	key := controllers.GitSSLNoVerify
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
 		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 
 	// verify the reconciler deployments don't have the key yet

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -24,7 +24,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -45,11 +44,11 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	key := controllers.GitSyncDepth
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
 		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 
 	err := validateDeploymentContainerHasEnvVar(nt, rootReconcilerNN,
@@ -143,11 +142,11 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	key := controllers.GitSyncDepth
 	rootReconcilerNN := types.NamespacedName{
 		Name:      nomostest.DefaultRootReconcilerName,
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
 		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 	}
 
 	err := validateDeploymentContainerHasEnvVar(nt, rootReconcilerNN,

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -26,7 +26,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -699,7 +698,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nsReconcilerBackendDeploymentGeneration++
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{},
+	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), configsync.ControllerNamespace, &appsv1.Deployment{},
 		testpredicates.GenerationEquals(nsReconcilerBackendDeploymentGeneration),
 		testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.Reconciler]),
 		testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.GitSync]),

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -26,7 +26,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -68,11 +67,11 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	var err error
 
 	// verify the deployment doesn't have the key yet
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -87,7 +86,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt.MustMergePatch(rootSync, syncURLHTTPSPatch(rootSyncHTTPS))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncHTTPS))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -97,7 +96,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -112,7 +111,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use HTTPS"))
 	// RepoSync should fail without caCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncHTTPS))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -124,7 +123,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -133,7 +132,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt.MustMergePatch(rootSync, caCertSecretPatch(""))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -144,7 +143,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncSSHURL))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync unset caCertSecret"))
 	// RepoSync should fail without caCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -170,7 +169,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -186,11 +185,11 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	var err error
 
 	// verify the deployment doesn't have the key yet
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -205,7 +204,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt.MustMergePatch(rootSync, syncURLHTTPSPatch(rootSyncHTTPS))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncHTTPS))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -215,7 +214,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -229,7 +228,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync use HTTPS"))
 	// RepoSync should fail without caCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncHTTPS))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncHTTPS))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -241,13 +240,13 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
 
 	// Check that the namespace secret was upserted to c-m-s namespace
-	err = nt.Validate(controllers.ReconcilerResourceName(reconcilerName, caCertSecret), v1.NSConfigManagementSystem, &corev1.Secret{})
+	err = nt.Validate(controllers.ReconcilerResourceName(reconcilerName, caCertSecret), configsync.ControllerNamespace, &corev1.Secret{})
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -256,7 +255,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt.MustMergePatch(rootSync, caCertSecretPatch(""))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -267,7 +266,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncSSHURL))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, rootSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -278,7 +277,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync unset caCertSecret"))
 	// RepoSync should fail without caCertSecret
 	nt.WaitForRepoSyncSourceError(backendNamespace, configsync.RepoSyncName, status.SourceErrorCode, "server certificate verification failed")
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -293,7 +292,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -309,11 +308,11 @@ func TestCACertSecretWatch(t *testing.T) {
 	var err error
 
 	// verify the deployment doesn't have the key yet
-	err = nt.Validate(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
+	err = nt.Validate(core.NsReconcilerName(backendNamespace, configsync.RepoSyncName), configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -333,7 +332,7 @@ func TestCACertSecretWatch(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, key, caCertPath))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -341,7 +340,7 @@ func TestCACertSecretWatch(t *testing.T) {
 	// Check that the namespace secret was upserted to c-m-s namespace
 	cmsSecret := &corev1.Secret{}
 	cmsSecretName := controllers.ReconcilerResourceName(reconcilerName, caCertSecret)
-	err = nt.Validate(cmsSecretName, v1.NSConfigManagementSystem, cmsSecret)
+	err = nt.Validate(cmsSecretName, configsync.ControllerNamespace, cmsSecret)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -349,7 +348,7 @@ func TestCACertSecretWatch(t *testing.T) {
 	nt.MustMergePatch(cmsSecret, secretDataPatch("foo", "bar"))
 	// Check that watch triggered resync of the c-m-s secret
 	require.NoError(nt.T,
-		nt.Watcher.WatchObject(kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem, []testpredicates.Predicate{
+		nt.Watcher.WatchObject(kinds.Secret(), cmsSecretName, configsync.ControllerNamespace, []testpredicates.Predicate{
 			testpredicates.SecretMissingKey("foo"),
 		}))
 	// Modify the secret in RepoSync namespace
@@ -361,7 +360,7 @@ func TestCACertSecretWatch(t *testing.T) {
 	nt.MustMergePatch(rsSecret, secretDataPatch("baz", "bat"))
 	// Check that the watch triggered upsert to c-m-s secret
 	require.NoError(nt.T,
-		nt.Watcher.WatchObject(kinds.Secret(), cmsSecretName, v1.NSConfigManagementSystem, []testpredicates.Predicate{
+		nt.Watcher.WatchObject(kinds.Secret(), cmsSecretName, configsync.ControllerNamespace, []testpredicates.Predicate{
 			testpredicates.SecretHasKey("baz", "bat"),
 		}))
 	// Unset caCertSecret for repoSyncBackend and use SSH
@@ -375,7 +374,7 @@ func TestCACertSecretWatch(t *testing.T) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate(reconcilerName, v1.NSConfigManagementSystem, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
+	err = nt.Validate(reconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncRepo, repoSyncSSHURL))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -31,7 +31,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -48,7 +47,7 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController)
 
 	rs := &v1beta1.RootSync{}
-	err := nt.Validate(configsync.RootSyncName, v1.NSConfigManagementSystem, rs)
+	err := nt.Validate(configsync.RootSyncName, configsync.ControllerNamespace, rs)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -60,17 +59,17 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 	// Verify Root Reconciler deployment no longer present.
 	_, err = retry.Retry(40*time.Second, func() error {
 		var errs error
-		errs = multierr.Append(errs, nt.ValidateNotFound(nomostest.DefaultRootReconcilerName, v1.NSConfigManagementSystem, fake.DeploymentObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, fake.DeploymentObject()))
 		// validate Root Reconciler configmaps are no longer present.
-		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-git-sync", v1.NSConfigManagementSystem, fake.ConfigMapObject()))
-		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-reconciler", v1.NSConfigManagementSystem, fake.ConfigMapObject()))
-		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-hydration-controller", v1.NSConfigManagementSystem, fake.ConfigMapObject()))
-		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-source-format", v1.NSConfigManagementSystem, fake.ConfigMapObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-git-sync", configsync.ControllerNamespace, fake.ConfigMapObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-reconciler", configsync.ControllerNamespace, fake.ConfigMapObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-hydration-controller", configsync.ControllerNamespace, fake.ConfigMapObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound("root-reconciler-source-format", configsync.ControllerNamespace, fake.ConfigMapObject()))
 		// validate Root Reconciler ServiceAccount is no longer present.
 		saName := core.RootReconcilerName(rs.Name)
-		errs = multierr.Append(errs, nt.ValidateNotFound(saName, v1.NSConfigManagementSystem, fake.ServiceAccountObject(saName)))
+		errs = multierr.Append(errs, nt.ValidateNotFound(saName, configsync.ControllerNamespace, fake.ServiceAccountObject(saName)))
 		// validate Root Reconciler ClusterRoleBinding is no longer present.
-		errs = multierr.Append(errs, nt.ValidateNotFound(controllers.RootSyncPermissionsName(nomostest.DefaultRootReconcilerName), v1.NSConfigManagementSystem, fake.ClusterRoleBindingObject()))
+		errs = multierr.Append(errs, nt.ValidateNotFound(controllers.RootSyncPermissionsName(nomostest.DefaultRootReconcilerName), configsync.ControllerNamespace, fake.ClusterRoleBindingObject()))
 		return errs
 	})
 	if err != nil {
@@ -93,7 +92,7 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 
 	// Validate RootSync is present.
 	var rs v1beta1.RootSync
-	err := nt.Validate(configsync.RootSyncName, v1.NSConfigManagementSystem, &rs)
+	err := nt.Validate(configsync.RootSyncName, configsync.ControllerNamespace, &rs)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -352,7 +351,7 @@ func TestRootSyncReconcilingStatus(t *testing.T) {
 	// Deployment is successfully created.
 	// Log error if the Reconciling condition does not progress to False before the timeout
 	// expires.
-	err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, v1.NSConfigManagementSystem,
+	err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
 		[]testpredicates.Predicate{
 			hasRootSyncReconcilingStatus(metav1.ConditionFalse),
 			hasRootSyncStalledStatus(metav1.ConditionFalse),

--- a/pkg/api/configmanagement/v1/constants.go
+++ b/pkg/api/configmanagement/v1/constants.go
@@ -22,9 +22,6 @@ const ClusterConfigName = "config-management-cluster-config"
 // CRDClusterConfigName is the name of the ClusterConfig for CRD resources.
 const CRDClusterConfigName = "config-management-crd-cluster-config"
 
-// NSConfigManagementSystem is the namespace reserved for ACM core components.
-const NSConfigManagementSystem = "config-management-system"
-
 // ConfigSyncState represents the states that a NamespaceConfig or ClusterConfig
 // can be in with regards to the source of truth.
 type ConfigSyncState string

--- a/pkg/parse/source.go
+++ b/pkg/parse/source.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -209,11 +209,11 @@ func hydratedError(errorFile, label string) hydrate.HydrationError {
 	content, err := os.ReadFile(errorFile)
 	if err != nil {
 		return hydrate.NewInternalError(errors.Errorf("Unable to load %s: %v. Please check %s logs for more info: kubectl logs -n %s -l %s -c %s",
-			errorFile, err, reconcilermanager.HydrationController, v1.NSConfigManagementSystem, label, reconcilermanager.HydrationController))
+			errorFile, err, reconcilermanager.HydrationController, configsync.ControllerNamespace, label, reconcilermanager.HydrationController))
 	}
 	if len(content) == 0 {
 		return hydrate.NewInternalError(fmt.Errorf("%s is empty. Please check %s logs for more info: kubectl logs -n %s -l %s -c %s",
-			errorFile, reconcilermanager.HydrationController, v1.NSConfigManagementSystem, label, reconcilermanager.HydrationController))
+			errorFile, reconcilermanager.HydrationController, configsync.ControllerNamespace, label, reconcilermanager.HydrationController))
 	}
 
 	payload := &hydrate.HydrationErrorPayload{}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -120,7 +119,7 @@ func (r *RepoSyncReconciler) Reconcile(ctx context.Context, req controllerruntim
 	rsRef := req.NamespacedName
 	start := time.Now()
 	reconcilerRef := types.NamespacedName{
-		Namespace: v1.NSConfigManagementSystem,
+		Namespace: configsync.ControllerNamespace,
 		Name:      core.NsReconcilerName(rsRef.Namespace, rsRef.Name),
 	}
 	ctx = r.setLoggerValues(ctx,

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -1834,7 +1833,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 
 	wantServiceAccount := fake.ServiceAccountObject(
 		nsReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
 		core.Labels(label),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -2080,7 +2079,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 
 	serviceAccount1 := fake.ServiceAccountObject(
 		nsReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label1),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2156,7 +2155,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 
 	serviceAccount2 := fake.ServiceAccountObject(
 		nsReconcilerName2,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label2),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2216,7 +2215,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 
 	serviceAccount3 := fake.ServiceAccountObject(
 		nsReconcilerName3,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs3.Spec.GCPServiceAccountEmail),
 		core.Labels(label3),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -2276,7 +2275,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 
 	serviceAccount4 := fake.ServiceAccountObject(
 		nsReconcilerName4,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label4),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2336,7 +2335,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	}
 	serviceAccount5 := fake.ServiceAccountObject(
 		nsReconcilerName5,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label5),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -3168,7 +3167,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 
 	wantServiceAccount := fake.ServiceAccountObject(
 		nsReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -3259,7 +3258,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 
 	wantServiceAccount = fake.ServiceAccountObject(
 		nsReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
 		core.Labels(label),
 		core.UID("1"), core.ResourceVersion("2"), core.Generation(1),
@@ -4237,7 +4236,7 @@ func namespacedName(name, namespace string) reconcile.Request {
 
 func repoSyncDeployment(reconcilerName string, muts ...depMutator) *appsv1.Deployment {
 	dep := fake.DeploymentObject(
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Name(reconcilerName),
 	)
 	var replicas int32 = 1

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/pointer"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -1654,7 +1653,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.GCPServiceAccountEmail),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -1881,7 +1880,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	serviceAccount1 := fake.ServiceAccountObject(
 		rootReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label1),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -1955,7 +1954,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	serviceAccount2 := fake.ServiceAccountObject(
 		rootReconcilerName2,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label2),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2015,7 +2014,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	serviceAccount3 := fake.ServiceAccountObject(
 		rootReconcilerName3,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs3.Spec.GCPServiceAccountEmail),
 		core.Labels(label3),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -2080,7 +2079,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 
 	serviceAccount4 := fake.ServiceAccountObject(
 		rootReconcilerName4,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label4),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2145,7 +2144,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	serviceAccount5 := fake.ServiceAccountObject(
 		rootReconcilerName5,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(label5),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2767,7 +2766,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 
 	wantServiceAccount := fake.ServiceAccountObject(
 		rootReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
@@ -2848,7 +2847,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 
 	wantServiceAccount = fake.ServiceAccountObject(
 		rootReconcilerName,
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Annotation(GCPSAAnnotationKey, rs.Spec.Oci.GCPServiceAccountEmail),
 		core.Labels(labels),
 		core.UID("1"), core.ResourceVersion("2"), core.Generation(1),
@@ -3572,7 +3571,7 @@ type depMutator func(*appsv1.Deployment)
 
 func rootSyncDeployment(reconcilerName string, muts ...depMutator) *appsv1.Deployment {
 	dep := fake.DeploymentObject(
-		core.Namespace(v1.NSConfigManagementSystem),
+		core.Namespace(configsync.ControllerNamespace),
 		core.Name(reconcilerName),
 	)
 	var replicas int32 = 1

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
@@ -48,7 +47,7 @@ const (
 )
 
 var nsReconcilerKey = types.NamespacedName{
-	Namespace: v1.NSConfigManagementSystem,
+	Namespace: configsync.ControllerNamespace,
 	Name:      nsReconcilerName,
 }
 


### PR DESCRIPTION
v1.NSConfigManagementSystem can be replaced by
configsync.ControllerNamespace. This simplifies a followup PR that restructures the configmanagement/v1 APIs.