### PR TITLE
test: fix addlicense & controller-gen install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ DOCKER_CLI_IMAGE := gcr.io/cloud-builders/docker:20.10.14
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
 
+ADDLICENSE_VERSION := v1.1.1
+ADDLICENSE := $(BIN_DIR)/addlicense
+
 GOLANGCI_LINT_VERSION := v1.52.0
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 
@@ -339,8 +342,16 @@ lint-bash:
 lint-license: buildenv-dirs
 	./scripts/lint-license.sh
 
-"$(GOBIN)/addlicense":
-	go install github.com/google/addlicense@v1.0.0
+"$(ADDLICENSE)": buildenv-dirs
+	GOPATH="$(GO_DIR)" go install github.com/google/addlicense@$(ADDLICENSE_VERSION)
+
+.PHONY: install-addlicense
+# install addlicense (user-friendly target alias)
+install-addlicense: "$(ADDLICENSE)"
+
+.PHONY: clean-addlicense
+clean-addlicense:
+	@rm -rf $(ADDLICENSE)
 
 "$(GOLANGCI_LINT)": buildenv-dirs
 	GOPATH="$(GO_DIR)" go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
@@ -412,12 +423,12 @@ clean-crane:
 	@rm -rf $(CRANE)
 
 .PHONY: license-headers
-license-headers: "$(GOBIN)/addlicense"
-	GOBIN=$(GOBIN) ./scripts/license-headers.sh add
+license-headers: "$(ADDLICENSE)"
+	./scripts/license-headers.sh add
 
 .PHONY: lint-license-headers
-lint-license-headers: "$(GOBIN)/addlicense"
-	GOBIN=$(GOBIN) ./scripts/license-headers.sh lint
+lint-license-headers: "$(ADDLICENSE)"
+	./scripts/license-headers.sh lint
 
 .PHONY: lint-yaml
 lint-yaml:
@@ -425,7 +436,7 @@ lint-yaml:
 
 .PHONY: test-loggers
 test-loggers:
-	GOBIN=$(GOBIN) ./scripts/generate-test-loggers.sh
+	./scripts/generate-test-loggers.sh
 
 # Print the value of a variable
 print-%:

--- a/Makefile.build
+++ b/Makefile.build
@@ -129,7 +129,7 @@ build-manifests: build-manifests-operator build-manifests-oss
 
 # Build Config Sync manifests for OSS installations
 .PHONY: build-manifests-oss
