### PR TITLE
refactor: rename test opt to RequireLocalGitProvider

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -103,7 +103,7 @@ func newOptStruct(testName, tmpDir string, t nomostesting.NTB, ntOptions ...ntop
 		t.Skip("Test skipped for non-gcenode auth types")
 	}
 
-	if *e2e.GitProvider != e2e.Local && optsStruct.SkipNonLocalGitProvider {
+	if *e2e.GitProvider != e2e.Local && optsStruct.RequireLocalGitProvider {
 		t.Skip("Test skipped for non-local GitProvider types")
 	}
 

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -46,8 +46,8 @@ type MultiRepo struct {
 	// Default: 5m.
 	ReconcileTimeout *time.Duration
 
-	// SkipNonLocalGitProvider will skip the test if run with a GitProvider type other than local.
-	SkipNonLocalGitProvider bool
+	// RequireLocalGitProvider will skip the test if run with a GitProvider type other than local.
+	RequireLocalGitProvider bool
 
 	// RepoSyncPermissions will grant a list of PolicyRules to NS reconcilers
 	RepoSyncPermissions []rbacv1.PolicyRule
@@ -73,9 +73,9 @@ func RootRepo(name string) func(opt *New) {
 	}
 }
 
-// SkipNonLocalGitProvider will skip the test with non-local GitProvider types
-func SkipNonLocalGitProvider(opt *New) {
-	opt.SkipNonLocalGitProvider = true
+// RequireLocalGitProvider will skip the test with non-local GitProvider types
+func RequireLocalGitProvider(opt *New) {
+	opt.RequireLocalGitProvider = true
 }
 
 // WithDelegatedControl will specify the Delegated Control Pattern.

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -62,7 +62,7 @@ func secretDataDeletePatch(key string) string {
 }
 
 func TestCACertSecretRefV1Alpha1(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
 
 	key := controllers.GitSSLCAInfo
@@ -180,7 +180,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 }
 
 func TestCACertSecretRefV1Beta1(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
 
 	key := controllers.GitSSLCAInfo
@@ -303,7 +303,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 }
 
 func TestCACertSecretWatch(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
 
 	key := controllers.GitSSLCAInfo

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestRootSyncSSHKnownHost(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider, ntopts.Unstructured)
 	var err error
 	rootSecret := &corev1.Secret{}
 	nt.T.Cleanup(func() {
@@ -125,7 +125,7 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 }
 
 func TestRepoSyncSSHKnownHost(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SkipNonLocalGitProvider, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider, ntopts.Unstructured,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName), ntopts.WithDelegatedControl,
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
 	var err error


### PR DESCRIPTION
This name avoids a double negative which helps readability.