### PR TITLE
Auto-generate manifests for ConfigManagement CRDs

### DIFF
--- a/Makefile.reconcilermanager
+++ b/Makefile.reconcilermanager
@@ -18,18 +18,32 @@ configsync-crds: install-controller-gen "$(KUSTOMIZE)" "$(GOBIN)/addlicense"
 	$(CONTROLLER_GEN) crd \
 		paths="./pkg/api/configsync/v1alpha1" \
 		paths="./pkg/api/configsync/v1beta1" \
+		paths="./pkg/api/configmanagement/v1" \
 		paths="./pkg/api/kpt.dev/v1alpha1" \
 		output:artifacts:config=./manifests \
 	&& mv ./manifests/configsync.gke.io_reposyncs.yaml ./manifests/patch/reposync-crd.yaml \
 	&& mv ./manifests/configsync.gke.io_rootsyncs.yaml ./manifests/patch/rootsync-crd.yaml \
+	&& mv ./manifests/configmanagement.gke.io_clusterselectors.yaml ./manifests/patch/cluster-selector-crd.yaml \
+	&& mv ./manifests/configmanagement.gke.io_hierarchyconfigs.yaml ./manifests/patch/hierarchyconfig-crd.yaml \
+	&& mv ./manifests/configmanagement.gke.io_namespaceselectors.yaml ./manifests/patch/namespace-selector-crd.yaml \
 	&& mv ./manifests/kpt.dev_resourcegroups.yaml ./manifests/patch/resourcegroup-crd.yaml \
 	&& "$(KUSTOMIZE)" build ./manifests/patch -o ./manifests \
 	&& mv ./manifests/*customresourcedefinition_rootsyncs* ./manifests/rootsync-crd.yaml \
 	&& mv ./manifests/*customresourcedefinition_reposyncs* ./manifests/reposync-crd.yaml \
+	&& mv ./manifests/*customresourcedefinition_clusterselectors* ./manifests/cluster-selector-crd.yaml \
+	&& mv ./manifests/*customresourcedefinition_hierarchyconfigs* ./manifests/hierarchyconfig-crd.yaml \
+	&& mv ./manifests/*customresourcedefinition_namespaceselectors* ./manifests/namespace-selector-crd.yaml \
 	&& mv ./manifests/*customresourcedefinition_resourcegroups* ./manifests/resourcegroup-crd.yaml \
 	&& rm ./manifests/patch/reposync-crd.yaml \
 	&& rm ./manifests/patch/rootsync-crd.yaml \
+	&& rm ./manifests/patch/cluster-selector-crd.yaml \
+	&& rm ./manifests/patch/hierarchyconfig-crd.yaml \
+	&& rm ./manifests/patch/namespace-selector-crd.yaml \
 	&& rm ./manifests/patch/resourcegroup-crd.yaml \
+	&& rm ./manifests/configmanagement.gke.io_clusterconfigs.yaml \
+	&& rm ./manifests/configmanagement.gke.io_namespaceconfigs.yaml \
+	&& rm ./manifests/configmanagement.gke.io_repoes.yaml \
+	&& rm ./manifests/configmanagement.gke.io_syncs.yaml \
 	&& "$(GOBIN)/addlicense" ./manifests
 
 .PHONY: install-controller-gen

--- a/manifests/cluster-selector-crd.yaml
+++ b/manifests/cluster-selector-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Custom Resource Definition for a Cluster Selector.
-# This is by and large identical spec to NamespaceSelector, but used in a
-# different context.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: clusterselectors.configmanagement.gke.io
   labels:
     configmanagement.gke.io/system: "true"
+  name: clusterselectors.configmanagement.gke.io
 spec:
-  preserveUnknownFields: false
   group: configmanagement.gke.io
   names:
     kind: ClusterSelector
     listKind: ClusterSelectorList
     plural: clusterselectors
     singular: clusterselector
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifests/hierarchyconfig-crd.yaml
+++ b/manifests/hierarchyconfig-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Custom Resource Definition for a declaring the hierarchy mode for resources
-# in the source of truth.
-# See pkg/api/configmanagement/v1alpha1/types.go for the CRD struct spec.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: hierarchyconfigs.configmanagement.gke.io
   labels:
     configmanagement.gke.io/system: "true"
+  name: hierarchyconfigs.configmanagement.gke.io
 spec:
-  preserveUnknownFields: false
   group: configmanagement.gke.io
   names:
     kind: HierarchyConfig
     listKind: HierarchyConfigList
     plural: hierarchyconfigs
     singular: hierarchyconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifests/namespace-selector-crd.yaml
+++ b/manifests/namespace-selector-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Custom Resource Definition for a Namespace Selector.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: namespaceselectors.configmanagement.gke.io
   labels:
     configmanagement.gke.io/system: "true"
+  name: namespaceselectors.configmanagement.gke.io
 spec:
-  preserveUnknownFields: false
   group: configmanagement.gke.io
   names:
     kind: NamespaceSelector
     listKind: NamespaceSelectorList
     plural: namespaceselectors
     singular: namespaceselector
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifests/patch/kustomization.yaml
+++ b/manifests/patch/kustomization.yaml
@@ -18,6 +18,9 @@ kind: Kustomization
 resources:
 - reposync-crd.yaml
 - rootsync-crd.yaml
+- cluster-selector-crd.yaml
+- hierarchyconfig-crd.yaml
+- namespace-selector-crd.yaml
 - resourcegroup-crd.yaml
 patches:
 - patch: |-
@@ -40,6 +43,33 @@ patches:
         configmanagement.gke.io/arch: "csmr"
     spec:
       preserveUnknownFields: false
+- patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterselectors.configmanagement.gke.io
+        labels:
+          configmanagement.gke.io/system: "true"
+      spec:
+        preserveUnknownFields: false
+- patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: hierarchyconfigs.configmanagement.gke.io
+        labels:
+          configmanagement.gke.io/system: "true"
+      spec:
+        preserveUnknownFields: false
+- patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: namespaceselectors.configmanagement.gke.io
+        labels:
+          configmanagement.gke.io/system: "true"
+      spec:
+        preserveUnknownFields: false
 - patch: |-
       apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition

--- a/pkg/api/configmanagement/v1/types.go
+++ b/pkg/api/configmanagement/v1/types.go
@@ -528,7 +528,23 @@ type ErrorResource struct {
 	// ResourceGVK is the GroupVersionKind of the affected K8S resource. This field may be empty for
 	// errors that are not associated with a specific resource.
 	// +optional
-	ResourceGVK schema.GroupVersionKind `json:"resourceGVK"`
+	ResourceGVK GroupVersionKind `json:"resourceGVK"`
+}
+
+// GroupVersionKind identifies a Kind. It substitutes schema.GroupVersionKind with json tags.
+type GroupVersionKind struct {
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+}
+
+// ParseSchemaGVK parses the schema.GroupVersionKind into custom groupVersionKind with json tags.
+func ParseSchemaGVK(gvk schema.GroupVersionKind) GroupVersionKind {
+	return GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/status/error.go
+++ b/pkg/status/error.go
@@ -177,7 +177,7 @@ func toErrorResource(r client.Object) v1.ErrorResource {
 		SourcePath:        GetSourceAnnotation(r),
 		ResourceName:      r.GetName(),
 		ResourceNamespace: r.GetNamespace(),
-		ResourceGVK:       r.GetObjectKind().GroupVersionKind(),
+		ResourceGVK:       v1.ParseSchemaGVK(r.GetObjectKind().GroupVersionKind()),
 	}
 }
 


### PR DESCRIPTION
The following manifests haven't been updated and are not auto-generated:
- cluster-selector-crd.yaml
- hierachyconfig-crd.yaml
- namespace-selector-crd.yaml

This commit updates the configsync-crd target to include them in the auto-generated manifests.
