### PR TITLE
test: fix go linter install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ DOCKER_CLI_IMAGE := gcr.io/cloud-builders/docker:20.10.14
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
 
+GOLANGCI_LINT_VERSION := v1.52.0
+GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
+
 KUSTOMIZE_VERSION := v5.1.1-gke.2
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
@@ -325,7 +328,7 @@ deps: tidy vendor
 lint: lint-go lint-bash lint-yaml lint-license lint-license-headers
 
 .PHONY: lint-go
-lint-go: buildenv-dirs
+lint-go: "$(GOLANGCI_LINT)"
 	./scripts/lint-go.sh $(NOMOS_GO_PKG)
 
 .PHONY: lint-bash
@@ -338,6 +341,17 @@ lint-license: buildenv-dirs
 
 "$(GOBIN)/addlicense":
 	go install github.com/google/addlicense@v1.0.0
+
+"$(GOLANGCI_LINT)": buildenv-dirs
+	GOPATH="$(GO_DIR)" go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+.PHONY: install-golangci-lint
+# install golangci-lint (user-friendly target alias)
+install-golangci-lint: "$(GOLANGCI_LINT)"
+
+.PHONY: clean-golangci-lint
+clean-golangci-lint:
+	@rm -rf $(GOLANGCI_LINT)
 
 "$(KUSTOMIZE)": buildenv-dirs
 	@KUSTOMIZE_VERSION="$(KUSTOMIZE_VERSION)" \
@@ -392,6 +406,10 @@ install-kind: "$(KIND)"
 .PHONY: install-crane
 # install crane (user-friendly target alias)
 install-crane: "$(CRANE)"
+
+.PHONY: clean-crane
+clean-crane:
+	@rm -rf $(CRANE)
 
 .PHONY: license-headers
 license-headers: "$(GOBIN)/addlicense"

--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -16,21 +16,20 @@
 
 set -euo pipefail
 
-export CGO_ENABLED=0
-
-# TODO: It is best practice to install directly on the Docker image,
-#  but for now it's unclear how to do this sanely.
-LINTER_VERSION="v1.52.0"
-go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${LINTER_VERSION}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
 
 # golangci-lint uses $HOME to determine where to store .cache information.
 # For the docker image this is running in, $HOME is set to "/", so for this
 # script we overwrite that as the docker image does not have permission to
 # create a /.cache directory.
-HOME=.output/
+if [[ "${HOME}" == "/" ]]; then
+  HOME="$(pwd)/.output/"
+  export HOME
+fi
 
 echo "Running golangci-lint: "
-if ! OUT="$(.output/go/bin/golangci-lint run --exclude-use-default=false)"; then
+if ! OUT="$(golangci-lint run --exclude-use-default=false)"; then
   echo "${OUT}"
 
   NC=''


### PR DESCRIPTION
Install with "go install" into .output/go/bin, instead of the local user's $GOPATH/bin.

The latest versions of go install respect GOPATH, but not GOBIN. But we can't set GOPATH as a global in the Makefile, otherwise we wouldn't be able to build, cache, and vendor using the system Go.