### PR TITLE
Implement the select mode in the NamespaceSelector API

### DIFF
--- a/cmd/nomos/hydrate/hydrate.go
+++ b/cmd/nomos/hydrate/hydrate.go
@@ -22,6 +22,7 @@ import (
 	"kpt.dev/configsync/cmd/nomos/flags"
 	nomosparse "kpt.dev/configsync/cmd/nomos/parse"
 	"kpt.dev/configsync/cmd/nomos/util"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem"
@@ -105,6 +106,9 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 
 		if sourceFormat == filesystem.SourceFormatHierarchy {
 			files = filesystem.FilterHierarchyFiles(rootDir, files)
+		} else {
+			// hydrate as a root repository to preview all the hydrated configs
+			validateOpts.Scope = declared.RootReconciler
 		}
 
 		filePaths := reader.FilePaths{
@@ -149,7 +153,7 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 
 			allObjects = append(allObjects, fileObjects...)
 		}
-		hydrate.ForEachCluster(parseOpts, validateOpts, clusterFilterFunc)
+		hydrate.ForEachCluster(cmd.Context(), parseOpts, validateOpts, clusterFilterFunc)
 
 		multiCluster := numClusters > 1
 		fileObjects := hydrate.GenerateFileObjects(multiCluster, allObjects...)

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -152,7 +152,7 @@ func runVet(ctx context.Context, namespace string, sourceFormat filesystem.Sourc
 			allObjects = append(allObjects, fileObjects...)
 		}
 	}
