### PR TITLE
test: refactor helm provider to not depend on gitproviders

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -827,7 +827,7 @@ func (nt *NT) RootSyncObjectOCI(name string, image *registryproviders.OCIImage) 
 	rs := RootSyncObjectV1Beta1FromRootRepo(nt, name)
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{
-		Image: image.FloatingBranchTag(),
+		Image: image.FloatingTag(),
 		Auth:  configsync.AuthNone,
 	}
 	switch *e2e.OCIProvider {
@@ -851,7 +851,7 @@ func (nt *NT) RepoSyncObjectOCI(nn types.NamespacedName, image *registryprovider
 	rs := RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{
-		Image: image.FloatingBranchTag(),
+		Image: image.FloatingTag(),
 		Auth:  configsync.AuthNone,
 	}
 	switch *e2e.OCIProvider {

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -101,10 +101,18 @@ func RequireKind(t testing.NTB) Opt {
 	return func(opt *New) {}
 }
 
-// RequireHelmArtifactRegistry requires the --helm-provider flag to be set to artifact_registry
+// RequireHelmArtifactRegistry requires the --helm-provider flag to be set to gar
 func RequireHelmArtifactRegistry(t testing.NTB) Opt {
 	if *e2e.HelmProvider != e2e.ArtifactRegistry {
-		t.Skip("The --helm-provider flag must be set to `artifact_registry` to run this test.")
+		t.Skip("The --helm-provider flag must be set to `gar` to run this test.")
+	}
+	return func(opt *New) {}
+}
+
+// RequireOCIArtifactRegistry requires the --oci-provider flag to be set to gar
+func RequireOCIArtifactRegistry(t testing.NTB) Opt {
+	if *e2e.OCIProvider != e2e.ArtifactRegistry {
+		t.Skip("The --oci-provider flag must be set to `gar` to run this test.")
 	}
 	return func(opt *New) {}
 }

--- a/e2e/nomostest/testkubeclient/object.go
+++ b/e2e/nomostest/testkubeclient/object.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testkubeclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	jserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"kpt.dev/configsync/pkg/syncer/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SerializeObject converts the object into bytes based on the provided format
+func SerializeObject(obj client.Object, ext string, scheme *runtime.Scheme) ([]byte, error) {
+	// We must convert through JSON/Unstructured to avoid "omitempty" fields
+	// from being specified.
+	uObj, err := reconcile.AsUnstructuredSanitized(obj)
+	if err != nil {
+		return nil, fmt.Errorf("sanitizing object: %w", err)
+	}
+	switch ext {
+	case ".yaml", ".yml":
+		// Encode converts to json then yaml, to handle "omitempty" directives.
+		yamlSerializer := jserializer.NewSerializerWithOptions(
+			jserializer.DefaultMetaFactory, scheme, scheme,
+			jserializer.SerializerOptions{Yaml: true},
+		)
+		bytes, err := runtime.Encode(yamlSerializer, uObj)
+		if err != nil {
+			return nil, fmt.Errorf("encoding object as yaml: %w", err)
+		}
+		return bytes, nil
+	case ".json":
+		bytes, err := json.MarshalIndent(uObj, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encoding object as json: %w", err)
+		}
+		return bytes, nil
+	default:
+		// If you're seeing this error, use "AddFile" instead to test ignoring
+		// files with extensions we ignore.
+		return nil, fmt.Errorf("invalid extension to write object to, %q, use .AddFile() instead", ext)
+	}
+}
+
+// WriteToFile writes the bytes to the provided path.
+func WriteToFile(absPath string, bytes []byte) error {
+	parentDir := filepath.Dir(absPath)
+	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+		return fmt.Errorf("creating directory %s: %w", parentDir, err)
+	}
+
+	// Write bytes to file.
+	if err := os.WriteFile(absPath, bytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing file %s: %w", absPath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Currently, it calls for a `UseHelmChart` function before building and pushing a Helm chart. The function resides inside the gitproviders package, which copies the test helm chart directory to the git local directory. Ideally, if the source type is changed from Git to Helm, it is not necessary to update the git repository.

This commit refactors the code to separate the helm repo dir from the git repo dir. When building and pushing a helm chart, it is optional to provide a test helm chart dir, any K8s objects, or a chart version.

It also makes similar changes to the oci provider.