### PR TITLE
fix: get clientgen version from go.mod file

### DIFF
--- a/Makefile.gen
+++ b/Makefile.gen
@@ -26,7 +26,8 @@ symlink-gopath:
 
 CLIENTGEN_TOOLS := client-gen deepcopy-gen informer-gen lister-gen conversion-gen
 # This should match the k8s.io/code-generator version in go.mod.
-CLIENTGEN_VERSION := "v0.22.2"
+# We do not install k8s.io/code-generator, so use client-go as a proxy.
+CLIENTGEN_VERSION := $(shell grep k8s.io/client-go go.mod | head -n1 | cut -d' ' -f2)
 
 INSTALL_CLIENTGEN_TOOLS := $(patsubst %,install-%,$(CLIENTGEN_TOOLS))
 

--- a/clientgen/apis/clientset.go
+++ b/clientgen/apis/clientset.go
@@ -4,6 +4,7 @@ package apis
 
 import (
 	"fmt"
+	"net/http"
 
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -24,8 +25,7 @@ type Interface interface {
 	KptV1alpha1() kptv1alpha1.KptV1alpha1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	configmanagementV1 *configmanagementv1.ConfigmanagementV1Client
@@ -71,7 +71,29 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// share the transport between all clients
+	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfigAndClient(&configShallowCopy, httpClient)
+}
+
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -79,30 +101,31 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
 	var cs Clientset
 	var err error
-	cs.configmanagementV1, err = configmanagementv1.NewForConfig(&configShallowCopy)
+	cs.configmanagementV1, err = configmanagementv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.configsyncV1alpha1, err = configsyncv1alpha1.NewForConfig(&configShallowCopy)
+	cs.configsyncV1alpha1, err = configsyncv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.configsyncV1beta1, err = configsyncv1beta1.NewForConfig(&configShallowCopy)
+	cs.configsyncV1beta1, err = configsyncv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.hubV1, err = hubv1.NewForConfig(&configShallowCopy)
+	cs.hubV1, err = hubv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.kptV1alpha1, err = kptv1alpha1.NewForConfig(&configShallowCopy)
+	cs.kptV1alpha1, err = kptv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -112,15 +135,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.configmanagementV1 = configmanagementv1.NewForConfigOrDie(c)
-	cs.configsyncV1alpha1 = configsyncv1alpha1.NewForConfigOrDie(c)
-	cs.configsyncV1beta1 = configsyncv1beta1.NewForConfigOrDie(c)
-	cs.hubV1 = hubv1.NewForConfigOrDie(c)
-	cs.kptV1alpha1 = kptv1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/clientgen/apis/typed/configmanagement/v1/configmanagement_client.go
+++ b/clientgen/apis/typed/configmanagement/v1/configmanagement_client.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"net/http"
+
 	rest "k8s.io/client-go/rest"
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -53,12 +55,28 @@ func (c *ConfigmanagementV1Client) Syncs() SyncInterface {
 }
 
 // NewForConfig creates a new ConfigmanagementV1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*ConfigmanagementV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new ConfigmanagementV1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*ConfigmanagementV1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_clusterconfig.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_clusterconfig.go
@@ -94,7 +94,7 @@ func (c *FakeClusterConfigs) UpdateStatus(ctx context.Context, clusterConfig *co
 // Delete takes name of the clusterConfig and deletes it. Returns an error if one occurs.
 func (c *FakeClusterConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterconfigsResource, name), &configmanagementv1.ClusterConfig{})
+		Invokes(testing.NewRootDeleteActionWithOptions(clusterconfigsResource, name, opts), &configmanagementv1.ClusterConfig{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_clusterselector.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_clusterselector.go
@@ -83,7 +83,7 @@ func (c *FakeClusterSelectors) Update(ctx context.Context, clusterSelector *conf
 // Delete takes name of the clusterSelector and deletes it. Returns an error if one occurs.
 func (c *FakeClusterSelectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterselectorsResource, name), &configmanagementv1.ClusterSelector{})
+		Invokes(testing.NewRootDeleteActionWithOptions(clusterselectorsResource, name, opts), &configmanagementv1.ClusterSelector{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_hierarchyconfig.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_hierarchyconfig.go
@@ -83,7 +83,7 @@ func (c *FakeHierarchyConfigs) Update(ctx context.Context, hierarchyConfig *conf
 // Delete takes name of the hierarchyConfig and deletes it. Returns an error if one occurs.
 func (c *FakeHierarchyConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(hierarchyconfigsResource, name), &configmanagementv1.HierarchyConfig{})
+		Invokes(testing.NewRootDeleteActionWithOptions(hierarchyconfigsResource, name, opts), &configmanagementv1.HierarchyConfig{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_namespaceconfig.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_namespaceconfig.go
@@ -94,7 +94,7 @@ func (c *FakeNamespaceConfigs) UpdateStatus(ctx context.Context, namespaceConfig
 // Delete takes name of the namespaceConfig and deletes it. Returns an error if one occurs.
 func (c *FakeNamespaceConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespaceconfigsResource, name), &configmanagementv1.NamespaceConfig{})
+		Invokes(testing.NewRootDeleteActionWithOptions(namespaceconfigsResource, name, opts), &configmanagementv1.NamespaceConfig{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_namespaceselector.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_namespaceselector.go
@@ -83,7 +83,7 @@ func (c *FakeNamespaceSelectors) Update(ctx context.Context, namespaceSelector *
 // Delete takes name of the namespaceSelector and deletes it. Returns an error if one occurs.
 func (c *FakeNamespaceSelectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespaceselectorsResource, name), &configmanagementv1.NamespaceSelector{})
+		Invokes(testing.NewRootDeleteActionWithOptions(namespaceselectorsResource, name, opts), &configmanagementv1.NamespaceSelector{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_repo.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_repo.go
@@ -94,7 +94,7 @@ func (c *FakeRepos) UpdateStatus(ctx context.Context, repo *configmanagementv1.R
 // Delete takes name of the repo and deletes it. Returns an error if one occurs.
 func (c *FakeRepos) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(reposResource, name), &configmanagementv1.Repo{})
+		Invokes(testing.NewRootDeleteActionWithOptions(reposResource, name, opts), &configmanagementv1.Repo{})
 	return err
 }
 

--- a/clientgen/apis/typed/configmanagement/v1/fake/fake_sync.go
+++ b/clientgen/apis/typed/configmanagement/v1/fake/fake_sync.go
@@ -94,7 +94,7 @@ func (c *FakeSyncs) UpdateStatus(ctx context.Context, sync *configmanagementv1.S
 // Delete takes name of the sync and deletes it. Returns an error if one occurs.
 func (c *FakeSyncs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(syncsResource, name), &configmanagementv1.Sync{})
+		Invokes(testing.NewRootDeleteActionWithOptions(syncsResource, name, opts), &configmanagementv1.Sync{})
 	return err
 }
 

--- a/clientgen/apis/typed/configsync/v1alpha1/configsync_client.go
+++ b/clientgen/apis/typed/configsync/v1alpha1/configsync_client.go
@@ -3,6 +3,8 @@
 package v1alpha1
 
 import (
+	"net/http"
+
 	rest "k8s.io/client-go/rest"
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	v1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
@@ -18,12 +20,28 @@ type ConfigsyncV1alpha1Client struct {
 }
 
 // NewForConfig creates a new ConfigsyncV1alpha1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*ConfigsyncV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new ConfigsyncV1alpha1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*ConfigsyncV1alpha1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/clientgen/apis/typed/configsync/v1beta1/configsync_client.go
+++ b/clientgen/apis/typed/configsync/v1beta1/configsync_client.go
@@ -3,6 +3,8 @@
 package v1beta1
 
 import (
+	"net/http"
+
 	rest "k8s.io/client-go/rest"
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	v1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -18,12 +20,28 @@ type ConfigsyncV1beta1Client struct {
 }
 
 // NewForConfig creates a new ConfigsyncV1beta1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*ConfigsyncV1beta1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new ConfigsyncV1beta1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*ConfigsyncV1beta1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/clientgen/apis/typed/hub/v1/hub_client.go
+++ b/clientgen/apis/typed/hub/v1/hub_client.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"net/http"
+
 	rest "k8s.io/client-go/rest"
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	v1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -18,12 +20,28 @@ type HubV1Client struct {
 }
 
 // NewForConfig creates a new HubV1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*HubV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new HubV1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*HubV1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/clientgen/apis/typed/kpt.dev/v1alpha1/kpt.dev_client.go
+++ b/clientgen/apis/typed/kpt.dev/v1alpha1/kpt.dev_client.go
@@ -3,6 +3,8 @@
 package v1alpha1
 
 import (
+	"net/http"
+
 	rest "k8s.io/client-go/rest"
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	v1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
@@ -18,12 +20,28 @@ type KptV1alpha1Client struct {
 }
 
 // NewForConfig creates a new KptV1alpha1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*KptV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new KptV1alpha1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*KptV1alpha1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/clientgen/informer/factory.go
+++ b/clientgen/informer/factory.go
@@ -31,6 +31,11 @@ type sharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
+	// wg tracks how many goroutines were started.
+	wg sync.WaitGroup
+	// shuttingDown is true when Shutdown has been called. It may still be running
+	// because it needs to wait for goroutines.
+	shuttingDown bool
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
@@ -91,20 +96,39 @@ func NewSharedInformerFactoryWithOptions(client apis.Interface, defaultResync ti
 	return factory
 }
 
-// Start initializes all requested informers.
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.shuttingDown {
+		return
+	}
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			f.wg.Add(1)
+			// We need a new variable in each loop iteration,
+			// otherwise the goroutine would use the loop variable
+			// and that keeps changing.
+			informer := informer
+			go func() {
+				defer f.wg.Done()
+				informer.Run(stopCh)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}
 }
 
-// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *sharedInformerFactory) Shutdown() {
+	f.lock.Lock()
+	f.shuttingDown = true
+	f.lock.Unlock()
+
+	// Will return immediately if there is nothing to wait for.
+	f.wg.Wait()
+}
+
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
@@ -151,10 +175,57 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
+//
+// It is typically used like this:
+//
+//	ctx, cancel := context.Background()
+//	defer cancel()
+//	factory := NewSharedInformerFactory(client, resyncPeriod)
+//	defer factory.WaitForStop()    // Returns immediately if nothing was started.
+//	genericInformer := factory.ForResource(resource)
+//	typedInformer := factory.SomeAPIGroup().V1().SomeType()
+//	factory.Start(ctx.Done())          // Start processing these informers.
+//	synced := factory.WaitForCacheSync(ctx.Done())
+//	for v, ok := range synced {
+//	    if !ok {
+//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
+//	        return
+//	    }
+//	}
+//
+//	// Creating informers can also be created after Start, but then
+//	// Start must be called again:
+//	anotherGenericInformer := factory.ForResource(resource)
+//	factory.Start(ctx.Done())
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
-	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
+
+	// Start initializes all requested informers. They are handled in goroutines
+	// which run until the stop channel gets closed.
+	Start(stopCh <-chan struct{})
+
+	// Shutdown marks a factory as shutting down. At that point no new
+	// informers can be started anymore and Start will return without
+	// doing anything.
+	//
+	// In addition, Shutdown blocks until all goroutines have terminated. For that
+	// to happen, the close channel(s) that they were started with must be closed,
+	// either before Shutdown gets called or while it is waiting.
+	//
+	// Shutdown may be called multiple times, even concurrently. All such calls will
+	// block until all goroutines have terminated.
+	Shutdown()
+
+	// WaitForCacheSync blocks until all started informers' caches were synced
+	// or the stop channel gets closed.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// ForResource gives generic access to a shared informer of the matching type.
+	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
+
+	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+	// client.
+	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 
 	Configmanagement() configmanagement.Interface
 }


### PR DESCRIPTION
The version for the clientgen tools was previously hard coded, which
required a manual update and allowed for drift from the k8s version
set in the go dependencies. Parsing the version from go.mod ensures
there is no drift by default.

Based on https://github.com/GoogleContainerTools/kpt-config-sync/pull/1041