### PR TITLE
fix: use more limited securityContext for pods

### DIFF
--- a/manifests/templates/admission-webhook.yaml
+++ b/manifests/templates/admission-webhook.yaml
@@ -50,6 +50,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 10m
@@ -76,6 +79,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: admission-webhook-cert
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -115,6 +115,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf
@@ -138,3 +141,6 @@ spec:
         fsGroup: 2000
         runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -73,7 +73,7 @@ data:
              readOnlyRootFilesystem: false
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
              runAsUser: 65533
          - name: reconciler
            image: RECONCILER_IMAGE_NAME
@@ -98,7 +98,7 @@ data:
              readOnlyRootFilesystem: true
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
            imagePullPolicy: IfNotPresent
          - name: git-sync
            image: gcr.io/config-management-release/git-sync:v4.1.0-gke.7__linux_amd64
@@ -115,7 +115,7 @@ data:
              readOnlyRootFilesystem: false
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
              runAsUser: 65533
          - name: gcenode-askpass-sidecar
            image: ASKPASS_IMAGE_NAME
@@ -128,7 +128,7 @@ data:
              readOnlyRootFilesystem: false
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
          - name: oci-sync
            image: OCI_SYNC_IMAGE_NAME
            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
@@ -141,7 +141,7 @@ data:
              readOnlyRootFilesystem: false
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
              runAsUser: 65533
          - name: helm-sync
            image: HELM_SYNC_IMAGE_NAME
@@ -158,7 +158,7 @@ data:
              readOnlyRootFilesystem: false
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
              runAsUser: 65533
          - name: otel-agent
            image: gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.5
@@ -174,7 +174,7 @@ data:
              readOnlyRootFilesystem: true
              capabilities:
                drop:
-               - NET_RAW
+               - ALL
            ports:
            - containerPort: 55678 # Default OpenCensus receiver port.
              protocol: TCP
@@ -277,6 +277,7 @@ data:
          securityContext:
            fsGroup: 65533
            runAsUser: 1000
+           runAsGroup: 1000
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -47,6 +47,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 10m
@@ -81,6 +84,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - name: otel-agent-config-vol
           mountPath: /conf
@@ -140,4 +146,7 @@ spec:
           name: otel-agent
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -226,8 +226,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
       - args:
         - --config=/conf/otel-agent-config.yaml
         command:
@@ -281,8 +282,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /conf
           name: otel-agent-config-vol
@@ -292,3 +294,9 @@ spec:
       - configMap:
           name: resource-group-otel-agent
         name: otel-agent-config-vol
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
This restricts some of the default security context fields to follow principle of least privilege.