-	hydrate.ForEachCluster(parseOpts, validateOpts, clusterFilterFunc)
+	hydrate.ForEachCluster(ctx, parseOpts, validateOpts, clusterFilterFunc)
 	if keepOutput {
 		multiCluster := numClusters > 1
 		fileObjects := hydrate.GenerateFileObjects(multiCluster, allObjects...)

--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -375,6 +375,9 @@ func Generate() AllExamples {
 	// The transient error is not exposed in the R*Sync API, and is supposed to be autoresolvable.
 	result.add(status.TransientError(errors.New("transient error")))
 
+	// 2017
+	result.add(selectors.ListNamespaceError(errors.New("k8s api List error")))
+
 	// 9998
 	result.add(status.InternalError("we made a mistake"))
 

--- a/e2e/nomostest/webhook.go
+++ b/e2e/nomostest/webhook.go
@@ -40,6 +40,9 @@ func WaitForWebhookReadiness(nt *NT) {
 
 // StopWebhook removes the Config Sync ValidatingWebhookConfiguration object.
 func StopWebhook(nt *NT) {
+	if *nt.WebhookDisabled {
+		return
+	}
 	webhookName := configuration.Name
 	webhookGK := "validatingwebhookconfigurations.admissionregistration.k8s.io"
 

--- a/pkg/api/configmanagement/v1/constants.go
+++ b/pkg/api/configmanagement/v1/constants.go
@@ -134,3 +134,10 @@ const (
 	// update the resources in a specific Namespace.
 	EventReasonNamespaceUpdateFailed = "NamespaceUpdateFailed"
 )
+
+const (
+	// NSSelectorStaticMode indicates the NamespaceSelector uses `static` mode.
+	NSSelectorStaticMode string = "static"
+	// NSSelectorDynamicMode indicates the NamespaceSelector uses `dynamic` mode.
+	NSSelectorDynamicMode string = "dynamic"
+)

--- a/pkg/hydrate/for_each_cluster.go
+++ b/pkg/hydrate/for_each_cluster.go
@@ -15,6 +15,8 @@
 package hydrate
 
 import (
+	"context"
+
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/importer/filesystem"
@@ -61,7 +63,7 @@ type ClusterFilterFunc func(clusterName string, fileObjects []ast.FileObject, er
 // - err, the MultiError which Parser.Parse returned, if there was one.
 //
 // Per standard ForEach conventions, ForEachCluster has no return value.
-func ForEachCluster(parseOpts ParseOptions, validateOpts validate.Options, f ClusterFilterFunc) {
+func ForEachCluster(ctx context.Context, parseOpts ParseOptions, validateOpts validate.Options, f ClusterFilterFunc) {
 	var errs status.MultiError
 	clusterRegistry, err := parseOpts.Parser.ReadClusterRegistryResources(parseOpts.FilePaths, parseOpts.SourceFormat)
 	errs = status.Append(errs, err)
@@ -78,7 +80,7 @@ func ForEachCluster(parseOpts ParseOptions, validateOpts validate.Options, f Clu
 	if parseOpts.SourceFormat == filesystem.SourceFormatHierarchy {
 		defaultFileObjects, err = validate.Hierarchical(defaultFileObjects, validateOpts)
 	} else {
-		defaultFileObjects, err = validate.Unstructured(defaultFileObjects, validateOpts)
+		defaultFileObjects, err = validate.Unstructured(ctx, nil, defaultFileObjects, validateOpts)
 	}
 	errs = status.Append(errs, err)
 
@@ -105,7 +107,7 @@ func ForEachCluster(parseOpts ParseOptions, validateOpts validate.Options, f Clu
 		if parseOpts.SourceFormat == filesystem.SourceFormatHierarchy {
 			fileObjects, err = validate.Hierarchical(fileObjects, validateOpts)
 		} else {
-			fileObjects, err = validate.Unstructured(fileObjects, validateOpts)
+			fileObjects, err = validate.Unstructured(ctx, nil, fileObjects, validateOpts)
 		}
 
 		errs = status.Append(errs, err)

--- a/pkg/importer/analyzer/transform/selectors/namespace_selectors.go
+++ b/pkg/importer/analyzer/transform/selectors/namespace_selectors.go
@@ -38,3 +38,16 @@ func ObjectNotInNamespaceSelectorSubdirectory(resource client.Object, selector c
 			resource.GetName(), metadata.NamespaceSelectorAnnotationKey, selector.GetName(), resource.GetName(), selector.GetName(), resource.GetName()).
 		BuildWithResources(selector, resource)
 }
+
+// ListNamespaceErrorCode is the error code for ListNamespaceError used in NamespaceSelector
+const ListNamespaceErrorCode = "2017"
+
+// listNamespaceErrorBuilder registers the new error code.
+var listNamespaceErrorBuilder = status.NewErrorBuilder(ListNamespaceErrorCode)
+
+// ListNamespaceError reports a LIST namespace error when applying NamespaceSelectors.
+func ListNamespaceError(err error) status.Error {
+	return listNamespaceErrorBuilder.Wrap(err).
+		Sprint("listing on-cluster Namespaces to apply NamespaceSelectors").
+		Build()
+}

--- a/pkg/parse/repository_scope.go
+++ b/pkg/parse/repository_scope.go
@@ -15,7 +15,6 @@
 package parse
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
@@ -27,12 +26,8 @@ import (
 // OptionsForScope returns new Options that have been updated for the given
 // Scope.
 func OptionsForScope(options validate.Options, scope declared.Scope) validate.Options {
-	if scope == declared.RootReconciler {
-		options.DefaultNamespace = metav1.NamespaceDefault
-		options.IsNamespaceReconciler = false
-	} else {
-		options.DefaultNamespace = string(scope)
-		options.IsNamespaceReconciler = true
+	options.Scope = scope
+	if scope != declared.RootReconciler {
 		options.Visitors = append(options.Visitors, repositoryScopeVisitor(scope))
 	}
 	return options

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -461,8 +461,6 @@ func TestRoot_Parse(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			parser := &root{
-				sourceFormat:      tc.format,
-				namespaceStrategy: tc.namespaceStrategy,
 				Options: &Options{
 					Parser:             &fakeParser{parse: tc.parsed},
 					SyncName:           rootSyncName,
@@ -477,6 +475,10 @@ func TestRoot_Parse(t *testing.T) {
 						Applier:    &fakeApplier{},
 					},
 					mux: &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat:      tc.format,
+					NamespaceStrategy: tc.namespaceStrategy,
 				},
 			}
 			for _, o := range tc.existingObjects {
@@ -707,8 +709,6 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			parser := &root{
-				sourceFormat:      filesystem.SourceFormatUnstructured,
-				namespaceStrategy: configsync.NamespaceStrategyImplicit,
 				Options: &Options{
 					Parser:             &fakeParser{parse: tc.parsed},
 					SyncName:           rootSyncName,
@@ -723,6 +723,10 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 						Applier:    &fakeApplier{},
 					},
 					mux: &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat:      filesystem.SourceFormatUnstructured,
+					NamespaceStrategy: configsync.NamespaceStrategyImplicit,
 				},
 			}
 			state := reconcilerState{}
@@ -768,7 +772,6 @@ func TestRoot_ParseErrorsMetricValidation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			parser := &root{
-				sourceFormat: filesystem.SourceFormatUnstructured,
 				Options: &Options{
 					Parser:             &fakeParser{errors: tc.errors},
 					SyncName:           rootSyncName,
@@ -780,6 +783,9 @@ func TestRoot_ParseErrorsMetricValidation(t *testing.T) {
 						Resources: &declared.Resources{},
 					},
 					mux: &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat: filesystem.SourceFormatUnstructured,
 				},
 			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, &reconcilerState{})
@@ -826,7 +832,6 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 			m := testmetrics.RegisterMetrics(metrics.ReconcilerErrorsView)
 
 			parser := &root{
-				sourceFormat: filesystem.SourceFormatUnstructured,
 				Options: &Options{
 					Parser:             &fakeParser{errors: tc.parseErrors},
 					SyncName:           rootSyncName,
@@ -838,6 +843,9 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 						Resources: &declared.Resources{},
 					},
 					mux: &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat: filesystem.SourceFormatUnstructured,
 				},
 			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, &reconcilerState{})
@@ -893,7 +901,6 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 			m := testmetrics.RegisterMetrics(metrics.ReconcilerErrorsView)
 
 			parser := &root{
-				sourceFormat: filesystem.SourceFormatUnstructured,
 				Options: &Options{
 					Parser: &fakeParser{},
 					Updater: Updater{
@@ -907,6 +914,9 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					mux:                &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat: filesystem.SourceFormatUnstructured,
 				},
 			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, &reconcilerState{})

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -57,7 +57,9 @@ func newParser(t *testing.T, fs FileSource, renderingEnabled bool) Parser {
 		t.Fatal(err)
 	}
 
-	parser.sourceFormat = filesystem.SourceFormatUnstructured
+	parser.RootOptions = &RootOptions{
+		SourceFormat: filesystem.SourceFormatUnstructured,
+	}
 	parser.Options = &Options{
 		Parser:             filesystem.NewParser(&reader.File{}),
 		StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -106,7 +106,6 @@ func TestReadConfigFiles(t *testing.T) {
 			}
 
 			parser := &root{
-				sourceFormat: filesystem.SourceFormatUnstructured,
 				Options: &Options{
 					Parser:             &fakeParser{},
 					SyncName:           rootSyncName,
@@ -118,6 +117,9 @@ func TestReadConfigFiles(t *testing.T) {
 						Resources: &declared.Resources{},
 					},
 					mux: &sync.Mutex{},
+				},
+				RootOptions: &RootOptions{
+					SourceFormat: filesystem.SourceFormatUnstructured,
 				},
 			}
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -250,8 +250,15 @@ func Run(opts Options) {
 			Remediator: rem,
 		},
 	}
+	nsControllerState := namespacecontroller.NewState()
 	if opts.ReconcilerScope == declared.RootReconciler {
-		parser = parse.NewRootRunner(parseOpts, opts.SourceFormat, opts.NamespaceStrategy)
+		rootOpts := &parse.RootOptions{
+			SourceFormat:             opts.SourceFormat,
+			NamespaceStrategy:        opts.NamespaceStrategy,
+			DynamicNSSelectorEnabled: opts.DynamicNSSelectorEnabled,
+			NSControllerState:        nsControllerState,
+		}
+		parser = parse.NewRootRunner(parseOpts, rootOpts)
 	} else {
 		parser = parse.NewNamespaceRunner(parseOpts)
 		if err != nil {
@@ -317,9 +324,7 @@ func Run(opts Options) {
 	// Only create and register the Namespace Controller when the flag is enabled.
 	// If the flag is disabled, no need to watch the Namespace events.
 	// The NamespaceSelector will dis-select those dynamic/on-cluster Namespaces.
-	var nsControllerState *namespacecontroller.State
 	if opts.DynamicNSSelectorEnabled {
-		nsControllerState = namespacecontroller.NewState()
 		nsController := namespacecontroller.New(cl, nsControllerState)
 
 		// Register the Namespace Controller

--- a/pkg/validate/objects/scoped.go
+++ b/pkg/validate/objects/scoped.go
@@ -15,7 +15,9 @@
 package objects
 
 import (
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/reconciler/namespacecontroller"
 	"kpt.dev/configsync/pkg/status"
 )
 
@@ -25,11 +27,21 @@ type ScopedVisitor func(s *Scoped) status.MultiError
 // Scoped contains a collection of FileObjects that are organized based upon if
 // they are cluster-scoped or namespace-scoped.
 type Scoped struct {
-	Cluster               []ast.FileObject
-	Namespace             []ast.FileObject
-	Unknown               []ast.FileObject
-	DefaultNamespace      string
-	IsNamespaceReconciler bool
+	Cluster   []ast.FileObject
+	Namespace []ast.FileObject
+	Unknown   []ast.FileObject
+	Scope     declared.Scope
+	SyncName  string
+	// AllowAPICall indicates whether the hydration process can send k8s API
+	// calls. Currently, only dynamic NamespaceSelector requires talking to
+	// k8s-api-server.
+	AllowAPICall bool
+	// DynamicNSSelectorEnabled indicates whether the dynamic mode of
+	// NamespaceSelector is enabled.
+	DynamicNSSelectorEnabled bool
+	// NSControllerState caches the NamespaceSelectors and selected Namespaces
+	// in the namespace controller.
+	NSControllerState *namespacecontroller.State
 }
 
 // Objects returns all FileObjects in the Scoped collection.

--- a/pkg/validate/raw/raw.go
+++ b/pkg/validate/raw/raw.go
@@ -15,6 +15,8 @@
 package raw
 
 import (
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/validate/objects"
 	"kpt.dev/configsync/pkg/validate/raw/hydrate"
@@ -48,7 +50,7 @@ func Hierarchical(objs *objects.Raw) status.MultiError {
 		objects.VisitAllRaw(validate.CRDName),
 		objects.VisitAllRaw(validate.RootSync),
 		objects.VisitAllRaw(validate.RepoSync),
-		objects.VisitAllRaw(validate.SelfReconcile(objs.ReconcilerName)),
+		objects.VisitAllRaw(validate.SelfReconcile(reconcilerName(objs.Scope, objs.SyncName))),
 		validate.DisallowedFields,
 		validate.RemovedCRDs,
 		validate.ClusterSelectorsForHierarchical,
@@ -102,7 +104,7 @@ func Unstructured(objs *objects.Raw) status.MultiError {
 		objects.VisitAllRaw(validate.CRDName),
 		objects.VisitAllRaw(validate.RootSync),
 		objects.VisitAllRaw(validate.RepoSync),
-		objects.VisitAllRaw(validate.SelfReconcile(objs.ReconcilerName)),
+		objects.VisitAllRaw(validate.SelfReconcile(reconcilerName(objs.Scope, objs.SyncName))),
 		validate.DisallowedFields,
 		validate.RemovedCRDs,
 		validate.ClusterSelectorsForUnstructured,
@@ -130,4 +132,12 @@ func Unstructured(objs *objects.Raw) status.MultiError {
 		errs = status.Append(errs, hydrator(objs))
 	}
 	return errs
+}
+
+// reconcilerName returns the reconciler name of the corresponding R*Sync.
+func reconcilerName(scope declared.Scope, syncName string) string {
+	if scope == declared.RootReconciler {
+		return core.RootReconcilerName(syncName)
+	}
+	return core.NsReconcilerName(string(scope), syncName)
 }

--- a/pkg/validate/scoped/hydrate/namespace_hydrator.go
+++ b/pkg/validate/scoped/hydrate/namespace_hydrator.go
@@ -15,85 +15,151 @@
 package hydrate
 
 import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/validate/objects"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NamespaceSelectors hydrates the given Scoped objects by performing namespace
-// selection to copy objects into namespaces which match their selector. It also
-// sets a default namespace on any namespace-scoped object that does not already
+// selection to copy objects into namespaces which match their selector. By
+// default, the target namespaces are those statically declared in the source of
+// truth. If NamespaceSelector uses the dynamic mode, it also copies objects
+// into namespaces that are dynamically present on the cluster. It also sets a
+// default namespace on any namespace-scoped object that does not already
 // have a namespace or namespace selector set.
-func NamespaceSelectors(objs *objects.Scoped) status.MultiError {
-	nsSelectors, errs := buildSelectorMap(objs)
-	if errs != nil {
-		return errs
-	}
-	var result []ast.FileObject
-	for _, obj := range objs.Namespace {
-		_, hasSelector := obj.GetAnnotations()[metadata.NamespaceSelectorAnnotationKey]
-		if hasSelector {
-			copies, err := makeNamespaceCopies(obj, nsSelectors)
-			if err != nil {
-				errs = status.Append(errs, err)
-			} else {
-				result = append(result, copies...)
-			}
-		} else {
-			if obj.GetNamespace() == "" {
-				obj.SetNamespace(objs.DefaultNamespace)
-			}
-			result = append(result, obj)
+func NamespaceSelectors(ctx context.Context, c client.Client) objects.ScopedVisitor {
+	return func(objs *objects.Scoped) status.MultiError {
+		nsSelectors, errs := buildSelectorMap(ctx, c, objs)
+		if errs != nil {
+			return errs
 		}
+		var result []ast.FileObject
+		for _, obj := range objs.Namespace {
+			_, hasSelector := obj.GetAnnotations()[metadata.NamespaceSelectorAnnotationKey]
+			if hasSelector {
+				copies, err := makeNamespaceCopies(obj, nsSelectors)
+				if err != nil {
+					errs = status.Append(errs, err)
+				} else {
+					result = append(result, copies...)
+				}
+			} else {
+				if obj.GetNamespace() == "" {
+					if objs.Scope == declared.RootReconciler {
+						obj.SetNamespace(metav1.NamespaceDefault)
+					} else {
+						obj.SetNamespace(string(objs.Scope))
+					}
+				}
+				result = append(result, obj)
+			}
+		}
+		if errs != nil {
+			return errs
+		}
+		objs.Namespace = result
+		return nil
 	}
-	if errs != nil {
-		return errs
-	}
-	objs.Namespace = result
-	return nil
 }
 
 // buildSelectorMap processes the given cluster-scoped objects to return a map
 // of NamespaceSelector names to the namespaces that are selected by each one.
 // Note that this modifies the Scoped objects to filter out the
 // NamespaceSelectors since they are no longer needed after this point.
-func buildSelectorMap(objs *objects.Scoped) (map[string][]string, status.MultiError) {
-	var namespaces, nsSelectors, others []ast.FileObject
+func buildSelectorMap(ctx context.Context, c client.Client, objs *objects.Scoped) (map[string][]string, status.MultiError) {
+	var namespaces, others []ast.FileObject
+	nsSelectorMap := make(map[string]labels.Selector)
+	selectedNamespaceMap := make(map[string][]labels.Selector)
+	var errs status.MultiError
+	hasDynamicNSSelector := false
+
 	for _, obj := range objs.Cluster {
 		switch obj.GetObjectKind().GroupVersionKind() {
 		case kinds.Namespace():
 			namespaces = append(namespaces, obj)
 		case kinds.NamespaceSelector():
-			nsSelectors = append(nsSelectors, obj)
+			nsSelector, err := convertToNamespaceSelector(obj)
+			if err != nil {
+				errs = status.Append(errs, err)
+				continue
+			}
+			selector, err := labelSelector(nsSelector)
+			if err != nil {
+				errs = status.Append(errs, err)
+				continue
+			}
+			nsSelectorMap[nsSelector.Name] = selector
+
+			if nsSelector.Spec.Mode == v1.NSSelectorDynamicMode {
+				hasDynamicNSSelector = true
+			}
 		default:
 			others = append(others, obj)
 		}
 	}
 
-	var errs status.MultiError
-	selectorMap := make(map[string][]string)
-
-	for _, obj := range nsSelectors {
-		var selected []string
-		selector, err := labelSelector(obj)
-		if err != nil {
+	if objs.AllowAPICall && objs.DynamicNSSelectorEnabled != hasDynamicNSSelector {
+		// The DynamicNSSelectorEnabled state mismatches with the required state, set the
+		// annotation so that the reconciler-manager will recreate the reconciler
+		// with the correct setting for the Namespace watch.
+		if err := setDynamicNSSelectorEnabled(ctx, c, objs.SyncName, hasDynamicNSSelector); err != nil {
 			errs = status.Append(errs, err)
-			continue
+			return nil, errs
 		}
+	}
 
-		for _, namespace := range namespaces {
-			if selector.Matches(labels.Set(namespace.GetLabels())) {
-				selected = append(selected, namespace.GetName())
+	nsList := &corev1.NamespaceList{}
+	// Fetch on-cluster Namespaces if allowing API calls and hasDynamicNSSelector,
+	// so that the NamespaceSelector can select resources matching on-cluster Namespaces.
+	if objs.AllowAPICall && hasDynamicNSSelector {
+		if err := c.List(ctx, nsList); err != nil {
+			errs = status.Append(errs, selectors.ListNamespaceError(err))
+			return nil, errs
+		}
+	}
+
+	selectorMap := make(map[string][]string)
+	for nsSelector, selector := range nsSelectorMap {
+		var selectedNamespaces []string
+		// Select dynamic/on-cluster Namespaces that match the NamespaceSelector's labels.
+		for _, ns := range nsList.Items {
+			if selector.Matches(labels.Set(ns.GetLabels())) {
+				selectedNamespaces = append(selectedNamespaces, ns.GetName())
+				// selectedNamespaceMap only stores dynamic Namespaces.
+				selectedNamespaceMap[ns.GetName()] = append(selectedNamespaceMap[ns.GetName()], selector)
 			}
 		}
 
-		selectorMap[obj.GetName()] = selected
+		// Select statically declared Namespaces that match the NamespaceSelector's labels.
+		for _, namespace := range namespaces {
+			if _, found := selectedNamespaceMap[namespace.GetName()]; found {
+				// Ignore static Namespaces that are already selected as dynamic
+				continue
+			}
+			if selector.Matches(labels.Set(namespace.GetLabels())) {
+				selectedNamespaces = append(selectedNamespaces, namespace.GetName())
+			}
+		}
+
+		selectorMap[nsSelector] = selectedNamespaces
 	}
 
 	if errs != nil {
@@ -102,22 +168,22 @@ func buildSelectorMap(objs *objects.Scoped) (map[string][]string, status.MultiEr
 
 	// We are done with NamespaceSelectors so we can filter them out now.
 	objs.Cluster = append(namespaces, others...)
+
+	// Update the NamespaceSelector cache in the Namespace Controller.
+	if objs.NSControllerState != nil {
+		objs.NSControllerState.SetSelectorCache(nsSelectorMap, selectedNamespaceMap)
+	}
 	return selectorMap, nil
 }
 
-func labelSelector(obj ast.FileObject) (labels.Selector, status.Error) {
-	s, sErr := obj.Structured()
-	if sErr != nil {
-		return nil, sErr
-	}
-	nss := s.(*v1.NamespaceSelector)
-
+// labelSelector returns the labelSelector from the NamespaceSelector object
+func labelSelector(nss *v1.NamespaceSelector) (labels.Selector, status.Error) {
 	selector, err := metav1.LabelSelectorAsSelector(&nss.Spec.Selector)
 	if err != nil {
-		return nil, selectors.InvalidSelectorError(obj, err)
+		return nil, selectors.InvalidSelectorError(nss, err)
 	}
 	if selector.Empty() {
-		return nil, selectors.EmptySelectorError(obj)
+		return nil, selectors.EmptySelectorError(nss)
 	}
 	return selector, nil
 }
@@ -138,4 +204,38 @@ func makeNamespaceCopies(obj ast.FileObject, nsSelectors map[string][]string) ([
 		result = append(result, objCopy)
 	}
 	return result, nil
+}
+
+// convertToNamespaceSelector converts the FileObject into the NamespaceSelector type.
+func convertToNamespaceSelector(obj ast.FileObject) (*v1.NamespaceSelector, status.Error) {
+	s, sErr := obj.Structured()
+	if sErr != nil {
+		return nil, sErr
+	}
+	return s.(*v1.NamespaceSelector), nil
+}
+
+// setDynamicNSSelectorEnabled sets the requires-ns-controller annotation on the RootSync object.
+func setDynamicNSSelectorEnabled(ctx context.Context, c client.Client, syncName string, hasDynamicNSSelector bool) status.Error {
+	rs := &v1beta1.RootSync{}
+	objKey := rootsync.ObjectKey(syncName)
+	if err := c.Get(ctx, objKey, rs); err != nil {
+		return status.APIServerError(err, fmt.Sprintf("failed to get RootSync %s for setting the %s annotation",
+			objKey, metadata.DynamicNSSelectorEnabledAnnotationKey))
+	}
+	newVal := strconv.FormatBool(hasDynamicNSSelector)
+	curVal := core.GetAnnotation(rs, metadata.DynamicNSSelectorEnabledAnnotationKey)
+	if curVal == newVal {
+		// avoid unnecessary updates
+		return nil
+	}
+	klog.Infof("The RootSync annotation %s=%s mismatches the reconciler's env %s=%s, so update the annotation to %s",
+		metadata.DynamicNSSelectorEnabledAnnotationKey, curVal, reconcilermanager.DynamicNSSelectorEnabled, newVal, newVal)
+	existing := rs.DeepCopy()
+	core.SetAnnotation(rs, metadata.DynamicNSSelectorEnabledAnnotationKey, newVal)
+	if err := c.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+		return status.APIServerErrorf(err, fmt.Sprintf("failed to patch RootSync %s to set the %s annotation to %s",
+			objKey, metadata.DynamicNSSelectorEnabledAnnotationKey, newVal))
+	}
+	return nil
 }

--- a/pkg/validate/scoped/hydrate/namespace_hydrator_test.go
+++ b/pkg/validate/scoped/hydrate/namespace_hydrator_test.go
@@ -15,45 +15,66 @@
 package hydrate
 
 import (
+	"context"
 	"errors"
+	"strconv"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconciler/namespacecontroller"
 	"kpt.dev/configsync/pkg/status"
+	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/validate/objects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	namespaceSelectorObject = fake.NamespaceSelectorObject(core.Name("dev-only"),
+	devOnlyNSS = fake.NamespaceSelectorObject(core.Name("dev-only"),
 		func(o client.Object) {
 			o.(*v1.NamespaceSelector).Spec.Selector.MatchLabels = map[string]string{
 				"environment": "dev",
 			}
 		})
-	namespaceSelector = fake.FileObject(namespaceSelectorObject, "prod-only-nss.yaml")
-	emptyNss          = fake.NamespaceSelector(core.Name("empty"))
-	invalidNSSObject  = fake.NamespaceSelectorObject(core.Name("invalid"),
+	devOnlyNSSFileObject = fake.FileObject(devOnlyNSS, "dev-only-nss.yaml")
+	emptyNss             = fake.NamespaceSelector(core.Name("empty"))
+	invalidNSSObject     = fake.NamespaceSelectorObject(core.Name("invalid"),
 		func(o client.Object) {
 			o.(*v1.NamespaceSelector).Spec.Selector.MatchLabels = map[string]string{
 				"environment": "xin prod",
 			}
 		})
-	invalidNSS = fake.FileObject(invalidNSSObject, "invalid-nss.yaml")
+	invalidNSS        = fake.FileObject(invalidNSSObject, "invalid-nss.yaml")
+	devOnlyDynamicNSS = fake.NamespaceSelectorObject(core.Name("dev-only"),
+		func(o client.Object) {
+			ns := o.(*v1.NamespaceSelector)
+			ns.Spec.Selector.MatchLabels = map[string]string{
+				"environment": "dev",
+			}
+			ns.Spec.Mode = v1.NSSelectorDynamicMode
+		})
+	devOnlyDynamicNSSFileObject = fake.FileObject(devOnlyDynamicNSS, "dev-only-nss.yaml")
 )
 
 func TestNamespaceSelectors(t *testing.T) {
 	testCases := []struct {
-		name     string
-		objs     *objects.Scoped
-		want     *objects.Scoped
-		wantErrs status.MultiError
+		name                                   string
+		objs                                   *objects.Scoped
+		onClusterObjects                       []client.Object
+		originalDynamicNSSelectorEnabled       bool
+		want                                   *objects.Scoped
+		wantErrs                               status.MultiError
+		wantDynamicNSSelectorEnabledAnnotation bool
 	}{
 		{
 			name: "No objects",
@@ -64,7 +85,7 @@ func TestNamespaceSelectors(t *testing.T) {
 			name: "Keep object with no namespace selector",
 			objs: &objects.Scoped{
 				Cluster: []ast.FileObject{
-					namespaceSelector,
+					devOnlyNSSFileObject,
 					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
 				},
 				Namespace: []ast.FileObject{
@@ -84,13 +105,13 @@ func TestNamespaceSelectors(t *testing.T) {
 			name: "Copy object with active namespace selector",
 			objs: &objects.Scoped{
 				Cluster: []ast.FileObject{
-					namespaceSelector,
+					devOnlyNSSFileObject,
 					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
 					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
 					fake.Namespace("namespaces/dev2", core.Label("environment", "dev")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev-only")),
+					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
 				},
 			},
 			want: &objects.Scoped{
@@ -102,10 +123,10 @@ func TestNamespaceSelectors(t *testing.T) {
 				Namespace: []ast.FileObject{
 					fake.Role(
 						core.Namespace("dev1"),
-						core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev-only")),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
 					fake.Role(
 						core.Namespace("dev2"),
-						core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev-only")),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
 				},
 			},
 		},
@@ -113,11 +134,11 @@ func TestNamespaceSelectors(t *testing.T) {
 			name: "Remove object with inactive namespace selector",
 			objs: &objects.Scoped{
 				Cluster: []ast.FileObject{
-					namespaceSelector,
+					devOnlyNSSFileObject,
 					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev-only")),
+					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
 				},
 			},
 			want: &objects.Scoped{
@@ -127,9 +148,9 @@ func TestNamespaceSelectors(t *testing.T) {
 			},
 		},
 		{
-			name: "Set default namespace on namespaced object without namespace",
+			name: "Set default namespace on namespaced object without namespace or NamespaceSelector",
 			objs: &objects.Scoped{
-				DefaultNamespace: "hello",
+				Scope: "hello",
 				Cluster: []ast.FileObject{
 					fake.ClusterRole(),
 				},
@@ -139,7 +160,7 @@ func TestNamespaceSelectors(t *testing.T) {
 				},
 			},
 			want: &objects.Scoped{
-				DefaultNamespace: "hello",
+				Scope: "hello",
 				Cluster: []ast.FileObject{
 					fake.ClusterRole(),
 				},
@@ -148,6 +169,110 @@ func TestNamespaceSelectors(t *testing.T) {
 					fake.Role(core.Namespace("world")),
 				},
 			},
+		},
+		{
+			name: "Select namespace-scoped resources in both static namespaces and on-cluster namespaces",
+			objs: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					devOnlyDynamicNSSFileObject,
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			onClusterObjects: []client.Object{
+				fake.NamespaceObject("dev2", core.Label("environment", "dev")),
+			},
+			want: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(
+						core.Namespace("dev2"),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+					fake.Role(
+						core.Namespace("dev1"),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			wantDynamicNSSelectorEnabledAnnotation: true,
+		},
+		{
+			name: "Select namespace-scoped resources in both static namespaces and on-cluster namespaces, but they should not be double selected",
+			objs: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					devOnlyDynamicNSSFileObject,
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			onClusterObjects: []client.Object{
+				fake.NamespaceObject("dev1", core.Label("environment", "dev")),
+				fake.NamespaceObject("dev2", core.Label("environment", "dev")),
+			},
+			want: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(
+						core.Namespace("dev1"),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+					fake.Role(
+						core.Namespace("dev2"),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			wantDynamicNSSelectorEnabledAnnotation: true,
+		},
+		{
+			name: "Unselect namespace-scoped resources in on-cluster namespaces",
+			objs: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					devOnlyNSSFileObject,
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			onClusterObjects: []client.Object{
+				fake.NamespaceObject("dev2", core.Label("environment", "dev")),
+			},
+			originalDynamicNSSelectorEnabled: true,
+			want: &objects.Scoped{
+				Scope:    declared.RootReconciler,
+				SyncName: configsync.RootSyncName,
+				Cluster: []ast.FileObject{
+					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+				},
+				Namespace: []ast.FileObject{
+					fake.Role(
+						core.Namespace("dev1"),
+						core.Annotation(metadata.NamespaceSelectorAnnotationKey, devOnlyNSS.Name)),
+				},
+			},
+			wantDynamicNSSelectorEnabledAnnotation: false,
 		},
 		{
 			name: "Error for missing namespace selector",
@@ -217,13 +342,46 @@ func TestNamespaceSelectors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := NamespaceSelectors(tc.objs)
+
+			s := runtime.NewScheme()
+			if err := corev1.AddToScheme(s); err != nil {
+				t.Fatal(err)
+			}
+			if err := v1beta1.AddToScheme(s); err != nil {
+				t.Fatal(err)
+			}
+
+			rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+				core.Annotation(metadata.DynamicNSSelectorEnabledAnnotationKey, strconv.FormatBool(tc.originalDynamicNSSelectorEnabled)))
+			tc.onClusterObjects = append(tc.onClusterObjects, rs)
+			fakeClient := syncerFake.NewClient(t, s, tc.onClusterObjects...)
+
+			tc.objs.AllowAPICall = true
+			tc.objs.DynamicNSSelectorEnabled = tc.originalDynamicNSSelectorEnabled
+			tc.objs.NSControllerState = &namespacecontroller.State{}
+			errs := NamespaceSelectors(context.Background(), fakeClient)(tc.objs)
 			if !errors.Is(errs, tc.wantErrs) {
 				t.Errorf("Got NamespaceSelectors() error %v, want %v", errs, tc.wantErrs)
 			}
-			if diff := cmp.Diff(tc.want, tc.objs, ast.CompareFileObject); diff != "" {
-				t.Error(diff)
+			assert.ElementsMatch(t, tc.want.Cluster, tc.objs.Cluster)
+			assert.ElementsMatch(t, tc.want.Namespace, tc.objs.Namespace)
+			assert.ElementsMatch(t, tc.want.Unknown, tc.objs.Unknown)
+			assert.Equal(t, tc.want.Scope, tc.objs.Scope)
+			assert.Equal(t, tc.want.SyncName, tc.objs.SyncName)
+
+			updatedDynamicNSSelectorEnabled, err := dynamicNSSelectorEnabled(fakeClient)
+			if err != nil {
+				t.Fatal(err)
 			}
+			assert.Equal(t, tc.wantDynamicNSSelectorEnabledAnnotation, updatedDynamicNSSelectorEnabled)
 		})
 	}
+}
+
+func dynamicNSSelectorEnabled(fakeClient client.Client) (bool, error) {
+	rs := &v1beta1.RootSync{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKey{Namespace: configsync.ControllerNamespace, Name: configsync.RootSyncName}, rs); err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(rs.Annotations[metadata.DynamicNSSelectorEnabledAnnotationKey])
 }


### PR DESCRIPTION
Previously, NamespaceSelector only supports selecting namespace-scoped
resources whose labels match those labels of the Namespaces that are
statically declared in the source of truth.

This commit updates the NamespaceSelector to support selecting
dynmaic/on-cluster Namespaces as well.
When it applies the NamespaceSelector, it sends out a LIST request to
get all Namespaces and select resources match the on-cluster Namespaces.
