### PR TITLE
Increase the default resource requests for helm-sync on Autopilot clusters (#1105)

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_container_resources.go
+++ b/pkg/reconcilermanager/controllers/reconciler_container_resources.go
@@ -98,10 +98,10 @@ func ReconcilerContainerResourceDefaultsForAutopilot() map[string]v1beta1.Contai
 		},
 		reconcilermanager.HelmSync: {
 			ContainerName: reconcilermanager.HelmSync,
-			CPURequest:    resource.MustParse("150m"),
-			CPULimit:      resource.MustParse("150m"),
-			MemoryRequest: resource.MustParse("256Mi"),
-			MemoryLimit:   resource.MustParse("256Mi"),
+			CPURequest:    resource.MustParse("250m"),
+			CPULimit:      resource.MustParse("250m"),
+			MemoryRequest: resource.MustParse("384Mi"),
+			MemoryLimit:   resource.MustParse("384Mi"),
 		},
 		reconcilermanager.GitSync: {
 			ContainerName: reconcilermanager.GitSync,


### PR DESCRIPTION
The Config Sync Autopilot CI failures indicate the helm-sync container is hitting both OOMKilled and `signal: killed` (insufficient CPU) on Autopilot clusters.

- OOMKilled:
  - autopilot regular: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-regular/1745822836569673728
  - autopilot stable: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-stable/1745836426253045760
- insufficient CPU:
  - autopilot rapid: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-rapid/1745826108181319680
  - autopilot rapid-latest: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-rapid-latest/1745819564941250560

This commit increases the default requests for helm-sync on Autopilot only.