### PR TITLE
feat: Add klog flags to nomos cli

### DIFF
--- a/cmd/nomos/bugreport/bugreport.go
+++ b/cmd/nomos/bugreport/bugreport.go
@@ -15,7 +15,6 @@
 package bugreport
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -42,10 +41,9 @@ var Cmd = &cobra.Command{
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true
 
-		// hack to set the hidden variable in klog to also print info statements
-		// cobra does not expose core golang-style flags
-		if err := flag.CommandLine.Parse([]string{"--stderrthreshold=0"}); err != nil {
-			klog.Errorf("could not increase logging verbosity: %v", err)
+		// Send all logs to STDERR.
+		if err := cmd.InheritedFlags().Lookup("stderrthreshold").Value.Set("0"); err != nil {
+			klog.Errorf("failed to increase logging STDERR threshold: %v", err)
 		}
 
 		cfg, err := restconfig.NewRestConfig(flags.ClientTimeout)

--- a/cmd/nomos/nomos.go
+++ b/cmd/nomos/nomos.go
@@ -51,8 +51,15 @@ func init() {
 }
 
 func main() {
-	klog.InitFlags(nil)
-	flag.Parse()
+	// Use the default flag set, because some libs register flags with init.
+	fs := flag.CommandLine
+
+	// Register klog flags
+	klog.InitFlags(fs)
+
+	// Cobra uses the pflag lib, instead of the go flag lib.
+	// So re-register all go flags as global (aka persistent) pflags.
+	rootCmd.PersistentFlags().AddGoFlagSet(fs)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Before:
```
Flags:
  -h, --help   help for nomos
```

After
```
Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
  -h, --help                             help for nomos
      --kubeconfig string                Path to the client config file.
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```