### PR TITLE
fix: enable user output for version list

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -938,7 +939,6 @@ func fetchServiceAccountKeyFile(nt *nomostest.NT, projectID, gsaKeySecretID, gsa
 	out, err := nt.Shell.ExecWithDebug("gcloud", "secrets", "versions", "list",
 		gsaKeySecretID,
 		"--filter", "state=ENABLED",
-		"--no-user-output-enabled", // suppress warning messages that interfere with parsing
 		"--limit", "1",
 		"--format", "value(name)",
 		"--project", projectID)
@@ -963,13 +963,16 @@ func fetchServiceAccountKeyFile(nt *nomostest.NT, projectID, gsaKeySecretID, gsa
 	// even tho in json the "name" field is the full name.
 	// But what the access command wants is the version. So it's fine.
 	gsaKeySecretVersion := strings.TrimSpace(string(out))
-	if gsaKeySecretVersion == "" {
+	if gsaKeySecretVersion == "" || strings.HasPrefix(gsaKeySecretVersion, "WARNING: ") {
 		nt.T.Log("No enabled secrets versions")
 		err = generateServiceAccountKey(nt, projectID, gsaKeySecretID, gsaEmail, gsaKeyFilePath)
 		if err != nil {
 			return "", err
 		}
 		return gsaKeyFilePath, nil
+	}
+	if _, err := strconv.Atoi(gsaKeySecretVersion); err != nil {
+		return "", fmt.Errorf("converting version to int: %w", err)
 	}
 
 	nt.T.Log("Reading service account key from Secret Manager")


### PR DESCRIPTION
Suppressing the user output also disabled output for the happy path where a version exists. This reverts the behavior back to how it was before with an error check on the output.