### PR TITLE
Update the reconciler-manager to set the ns-controller-requires flag

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -101,7 +101,7 @@ var (
 		fmt.Sprintf("Set the namespace strategy for the reconciler. Must be %s or %s. Default: %s.",
 			configsync.NamespaceStrategyImplicit, configsync.NamespaceStrategyExplicit, configsync.NamespaceStrategyImplicit))
 
-	nsControllerEnabled = flag.Bool("ns-controller-enabled", util.EnvBool(reconcilermanager.NSControllerEnabled, false), "")
+	dynamicNSSelectorEnabled = flag.Bool("dynamic-ns-selector-enabled", util.EnvBool(reconcilermanager.DynamicNSSelectorEnabled, false), "")
 )
 
 var flags = struct {
@@ -172,30 +172,30 @@ func main() {
 	}
 
 	opts := reconciler.Options{
-		ClusterName:             *clusterName,
-		FightDetectionThreshold: *fightDetectionThreshold,
-		NumWorkers:              *workers,
-		ReconcilerScope:         declared.Scope(*scope),
-		ResyncPeriod:            *resyncPeriod,
-		PollingPeriod:           *pollingPeriod,
-		RetryPeriod:             configsync.DefaultReconcilerRetryPeriod,
-		StatusUpdatePeriod:      configsync.DefaultReconcilerSyncStatusUpdatePeriod,
-		SourceRoot:              absSourceDir,
-		RepoRoot:                absRepoRoot,
-		HydratedRoot:            *hydratedRootDir,
-		HydratedLink:            *hydratedLinkDir,
-		SourceRev:               *sourceRev,
-		SourceBranch:            *sourceBranch,
-		SourceType:              v1beta1.SourceType(*sourceType),
-		SourceRepo:              *sourceRepo,
-		SyncDir:                 relSyncDir,
-		SyncName:                *syncName,
-		ReconcilerName:          *reconcilerName,
-		StatusMode:              *statusMode,
-		ReconcileTimeout:        *reconcileTimeout,
-		APIServerTimeout:        *apiServerTimeout,
-		RenderingEnabled:        *renderingEnabled,
-		NSControllerEnabled:     *nsControllerEnabled,
+		ClusterName:              *clusterName,
+		FightDetectionThreshold:  *fightDetectionThreshold,
+		NumWorkers:               *workers,
+		ReconcilerScope:          declared.Scope(*scope),
+		ResyncPeriod:             *resyncPeriod,
+		PollingPeriod:            *pollingPeriod,
+		RetryPeriod:              configsync.DefaultReconcilerRetryPeriod,
+		StatusUpdatePeriod:       configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+		SourceRoot:               absSourceDir,
+		RepoRoot:                 absRepoRoot,
+		HydratedRoot:             *hydratedRootDir,
+		HydratedLink:             *hydratedLinkDir,
+		SourceRev:                *sourceRev,
+		SourceBranch:             *sourceBranch,
+		SourceType:               v1beta1.SourceType(*sourceType),
+		SourceRepo:               *sourceRepo,
+		SyncDir:                  relSyncDir,
+		SyncName:                 *syncName,
+		ReconcilerName:           *reconcilerName,
+		StatusMode:               *statusMode,
+		ReconcileTimeout:         *reconcileTimeout,
+		APIServerTimeout:         *apiServerTimeout,
+		RenderingEnabled:         *renderingEnabled,
+		DynamicNSSelectorEnabled: *dynamicNSSelectorEnabled,
 	}
 
 	if declared.Scope(*scope) == declared.RootReconciler {

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -145,6 +145,14 @@ const (
 	// reconciler-manager will create the reconciler with the hydration-controller
 	// sidecar container.
 	RequiresRenderingAnnotationKey = configsync.ConfigSyncPrefix + "requires-rendering"
+
+	// DynamicNSSelectorEnabledAnnotationKey is the annotation key set on R*Sync
+	// object to indicate whether the source of truth contains at least one
+	// NamespaceSelector using the dynamic mode, which requires the Namespace
+	// controller. The reconciler writes the value of this annotation and the
+	// reconciler-manager reads it. If set to true, the reconciler-manager will
+	// create the reconciler with the Namespace controller in the reconciler container.
+	DynamicNSSelectorEnabledAnnotationKey = configsync.ConfigSyncPrefix + "dynamic-ns-selector-enabled"
 )
 
 // Lifecycle annotations

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -115,9 +115,10 @@ type Options struct {
 	// Root reconciler.
 	// Unset for Namespace repositories.
 	*RootOptions
-	// NSControllerEnabled indicates whether a separate Namespace controller is
-	// running to watch Namespace events.
-	NSControllerEnabled bool
+	// DynamicNSSelectorEnabled indicates whether there exists at least one
+	// NamespaceSelector using the dynamic mode, which requires Namespace
+	// controller running to watch Namespace events.
+	DynamicNSSelectorEnabled bool
 }
 
 // RootOptions are the options specific to parsing Root repositories.
@@ -296,7 +297,7 @@ func Run(opts Options) {
 	// If the flag is disabled, no need to watch the Namespace events.
 	// The NamespaceSelector will dis-select those dynamic/on-cluster Namespaces.
 	var nsControllerState *namespacecontroller.State
-	if opts.NSControllerEnabled {
+	if opts.DynamicNSSelectorEnabled {
 		nsControllerState = namespacecontroller.NewState()
 		nsController := namespacecontroller.New(cl, nsControllerState)
 

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -93,9 +93,10 @@ const (
 	// use
 	NamespaceStrategy = "NAMESPACE_STRATEGY"
 
-	// NSControllerEnabled tells the reconciler container whether the namespace
-	// controller in running.
-	NSControllerEnabled = "NS_CONTROLLER_ENABLED"
+	// DynamicNSSelectorEnabled tells the reconciler container whether the dynamic
+	// mode is enabled in NamespaceSelectors, which requires a Namespace controller
+	// to be running.
+	DynamicNSSelectorEnabled = "DYNAMIC_NS_SELECTOR_ENABLED"
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -851,7 +851,9 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			statusMode:        rs.Spec.SafeOverride().StatusMode,
 			reconcileTimeout:  v1beta1.GetReconcileTimeout(rs.Spec.SafeOverride().ReconcileTimeout),
 			apiServerTimeout:  v1beta1.GetAPIServerTimeout(rs.Spec.SafeOverride().APIServerTimeout),
-			requiresRendering: enableRendering(rs.GetAnnotations()),
+			requiresRendering: annotationEnabled(metadata.RequiresRenderingAnnotationKey, rs.GetAnnotations()),
+			// Namespace reconciler doesn't support NamespaceSelector at all.
+			dynamicNSSelectorEnabled: false,
 		}),
 	}
 	switch v1beta1.SourceType(rs.Spec.SourceType) {
@@ -1125,7 +1127,7 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 			case reconcilermanager.Reconciler:
 				container.Env = append(container.Env, containerEnvs[container.Name]...)
 			case reconcilermanager.HydrationController:
-				if !enableRendering(rs.GetAnnotations()) {
+				if !annotationEnabled(metadata.RequiresRenderingAnnotationKey, rs.GetAnnotations()) {
 					// if the sync source does not require rendering, omit the hydration controller
 					// this minimizes the resource footprint of the reconciler
 					addContainer = false

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -310,6 +310,13 @@ func rootsyncRenderingRequired(renderingRequired bool) func(*v1beta1.RootSync) {
 	}
 }
 
+func rootsyncDynamicNSSelectorEnabled(dynamicNSSelectorEnabled bool) func(*v1beta1.RootSync) {
+	return func(rs *v1beta1.RootSync) {
+		val := strconv.FormatBool(dynamicNSSelectorEnabled)
+		core.SetAnnotation(rs, metadata.DynamicNSSelectorEnabledAnnotationKey, val)
+	}
+}
+
 func rootSync(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	rs := fake.RootSyncObjectV1Beta1(name)
 	// default to require rendering for convenience with existing tests
@@ -3479,6 +3486,16 @@ func TestPopulateRootContainerEnvs(t *testing.T) {
 			),
 			expected: createEnv(map[string]map[string]string{
 				reconcilermanager.Reconciler: {reconcilermanager.RenderingEnabled: "true"},
+			}),
+		},
+		{
+			name: "dynamic-ns-selector-enabled annotation sets env var",
+			rootSync: rootSyncWithGit(rootsyncName,
+				rootsyncRenderingRequired(false),
+				rootsyncDynamicNSSelectorEnabled(true),
+			),
+			expected: createEnv(map[string]map[string]string{
+				reconcilermanager.Reconciler: {reconcilermanager.DynamicNSSelectorEnabled: "true"},
 			}),
 		},
 	}

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -94,20 +94,21 @@ func hydrationEnvs(opts hydrationOptions) []corev1.EnvVar {
 }
 
 type reconcilerOptions struct {
-	clusterName       string
-	syncName          string
-	syncGeneration    int64
-	reconcilerName    string
-	reconcilerScope   declared.Scope
-	sourceType        string
-	gitConfig         *v1beta1.Git
-	ociConfig         *v1beta1.Oci
-	helmConfig        *v1beta1.HelmBase
-	pollPeriod        string
-	statusMode        string
-	reconcileTimeout  string
-	apiServerTimeout  string
-	requiresRendering bool
+	clusterName              string
+	syncName                 string
+	syncGeneration           int64
+	reconcilerName           string
+	reconcilerScope          declared.Scope
+	sourceType               string
+	gitConfig                *v1beta1.Git
+	ociConfig                *v1beta1.Oci
+	helmConfig               *v1beta1.HelmBase
+	pollPeriod               string
+	statusMode               string
+	reconcileTimeout         string
+	apiServerTimeout         string
+	requiresRendering        bool
+	dynamicNSSelectorEnabled bool
 }
 
 // reconcilerEnvs returns environment variables for namespace reconciler.
@@ -207,6 +208,15 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 			Value: strconv.FormatBool(opts.requiresRendering),
 		},
 	)
+
+	if opts.dynamicNSSelectorEnabled {
+		result = append(result,
+			corev1.EnvVar{
+				Name:  reconcilermanager.DynamicNSSelectorEnabled,
+				Value: strconv.FormatBool(opts.dynamicNSSelectorEnabled),
+			},
+		)
+	}
 
 	if syncBranch != "" {
 		result = append(result, corev1.EnvVar{


### PR DESCRIPTION
The reconciler-manager checks the
`configsync.gke.io/requries-ns-controller` annotation in the RSync object and sets the `ns-controller-requires` flag in the reconciler container if the annoation is true.