### PR TITLE
feat: add managed-by label for manager

### DIFF
--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -56,6 +56,11 @@ const (
 	// This is used to enable selecting pods by label, primarily for printing logs.
 	// Example: kubectl logs deployment/<deploy-name> <container-name> -n config-management-system
 	DeploymentNameLabel = configsync.ConfigSyncPrefix + "deployment-name"
+
+	// ConfigSyncManagedByLabel indicates which Config Sync component is managing
+	// the resource. Similar to the well known app.kubernetes.io/managed-by label,
+	// but scoped to Config Sync.
+	ConfigSyncManagedByLabel = configsync.ConfigSyncPrefix + "managed-by"
 )
 
 // DepthSuffix is a label suffix for hierarchical namespace depth.

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -637,14 +637,22 @@ func (r *reconcilerBase) setupOrTeardown(ctx context.Context, syncObj client.Obj
 	return nil
 }
 
+// ManagedByLabel is a uniform label that is applied to all resources which are
+// managed by reconciler-manager.
+func ManagedByLabel() map[string]string {
+	return map[string]string{
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
+	}
+}
+
 // ManagedObjectLabelMap returns the standard labels applied to objects related
 // to a RootSync/RepoSync that are created by reconciler-manager.
 func ManagedObjectLabelMap(syncKind string, rsRef types.NamespacedName) map[string]string {
-	return map[string]string{
-		metadata.SyncNamespaceLabel: rsRef.Namespace,
-		metadata.SyncNameLabel:      rsRef.Name,
-		metadata.SyncKindLabel:      syncKind,
-	}
+	labelMap := ManagedByLabel()
+	labelMap[metadata.SyncNamespaceLabel] = rsRef.Namespace
+	labelMap[metadata.SyncNameLabel] = rsRef.Name
+	labelMap[metadata.SyncKindLabel] = syncKind
+	return labelMap
 }
 
 func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef, rsRef types.NamespacedName, binding client.Object) error {

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -1826,9 +1826,10 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	}
 
 	label := map[string]string{
-		metadata.SyncNamespaceLabel: rs.Namespace,
-		metadata.SyncNameLabel:      rs.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs.Namespace,
+		metadata.SyncNameLabel:            rs.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(
@@ -2072,9 +2073,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
-		metadata.SyncNamespaceLabel: rs1.Namespace,
-		metadata.SyncNameLabel:      rs1.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs1.Namespace,
+		metadata.SyncNameLabel:            rs1.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	serviceAccount1 := fake.ServiceAccountObject(
@@ -2134,9 +2136,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
-		metadata.SyncNamespaceLabel: rs2.Namespace,
-		metadata.SyncNameLabel:      rs2.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs2.Namespace,
+		metadata.SyncNameLabel:            rs2.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	repoContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, nsReconcilerName2)
@@ -2194,9 +2197,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
-		metadata.SyncNamespaceLabel: rs3.Namespace,
-		metadata.SyncNameLabel:      rs3.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs3.Namespace,
+		metadata.SyncNameLabel:            rs3.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	repoContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, nsReconcilerName3)
@@ -2253,9 +2257,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
-		metadata.SyncNamespaceLabel: rs4.Namespace,
-		metadata.SyncNameLabel:      rs4.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs4.Namespace,
+		metadata.SyncNameLabel:            rs4.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	repoContainerEnv4 := testReconciler.populateContainerEnvs(ctx, rs4, nsReconcilerName4)
@@ -2312,9 +2317,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	validateRepoSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{
-		metadata.SyncNamespaceLabel: rs5.Namespace,
-		metadata.SyncNameLabel:      rs5.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs5.Namespace,
+		metadata.SyncNameLabel:            rs5.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	repoContainerEnv5 := testReconciler.populateContainerEnvs(ctx, rs5, nsReconcilerName5)
@@ -3160,9 +3166,10 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	}
 
 	label := map[string]string{
-		metadata.SyncNamespaceLabel: rs.Namespace,
-		metadata.SyncNameLabel:      rs.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs.Namespace,
+		metadata.SyncNameLabel:            rs.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -102,9 +102,10 @@ func clusterrolebinding(name string, role string, opts ...core.MetaMutator) *rba
 func rootReconcilerClusterRoleBinding(reconcilerName, clusterRole string, opts ...core.MetaMutator) *rbacv1.ClusterRoleBinding {
 	defaultOpts := []core.MetaMutator{
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNameLabel:      rootsyncName,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNameLabel:            rootsyncName,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 		core.GenerateName(reconcilerName + "-"),
 		core.Generation(1),
@@ -121,9 +122,10 @@ func rootReconcilerRoleBinding(roleRef v1beta1.RootSyncRoleRef, opts ...core.Met
 	defaultOpts := []core.MetaMutator{
 		core.Namespace(roleRef.Namespace),
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNameLabel:      rootsyncName,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNameLabel:            rootsyncName,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 		core.GenerateName("root-reconciler-my-root-sync-"),
 		core.Generation(1),
@@ -1706,8 +1708,9 @@ func TestRootSyncCreateWithOverrideRoleRefs(t *testing.T) {
 		RootSyncBaseClusterRoleName,
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 	)
 	defaultCrb.Subjects = addSubjectByName(nil, rootReconcilerName)
@@ -1745,8 +1748,9 @@ func TestRootSyncCreateWithOverrideRoleRefs(t *testing.T) {
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 	)
 	clusterAdminCRB.Subjects = addSubjectByName(nil, rootReconcilerName)
@@ -1774,8 +1778,9 @@ func TestMigrationToIndividualClusterRoleBindingsWhenDefaultRootSyncExists(t *te
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 	)
 	oldBinding.Subjects = addSubjectByName(nil, rs1ReconcilerName)
@@ -1812,9 +1817,10 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	}
 
 	labels := map[string]string{
-		metadata.SyncNamespaceLabel: rs.Namespace,
-		metadata.SyncNameLabel:      rs.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs.Namespace,
+		metadata.SyncNameLabel:            rs.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(
@@ -2039,9 +2045,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	validateRootSyncStatus(t, wantRs1, fakeClient)
 
 	label1 := map[string]string{
-		metadata.SyncNamespaceLabel: rs1.Namespace,
-		metadata.SyncNameLabel:      rs1.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs1.Namespace,
+		metadata.SyncNameLabel:            rs1.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	serviceAccount1 := fake.ServiceAccountObject(
@@ -2057,8 +2064,9 @@ func TestMultipleRootSyncs(t *testing.T) {
 		"cluster-admin",
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 		core.Labels(map[string]string{
-			metadata.SyncKindLabel:      configsync.RootSyncKind,
-			metadata.SyncNamespaceLabel: configsync.ControllerNamespace,
+			metadata.SyncKindLabel:            configsync.RootSyncKind,
+			metadata.SyncNamespaceLabel:       configsync.ControllerNamespace,
+			metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 		}),
 	)
 	crb.Subjects = addSubjectByName(crb.Subjects, rootReconcilerName)
@@ -2104,9 +2112,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	validateRootSyncStatus(t, wantRs2, fakeClient)
 
 	label2 := map[string]string{
-		metadata.SyncNamespaceLabel: rs2.Namespace,
-		metadata.SyncNameLabel:      rs2.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs2.Namespace,
+		metadata.SyncNameLabel:            rs2.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	rootContainerEnv2 := testReconciler.populateContainerEnvs(ctx, rs2, rootReconcilerName2)
@@ -2161,9 +2170,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	validateRootSyncStatus(t, wantRs3, fakeClient)
 
 	label3 := map[string]string{
-		metadata.SyncNamespaceLabel: rs3.Namespace,
-		metadata.SyncNameLabel:      rs3.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs3.Namespace,
+		metadata.SyncNameLabel:            rs3.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	rootContainerEnv3 := testReconciler.populateContainerEnvs(ctx, rs3, rootReconcilerName3)
@@ -2222,9 +2232,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	validateRootSyncStatus(t, wantRs4, fakeClient)
 
 	label4 := map[string]string{
-		metadata.SyncNamespaceLabel: rs4.Namespace,
-		metadata.SyncNameLabel:      rs4.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs4.Namespace,
+		metadata.SyncNameLabel:            rs4.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	rootContainerEnvs4 := testReconciler.populateContainerEnvs(ctx, rs4, rootReconcilerName4)
@@ -2283,9 +2294,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	validateRootSyncStatus(t, wantRs5, fakeClient)
 
 	label5 := map[string]string{
-		metadata.SyncNamespaceLabel: rs5.Namespace,
-		metadata.SyncNameLabel:      rs5.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs5.Namespace,
+		metadata.SyncNameLabel:            rs5.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	rootContainerEnvs5 := testReconciler.populateContainerEnvs(ctx, rs5, rootReconcilerName5)
@@ -2934,9 +2946,10 @@ func TestRootSyncWithOCI(t *testing.T) {
 	}
 
 	labels := map[string]string{
-		metadata.SyncNamespaceLabel: rs.Namespace,
-		metadata.SyncNameLabel:      rs.Name,
-		metadata.SyncKindLabel:      testReconciler.syncKind,
+		metadata.SyncNamespaceLabel:       rs.Namespace,
+		metadata.SyncNameLabel:            rs.Name,
+		metadata.SyncKindLabel:            testReconciler.syncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	}
 
 	wantServiceAccount := fake.ServiceAccountObject(

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,9 +74,10 @@ func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceTyp
 	result := fake.SecretObject(name, opts...)
 	result.Data = secretData(t, data, auth, sourceType)
 	result.SetLabels(map[string]string{
-		metadata.SyncNamespaceLabel: reposyncNs,
-		metadata.SyncNameLabel:      reposyncName,
-		metadata.SyncKindLabel:      configsync.RepoSyncKind,
+		metadata.SyncNamespaceLabel:       reposyncNs,
+		metadata.SyncNameLabel:            reposyncName,
+		metadata.SyncKindLabel:            configsync.RepoSyncKind,
+		metadata.ConfigSyncManagedByLabel: reconcilermanager.ManagerName,
 	})
 	return result
 }


### PR DESCRIPTION
This change adds a managed-by label which is applied uniformly to all
resources which are managed by the reconciler-manager. With the
existence of this new label, we can eventually add a label selector to
optimize the API calls of the reconciler-manager client. The selector is
not added right now due to backwards compatibility concerns, but can be
added in the future.
