### PR TITLE
Configure git-sync timeout from Config Sync

### DIFF
--- a/e2e/testcases/override_git_sync_timeout_test.go
+++ b/e2e/testcases/override_git_sync_timeout_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/testing/fake"
+)
+
+func TestOverrideRootSyncGitSyncTimeout(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+
+	rootSyncName := nomostest.RootSyncNN(configsync.RootSyncName)
+	rootReconcilerName := core.RootReconcilerObjectKey(rootSyncName.Name)
+	rootSyncV1 := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+
+	// apply override to one container and validate the others are unaffected
+	nt.MustMergePatch(rootSyncV1, `{"spec": {"override": {"gitSyncOverride": {"gitSyncTimeout": 500}}}}`)
+
+	err := nt.Watcher.WatchObject(kinds.Deployment(),
+		rootReconcilerName.Name, rootReconcilerName.Namespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "--timeout=500"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+}
+
+func TestOverrideRepoSyncGitSyncTimeout(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured, ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+	frontendReconcilerNN := core.NsReconcilerObjectKey(frontendNamespace, configsync.RepoSyncName)
+	frontendNN := nomostest.RepoSyncNN(frontendNamespace, configsync.RepoSyncName)
+	repoSyncFrontend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, frontendNN)
+
+	// Override the log level of the reconciler container of ns-reconciler-frontend
+	repoSyncFrontend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{
+		OverrideSpec: v1beta1.OverrideSpec{
+			GitSyncOverride: v1beta1.GitSyncOverride{
+				GitSyncTimeout: 500,
+			},
+		},
+	}
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update log level of frontend Reposync"))
+
+	// validate override and make sure other containers are unaffected
+	err := nt.Watcher.WatchObject(kinds.Deployment(),
+		frontendReconcilerNN.Name, frontendReconcilerNN.Namespace,
+		[]testpredicates.Predicate{
+			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "--timeout=500"),
+		},
+	)
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+}

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -337,6 +337,16 @@ spec:
                     format: int64
                     minimum: 0
                     type: integer
+                  gitSyncOverride:
+                    description: gitSyncOverride specify git-sync container override
+                    properties:
+                      gitSyncTimeout:
+                        description: gitSyncTimeout allows one to configure the timeout
+                          for the git-sync container. Must be no less than 0. If this
+                          field is not provided, the default value is 2 minutes.
+                        minimum: 0
+                        type: integer
+                    type: object
                   logLevels:
                     description: logLevels specify the container name and log level
                       override value for the reconciler deployment container. Each
@@ -1388,6 +1398,16 @@ spec:
                     format: int64
                     minimum: 0
                     type: integer
+                  gitSyncOverride:
+                    description: gitSyncOverride specify git-sync container override
+                    properties:
+                      gitSyncTimeout:
+                        description: gitSyncTimeout allows one to configure the timeout
+                          for the git-sync container. Must be no less than 0. If this
+                          field is not provided, the default value is 2 minutes.
+                        minimum: 0
+                        type: integer
+                    type: object
                   logLevels:
                     description: logLevels specify the container name and log level
                       override value for the reconciler deployment container. Each

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -347,6 +347,16 @@ spec:
                     format: int64
                     minimum: 0
                     type: integer
+                  gitSyncOverride:
+                    description: gitSyncOverride specify git-sync container override
+                    properties:
+                      gitSyncTimeout:
+                        description: gitSyncTimeout allows one to configure the timeout
+                          for the git-sync container. Must be no less than 0. If this
+                          field is not provided, the default value is 2 minutes.
+                        minimum: 0
+                        type: integer
+                    type: object
                   logLevels:
                     description: logLevels specify the container name and log level
                       override value for the reconciler deployment container. Each
@@ -1453,6 +1463,16 @@ spec:
                     format: int64
                     minimum: 0
                     type: integer
+                  gitSyncOverride:
+                    description: gitSyncOverride specify git-sync container override
+                    properties:
+                      gitSyncTimeout:
+                        description: gitSyncTimeout allows one to configure the timeout
+                          for the git-sync container. Must be no less than 0. If this
+                          field is not provided, the default value is 2 minutes.
+                        minimum: 0
+                        type: integer
+                    type: object
                   logLevels:
                     description: logLevels specify the container name and log level
                       override value for the reconciler deployment container. Each

