### PR TITLE
fix: use google-cloud-cli package instead of sdk

### DIFF
--- a/build/prow/e2e/Dockerfile
+++ b/build/prow/e2e/Dockerfile
@@ -21,7 +21,7 @@ ARG DOCKER_CLI_IMAGE
 FROM ${GCLOUD_IMAGE} as gcloud-install
 
 RUN apt-get update && apt-get install -y \
-    kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+    kubectl google-cloud-cli-gke-gcloud-auth-plugin
 
 FROM ${GOLANG_IMAGE} as builder
 


### PR DESCRIPTION
The package name has transitioned to cli instead of sdk, and the sdk package is currently broken.