### PR TITLE
test: auto-rotate service account key & secret

### DIFF
--- a/e2e/nomostest/artifactregistry/image.go
+++ b/e2e/nomostest/artifactregistry/image.go
@@ -34,10 +34,15 @@ import (
 // repositories. In this case, `us`, which is a multi-region location.
 const DefaultLocation = "us"
 
+// RegistryReaderAccountName is the name of the google service account
+// with permission to read from Artifact Registry.
+const RegistryReaderAccountName = "e2e-test-ar-reader"
+
 // RegistryReaderAccountEmail returns the email of the google service account
 // with permission to read from Artifact Registry.
 func RegistryReaderAccountEmail() string {
-	return fmt.Sprintf("e2e-test-ar-reader@%s.iam.gserviceaccount.com", *e2e.GCPProject)
+	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com",
+		RegistryReaderAccountName, *e2e.GCPProject)
 }
 
 // SetupImage constructs a new Image for use during an e2e test, along with its


### PR DESCRIPTION
Updated TestHelmARTokenAuth to include code to auto-rotate expired service account keys and also repair a few edge cases, like no enabled secret versions, invalid secret version, latest secret version disabled/destroyed, etc. So as long as the service account exists and the secret exists, the code should be able to re-generate a valid key on-demand and add it as a new secret version.

Note: Because these steps are not atomic and might be run in parallel in the same project, it's possible that the test might fail due to concurrent regeneration, but it's unlikely due to the order of the steps. It's more likely that a duplicate key is ocationally generated, which shouldn't cause test failure. If this happens frequently, it might exceed the maximum 10 keys per account, but otherwise the keys will eventually be auto-deleted after they expire.