### PR TITLE
fix: prevent remediator watch race with applier

### DIFF
--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -370,8 +370,15 @@ func TestFilteredWatcher(t *testing.T) {
 				}
 			}()
 			// w.Run() blocks until w.Stop() is called or the context is cancelled.
-			err := w.Run(ctx)
+			startCh := make(chan error)
+			assertCh := make(chan error)
+			go func() {
+				err := <-startCh
+				assertCh <- err
+			}()
+			err := w.Run(ctx, startCh)
 			require.Equal(t, tc.wantErr, err)
+			require.NoError(t, <-assertCh)
 
 			var got []core.ID
 			for q.Len() > 0 {


### PR DESCRIPTION
This change starts the remediator watches before the applier applies objects to the cluster. This prevents a race condition which can occur if an update is made after the applier runs but before watches are started. If this race condition occurs, it is possible that the remediator will miss the watch event and drift is not corrected. By starting the watches before the applier runs, applier updates should result in a remediator no-op but actual drift will be remediated.