### PR TITLE
feat: optimize lists which only use metadata

### DIFF
--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -194,6 +194,11 @@ func ConfigMap() schema.GroupVersionKind {
 	return corev1.SchemeGroupVersion.WithKind("ConfigMap")
 }
 
+// ConfigMapList returns the canonical ConfigMapList GroupVersionKind.
+func ConfigMapList() schema.GroupVersionKind {
+	return corev1.SchemeGroupVersion.WithKind("ConfigMapList")
+}
+
 // Job returns the canonical Job GroupVersionKind.
 func Job() schema.GroupVersionKind {
 	return batchv1.SchemeGroupVersion.WithKind("Job")
@@ -224,6 +229,11 @@ func RepoSyncV1Beta1() schema.GroupVersionKind {
 	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RepoSyncKind)
 }
 
+// RepoSyncListV1Beta1 returns the v1beta1 RepoSyncList GroupVersionKind.
+func RepoSyncListV1Beta1() schema.GroupVersionKind {
+	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RepoSyncKind + "List")
+}
+
 // RootSyncV1Alpha1 returns the canonical RootSync GroupVersionKind.
 func RootSyncV1Alpha1() schema.GroupVersionKind {
 	return v1alpha1.SchemeGroupVersion.WithKind(configsync.RootSyncKind)
@@ -234,6 +244,11 @@ func RootSyncV1Beta1() schema.GroupVersionKind {
 	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RootSyncKind)
 }
 
+// RootSyncListV1Beta1 returns the v1beta1 RootSyncList GroupVersionKind.
+func RootSyncListV1Beta1() schema.GroupVersionKind {
+	return configsyncv1beta1.SchemeGroupVersion.WithKind(configsync.RootSyncKind + "List")
+}
+
 // Service returns the canonical Service GroupVersionKind.
 func Service() schema.GroupVersionKind {
 	return corev1.SchemeGroupVersion.WithKind("Service")
@@ -242,6 +257,11 @@ func Service() schema.GroupVersionKind {
 // Secret returns the canonical Secret GroupVersionKind.
 func Secret() schema.GroupVersionKind {
 	return corev1.SchemeGroupVersion.WithKind("Secret")
+}
+
+// SecretList returns the canonical SecretList GroupVersionKind.
+func SecretList() schema.GroupVersionKind {
+	return corev1.SchemeGroupVersion.WithKind("SecretList")
 }
 
 // ServiceAccount returns the canonical ServiceAccount GroupVersionKind.

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -29,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -583,7 +584,8 @@ func (r *RepoSyncReconciler) mapMembershipToRepoSyncs() func(client.Object) []re
 }
 
 func (r *RepoSyncReconciler) requeueAllRepoSyncs() []reconcile.Request {
-	allRepoSyncs := &v1beta1.RepoSyncList{}
+	allRepoSyncs := &metav1.PartialObjectMetadataList{}
+	allRepoSyncs.SetGroupVersionKind(kinds.RepoSyncListV1Beta1())
 	if err := r.client.List(context.Background(), allRepoSyncs); err != nil {
 		klog.Errorf("RepoSync list failed: %v", err)
 		return nil
@@ -778,7 +780,8 @@ func (r *RepoSyncReconciler) mapObjectToRepoSync(obj client.Object) []reconcile.
 		}
 	}
 
-	allRepoSyncs := &v1beta1.RepoSyncList{}
+	allRepoSyncs := &metav1.PartialObjectMetadataList{}
+	allRepoSyncs.SetGroupVersionKind(kinds.RepoSyncListV1Beta1())
 	if err := r.client.List(context.Background(), allRepoSyncs); err != nil {
 		klog.Errorf("failed to list all RepoSyncs for %s (%s): %v",
 			obj.GetObjectKind().GroupVersionKind().Kind, objRef, err)

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -30,6 +30,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -559,7 +560,8 @@ func (r *RootSyncReconciler) mapObjectToRootSync(obj client.Object) []reconcile.
 		return nil
 	}
 
-	allRootSyncs := &v1beta1.RootSyncList{}
+	allRootSyncs := &metav1.PartialObjectMetadataList{}
+	allRootSyncs.SetGroupVersionKind(kinds.RootSyncListV1Beta1())
 	if err := r.client.List(context.Background(), allRootSyncs); err != nil {
 		klog.Errorf("failed to list all RootSyncs for %s (%s): %v",
 			obj.GetObjectKind().GroupVersionKind().Kind, objRef, err)
@@ -604,7 +606,7 @@ func (r *RootSyncReconciler) mapObjectToRootSync(obj client.Object) []reconcile.
 	return requests
 }
 
-func requeueRootSyncRequest(obj client.Object, rs *v1beta1.RootSync) []reconcile.Request {
+func requeueRootSyncRequest(obj client.Object, rs client.Object) []reconcile.Request {
 	rsRef := client.ObjectKeyFromObject(rs)
 	klog.Infof("Changes to %s (%s) triggers a reconciliation for the RootSync (%s)",
 		obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj), rsRef)
@@ -616,7 +618,8 @@ func requeueRootSyncRequest(obj client.Object, rs *v1beta1.RootSync) []reconcile
 }
 
 func (r *RootSyncReconciler) requeueAllRootSyncs() []reconcile.Request {
-	allRootSyncs := &v1beta1.RootSyncList{}
+	allRootSyncs := &metav1.PartialObjectMetadataList{}
+	allRootSyncs.SetGroupVersionKind(kinds.RootSyncListV1Beta1())
 	if err := r.client.List(context.Background(), allRootSyncs); err != nil {
 		klog.Errorf("RootSync list failed: %v", err)
 		return nil


### PR DESCRIPTION
This change optimizes lists done by the reconciler-manager to only fetch metadata when only the items are only used for metadata.