### PR TITLE
test: fix test flake for role ref on autopilot

### DIFF
--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -160,10 +160,10 @@ func TestRootSyncRoleRefs(t *testing.T) {
 		nomostest.DefaultRootSha1Fn, nomostest.RootSyncHasStatusSyncCommit, nil); err != nil {
 		nt.T.Fatal(err)
 	}
+	if err := nt.Watcher.WatchForNotFound(kinds.RootSyncV1Beta1(), syncANN.Name, syncANN.Namespace); err != nil {
+		nt.T.Fatal(err)
+	}
 	tg = taskgroup.New()
-	tg.Go(func() error {
-		return nt.ValidateNotFound(syncANN.Name, syncANN.Namespace, &v1beta1.RootSync{})
-	})
 	tg.Go(func() error {
 		return validateRoleRefs(nt, configsync.RootSyncKind, syncANN, []v1beta1.RootSyncRoleRef{})
 	})


### PR DESCRIPTION
The validation for garbage collection was happening in parallel with the RootSync NotFound validation, which creates a race condition that can be exacerbated on autopilot. By waiting for the RootSync to be NotFound first, it should be guaranteed that all of the managed resources have been garbage collected.

Example test flake: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-stable/1725176860112850944