### PR TITLE
ci: rebalance e2e presubmit tests

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -94,12 +94,12 @@ test-e2e-kind-multi-repo: config-sync-manifest-local build-kind-e2e
 # This target runs the first group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group1
 test-e2e-kind-multi-repo-test-group1:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=acm-controller,selector,drift-control,lifecycle,nomos-cli" test-e2e-kind-multi-repo
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=acm-controller,selector,lifecycle,nomos-cli" test-e2e-kind-multi-repo
 
 # This target runs the second group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group2
 test-e2e-kind-multi-repo-test-group2:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1" test-e2e-kind-multi-repo
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1,drift-control" test-e2e-kind-multi-repo
 
 # This target runs the third group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group3


### PR DESCRIPTION
The test-group1 job is currently taking the longest of the three test groups, and test-group2 is taking the shortest amount of time on average. This rebalances the test features with the intention of reducing variance in run time between groups.