### PR TITLE
fix: Prevent RSync from premature Current status

### DIFF
--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -589,6 +589,7 @@ spec:
                   digest.
                 type: string
               observedGeneration:
+                default: 0
                 description: observedGeneration is the most recent generation observed
                   for the sync resource. It corresponds to the it's generation, which
                   is updated on mutation by the API Server.
@@ -1637,6 +1638,7 @@ spec:
                   digest.
                 type: string
               observedGeneration:
+                default: 0
                 description: observedGeneration is the most recent generation observed
                   for the sync resource. It corresponds to the it's generation, which
                   is updated on mutation by the API Server.

--- a/manifests/resourcegroup-crd.yaml
+++ b/manifests/resourcegroup-crd.yaml
@@ -165,6 +165,7 @@ spec:
                   type: object
                 type: array
               observedGeneration:
+                default: 0
                 description: observedGeneration is the most recent generation observed.
                   It corresponds to the Object's generation, which is updated on mutation
                   by the API Server. Everytime the controller does a successful reconcile,
@@ -284,8 +285,6 @@ spec:
                   - status
                   type: object
                 type: array
-            required:
-            - observedGeneration
             type: object
         type: object
     served: true

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -644,6 +644,7 @@ spec:
                   digest.
                 type: string
               observedGeneration:
+                default: 0
                 description: observedGeneration is the most recent generation observed
                   for the sync resource. It corresponds to the it's generation, which
                   is updated on mutation by the API Server.
@@ -1747,6 +1748,7 @@ spec:
                   digest.
                 type: string
               observedGeneration:
+                default: 0
                 description: observedGeneration is the most recent generation observed
                   for the sync resource. It corresponds to the it's generation, which
                   is updated on mutation by the API Server.

--- a/pkg/api/configsync/v1alpha1/sync_types.go
+++ b/pkg/api/configsync/v1alpha1/sync_types.go
@@ -23,7 +23,8 @@ type Status struct {
 	// observedGeneration is the most recent generation observed for the sync resource.
 	// It corresponds to the it's generation, which is updated on mutation by the API Server.
 	// +optional
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +kubebuilder:default:=0
+	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// reconciler is the name of the reconciler process which corresponds to the
 	// sync resource.

--- a/pkg/api/configsync/v1beta1/sync_types.go
+++ b/pkg/api/configsync/v1beta1/sync_types.go
@@ -23,7 +23,8 @@ type Status struct {
 	// observedGeneration is the most recent generation observed for the sync resource.
 	// It corresponds to the it's generation, which is updated on mutation by the API Server.
 	// +optional
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +kubebuilder:default:=0
+	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// reconciler is the name of the reconciler process which corresponds to the
 	// sync resource.

--- a/pkg/api/kpt.dev/v1alpha1/resourcegroup_types.go
+++ b/pkg/api/kpt.dev/v1alpha1/resourcegroup_types.go
@@ -67,15 +67,20 @@ type ResourceGroupStatus struct {
 	// mutation by the API Server.
 	// Everytime the controller does a successful reconcile, it sets
 	// observedGeneration to match ResourceGroup.metadata.generation.
+	// +optional
+	// +kubebuilder:default:=0
 	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// resourceStatuses lists the status for each resource in the group
+	// +optional
 	ResourceStatuses []ResourceStatus `json:"resourceStatuses,omitempty"`
 
 	// subgroupStatuses lists the status for each subgroup.
+	// +optional
 	SubgroupStatuses []GroupStatus `json:"subgroupStatuses,omitempty"`
 
 	// conditions lists the conditions of the current status for the group
+	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
 }
 

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -282,7 +282,7 @@ func TestRoot_Parse(t *testing.T) {
 					fake.WithRootSyncSourceType(v1beta1.GitSource),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1beta1"),
-					core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
+					core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:observedGeneration":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
 					core.Annotation(metadata.SourcePathAnnotationKey, fmt.Sprintf("namespaces/%s/test.yaml", configsync.ControllerNamespace)),
 					core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 					core.Annotation(metadata.GitContextKey, nilGitContext),

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -57,6 +57,7 @@ import (
 	"kpt.dev/configsync/pkg/util/discovery"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -944,7 +945,7 @@ func TestHierarchical(t *testing.T) {
 				),
 				validRepoSync("bookstore", "repo-sync-1", "namespaces/bookstore/rs.yaml",
 					core.Annotation(csmetadata.SourcePathAnnotationKey, "acme/namespaces/bookstore/rs.yaml"),
-					core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
+					core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:observedGeneration":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
 					core.Label(csmetadata.DeclaredVersionLabel, "v1beta1"),
 				)},
 		},
@@ -1320,7 +1321,7 @@ func TestUnstructured(t *testing.T) {
 			},
 			want: []ast.FileObject{validRootSync("root-sync-1", "rs.yaml",
 				core.Annotation(csmetadata.SourcePathAnnotationKey, "acme/rs.yaml"),
-				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
+				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:observedGeneration":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
 				core.Label(csmetadata.DeclaredVersionLabel, "v1beta1"),
 			)},
 		},
@@ -1346,7 +1347,7 @@ func TestUnstructured(t *testing.T) {
 			},
 			want: []ast.FileObject{validRepoSync("bookstore", "repo-sync-1", "rs.yaml",
 				core.Annotation(csmetadata.SourcePathAnnotationKey, "acme/rs.yaml"),
-				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
+				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:spec":{".":{},"f:git":{".":{},"f:auth":{},"f:period":{},"f:repo":{}},"f:sourceType":{}},"f:status":{".":{},"f:observedGeneration":{},"f:rendering":{".":{},"f:lastUpdate":{}},"f:source":{".":{},"f:lastUpdate":{}},"f:sync":{".":{},"f:lastUpdate":{}}}}`),
 				core.Label(csmetadata.DeclaredVersionLabel, "v1beta1"),
 			)},
 		},
@@ -1384,7 +1385,7 @@ func TestUnstructured(t *testing.T) {
 			if !errors.Is(errs, tc.wantErrs) {
 				t.Errorf("got Unstructured() error %v; want %v", errs, tc.wantErrs)
 			}
-			assert.ElementsMatch(t, tc.want, got)
+			testutil.AssertEqual(t, tc.want, got)
 
 			updatedDynamicNSSelectorEnabled, err := dynamicNSSelectorEnabled(fakeClient)
 			if err != nil {


### PR DESCRIPTION
Setting the default observedGeneration to 0 should ensure that it is initialized even when using Unstructured resources. This should prevent kstatus.Compute from considering the object to be Current before the controller has updated the status. This should prevent the Config Sync reconciler from considering the object to be reconciled and returning prematurely. This should prevent any dependencies from being applied or deleted prematurely, avoiding out of order problems.