### PR TITLE
v1.17 cherry-pick: webhook fix & otel-agent log level fix

### DIFF
--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -354,12 +354,14 @@ spec:
                           pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
-                          description: logLevel specifies the log level override value
-                            for the container. The default value for git-sync container
-                            is 5, while all other containers will default to 0. Allowed
-                            values are from -1 to 10
+                          description: logLevel specifies the verbosity level of the
+                            logging for a specific container. The "git-sync" and "otel-agent"
+                            containers default to 5, while all other containers default
+                            to 0. Increasing the value of logLevel increases the verbosity
+                            of the logs. Lower severity messages are logged at higher
+                            verbosity. Allowed values are from 0 to 10.
                           maximum: 10
-                          minimum: -1
+                          minimum: 0
                           type: integer
                       required:
                       - containerName
@@ -1403,12 +1405,14 @@ spec:
                           pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
-                          description: logLevel specifies the log level override value
-                            for the container. The default value for git-sync container
-                            is 5, while all other containers will default to 0. Allowed
-                            values are from -1 to 10
+                          description: logLevel specifies the verbosity level of the
+                            logging for a specific container. The "git-sync" and "otel-agent"
+                            containers default to 5, while all other containers default
+                            to 0. Increasing the value of logLevel increases the verbosity
+                            of the logs. Lower severity messages are logged at higher
+                            verbosity. Allowed values are from 0 to 10.
                           maximum: 10
-                          minimum: -1
+                          minimum: 0
                           type: integer
                       required:
                       - containerName

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -364,12 +364,14 @@ spec:
                           pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
-                          description: logLevel specifies the log level override value
-                            for the container. The default value for git-sync container
-                            is 5, while all other containers will default to 0. Allowed
-                            values are from -1 to 10
+                          description: logLevel specifies the verbosity level of the
+                            logging for a specific container. The "git-sync" and "otel-agent"
+                            containers default to 5, while all other containers default
+                            to 0. Increasing the value of logLevel increases the verbosity
+                            of the logs. Lower severity messages are logged at higher
+                            verbosity. Allowed values are from 0 to 10.
                           maximum: 10
-                          minimum: -1
+                          minimum: 0
                           type: integer
                       required:
                       - containerName
@@ -1468,12 +1470,14 @@ spec:
                           pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         logLevel:
-                          description: logLevel specifies the log level override value
-                            for the container. The default value for git-sync container
-                            is 5, while all other containers will default to 0. Allowed
-                            values are from -1 to 10
+                          description: logLevel specifies the verbosity level of the
+                            logging for a specific container. The "git-sync" and "otel-agent"
+                            containers default to 5, while all other containers default
+                            to 0. Increasing the value of logLevel increases the verbosity
+                            of the logs. Lower severity messages are logged at higher
+                            verbosity. Allowed values are from 0 to 10.
                           maximum: 10
-                          minimum: -1
+                          minimum: 0
                           type: integer
                       required:
                       - containerName

--- a/manifests/templates/admission-webhook.yaml
+++ b/manifests/templates/admission-webhook.yaml
@@ -142,4 +142,3 @@ metadata:
     app: admission-webhook
     configmanagement.gke.io/system: "true"
     configmanagement.gke.io/arch: "csmr"
-webhooks: []

--- a/pkg/api/configsync/v1alpha1/resource_override.go
+++ b/pkg/api/configsync/v1alpha1/resource_override.go
@@ -160,10 +160,12 @@ type ContainerLogLevelOverride struct {
 	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	ContainerName string `json:"containerName"`
 
-	// logLevel specifies the log level override value for the container.
-	// The default value for git-sync container is 5, while all other containers will default to 0.
-	// Allowed values are from -1 to 10
-	// +kubebuilder:validation:Minimum=-1
+	// logLevel specifies the verbosity level of the logging for a specific container.
+	// The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+	// Increasing the value of logLevel increases the verbosity of the logs.
+	// Lower severity messages are logged at higher verbosity.
+	// Allowed values are from 0 to 10.
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=10
 	// +kubebuilder:validation:Required
 	LogLevel int `json:"logLevel"`

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -160,10 +160,12 @@ type ContainerLogLevelOverride struct {
 	// +kubebuilder:validation:Pattern=^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
 	ContainerName string `json:"containerName"`
 
-	// logLevel specifies the log level override value for the container.
-	// The default value for git-sync container is 5, while all other containers will default to 0.
-	// Allowed values are from -1 to 10
-	// +kubebuilder:validation:Minimum=-1
+	// logLevel specifies the verbosity level of the logging for a specific container.
+	// The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+	// Increasing the value of logLevel increases the verbosity of the logs.
+	// Lower severity messages are logged at higher verbosity.
+	// Allowed values are from 0 to 10.
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=10
 	// +kubebuilder:validation:Required
 	LogLevel int `json:"logLevel"`

--- a/pkg/reconcilermanager/controllers/reconciler_container_log_level_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_log_level_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/metrics"
+)
+
+func TestMutateContainerLogLevelOtelAgent(t *testing.T) {
+	testCases := map[string]struct {
+		logLevel      int
+		expectedLevel string
+	}{
+		"otel-agent with 0 log level": {
+			logLevel:      0,
+			expectedLevel: "fatal",
+		},
+		"otel-agent with 1 log level": {
+			logLevel:      1,
+			expectedLevel: "panic",
+		},
+		"otel-agent with 2 log level": {
+			logLevel:      2,
+			expectedLevel: "dpanic",
+		},
+		"otel-agent with 3 log level": {
+			logLevel:      3,
+			expectedLevel: "error",
+		},
+		"otel-agent with 4 log level": {
+			logLevel:      4,
+			expectedLevel: "warn",
+		},
+		"otel-agent with 5 log level": {
+			logLevel:      5,
+			expectedLevel: "info",
+		},
+		"otel-agent with 6 log level": {
+			logLevel:      6,
+			expectedLevel: "debug",
+		},
+		"otel-agent with 7 log level": {
+			logLevel:      7,
+			expectedLevel: "debug",
+		},
+		"otel-agent with 8 log level": {
+			logLevel:      8,
+			expectedLevel: "debug",
+		},
+		"otel-agent with 9 log level": {
+			logLevel:      9,
+			expectedLevel: "debug",
+		},
+		"otel-agent with 10 log level": {
+			logLevel:      10,
+			expectedLevel: "debug",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			container := &corev1.Container{
+				Name: metrics.OtelAgentName,
+			}
+			override := []v1beta1.ContainerLogLevelOverride{
+				{
+					ContainerName: metrics.OtelAgentName,
+					LogLevel:      tc.logLevel,
+				},
+			}
+			err := mutateContainerLogLevel(container, override)
+			assert.NoError(t, err)
+			expectedArgs := []string{fmt.Sprintf("--set=service.telemetry.logs.level=%s", tc.expectedLevel)}
+			assert.Equal(t, expectedArgs, container.Args)
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick two last-minute changes for 1.17.1. 

Added the extra hydration-controller validation  commit to avoid merge conflicts.