-build-manifests-oss: "$(GOBIN)/addlicense" "$(KUSTOMIZE)" $(OUTPUT_DIR)
+build-manifests-oss: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 	@ echo "+++ Generating manifests in $(OSS_MANIFEST_STAGING_DIR)"
 	@ echo " Using tags: $(REGISTRY)/*:$(IMAGE_TAG)"
 	@ rm -f $(OSS_MANIFEST_STAGING_DIR)/*
@@ -143,7 +143,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
 		> $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
-	@ "$(GOBIN)/addlicense" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+	@ "$(ADDLICENSE)" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 
 	@ # Additional optional OSS manifests
 	@ cat "manifests/templates/admission-webhook.yaml" \
@@ -154,7 +154,7 @@ build-manifests-oss: "$(GOBIN)/addlicense" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 
 # Build Config Sync manifests for ACM operator
 .PHONY: build-manifests-operator
-build-manifests-operator: "$(GOBIN)/addlicense" "$(KUSTOMIZE)" $(OUTPUT_DIR)
+build-manifests-operator: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 	@ echo "+++ Generating manifests in $(NOMOS_MANIFEST_STAGING_DIR)"
 	@ echo " Using tags: $(REGISTRY)/*:$(IMAGE_TAG)"
 	@ rm -f $(NOMOS_MANIFEST_STAGING_DIR)/*
@@ -169,7 +169,7 @@ build-manifests-operator: "$(GOBIN)/addlicense" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
 		> $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
-	@ "$(GOBIN)/addlicense" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
+	@ "$(ADDLICENSE)" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 
 	@ echo "+++ Manifests generated in $(NOMOS_MANIFEST_STAGING_DIR)"
 

--- a/Makefile.reconcilermanager
+++ b/Makefile.reconcilermanager
@@ -1,11 +1,12 @@
 
 
-CONTROLLER_GEN := $(GOBIN)/controller-gen
+CONTROLLER_GEN_VERSION := v0.13.0
+CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 
 .PHONY: generate
 # Generate DeepCopy and runtime.Object implementation methods.
-generate: install-controller-gen
-	$(CONTROLLER_GEN) \
+generate: "$(CONTROLLER_GEN)"
+	"$(CONTROLLER_GEN)" \
 		object:headerFile="hack/boilerplate.txt" \
 		paths="./pkg/api/configsync/v1alpha1" \
 		paths="./pkg/api/configsync/v1beta1" \
@@ -14,8 +15,8 @@ generate: install-controller-gen
 
 .PHONY: configsync-crds
 # Generate configsync CRDs and then patch them with kustomize
-configsync-crds: install-controller-gen "$(KUSTOMIZE)" "$(GOBIN)/addlicense"
-	$(CONTROLLER_GEN) crd \
+configsync-crds: "$(CONTROLLER_GEN)" "$(KUSTOMIZE)" "$(ADDLICENSE)"
+	"$(CONTROLLER_GEN)" crd \
 		paths="./pkg/api/configsync/v1alpha1" \
 		paths="./pkg/api/configsync/v1beta1" \
 		paths="./pkg/api/configmanagement/v1" \
@@ -44,12 +45,18 @@ configsync-crds: install-controller-gen "$(KUSTOMIZE)" "$(GOBIN)/addlicense"
 	&& rm ./manifests/configmanagement.gke.io_namespaceconfigs.yaml \
 	&& rm ./manifests/configmanagement.gke.io_repoes.yaml \
 	&& rm ./manifests/configmanagement.gke.io_syncs.yaml \
-	&& "$(GOBIN)/addlicense" ./manifests
+	&& "$(ADDLICENSE)" ./manifests
+
+"$(CONTROLLER_GEN)": buildenv-dirs
+	GOPATH="$(GO_DIR)" go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 .PHONY: install-controller-gen
-# install controller-gen from source
-install-controller-gen:
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
+# install controller-gen (user-friendly target alias)
+install-controller-gen: "$(CONTROLLER_GEN)"
+
+.PHONY: clean-controller-gen
+clean-controller-gen:
+	@rm -rf $(CONTROLLER_GEN)
 
 .PHONY: generate-in-docker
 # Run make generate-in-docker in the docker buildenv container

--- a/manifests/cluster-selector-crd.yaml
+++ b/manifests/cluster-selector-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/hierarchyconfig-crd.yaml
+++ b/manifests/hierarchyconfig-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/namespace-selector-crd.yaml
+++ b/manifests/namespace-selector-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/resourcegroup-crd.yaml
+++ b/manifests/resourcegroup-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/generate-test-loggers.sh
+++ b/scripts/generate-test-loggers.sh
@@ -15,13 +15,12 @@
 
 set -euo pipefail
 
-if [ "${GOBIN:-"unset"}" == "unset" ]; then
-  echo "GOBIN unset"
+if [[ -z "$(which addlicense)" ]]; then
+  echo "addlicense not in PATH"
   exit 1
 fi
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${REPO_ROOT}"
 
 GO_MODULE="$(grep "^module" "go.mod" | cut -d' ' -f2)"
@@ -71,6 +70,6 @@ for source_path in "${source_paths[@]}"; do
     PACKAGE_NAME="$(basename "${test_dir_path}")"
     PACKAGE_PATH="${test_dir_path}"
     render_main_test > "${file_name}"
-    "${GOBIN}/addlicense" -c "Google LLC" -f LICENSE_TEMPLATE "${file_name}"
+    "addlicense" -c "Google LLC" -f LICENSE_TEMPLATE "${file_name}"
   done <<< "$(find_test_dirs "${source_path}")"
 done

--- a/scripts/license-headers.sh
+++ b/scripts/license-headers.sh
@@ -15,10 +15,13 @@
 
 set -euo pipefail
 
-if [ "${GOBIN:-"unset"}" == "unset" ]; then
-  echo "GOBIN unset"
+if [[ -z "$(which addlicense)" ]]; then
+  echo "addlicense not in PATH"
   exit 1
 fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
 
 ignores=(
   "-ignore=vendor/**"
@@ -31,10 +34,10 @@ ignores=(
 
 case "$1" in
   lint)
-    "${GOBIN}/addlicense" -check "${ignores[@]}" . 2>&1 | sed '/ skipping: / d'
+    "addlicense" -check "${ignores[@]}" . 2>&1 | sed '/ skipping: / d'
     ;;
   add)
-    "${GOBIN}/addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE \
+    "addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE \
       "${ignores[@]}" \
       . 2>&1 | sed '/ skipping: / d'
     ;;


### PR DESCRIPTION
Install with "go install" into .output/go/bin, instead of the local user's $GOPATH/bin.

The latest versions of go install respect GOPATH, but not GOBIN. But we can't set GOPATH as a global in the Makefile, otherwise we wouldn't be able to build, cache, and vendor using the system Go.