### PR TITLE
fix: apply managed resource labels consistently

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -649,7 +649,7 @@ func ManagedObjectLabelMap(syncKind string, rsRef types.NamespacedName) map[stri
 	}
 }
 
-func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef types.NamespacedName, binding client.Object) error {
+func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef, rsRef types.NamespacedName, binding client.Object) error {
 	existingBinding := binding.DeepCopyObject()
 	subjects := []rbacv1.Subject{r.serviceAccountSubject(reconcilerRef)}
 	if crb, ok := binding.(*rbacv1.ClusterRoleBinding); ok {
@@ -657,6 +657,7 @@ func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef ty
 	} else if rb, ok := binding.(*rbacv1.RoleBinding); ok {
 		rb.Subjects = subjects
 	}
+	core.AddLabels(binding, ManagedObjectLabelMap(r.syncKind, rsRef))
 	if equality.Semantic.DeepEqual(existingBinding, binding) {
 		return nil
 	}

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -1579,11 +1579,10 @@ func validateReconcilerClusterRoleBindings(fakeClient *syncerFake.Client, rootSy
 
 	opts := &client.ListOptions{}
 	opts.LabelSelector = client.MatchingLabelsSelector{
-		Selector: labels.SelectorFromSet(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNameLabel:      rootSyncName,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
-		}),
+		Selector: labels.SelectorFromSet(ManagedObjectLabelMap(
+			configsync.RootSyncKind,
+			types.NamespacedName{Name: rootSyncName, Namespace: configsync.ControllerNamespace},
+		)),
 	}
 	err := fakeClient.List(ctx, got, opts)
 	if err != nil {
@@ -1619,11 +1618,7 @@ func validateReconcilerRoleBindings(fakeClient *syncerFake.Client, syncKind stri
 
 	opts := &client.ListOptions{}
 	opts.LabelSelector = client.MatchingLabelsSelector{
-		Selector: labels.SelectorFromSet(map[string]string{
-			metadata.SyncKindLabel:      syncKind,
-			metadata.SyncNameLabel:      rsRef.Name,
-			metadata.SyncNamespaceLabel: rsRef.Namespace,
-		}),
+		Selector: labels.SelectorFromSet(ManagedObjectLabelMap(syncKind, rsRef)),
 	}
 	err := fakeClient.List(ctx, got, opts)
 	if err != nil {
@@ -1710,6 +1705,10 @@ func TestRootSyncCreateWithOverrideRoleRefs(t *testing.T) {
 		RootSyncBaseClusterRoleBindingName,
 		RootSyncBaseClusterRoleName,
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+		core.Labels(map[string]string{
+			metadata.SyncKindLabel:      configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+		}),
 	)
 	defaultCrb.Subjects = addSubjectByName(nil, rootReconcilerName)
 
@@ -1745,6 +1744,10 @@ func TestRootSyncCreateWithOverrideRoleRefs(t *testing.T) {
 		RootSyncLegacyClusterRoleBindingName,
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+		core.Labels(map[string]string{
+			metadata.SyncKindLabel:      configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+		}),
 	)
 	clusterAdminCRB.Subjects = addSubjectByName(nil, rootReconcilerName)
 	if err := validateClusterRoleBinding(clusterAdminCRB, fakeClient); err != nil {
@@ -1770,6 +1773,10 @@ func TestMigrationToIndividualClusterRoleBindingsWhenDefaultRootSyncExists(t *te
 		RootSyncLegacyClusterRoleBindingName,
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+		core.Labels(map[string]string{
+			metadata.SyncKindLabel:      configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+		}),
 	)
 	oldBinding.Subjects = addSubjectByName(nil, rs1ReconcilerName)
 	oldBinding.Subjects = addSubjectByName(oldBinding.Subjects, rs2ReconcilerName)
@@ -2049,6 +2056,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 		RootSyncLegacyClusterRoleBindingName,
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
+		core.Labels(map[string]string{
+			metadata.SyncKindLabel:      configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+		}),
 	)
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName)
 	rootContainerEnv1 := testReconciler.populateContainerEnvs(ctx, rs1, rootReconcilerName)

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -75,6 +75,7 @@ func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceTyp
 	result.SetLabels(map[string]string{
 		metadata.SyncNamespaceLabel: reposyncNs,
 		metadata.SyncNameLabel:      reposyncName,
+		metadata.SyncKindLabel:      configsync.RepoSyncKind,
 	})
 	return result
 }
@@ -197,7 +198,11 @@ func TestUpsertAuthSecret(t *testing.T) {
 				},
 				client: tc.client,
 			}
-			sKey, err := r.upsertAuthSecret(ctx, tc.reposync, nsReconcilerKey)
+			labelMap := ManagedObjectLabelMap(configsync.RepoSyncKind, types.NamespacedName{
+				Name:      tc.reposync.Name,
+				Namespace: tc.reposync.Namespace,
+			})
+			sKey, err := r.upsertAuthSecret(ctx, tc.reposync, nsReconcilerKey, labelMap)
 			assert.Equal(t, tc.wantKey, sKey, "unexpected secret key returned")
 			if tc.wantError {
 				assert.Error(t, err, "expected upsertAuthSecret to error")


### PR DESCRIPTION
This change updates the label logic for the resources managed by reconciler-manager to apply a consistent set of rules.

- Apply the sync-kind and sync-namespace label for shared RBAC bindings, leaving out the sync-name field given that multiple RSyncs may be mapped to the same binding.