### PR TITLE
ci: set CGO_ENABLED=0 for local crane binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,9 @@ clean-helm:
 # install kind (user-friendly target alias)
 install-kind: "$(KIND)"
 
+# Set CGO_ENABLED=0 for compatibility with containers missing glibc
 "$(GOBIN)/crane":
-	go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)
+	CGO_ENABLED=0 go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)
 
 "$(CRANE)": "$(GOBIN)/crane" buildenv-dirs
 	cp $(GOBIN)/crane $(CRANE)


### PR DESCRIPTION
The crane binary is used by some of the e2e tests, which can be run in a container which does not have glibc. Compiling with CGO causes an error when invoking the binary in such a container.