### PR TITLE
test: prevent eviction of test pods

### DIFF
--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -127,9 +127,6 @@ func gitDeployment() *appsv1.Deployment {
 		core.Namespace(testGitNamespace),
 		core.Labels(testGitServerSelector()),
 	)
-	if *e2e.GKEAutopilot {
-		deployment.SetAnnotations(map[string]string{safeToEvictAnnotation: "false"})
-	}
 	gitGID := int64(1000)
 	deployment.Spec = appsv1.DeploymentSpec{
 		MinReadySeconds: 2,
@@ -138,6 +135,9 @@ func gitDeployment() *appsv1.Deployment {
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: v1.ObjectMeta{
 				Labels: testGitServerSelector(),
+				Annotations: map[string]string{
+					safeToEvictAnnotation: "false",
+				},
 			},
 			Spec: corev1.PodSpec{
 				Volumes: []corev1.Volume{

--- a/e2e/nomostest/registry_server.go
+++ b/e2e/nomostest/registry_server.go
@@ -238,6 +238,9 @@ func registryDeployment() *appsv1.Deployment {
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: testRegistryServerSelector(),
+				Annotations: map[string]string{
+					safeToEvictAnnotation: "false",
+				},
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{

--- a/e2e/testdata/prometheus/prometheus.yaml
+++ b/e2e/testdata/prometheus/prometheus.yaml
@@ -162,10 +162,9 @@ spec:
       labels:
         app: prometheus-server
       annotations:
-        # Allow eviction & rescheduling by cluster-autoscaler.
-        # This will delete ephemeral metrics storage,
-        # but is required for usage on GKE Autopilot.
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        # Prevent eviction & rescheduling by cluster-autoscaler.
+        # This preserves ephemeral metrics storage.
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       containers:
         - name: prometheus


### PR DESCRIPTION
Autopilot now allows setting the safe-to-evict annotation to request an extended runtime of Pods. This change sets the annotation on each of the test components which use ephemeral storage, which should reduce flakiness. These Deployments are deleted at the end of test execution, which will allow scale down.