### PR TITLE
chore: Validate RSync reconciliation status

### DIFF
--- a/pkg/kinds/resources.go
+++ b/pkg/kinds/resources.go
@@ -17,9 +17,20 @@ package kinds
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 )
 
 // DeploymentResource returns the canonical Deployment GroupVersionResource.
 func DeploymentResource() schema.GroupVersionResource {
 	return appsv1.SchemeGroupVersion.WithResource("deployments")
+}
+
+// RootSyncResource returns the canonical RootSync GroupVersionResource.
+func RootSyncResource() schema.GroupVersionResource {
+	return configsyncv1beta1.SchemeGroupVersion.WithResource("rootsyncs")
+}
+
+// RepoSyncResource returns the canonical RepoSync GroupVersionResource.
+func RepoSyncResource() schema.GroupVersionResource {
+	return configsyncv1beta1.SchemeGroupVersion.WithResource("reposyncs")
 }

--- a/pkg/syncer/syncertest/fake/dynamic_client.go
+++ b/pkg/syncer/syncertest/fake/dynamic_client.go
@@ -318,6 +318,7 @@ func (dc *DynamicClient) watch(action clienttesting.Action) (bool, watch.Interfa
 	if err != nil {
 		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
 	}
+	listGVK := kinds.ListGVKForItemGVK(gvk)
 	restrictions := watchAction.GetWatchRestrictions()
 	opts := &client.ListOptions{
 		Namespace:     watchAction.GetNamespace(),
@@ -328,7 +329,7 @@ func (dc *DynamicClient) watch(action clienttesting.Action) (bool, watch.Interfa
 		},
 	}
 	exampleList := &unstructured.UnstructuredList{}
-	exampleList.SetGroupVersionKind(gvk)
+	exampleList.SetGroupVersionKind(listGVK)
 	watcher, err := dc.storage.Watch(context.Background(), exampleList, opts)
 	if err != nil {
 		return true, nil, err

--- a/pkg/util/watch/until.go
+++ b/pkg/util/watch/until.go
@@ -31,6 +31,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// UntilDeleted watches the specified object and blocks until it is fully
+// deleted (NotFound, not just deleteTimestamp). This allows for any finalizers
+// to complete.
+//
+// Unlike client-go's watch.Until, this function uses an informer, which means
+// it does a ListAndWatch, not just a Watch. So it will return immediately if
+// the object was already deleted.
+//
+// For timeout, use:
+// watchCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+// defer cancel()
+func UntilDeleted(ctx context.Context, c client.WithWatch, obj client.Object) error {
+	return UntilDeletedWithSync(ctx, c, obj, nil)
+}
+
 // UntilDeletedWithSync watches the specified object and blocks until it is
 // fully deleted (NotFound, not just deleteTimestamp). This allows for any
 // finalizers to complete.


### PR DESCRIPTION
Add unit tests for changes from #1066

Now that observedGeneration has a default, the status should always be non-Current until reconciliation is complete.

Validate this in setup by running a deployment controller simulator and validator in parallel.

Validate this in teardown by blocking teardown with a ServiceAccount finalizer.

b/315199932