### PR TITLE
fix: setup/teardown keep finalizer on reconcile err

### DIFF
--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -41,6 +41,7 @@ import (
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/util/log"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -1146,6 +1147,35 @@ func RootSyncHasCondition(expected *v1beta1.RootSyncCondition) Predicate {
 }
 
 func validateRootSyncCondition(actual *v1beta1.RootSyncCondition, expected *v1beta1.RootSyncCondition) error {
+	e := expected.DeepCopy()
+	e.LastUpdateTime = actual.LastUpdateTime
+	e.LastTransitionTime = actual.LastTransitionTime
+	if diff := cmp.Diff(e, actual); diff != "" {
+		return fmt.Errorf("unexpected diff: %s", diff)
+	}
+	return nil
+}
+
+// RepoSyncHasCondition returns a Predicate that errors if the RepoSync does not
+// have the specified RepoSyncCondition. Fields such as timestamps are ignored.
+func RepoSyncHasCondition(expected *v1beta1.RepoSyncCondition) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		rs, ok := o.(*v1beta1.RepoSync)
+		if !ok {
+			return WrongTypeErr(rs, &v1beta1.RepoSync{})
+		}
+		condition := reposync.GetCondition(rs.Status.Conditions, expected.Type)
+		if condition == nil {
+			return fmt.Errorf("RepoSyncCondition with type %s not found", expected.Type)
+		}
+		return validateRepoSyncCondition(condition, expected)
+	}
+}
+
+func validateRepoSyncCondition(actual *v1beta1.RepoSyncCondition, expected *v1beta1.RepoSyncCondition) error {
 	e := expected.DeepCopy()
 	e.LastUpdateTime = actual.LastUpdateTime
 	e.LastTransitionTime = actual.LastTransitionTime

--- a/pkg/reconcilermanager/controllers/errors.go
+++ b/pkg/reconcilermanager/controllers/errors.go
@@ -185,3 +185,23 @@ func NewObjectReconcileErrorWithID(err error, id core.ID, status kstatus.Status)
 		Cause:  err,
 	}
 }
+
+// NoRetryError is an error that should not immediately trigger a reconcile retry.
+type NoRetryError struct {
+	Cause error
+}
+
+// NewNoRetryError constructs a new NewNoRetryError
+func NewNoRetryError(cause error) *NoRetryError {
+	return &NoRetryError{Cause: cause}
+}
+
+// Error returns the error message
+func (n *NoRetryError) Error() string {
+	return fmt.Sprintf("no retry: %v", n.Cause)
+}
+
+// Unwrap returns the cause of this NoRetryError
+func (n *NoRetryError) Unwrap() error {
+	return n.Cause
+}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -394,7 +394,7 @@ func (r *RepoSyncReconciler) handleReconcileError(ctx context.Context, err error
 			// still making progress
 			reposync.SetReconciling(rs, statusErr.ID.Kind, err.Error())
 			reposync.ClearCondition(rs, v1beta1.RepoSyncStalled)
-			return nil // no immediate retry - wait for next event
+			return NewNoRetryError(err) // no immediate retry - wait for next event
 		default:
 			// failed or invalid
 			reposync.SetReconciling(rs, stage, fmt.Sprintf("%s stalled", stage))

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -352,7 +352,7 @@ func (r *RootSyncReconciler) handleReconcileError(ctx context.Context, err error
 			// still making progress
 			rootsync.SetReconciling(rs, statusErr.ID.Kind, err.Error())
 			rootsync.ClearCondition(rs, v1beta1.RootSyncStalled)
-			return nil // no retry - wait for next event
+			return NewNoRetryError(err) // no immediate retry - wait for next event
 		default:
 			// failed or invalid
 			rootsync.SetReconciling(rs, stage, fmt.Sprintf("%s stalled", stage))


### PR DESCRIPTION
Prior to this change, if one of the managed objects failed to reconcile during setup or teardown the error would get swallowed and the reconciler-manager would proceed. This resulted in the finalizer exiting prematurely if one of the deletions timed out while waiting to reconcile.

For example, on autopilot it has been observed that the Deployment deletion may timeout during reconcile. When this happens, the error is swallowed and the finalizer exits even if the other managed objects have not been deleted (e.g. ServiceAccount, ClusterRoleBinding, etc).

Example logs:
```
        I1117 14:10:13.788408       1 rootsync_controller.go:376] controllers/RootSync "msg"="Deleting managed objects" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
        I1117 14:10:13.788456       1 garbage_collector.go:65] controllers/RootSync "msg"="Deleting managed object" "object"="config-management-system/root-reconciler" "objectKind"="Deployment" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
        I1117 14:10:13.889507       1 delete.go:155] Deleting object "object"="config-management-system/root-reconciler", "objectKind"="Deployment"
        I1117 14:10:13.902522       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        I1117 14:10:13.902581       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        I1117 14:10:13.985079       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        I1117 14:10:13.985168       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        I1117 14:10:14.170274       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        I1117 14:10:14.170320       1 rootsync_controller.go:609] Changes to Deployment (config-management-system/root-reconciler) triggers a reconciliation for the RootSync (config-management-system/root-sync)
        W1117 14:10:43.904405       1 reflector.go:347] k8s.io/client-go/tools/watch/informerwatcher.go:146: watch of apps/v1, Kind=Deployment ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
        E1117 14:10:43.904650       1 rootsync_controller.go:346] controllers/RootSync "msg"="Teardown waiting for event" "error"="deleting reconciler deployment: Deployment (config-management-system/root-reconciler) Terminating: failed to watch for deletion of Deployment: config-management-system/root-reconciler: timed out waiting for the condition" "object"="config-management-system/root-reconciler" "objectKind"="Deployment" "objectStatus"="Terminating" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
        I1117 14:10:43.919739       1 rootsync_controller.go:1054] controllers/RootSync "msg"="Sync status update successful" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
        I1117 14:10:43.919791       1 rootsync_controller.go:317] controllers/RootSync "msg"="Teardown successful" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
        I1117 14:10:43.939844       1 reconciler_base.go:636] controllers/RootSync "msg"="Finalizer removal successful" "reconciler"="config-management-system/root-reconciler" "sync"="config-management-system/root-sync" "syncKind"="RootSync"
```