### PR TITLE
test: fix test failures caused by sub tests running in parallel

### DIFF
--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -40,6 +40,7 @@ import (
 	configmanagementv1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
 	resourcegroupv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/client/restconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,6 +94,7 @@ func newScheme(t testing.NTB) *runtime.Scheme {
 		rbacv1beta1.SchemeBuilder,
 		resourcegroupv1alpha1.SchemeBuilder.SchemeBuilder,
 		apiregistrationv1.SchemeBuilder,
+		hubv1.SchemeBuilder,
 	}
 	for _, b := range builders {
 		err := b.AddToScheme(s)

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -168,6 +168,7 @@ func TestWorkloadIdentity(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.Unstructured, ntopts.RequireGKE(t))
 			if err := workloadidentity.ValidateEnabled(nt); err != nil {


### PR DESCRIPTION
`workload_identity_test.go` defines a set of sub tests in a table driven format. Each sub test enables parallel execution with `t.Parallel()`. A go routine is created for each sub test. However, when it launches the go routines, the test case variables (the `tc` variable in the for loop iterator) are evaluated when the go routines run. Hence, by the time the go routine is actually executed, the for loop has completed, and each test ends up using the variables for the last test case.

To fix this issue, this commit rebinds the `tc` variable inside the loop. This creates a copy for the variable and go routine uses the local copy for execution.

It also adds the hubv1 schema because the test gets the Membership object to validate the Fleet workload identity credentials. loop