### PR TITLE
test: add timing measurements for each e2e feature

### DIFF
--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -134,6 +134,9 @@ func main(m *testing.M) int {
 			return 1
 		}
 	}
+	defer func() {
+		nomostest.PrintFeatureDurations()
+	}()
 	exitCode := m.Run()
 	return exitCode
 }


### PR DESCRIPTION
This change records time measurements for each test feature of the e2e tests and prints them out at the end of the suite. This is intended to help with tracking the duration of the sub-suites, and to help inform the sharding of test suites in the presubmits.