### PR TITLE
Add a new Namespace Controller

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -100,6 +100,8 @@ var (
 	namespaceStrategy = flag.String(flags.namespaceStrategy, util.EnvString(reconcilermanager.NamespaceStrategy, ""),
 		fmt.Sprintf("Set the namespace strategy for the reconciler. Must be %s or %s. Default: %s.",
 			configsync.NamespaceStrategyImplicit, configsync.NamespaceStrategyExplicit, configsync.NamespaceStrategyImplicit))
+
+	nsControllerEnabled = flag.Bool("ns-controller-enabled", util.EnvBool(reconcilermanager.NSControllerEnabled, false), "")
 )
 
 var flags = struct {
@@ -193,6 +195,7 @@ func main() {
 		ReconcileTimeout:        *reconcileTimeout,
 		APIServerTimeout:        *apiServerTimeout,
 		RenderingEnabled:        *renderingEnabled,
+		NSControllerEnabled:     *nsControllerEnabled,
 	}
 
 	if declared.Scope(*scope) == declared.RootReconciler {

--- a/pkg/reconciler/namespacecontroller/namespace_controller.go
+++ b/pkg/reconciler/namespacecontroller/namespace_controller.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespacecontroller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/status"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// NamespaceController is a controller that watches for Namespace events and
+// sets a flag to indicate whether the Reconciler thread needs to reconcile for
+// this namespace event.
+type NamespaceController struct {
+	client client.Client
+	state  *State
+}
+
+// New instantiates the namespace controller.
+func New(cl client.Client, state *State) *NamespaceController {
+	return &NamespaceController{
+		client: cl,
+		state:  state,
+	}
+}
+
+// Reconcile processes the Namespace request to set the flag to indicate whether
+// a new reconciliation needs to be executed by the Reconciler thread.
+func (nc *NamespaceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ns := &corev1.Namespace{}
+	if err := nc.client.Get(ctx, req.NamespacedName, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			if nc.state.isSelectedNamespace(req.Name) {
+				klog.Infof("A previously selected Namespace %s is deleted", req.Name)
+				nc.state.setSyncPending()
+			}
+			// Ignore the event of the non-selected namespaces
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, status.APIServerError(err, "failed to get Namespace "+req.Name)
+	}
+
+	if nc.state.matchChanged(ns) {
+		// The Namespace is either previously selected but no longer selected, or it
+		// is not selected but its labels match at least one NamespaceSelector's labels.
+		klog.Infof("The Namespace %s is either selected or unselected", req.Name)
+		nc.state.setSyncPending()
+	}
+	// Ignore the event of the non-selected and non-matching namespaces
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the Namespace Controller.
+func (nc *NamespaceController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("NamespaceController").
+		Watches(&source.Kind{Type: &corev1.Namespace{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(UnmanagedNamespacePredicate{})).
+		Complete(nc)
+
+}

--- a/pkg/reconciler/namespacecontroller/namespace_predicate.go
+++ b/pkg/reconciler/namespacecontroller/namespace_predicate.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespacecontroller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/syncer/differ"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ predicate.Predicate = UnmanagedNamespacePredicate{}
+
+// UnmanagedNamespacePredicate triggers a new reconciliation of the namespace
+// controller when receiving an unmanaged Namespace event.
+type UnmanagedNamespacePredicate struct {
+	predicate.Funcs
+}
+
+// isUnmanagedNamespace returns whether the Namespace is not managed by Config Sync.
+// If it is a managed Namespace, the event should be reconciled by the remediator.
+func isUnmanagedNamespace(obj client.Object) bool {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		// Skip the event if it is not a Namespace object.
+		return false
+	}
+	// Skip the event if the Namespace is already managed by CS
+	return !differ.ManagedByConfigSync(ns)
+}
+
+// Create implements default CreateEvent filter for validating namespace with additional labels.
+func (n UnmanagedNamespacePredicate) Create(e event.CreateEvent) bool {
+	return isUnmanagedNamespace(e.Object)
+}
+
+// Delete implements default DeleteEvent filter for validating namespace with additional labels.
+func (n UnmanagedNamespacePredicate) Delete(_ event.DeleteEvent) bool {
+	// It is not reliable to check if the deleted event is managed by Config Sync
+	// based on the last known labels because it may not match the actual last state.
+	// So it always return true to enqueue the request.
+	return true
+}
+
+// Update implements default UpdateEvent filter for validating namespace label change.
+func (n UnmanagedNamespacePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		klog.Errorf("update event has no old object to update, event: %v", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		klog.Errorf("update event has no new object to update, event: %v", e)
+		return false
+	}
+
+	return isUnmanagedNamespace(e.ObjectOld) || isUnmanagedNamespace(e.ObjectNew)
+}
+
+// Generic implements Predicate.
+func (n UnmanagedNamespacePredicate) Generic(e event.GenericEvent) bool {
+	return isUnmanagedNamespace(e.Object)
+}

--- a/pkg/reconciler/namespacecontroller/state.go
+++ b/pkg/reconciler/namespacecontroller/state.go
@@ -1,0 +1,129 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespacecontroller
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// State stores the state of the Namespace Controller.
+type State struct {
+	// eventMux is a RMMutex to protect read/write to 'isSyncingPending'.
+	// It is RWMutex because the cache is read more often than written.
+	eventMux sync.RWMutex
+
+	// isSyncPending indicates whether the namespace controller fires up an event that requires a new sync.
+	isSyncPending bool
+
+	// selectorMux is the mutex to protect read/write to 'nsSelectors' and 'selectedNamespaces'.
+	selectorMux sync.Mutex
+
+	// nsSelectors is a map of NamespaceSelector names to the LabelSelectors.
+	nsSelectors map[string]labels.Selector
+
+	// selectedNamespaces records the dynamic/on-cluster Namespaces selected by NamespaceSelectors.
+	// It is a map from the Namespace names to the list of NamespaceSelector's LabelSelectors.
+	// A Namespace can be selected by multiple NamespaceSelectors.
+	// The LabelSelectors determine whether a Namespace's select state is changed.
+	selectedNamespaces map[string][]labels.Selector
+}
+
+// NewState instantiates the namespace controller state.
+func NewState() *State {
+	return &State{
+		nsSelectors:        make(map[string]labels.Selector),
+		selectedNamespaces: make(map[string][]labels.Selector),
+	}
+}
+
+// setSyncPending indicates an event is detected to trigger a new sync.
+func (s *State) setSyncPending() {
+	s.eventMux.Lock()
+	defer s.eventMux.Unlock()
+	s.isSyncPending = true
+}
+
+// ScheduleSync checks whether the isSyncPending flag is true.
+// If it is true, a sync should be scheduled by the reconciler thread, and it
+// flips the internal flag to false.
+// If it is false, no sync will be scheduled.
+func (s *State) ScheduleSync() bool {
+	s.eventMux.Lock()
+	defer s.eventMux.Unlock()
+	isSyncingPending := s.isSyncPending
+	if s.isSyncPending {
+		// Reset the Sync pending state after a sync regardless if succeeds or not.
+		// If it fails, a retry should be triggered.
+		s.isSyncPending = false
+	}
+	return isSyncingPending
+}
+
+// SetSelectorCache is invoked by the reconciler to set the cache after parsing the NamespaceSelectors.
+func (s *State) SetSelectorCache(nsSelectors map[string]labels.Selector, selectedNamespaces map[string][]labels.Selector) {
+	s.selectorMux.Lock()
+	defer s.selectorMux.Unlock()
+
+	nssMapCopy := make(map[string]labels.Selector, len(nsSelectors))
+	selectedNSMapCopy := make(map[string][]labels.Selector, len(selectedNamespaces))
+	for nss, selector := range nsSelectors {
+		nssMapCopy[nss] = selector
+	}
+	for ns, selector := range selectedNamespaces {
+		selectedNSMapCopy[ns] = selector
+	}
+
+	s.nsSelectors = nssMapCopy
+	s.selectedNamespaces = selectedNSMapCopy
+}
+
+// isSelectedNamespace returns whether the namespace is previously selected.
+func (s *State) isSelectedNamespace(ns string) bool {
+	s.selectorMux.Lock()
+	defer s.selectorMux.Unlock()
+
+	_, found := s.selectedNamespaces[ns]
+	return found
+}
+
+// matchChanged returns whether the match of Namespace's labels and the cached selector has changed.
+func (s *State) matchChanged(ns *corev1.Namespace) bool {
+	s.selectorMux.Lock()
+	defer s.selectorMux.Unlock()
+
+	nsSelectors, found := s.selectedNamespaces[ns.Name]
+	if !found {
+		for _, selector := range s.nsSelectors {
+			// The Namespace is not selected before, but is now selected.
+			if selector.Matches(labels.Set(ns.GetLabels())) {
+				return true
+			}
+		}
+		// The Namespace is neither selected before, nor selected now, so no change.
+		return false
+	}
+
+	for _, selector := range nsSelectors {
+		// The Namespace is previously selected, but no longer selected by the selector.
+		if !selector.Matches(labels.Set(ns.GetLabels())) {
+			return true
+		}
+	}
+	// The Namespace is selected both before and now.
+	return false
+}

--- a/pkg/reconciler/namespacecontroller/state_test.go
+++ b/pkg/reconciler/namespacecontroller/state_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespacecontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/testing/fake"
+)
+
+var (
+	devLabelSelector     = labels.SelectorFromSet(map[string]string{"environment": "dev"})
+	featureLabelSelector = labels.SelectorFromSet(map[string]string{"feature": "abc"})
+)
+
+func TestMatchChanged(t *testing.T) {
+	testCases := []struct {
+		name               string
+		nsSelectors        map[string]labels.Selector
+		selectedNamespaces map[string][]labels.Selector
+		ns                 *corev1.Namespace
+		wantChanged        bool
+	}{
+		{
+			name:               "a Namespace was previously selected by two selectors, but not selected at all",
+			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
+			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
+			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "prod")),
+			wantChanged:        true,
+		},
+		{
+			name:               "a Namespace was previously selected by two selectors, but only partially selected",
+			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
+			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
+			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "dev")),
+			wantChanged:        true,
+		},
+		{
+			name:               "a Namespace was previously selected, and is also selected now",
+			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
+			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
+			ns:                 fake.NamespaceObject("test-ns", core.Labels(map[string]string{"environment": "dev", "feature": "abc"})),
+			wantChanged:        false,
+		},
+		{
+			name:               "a Namespace was not selected before, but is selected now",
+			nsSelectors:        map[string]labels.Selector{"test-nss": devLabelSelector},
+			selectedNamespaces: map[string][]labels.Selector{"other-ns": {devLabelSelector}},
+			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "dev")),
+			wantChanged:        true,
+		},
+		{
+			name:               "a Namespace is neither selected before nor selected now",
+			nsSelectors:        map[string]labels.Selector{"test-nss": devLabelSelector},
+			selectedNamespaces: map[string][]labels.Selector{"test-other": {devLabelSelector}},
+			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "prod")),
+			wantChanged:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewState()
+			state.SetSelectorCache(tc.nsSelectors, tc.selectedNamespaces)
+			changed := state.matchChanged(tc.ns)
+			assert.Equal(t, tc.wantChanged, changed)
+		})
+	}
+}

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -92,6 +92,10 @@ const (
 	// NamespaceStrategy tells the reconciler container which NamespaceStrategy to
 	// use
 	NamespaceStrategy = "NAMESPACE_STRATEGY"
+
+	// NSControllerEnabled tells the reconciler container whether the namespace
+	// controller in running.
+	NSControllerEnabled = "NS_CONTROLLER_ENABLED"
 )
 
 const (


### PR DESCRIPTION
The Namespace controller watches for Namespace events. If an event is detected, it checks whether the corresponding Namespace was previously selected or will be selected. If it does, it updates a flag to indicate a reconciliation needs to be executed by the reconciler.