### PR TITLE
feat: use label selector for remediator list/watch

### DIFF
--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -75,6 +75,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns1
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _namespace_test-ns1
@@ -104,6 +106,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns2
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _namespace_test-ns2
@@ -140,6 +144,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns3
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _namespace_test-ns3
@@ -174,6 +180,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns4
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _namespace_wrong-ns4
@@ -230,6 +238,8 @@ kind: ConfigMap
 metadata:
   name: test-cm1
   namespace: bookstore
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _configmap_bookstore_test-cm1
@@ -261,6 +271,8 @@ kind: ConfigMap
 metadata:
   name: test-cm2
   namespace: bookstore
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _configmap_bookstore_wrong-cm2
@@ -300,6 +312,8 @@ kind: ConfigMap
 metadata:
   name: test-cm3
   namespace: bookstore
+  labels:
+    app.kubernetes.io/managed-by: configmanagement.gke.io
   annotations:
     configmanagement.gke.io/managed: enabled
     configsync.gke.io/resource-id: _configmap_bookstore_test-cm3

--- a/e2e/testcases/remediator_test.go
+++ b/e2e/testcases/remediator_test.go
@@ -21,9 +21,13 @@ import (
 
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/metrics"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/testing/fake"
 )
@@ -75,6 +79,51 @@ func TestSurfaceFightError(t *testing.T) {
 
 	nt.T.Log("The fight error should be auto-resolved if no more fights")
 	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestRemediateDrift(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+
+	nt.T.Logf("Stop the admission webhook to allow drift")
+	nomostest.StopWebhook(nt)
+
+	ns := fake.NamespaceObject("test-ns", core.Annotation("foo", "bar"))
+	rb := roleBinding("test-rb", ns.Name, map[string]string{"foo": "bar"})
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+		fmt.Sprintf("acme/namespaces/%s/ns.yaml", ns.Name), ns))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+		fmt.Sprintf("acme/namespaces/%s/rb.yaml", ns.Name), rb))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add Namespace and RoleBinding"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	actualRB := fake.RoleBindingObject()
+	if err := nt.KubeClient.Get(rb.Name, rb.Namespace, actualRB); err != nil {
+		nt.T.Fatal(err)
+	}
+	// Remove managed-by label to ensure remediator can recover the label
+	labels := actualRB.GetLabels()
+	delete(labels, metadata.ManagedByKey)
+	actualRB.SetLabels(labels)
+	// Update a declared annotation to cause a resource conflict
+	annotations := actualRB.GetAnnotations()
+	annotations["foo"] = "baz"
+	actualRB.SetAnnotations(annotations)
+	nt.T.Log("Update the RoleBinding to create drift")
+	if err := nt.KubeClient.Update(actualRB); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Wait for the drift to be remediated")
+	err := nt.Watcher.WatchObject(kinds.RoleBinding(), rb.Name, rb.Namespace,
+		[]testpredicates.Predicate{
+			testpredicates.HasLabel(metadata.ManagedByKey, metadata.ManagedByValue),
+			testpredicates.HasAnnotation("foo", "bar"),
+		})
+	if err != nil {
 		nt.T.Fatal(err)
 	}
 }

--- a/pkg/parse/annotations.go
+++ b/pkg/parse/annotations.go
@@ -45,6 +45,7 @@ func addAnnotationsAndLabels(objs []ast.FileObject, scope declared.Scope, syncNa
 		inventoryID = applier.InventoryID(syncName, string(scope))
 	}
 	for _, obj := range objs {
+		// Note: this label is used as a label selector by the remediator
 		core.SetLabel(obj, metadata.ManagedByKey, metadata.ManagedByValue)
 		core.SetAnnotation(obj, metadata.GitContextKey, string(gcVal))
 		core.SetAnnotation(obj, metadata.ResourceManagerKey, declared.ResourceManager(scope, syncName))


### PR DESCRIPTION
This optimizes the list/watch of the remediator to only watch resources managed by the reconciler. This label has historically been added to all objects by the applier.