### PR TITLE
test: wait for test dependencies asyncronously

### DIFF
--- a/e2e/nomostest/config-connector.go
+++ b/e2e/nomostest/config-connector.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// kccSA is the name of the service account used for KCC tests
+	kccSA = "kcc-integration"
+	// kccProject is the name of the GCP project used for KCC tests
+	kccProject = "cs-dev-hub"
+)
+
+// setupConfigConnector creates the ConfigConnector CR on the KCC cluster.
+// The target project and associated resources (e.g. GSAs) are currently hard
+// coded due to lack of provisioning automation. Eventually we may want to make
+// this more flexible/repeatable for different environments.
+func setupConfigConnector(nt *NT) error {
+	gvk := schema.GroupVersionKind{
+		Group:   "core.cnrm.cloud.google.com",
+		Version: "v1beta1",
+		Kind:    "ConfigConnector",
+	}
+	kccObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"mode":                 "cluster",
+				"googleServiceAccount": fmt.Sprintf("%s@%s.iam.gserviceaccount.com", kccSA, kccProject),
+			},
+		},
+	}
+	kccObj.SetGroupVersionKind(gvk)
+	kccObj.SetName(fmt.Sprintf("configconnector.%s", gvk.Group))
+
+	// TODO(sdowell): there are currently issues with cleanup, most likely related to a
+	// known issue in cli-utils. This currently only runs on a dedicated KCC cluster,
+	// so it shouldn't be too disruptive to skip cleanup of the ConfigConnector CR.
+	//nt.T.Cleanup(func() {
+	//	if err := nt.KubeClient.Delete(kccObj); err != nil {
+	//		nt.T.Error(err)
+	//	}
+	//})
+
+	if err := nt.KubeClient.Apply(kccObj); err != nil {
+		return fmt.Errorf("applying config connector manifest: %w", err)
+	}
+
+	return nt.Watcher.WatchForCurrentStatus(gvk, kccObj.GetName(), "")
+}

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -28,7 +28,6 @@ import (
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/e2e/nomostest/gitproviders"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/portforwarder"
@@ -66,13 +65,6 @@ import (
 // This must be different from the field manager used by config sync, in order
 // to allow both clients to manage different fields on the same objects.
 const FieldManager = configsync.GroupName + "/nomostest"
-
-const (
-	// kccSA is the name of the service account used for KCC tests
-	kccSA = "kcc-integration"
-	// kccProject is the name of the GCP project used for KCC tests
-	kccProject = "cs-dev-hub"
-)
 
 // NT represents the test environment for a single Nomos end-to-end test case.
 type NT struct {
@@ -808,37 +800,6 @@ func (nt *NT) detectGKEAutopilot(skipAutopilot bool) {
 	}
 	if nt.IsGKEAutopilot && skipAutopilot {
 		nt.T.Skip("Test skipped when running on Autopilot clusters")
-	}
-}
-
-// setupConfigConnector creates the ConfigConnector CR on the KCC cluster.
-// The target project and associated resources (e.g. GSAs) are currently hard
-// coded due to lack of provisioning automation. Eventually we may want to make
-// this more flexible/repeatable for different environments.
-func (nt *NT) setupConfigConnector() {
-	kccObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "core.cnrm.cloud.google.com/v1beta1",
-			"kind":       "ConfigConnector",
-			"metadata": map[string]interface{}{
-				"name": "configconnector.core.cnrm.cloud.google.com",
-			},
-			"spec": map[string]interface{}{
-				"mode":                 "cluster",
-				"googleServiceAccount": fmt.Sprintf("%s@%s.iam.gserviceaccount.com", kccSA, kccProject),
-			},
-		},
-	}
-	// TODO(sdowell): there are currently issues with cleanup, most likely related to a
-	// known issue in cli-utils. This currently only runs on a dedicated KCC cluster,
-	// so it shouldn't be too disruptive to skip cleanup of the ConfigConnector CR.
-	//nt.T.Cleanup(func() {
-	//	if err := nt.KubeClient.Delete(kccObj); err != nil {
-	//		nt.T.Error(err)
-	//	}
-	//})
-	if err := nt.KubeClient.Apply(kccObj); err != nil {
-		nt.T.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Apply config sync, prometheus, and config connector async. This should speed up test setup, since some of these take a minutes to reconcile.