### PR TITLE
chore: remove scope from the namespace struct

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -253,7 +253,7 @@ func Run(opts Options) {
 	if opts.ReconcilerScope == declared.RootReconciler {
 		parser = parse.NewRootRunner(parseOpts, opts.SourceFormat, opts.NamespaceStrategy)
 	} else {
-		parser = parse.NewNamespaceRunner(parseOpts, opts.ReconcilerScope)
+		parser = parse.NewNamespaceRunner(parseOpts)
 		if err != nil {
 			klog.Fatalf("Instantiating Namespace Repository Parser: %v", err)
 		}


### PR DESCRIPTION
The scope is defined in the Updater, which is part of the `namespace` struct, so no need to redefine it.