### PR TITLE
Remove the `webhooks` field from the validatingwebhookconfigurations object

### DIFF
--- a/manifests/templates/admission-webhook.yaml
+++ b/manifests/templates/admission-webhook.yaml
@@ -142,4 +142,3 @@ metadata:
     app: admission-webhook
     configmanagement.gke.io/system: "true"
     configmanagement.gke.io/arch: "csmr"
-webhooks: []


### PR DESCRIPTION
The field was added into the CS manifest in CS 1.13.0 (http://tg/1499888) to reduce errors and log spam: https://github.com/GoogleContainerTools/kpt-config-sync/blob/v1.13.0/manifests/templates/admission-webhook.yaml.

This is no longer needed since the behavior of cert-controller has been improved in
https://github.com/open-policy-agent/cert-controller/pull/48, and the cert-controller library has been updated in Config Sync in https://github.com/GoogleContainerTools/kpt-config-sync/pull/146.

Another reason to remove this field is that it causes nomos-operator to update the validatingwebhookconfigurations object constantly (b/316959632).