--- a/pkg/api/configsync/v1alpha1/resource_override.go
+++ b/pkg/api/configsync/v1alpha1/resource_override.go
@@ -74,6 +74,10 @@ type OverrideSpec struct {
 	// +listMapKey=containerName
 	// +optional
 	LogLevels []ContainerLogLevelOverride `json:"logLevels,omitempty"`
+
+	// gitSyncOverride specify git-sync container override
+	// +optional
+	GitSyncOverride GitSyncOverride `json:"gitSyncOverride,omitempty"`
 }
 
 // RootSyncOverrideSpec allows to override the settings for a RootSync reconciler pod
@@ -169,4 +173,15 @@ type ContainerLogLevelOverride struct {
 	// +kubebuilder:validation:Maximum=10
 	// +kubebuilder:validation:Required
 	LogLevel int `json:"logLevel"`
+}
+
+// GitSyncOverride specifies the git-sync container override value
+type GitSyncOverride struct {
+	// gitSyncTimeout allows one to configure the timeout for the git-sync container.
+	// Must be no less than 0.
+	// If this field is not provided, the default value is 2 minutes.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	GitSyncTimeout int `json:"gitSyncTimeout,omitempty"`
 }

--- a/pkg/api/configsync/v1beta1/resource_override.go
+++ b/pkg/api/configsync/v1beta1/resource_override.go
@@ -74,6 +74,10 @@ type OverrideSpec struct {
 	// +listMapKey=containerName
 	// +optional
 	LogLevels []ContainerLogLevelOverride `json:"logLevels,omitempty"`
+
+	// gitSyncOverride specify git-sync container override
+	// +optional
+	GitSyncOverride GitSyncOverride `json:"gitSyncOverride,omitempty"`
 }
 
 // RootSyncOverrideSpec allows to override the settings for a RootSync reconciler pod
@@ -169,4 +173,15 @@ type ContainerLogLevelOverride struct {
 	// +kubebuilder:validation:Maximum=10
 	// +kubebuilder:validation:Required
 	LogLevel int `json:"logLevel"`
+}
+
+// GitSyncOverride specifies the git-sync container override value
+type GitSyncOverride struct {
+	// gitSyncTimeout allows one to configure the timeout for the git-sync container.
+	// Must be no less than 0.
+	// If this field is not provided, the default value is 2 minutes.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	GitSyncTimeout int `json:"gitSyncTimeout,omitempty"`
 }

--- a/pkg/reconcilermanager/controllers/gitsync_timeout.go
+++ b/pkg/reconcilermanager/controllers/gitsync_timeout.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func mutateGitsyncTimeout(c *corev1.Container, override int) error {
+	// If no overrides are provided, return
+	if override <= 0 {
+		return nil
+	}
+
+	c.Args = append(c.Args, fmt.Sprintf("--timeout=%d", override))
+	return nil
+}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -1205,6 +1205,11 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 				if err := mutateContainerLogLevel(&container, containerLogLevels); err != nil {
 					return err
 				}
+				if container.Name == reconcilermanager.GitSync {
+					if err := mutateGitsyncTimeout(&container, overrides.GitSyncOverride.GitSyncTimeout); err != nil {
+						return err
+					}
+				}
 				updatedContainers = append(updatedContainers, container)
 			}
 		}

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -1247,6 +1247,7 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 					sRef := client.ObjectKey{Namespace: rs.Namespace, Name: secretName}
 					keys := GetSecretKeys(ctx, r.client, sRef)
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
+
 				}
 			case reconcilermanager.GCENodeAskpassSidecar:
 				if !enableAskpassSidecar(rs.Spec.SourceType, auth) {
@@ -1266,6 +1267,11 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 				mutateContainerResource(&container, containerResources)
 				if err := mutateContainerLogLevel(&container, containerLogLevels); err != nil {
 					return err
+				}
+				if container.Name == reconcilermanager.GitSync {
+					if err := mutateGitsyncTimeout(&container, overrides.GitSyncOverride.GitSyncTimeout); err != nil {
+						return err
+					}
 				}
 				updatedContainers = append(updatedContainers, container)
 			}


### PR DESCRIPTION
The current `git-sync` timeout is 2 minutes, which should be enough for most cases, but not configurable from Config Sync side. These change will allow users to change git-sync timeout using override API 

b/279565020