### PR TITLE
feat: add CA cert support for helm-sync

### DIFF
--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -31,6 +31,8 @@ import (
 )
 
 var (
+	flCACert = flag.String("ca-cert", os.Getenv(reconcilermanager.HelmCACert),
+		"CA cert to use for validating HTTPS connections")
 	flRepo = flag.String("repo", os.Getenv(reconcilermanager.HelmRepo),
 		"helm repository url where to locate the requested chart")
 	flChart = flag.String("chart", os.Getenv(reconcilermanager.HelmChart),
@@ -129,6 +131,7 @@ func main() {
 			Dest:            *flDest,
 			UserName:        *flUsername,
 			Password:        *flPassword,
+			CACertFilePath:  *flCACert,
 		}
 
 		if err := hydrator.HelmTemplate(ctx); err != nil {

--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -108,6 +108,10 @@ var GitProvider = flag.String("git-provider", Local,
 var OCIProvider = flag.String("oci-provider", Local,
 	"The registry provider that hosts the OCI repositories. Defaults to local.")
 
+// HelmProvider is the provider that hosts the OCI repositories.
+var HelmProvider = flag.String("helm-provider", Local,
+	"The registry provider that hosts the helm packages. Defaults to local.")
+
 // TestFeatures is the list of features to run.
 var TestFeatures = flag.String("test-features", "",
 	"A list of features to run, separated by comma. Defaults to empty, which should run all tests.")

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -52,6 +52,9 @@ type MultiRepo struct {
 	// RequireLocalOCIProvider will skip the test if run with a OCIProvider type other than local.
 	RequireLocalOCIProvider bool
 
+	// RequireLocalHelmProvider will skip the test if run with a HelmProvider type other than local.
+	RequireLocalHelmProvider bool
+
 	// RepoSyncPermissions will grant a list of PolicyRules to NS reconcilers
 	RepoSyncPermissions []rbacv1.PolicyRule
 }
@@ -84,6 +87,11 @@ func RequireLocalGitProvider(opt *New) {
 // RequireLocalOCIProvider will skip the test with non-local OCIProvider types
 func RequireLocalOCIProvider(opt *New) {
 	opt.RequireLocalOCIProvider = true
+}
+
+// RequireLocalHelmProvider will skip the test with non-local HelmProvider types
+func RequireLocalHelmProvider(opt *New) {
+	opt.RequireLocalHelmProvider = true
 }
 
 // WithDelegatedControl will specify the Delegated Control Pattern.

--- a/e2e/nomostest/registryproviders/helm.go
+++ b/e2e/nomostest/registryproviders/helm.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registryproviders
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"kpt.dev/configsync/e2e/nomostest/gitproviders"
+	"kpt.dev/configsync/e2e/nomostest/testshell"
+	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/yaml"
+)
+
+// use an auto-incrementing index to create unique file names for tarballs
+var helmIndex int
+
+// BuildHelmPackage creates a new OCIImage object and associated tarball using the provided
+// Repository. The contents of the git repository will be bundled into a tarball
+// at the artifactDir. The resulting OCIImage object can be pushed to a remote
+// registry using its Push method.
+func BuildHelmPackage(artifactDir string, shell *testshell.TestShell, repository *gitproviders.Repository, provider RegistryProvider) (*HelmPackage, error) {
+	commitHash, err := repository.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("getting hash: %w", err)
+	}
+	branch, err := repository.CurrentBranch()
+	if err != nil {
+		return nil, fmt.Errorf("getting branch: %w", err)
+	}
+	// replace / with - to avoid creating nested directories/paths
+	name := strings.Replace(repository.Name, "/", "-", -1)
+	// helm forces a semver, but we can append the branch to create a floating tag
+	version := fmt.Sprintf("v1.0.0-%s", branch)
+	// Use branch/hash for context and imageIndex to enforce file name uniqueness.
+	// This avoids file name collision even if the test builds an image twice with
+	// a dirty repo state.
+	tmpDir := filepath.Join(artifactDir, branch, commitHash, strconv.Itoa(helmIndex))
+	if err := copyutil.CopyDir(repository.Root, tmpDir); err != nil {
+		return nil, fmt.Errorf("copying package directory: %v", err)
+	}
+	updateFn := func(chartMap map[string]interface{}) error {
+		chartMap["name"] = name
+		chartMap["version"] = version
+		return nil
+	}
+	if err := updateYAMLFile(filepath.Join(tmpDir, "Chart.yaml"), updateFn); err != nil {
+		return nil, fmt.Errorf("updating Chart.yaml: %v", err)
+	}
+	packagePath := tmpDir + string(filepath.Separator)
+	helmIndex++
+	if _, err := shell.Helm("package", tmpDir, "--destination", packagePath); err != nil {
+		return nil, fmt.Errorf("packaging helm chart: %w", err)
+	}
+	helmPackage := &HelmPackage{
+		localChartFile: filepath.Join(tmpDir, fmt.Sprintf("%s-%s.tgz", name, version)),
+		Name:           name,
+		Version:        version,
+		syncURL:        provider.SyncURL(name),
+		branch:         branch,
+		shell:          shell,
+	}
+	return helmPackage, nil
+}
+
+func updateYAMLFile(name string, updateFn func(map[string]interface{}) error) error {
+	chartBytes, err := os.ReadFile(name)
+	if os.IsNotExist(err) {
+		chartBytes = []byte{}
+	} else if err != nil {
+		return fmt.Errorf("reading file: %s: %w", name, err)
+	}
+	chartManifest := make(map[string]interface{})
+	if err := yaml.Unmarshal(chartBytes, &chartManifest); err != nil {
+		return fmt.Errorf("parsing yaml file: %s: %w", name, err)
+	}
+	if err := updateFn(chartManifest); err != nil {
+		return fmt.Errorf("updating yaml map for %s: %w", name, err)
+	}
+	chartBytes, err = yaml.Marshal(chartManifest)
+	if err != nil {
+		return fmt.Errorf("formatting yaml for %s: %w", name, err)
+	}
+	if err := os.WriteFile(name, chartBytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing file: %s: %w", name, err)
+	}
+	return nil
+}
+
+// HelmPackage represents a helm package that is pushed to a remote registry by the
+// test scaffolding. It uses git references as version tags to enable straightforward
+// integration with the git e2e tooling and to mimic how a user might leverage
+// git and helm.
+type HelmPackage struct {
+	localChartFile string
+	syncURL        string
+	branch         string
+	Name           string
+	Version        string
+	Digest         string
+	shell          *testshell.TestShell
+}
+
+// Push the image to the remote registry using the provided registry endpoint.
+func (h *HelmPackage) Push(registry string) error {
+	if _, err := h.shell.Helm("push", h.localChartFile, registry); err != nil {
+		return fmt.Errorf("pushing helm chart: %w", err)
+	}
+	// helm doesn't provide a great UX for deleting images, so just use crane
+	imageTag := fmt.Sprintf("%s/%s:%s", strings.TrimPrefix(registry, "oci://"), h.Name, h.Version)
+	out, err := h.shell.ExecWithDebug("crane", "digest", imageTag)
+	if err != nil {
+		return fmt.Errorf("getting digest: %w", err)
+	}
+	h.Digest = strings.TrimSpace(string(out))
+	return nil
+}
+
+// Delete the image from the remote registry using the provided registry endpoint.
+func (h *HelmPackage) Delete(registry string) error {
+	imageTag := fmt.Sprintf("%s/%s@%s", strings.TrimPrefix(registry, "oci://"), h.Name, h.Digest)
+	_, err := h.shell.ExecWithDebug("crane", "delete", imageTag)
+	if err != nil {
+		return fmt.Errorf("deleting image: %w", err)
+	}
+	return nil
+}

--- a/e2e/nomostest/registryproviders/local.go
+++ b/e2e/nomostest/registryproviders/local.go
@@ -64,3 +64,35 @@ func (l *LocalOCIProvider) PushURLWithPort(localPort int, name string) string {
 func (l *LocalOCIProvider) SyncURL(name string) string {
 	return fmt.Sprintf("test-registry-server.test-registry-system/oci/%s", name)
 }
+
+// LocalHelmProvider provides methods for interacting with the test registry-server
+// using the oci-sync interface.
+type LocalHelmProvider struct {
+	LocalProvider
+}
+
+// PushURL returns a URL for pushing images to the remote registry.
+// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
+func (l *LocalHelmProvider) PushURL(name string) (string, error) {
+	if l.PortForwarder == nil {
+		return "", fmt.Errorf("PortForwarder must be set for LocalProvider.OCIPushURL()")
+	}
+	port, err := l.PortForwarder.LocalPort()
+	if err != nil {
+		return "", err
+	}
+	return l.PushURLWithPort(port, name), nil
+}
+
+// PushURLWithPort returns a URL for pushing images to the remote registry.
+// localPort refers to the local port the PortForwarder is listening on.
+// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
+func (l *LocalHelmProvider) PushURLWithPort(localPort int, name string) string {
+	return fmt.Sprintf("oci://localhost:%d/helm/%s", localPort, name)
+}
+
+// SyncURL returns a URL for Config Sync to sync from using helm.
+// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
+func (l *LocalHelmProvider) SyncURL(name string) string {
+	return fmt.Sprintf("oci://test-registry-server.test-registry-system/helm/%s", name)
+}

--- a/e2e/nomostest/registryproviders/registry_provider.go
+++ b/e2e/nomostest/registryproviders/registry_provider.go
@@ -39,3 +39,13 @@ func NewOCIProvider(provider string) RegistryProvider {
 		return &LocalOCIProvider{}
 	}
 }
+
+// NewHelmProvider creates a RegistryProvider for the specific helm provider type.
+// This enables writing tests that can run against multiple types of registries.
+func NewHelmProvider(provider string) RegistryProvider {
+	switch provider {
+	// TODO: Refactor existing Artifact Registry impl to this interface
+	default:
+		return &LocalHelmProvider{}
+	}
+}

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -179,6 +179,20 @@ spec:
                     - token
                     - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: caCertSecretRef specifies the name of the secret
+                      where the CA certificate is stored. The creation of the secret
+                      should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the
+                      secret must be created in the same namespace as the RepoSync.
+                      For RootSync resource, the secret must be created in the config-management-system
+                      namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string
@@ -1243,6 +1257,20 @@ spec:
                     - token
                     - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: caCertSecretRef specifies the name of the secret
+                      where the CA certificate is stored. The creation of the secret
+                      should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the
+                      secret must be created in the same namespace as the RepoSync.
+                      For RootSync resource, the secret must be created in the config-management-system
+                      namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -179,6 +179,20 @@ spec:
                     - token
                     - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: caCertSecretRef specifies the name of the secret
+                      where the CA certificate is stored. The creation of the secret
+                      should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the
+                      secret must be created in the same namespace as the RepoSync.
+                      For RootSync resource, the secret must be created in the config-management-system
+                      namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string
@@ -1298,6 +1312,20 @@ spec:
                     - token
                     - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: caCertSecretRef specifies the name of the secret
+                      where the CA certificate is stored. The creation of the secret
+                      should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the
+                      secret must be created in the same namespace as the RepoSync.
+                      For RootSync resource, the secret must be created in the config-management-system
+                      namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string

--- a/pkg/api/configsync/v1alpha1/helmconfig.go
+++ b/pkg/api/configsync/v1alpha1/helmconfig.go
@@ -111,6 +111,15 @@ type HelmBase struct {
 	// +nullable
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty"`
+
+	// caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+	// The creation of the secret should be done out of band by the user and should store the
+	// certificate in a key named "cert". For RepoSync resources, the secret must be
+	// created in the same namespace as the RepoSync. For RootSync resource, the secret
+	// must be created in the config-management-system namespace.
+	// +nullable
+	// +optional
+	CACertSecretRef *SecretReference `json:"caCertSecretRef,omitempty"`
 }
 
 // ValuesFileRef references a ConfigMap object that contains a values file to use for

--- a/pkg/api/configsync/v1beta1/helmconfig.go
+++ b/pkg/api/configsync/v1beta1/helmconfig.go
@@ -112,6 +112,15 @@ type HelmBase struct {
 	// +nullable
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty"`
+
+	// caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+	// The creation of the secret should be done out of band by the user and should store the
+	// certificate in a key named "cert". For RepoSync resources, the secret must be
+	// created in the same namespace as the RepoSync. For RootSync resource, the secret
+	// must be created in the config-management-system namespace.
+	// +nullable
+	// +optional
+	CACertSecretRef *SecretReference `json:"caCertSecretRef,omitempty"`
 }
 
 // ValuesFileRef references a ConfigMap object that contains a values file to use for

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -174,4 +174,7 @@ const (
 
 	// HelmSyncWait is the OS env variable key for the Helm sync wait period in seconds.
 	HelmSyncWait = "HELM_SYNC_WAIT"
+
+	// HelmCACert is the OS env variable key for the Helm sync CA cert file path.
+	HelmCACert = "HELM_CA_CERT"
 )

--- a/pkg/reconcilermanager/controllers/secret.go
+++ b/pkg/reconcilermanager/controllers/secret.go
@@ -56,6 +56,11 @@ func getCACertName(rs *v1beta1.RepoSync) (string, bool) {
 			return "", false
 		}
 		return v1beta1.GetSecretName(rs.Spec.Oci.CACertSecretRef), true
+	case v1beta1.HelmSource:
+		if rs.Spec.Helm == nil || rs.Spec.Helm.CACertSecretRef == nil {
+			return "", false
+		}
+		return v1beta1.GetSecretName(rs.Spec.Helm.CACertSecretRef), true
 	default:
 		return "", false
 	}

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -291,6 +291,7 @@ type helmOptions struct {
 	helmBase         *v1beta1.HelmBase
 	releaseNamespace string
 	deployNamespace  string
+	caCertSecretRef  string
 }
 
 // helmSyncEnvs returns the environment variables for the helm-sync container.
@@ -331,6 +332,12 @@ func helmSyncEnvs(opts helmOptions) []corev1.EnvVar {
 		Name:  reconcilermanager.HelmSyncWait,
 		Value: fmt.Sprintf("%f", v1beta1.GetPeriod(opts.helmBase.Period, configsync.DefaultHelmSyncVersionPollingPeriod).Seconds()),
 	})
+	if useCACert(opts.caCertSecretRef) {
+		result = append(result, corev1.EnvVar{
+			Name:  reconcilermanager.HelmCACert,
+			Value: fmt.Sprintf("%s/%s", CACertPath, CACertSecretKey),
+		})
+	}
 	return result
 }
 


### PR DESCRIPTION
This change adds a caCertSecretRef API field for the helm api which is analogous to the existing git/oci api fields. This can be used by users to provide a CA certificate for verifying the authenticity of the helm repository.