### PR TITLE
v1.17 cherry-pick: chore: bump manifest headers to 2024 (#1092)

### DIFF
--- a/manifests/cluster-selector-crd.yaml
+++ b/manifests/cluster-selector-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manifests/hierarchyconfig-crd.yaml
+++ b/manifests/hierarchyconfig-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manifests/namespace-selector-crd.yaml
+++ b/manifests/namespace-selector-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manifests/resourcegroup-crd.yaml
+++ b/manifests/resourcegroup-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The license headers for the manifests are generated as part of the presubmits, and need to be bumped for the new year.

(This is a workaround for a known automation bug that violates Google copyright update policy. Bug is in the backlog.)