### PR TITLE
Add required IAM settings for the test infra

### DIFF
--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -78,3 +78,15 @@ resource "google_service_account_iam_member" "e2e_metric_writer_gke_binding" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-monitoring/default]"
 }
+
+# Grant source reader permissions to the RootSync's KSA with GKE workload identity.
+resource "google_project_iam_member" "root-reconciler-wi-sa-iam" {
+  for_each = toset([
+    "roles/source.reader",
+    "roles/artifactregistry.reader",
+    "roles/storage.objectViewer",
+  ])
+  role    = each.value
+  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler]"
+  project = data.google_project.project.id
+}

--- a/e2e/testinfra/terraform/prow/service_accounts.tf
+++ b/e2e/testinfra/terraform/prow/service_accounts.tf
@@ -37,3 +37,15 @@ resource "google_service_account_iam_member" "admin-account-iam" {
   role               = "roles/iam.serviceAccountKeyAdmin"
   member             = "serviceAccount:e2e-test-runner@oss-prow-build-kpt-config-sync.iam.gserviceaccount.com"
 }
+
+# Grant source reader permissions to the RootSync's KSA with Fleet workload identity.
+resource "google_project_iam_member" "root-reconciler-fwi-sa-iam" {
+  for_each = toset([
+    "roles/source.reader",
+    "roles/artifactregistry.reader",
+    "roles/storage.objectViewer",
+  ])
+  role    = each.value
+  member             = "serviceAccount:cs-dev-hub.svc.id.goog[config-management-system/root-reconciler]"
+  project = data.google_project.project.id
+}


### PR DESCRIPTION
The new k8sserviceaccount requires reader permissions to be granted to the KSA, along with the workload identity pool. This commit adds IAM settings as a one-off config.