### PR TITLE
ci: create junit report for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-inf
 # When upgrading this tag, the image will be rebuilt locally during presubmits.
 # After the change is submitted, a postsubmit job will publish the new tag.
 # There is no need to manually publish this image.
-BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.3.1
+BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.3.2
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler
@@ -186,6 +186,8 @@ DOCKER_RUN_ARGS = \
 	-u $(UID):$(GID)                                                   \
 	-v $(GO_DIR):/go                                                   \
 	-v $$(pwd):/go/src/$(REPO)                                         \
+	-v $(ARTIFACTS):/logs/artifacts \
+	--env ARTIFACTS=/logs/artifacts \
 	-v $(GO_DIR)/std/linux_amd64_static:/usr/local/go/pkg/linux_amd64_static    \
 	-v $(GO_DIR)/std/linux_arm64_static:/usr/local/go/pkg/linux_arm64_static    \
 	-v $(GO_DIR)/std/darwin_amd64_static:/usr/local/go/pkg/darwin_amd64_static   \

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -41,7 +41,7 @@ test-e2e: config-sync-manifest-local __install-nomos-local test-e2e-nobuild
 # Useful for modifying test code and rerunning tests without rebuilding images.
 .PHONY: test-e2e-go-nobuild
 test-e2e-nobuild: "$(KUSTOMIZE)" "$(HELM)" "$(CRANE)"
-	./scripts/e2e.sh $(E2E_ARGS)
+	./scripts/test-e2e.sh $(E2E_ARGS)
 
 # Run the Go e2e tests on GKE without building images/manifests.
 # The test framework will create/teardown the GKE clusters.
@@ -84,7 +84,7 @@ test-e2e-kind-multi-repo: config-sync-manifest-local build-kind-e2e
 		--network="host" \
 		--rm \
 		$(KIND_IMAGE) \
-		./scripts/e2e.sh \
+		./scripts/test-e2e.sh \
 			--share-test-env \
 			--timeout $(KIND_E2E_TIMEOUT) \
 			--test.v -v \

--- a/build/buildenv/Dockerfile
+++ b/build/buildenv/Dockerfile
@@ -63,6 +63,8 @@ RUN go install golang.org/x/tools/cmd/goimports@v0.7.0
 ARG GOTOPT2_REPO="github.com/filmil/gotopt2"
 RUN go install ${GOTOPT2_REPO}/cmd/gotopt2@v0.1.2
 
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
+
 # The build environment docker file.
 FROM ${GOLANG_IMAGE}
 

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -16,12 +16,7 @@
 set -euo pipefail
 
 
-./scripts/test-with-junit.sh -installsuffix "static" "$@"
-
-echo "Running nomoserrors"
-# "none" is just a dummy value so nomoserrors doesn't actually print out errors.
-# "none" isn't a special value; any non-numeric non-empty string will do.
-go run cmd/nomoserrors/main.go --id=none
+./scripts/test-with-junit.sh ./e2e/... --p 1 --e2e "$@"
 
 echo "PASS"
 


### PR DESCRIPTION
This generalizes the junit wrapper so that it can be ran for both the
e2e tests and the unit tests in a similar way. This is intended to make
it easier to digest test results in the prow UI.

Based on https://github.com/GoogleContainerTools/kpt-config-sync/pull/997 for the common installation path of the local junit-report binary