### PR TITLE
ci: add clientgen/generate to presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ include Makefile.reconcilermanager
 -include Makefile.release
 
 .PHONY: all
-all: test deps configsync-crds
+all: test deps configsync-crds generate clientgen
 
 # Cleans all artifacts.
 .PHONY: clean

--- a/scripts/fail-if-dirty-repo.sh
+++ b/scripts/fail-if-dirty-repo.sh
@@ -25,5 +25,6 @@ if is_dirty_repo; then
   echo "Git status output:"
   # Prefix git status output with a pound sign for better readability
   git status | sed 's/.*/# &/'
+  git diff
   exit 1
 fi

--- a/scripts/generate-clientset.sh
+++ b/scripts/generate-clientset.sh
@@ -32,7 +32,7 @@
 # Alternatively, make a symlink from the GOPATH package source directory to the
 # repo directory.
 
-set -euox pipefail
+set -euo pipefail
 
 GOPATH="${GOPATH:-$(go env GOPATH)}"
 


### PR DESCRIPTION
This adds the clientgen and generate calls to the presubmit check. This ensures that the generated code is always up to date.