### PR TITLE
chore: ignore self-assignment lint for validation

### DIFF
--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -19,7 +19,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${REPO_ROOT}"
 
 # Required environment variables
+# shellcheck disable=SC2269 # validate non-null with errexit + nounset
 HELM_VERSION=${HELM_VERSION}
+# shellcheck disable=SC2269 # validate non-null with errexit + nounset
 INSTALL_DIR=${INSTALL_DIR}
 
 # Optional environment variables

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -19,7 +19,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${REPO_ROOT}"
 
 # Required environment variables
+# shellcheck disable=SC2269 # validate non-null with errexit + nounset
 KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION}
+# shellcheck disable=SC2269 # validate non-null with errexit + nounset
 INSTALL_DIR=${INSTALL_DIR}
 
 # Optional environment variables


### PR DESCRIPTION
This isn't a problem when you lint in the container with the right linter version, but is when you have a different version installed locally. I'd like it to work on my machine without needing to always lint in a container.