### PR TITLE
chore: removing the old errors package.

### DIFF
--- a/cmd/nomos/bugreport/bugreport.go
+++ b/cmd/nomos/bugreport/bugreport.go
@@ -17,7 +17,6 @@ package bugreport
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -48,20 +47,20 @@ var Cmd = &cobra.Command{
 
 		cfg, err := restconfig.NewRestConfig(flags.ClientTimeout)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create rest config")
+			return fmt.Errorf("failed to create rest config: %w", err)
 		}
 		cs, err := kubernetes.NewForConfig(cfg)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create kubernetes client set")
+			return fmt.Errorf("failed to create kubernetes client set: %w", err)
 		}
 		c, err := client.New(cfg, client.Options{})
 		if err != nil {
-			return errors.Wrapf(err, "failed to create kubernetes client")
+			return fmt.Errorf("failed to create kubernetes client: %w", err)
 		}
 
 		report, err := bugreport.New(cmd.Context(), c, cs)
 		if err != nil {
-			return errors.Wrap(err, "failed to initialize bug reporter")
+			return fmt.Errorf("failed to initialize bug reporter: %w", err)
 		}
 
 		if err = report.Open(); err != nil {

--- a/cmd/nomos/hydrate/hydrate.go
+++ b/cmd/nomos/hydrate/hydrate.go
@@ -15,9 +15,9 @@
 package hydrate
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"kpt.dev/configsync/cmd/nomos/flags"
 	nomosparse "kpt.dev/configsync/cmd/nomos/parse"
@@ -142,7 +142,7 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 				if clusterName == "" {
 					clusterName = nomosparse.UnregisteredCluster
 				}
-				util.PrintErrOrDie(errors.Wrapf(err, "errors for Cluster %q", clusterName))
+				util.PrintErrOrDie(fmt.Errorf("errors for Cluster %q: %w", clusterName, err))
 
 				encounteredError = true
 

--- a/cmd/nomos/initialize/init.go
+++ b/cmd/nomos/initialize/init.go
@@ -15,11 +15,11 @@
 package initialize
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/printers"
 	"kpt.dev/configsync/cmd/nomos/flags"
@@ -65,7 +65,7 @@ func Initialize(root string, force bool) error {
 	if _, err := os.Stat(root); os.IsNotExist(err) {
 		err = os.MkdirAll(root, os.ModePerm)
 		if err != nil {
-			return errors.Wrapf(err, "unable to create dir %q", root)
+			return fmt.Errorf("unable to create dir %q: %w", root, err)
 		}
 	} else if err != nil {
 		return err
@@ -118,12 +118,12 @@ func Initialize(root string, force bool) error {
 func checkEmpty(dir cmpath.Absolute) error {
 	files, err := os.ReadDir(dir.OSPath())
 	if err != nil {
-		return errors.Wrapf(err, "error reading %q", dir)
+		return fmt.Errorf("error reading %q: %w", dir, err)
 	}
 
 	for _, file := range files {
 		if !strings.HasPrefix(file.Name(), ".") {
-			return errors.Errorf("passed dir %q has file %q; use --force to proceed", dir, file.Name())
+			return fmt.Errorf("passed dir %q has file %q; use --force to proceed", dir, file.Name())
 		}
 	}
 	return nil

--- a/cmd/nomos/parse/find_files.go
+++ b/cmd/nomos/parse/find_files.go
@@ -15,10 +15,10 @@
 package parse
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 )
 
@@ -32,7 +32,7 @@ import (
 func FindFiles(dir cmpath.Absolute) ([]cmpath.Absolute, error) {
 	out, err := exec.Command("find", dir.OSPath(), "-type", "f", "-not", "-path", "*/\\.git/*").CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrap(err, string(out))
+		return nil, fmt.Errorf("%s: %w", string(out), err)
 	}
 	files := strings.Split(string(out), "\n")
 	var result []cmpath.Absolute

--- a/cmd/nomos/parse/find_files_test.go
+++ b/cmd/nomos/parse/find_files_test.go
@@ -15,6 +15,7 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"sort"
@@ -22,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 )
 
@@ -62,7 +62,7 @@ func TestListPolicyFiles(t *testing.T) {
 			// Initialize a git repository.
 			out, err := exec.Command("git", "-C", dir.OSPath(), "init").CombinedOutput()
 			if err != nil {
-				t.Fatal(errors.Wrap(err, string(out)))
+				t.Fatal(fmt.Errorf("%s: %w", string(out), err))
 			}
 
 			// Add all of the specified files to the repository.
@@ -84,7 +84,7 @@ func TestListPolicyFiles(t *testing.T) {
 					}
 					out, err = exec.Command("git", "-C", dir.OSPath(), "add", f).CombinedOutput()
 					if err != nil {
-						t.Fatal(errors.Wrap(err, string(out)))
+						t.Fatal(fmt.Errorf("%s: %w", string(out), err))
 					}
 				}
 			}
@@ -97,7 +97,7 @@ func TestListPolicyFiles(t *testing.T) {
 					"-c", "user.email='team@example.comcmpath'",
 					"-C", dir.OSPath(), "commit", "-m", "add files").CombinedOutput()
 				if err != nil {
-					t.Fatal(errors.Wrap(err, string(out)))
+					t.Fatal(fmt.Errorf("%s: %w", string(out), err))
 				}
 			}
 

--- a/cmd/nomos/status/client.go
+++ b/cmd/nomos/status/client.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -454,7 +453,7 @@ func (c *ClusterClient) IsConfigured(ctx context.Context, cs *ClusterState) bool
 func ClusterClients(ctx context.Context, contexts []string) (map[string]*ClusterClient, error) {
 	configs, err := restconfig.AllKubectlConfigs(flags.ClientTimeout)
 	if configs == nil {
-		return nil, errors.Wrap(err, "failed to create client configs")
+		return nil, fmt.Errorf("failed to create client configs: %w", err)
 	}
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/nomos/util/configmanagement.go
+++ b/cmd/nomos/util/configmanagement.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +78,7 @@ func (c *ConfigManagementClient) NestedInt(ctx context.Context, fields ...string
 
 	val, _, err := unstructured.NestedInt64(unstr.UnstructuredContent(), fields...)
 	if err != nil {
-		return 0, errors.Wrap(err, "internal error parsing ConfigManagement")
+		return 0, fmt.Errorf("internal error parsing ConfigManagement: %w", err)
 	}
 
 	return int(val), nil
@@ -116,7 +115,7 @@ func (c *ConfigManagementClient) NestedBool(ctx context.Context, fields ...strin
 
 	val, _, err := unstructured.NestedBool(unstr.UnstructuredContent(), fields...)
 	if err != nil {
-		return false, errors.Wrap(err, "internal error parsing ConfigManagement")
+		return false, fmt.Errorf("internal error parsing ConfigManagement: %w", err)
 	}
 
 	return val, nil
@@ -132,7 +131,7 @@ func (c *ConfigManagementClient) NestedString(ctx context.Context, fields ...str
 
 	val, _, err := unstructured.NestedString(unstr.UnstructuredContent(), fields...)
 	if err != nil {
-		return "", errors.Wrap(err, "internal error parsing ConfigManagement")
+		return "", fmt.Errorf("internal error parsing ConfigManagement: %w", err)
 	}
 
 	return val, nil
@@ -148,7 +147,7 @@ func (c *ConfigManagementClient) NestedStringSlice(ctx context.Context, fields .
 
 	vals, _, err := unstructured.NestedStringSlice(unstr.UnstructuredContent(), fields...)
 	if err != nil {
-		return nil, errors.Wrap(err, "internal error parsing ConfigManagement")
+		return nil, fmt.Errorf("internal error parsing ConfigManagement: %w", err)
 	}
 
 	return vals, nil

--- a/cmd/nomos/version/version.go
+++ b/cmd/nomos/version/version.go
@@ -284,19 +284,15 @@ func tabulate(es []entry, out io.Writer) {
 	w := util.NewWriter(out)
 	defer func() {
 		if err := w.Flush(); err != nil {
-			// nolint:errcheck
 			fmt.Fprintf(os.Stderr, "error on Flush(): %v", err)
 		}
 	}()
-	// nolint:errcheck
 	fmt.Fprintf(w, format, "CURRENT", "CLUSTER_CONTEXT_NAME", "COMPONENT", "VERSION")
 	for _, e := range es {
 		if e.err != nil {
-			// nolint:errcheck
 			fmt.Fprintf(w, format, e.current, e.name, e.component, fmt.Sprintf("<error: %v>", e.err))
 			continue
 		}
-		// nolint:errcheck
 		fmt.Fprintf(w, format, e.current, e.name, e.component, e.version)
 	}
 }

--- a/cmd/nomos/version/version.go
+++ b/cmd/nomos/version/version.go
@@ -16,6 +16,7 @@ package version
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,7 +58,7 @@ func GetVersionReadCloser(ctx context.Context, contexts []string) (io.ReadCloser
 	versionInternal(ctx, allCfgs, writer, contexts)
 	err = w.Close()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to close version file writer with error: %v")
+		return nil, fmt.Errorf("failed to close version file writer with error: %w", err)
 	}
 
 	return io.NopCloser(r), nil
@@ -85,7 +85,7 @@ of the "nomos" client binary for debugging purposes.`,
 			versionInternal(cmd.Context(), allCfgs, os.Stdout, flags.Contexts)
 
 			if err != nil {
-				return errors.Wrap(err, "unable to parse kubectl config")
+				return fmt.Errorf("unable to parse kubectl config: %w", err)
 			}
 			return nil
 		},
@@ -96,12 +96,11 @@ of the "nomos" client binary for debugging purposes.`,
 func allKubectlConfigs() (map[string]*rest.Config, error) {
 	allCfgs, err := restconfig.AllKubectlConfigs(flags.ClientTimeout)
 	if err != nil {
-		// Unwrap the "no such file or directory" error for better readability
-		if unWrapped := errors.Cause(err); os.IsNotExist(unWrapped) {
-			err = unWrapped
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			err = pathErr
 		}
 
-		// nolint:errcheck
 		fmt.Printf("failed to create client configs: %v\n", err)
 	}
 
@@ -257,7 +256,7 @@ type entry struct {
 func entries(vs map[string]vErr) []entry {
 	currentContext, err := restconfig.CurrentContextName()
 	if err != nil {
-		fmt.Printf("Failed to get current context name with err: %v\n", errors.Cause(err))
+		fmt.Printf("Failed to get current context name with err: %v\n", err)
 	}
 
 	var es []entry

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -16,12 +16,12 @@ package vet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/cmd/nomos/flags"
 	nomosparse "kpt.dev/configsync/cmd/nomos/parse"
 	"kpt.dev/configsync/cmd/nomos/util"
@@ -95,7 +95,7 @@ func runVet(ctx context.Context, namespace string, sourceFormat filesystem.Sourc
 		if namespace != "" {
 			// The user could technically provide --source-format=unstructured.
 			// This nuance isn't necessary to communicate nor confusing to omit.
-			return errors.Errorf("if --namespace is provided, --%s must be omitted or set to %s",
+			return fmt.Errorf("if --namespace is provided, --%s must be omitted or set to %s",
 				reconcilermanager.SourceFormat, filesystem.SourceFormatUnstructured)
 		}
 

--- a/e2e/nomostest/clean.go
+++ b/e2e/nomostest/clean.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -182,7 +181,7 @@ func deleteManagedNamespacesAndWait(nt *NT) error {
 	protectedNamespacesWithTestLabel, nsListItems := filterNamespaces(nsList.Items,
 		protectedNamespaces...)
 	if len(protectedNamespacesWithTestLabel) > 0 {
-		return errors.Errorf("protected namespace(s) still have config sync labels and cannot be cleaned: %+v",
+		return fmt.Errorf("protected namespace(s) still have config sync labels and cannot be cleaned: %+v",
 			protectedNamespacesWithTestLabel)
 	}
 	return deleteNamespacesAndWait(nt, nsListItems)
@@ -211,7 +210,7 @@ func deleteImplicitNamespacesAndWait(nt *NT) error {
 	protectedNamespacesWithTestLabel, nsListFiltered := filterNamespaces(nsListFiltered,
 		protectedNamespaces...)
 	if len(protectedNamespacesWithTestLabel) > 0 {
-		return errors.Errorf("protected namespace(s) still have config sync annotations and cannot be cleaned: %+v",
+		return fmt.Errorf("protected namespace(s) still have config sync annotations and cannot be cleaned: %+v",
 			protectedNamespacesWithTestLabel)
 	}
 	return deleteNamespacesAndWait(nt, nsListFiltered)
@@ -398,8 +397,8 @@ func DeleteObjectsAndWait(nt *NT, objs ...client.Object) error {
 					// skip waiting
 					continue
 				}
-				return errors.Wrapf(err, "unable to delete %s object %s",
-					gvk.Kind, nn)
+				return fmt.Errorf("unable to delete %s object %s: %w",
+					gvk.Kind, nn, err)
 			}
 		}
 		tg.Go(func() error {

--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -15,11 +15,11 @@
 package nomostest
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -125,7 +125,7 @@ func upsertCluster(t testing.NTB, cluster Cluster, opts *ntopts.New) (bool, erro
 		return false, err
 	}
 	if exists && *e2e.CreateClusters != e2e.CreateClustersLazy {
-		return false, errors.Errorf("cluster %s already exists and create-clusters=%s", opts.ClusterName, *e2e.CreateClusters)
+		return false, fmt.Errorf("cluster %s already exists and create-clusters=%s", opts.ClusterName, *e2e.CreateClusters)
 	}
 	if exists && *e2e.CreateClusters == e2e.CreateClustersLazy {
 		t.Logf("cluster %s already exists, adopting (create-clusters=%s)", opts.ClusterName, *e2e.CreateClusters)

--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/retry"
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
@@ -90,7 +89,7 @@ func listOperations(ctx context.Context, t testing.NTB, name string) ([]string, 
 	cmd := exec.CommandContext(ctx, "gcloud", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.Errorf("failed to list operations for %s: %v\nstdout/stderr:\n%s",
+		return nil, fmt.Errorf("failed to list operations for %s: %v\nstdout/stderr:\n%s",
 			name, err, string(out))
 	}
 	operations := strings.Fields(string(out))
@@ -118,7 +117,7 @@ func waitOperation(ctx context.Context, t testing.NTB, operation string) error {
 	cmd := exec.CommandContext(ctx, "gcloud", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Errorf("failed to wait for operation %s: %v\nstdout/stderr:\n%s",
+		return fmt.Errorf("failed to wait for operation %s: %v\nstdout/stderr:\n%s",
 			operation, err, string(out))
 	}
 	return nil
@@ -168,7 +167,7 @@ func deleteGKECluster(t testing.NTB, name string) error {
 		cmd := exec.Command("gcloud", args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			return errors.Errorf("failed to delete cluster %s: %v\nstdout/stderr:\n%s", name, err, string(out))
+			return fmt.Errorf("failed to delete cluster %s: %v\nstdout/stderr:\n%s", name, err, string(out))
 		}
 		return nil
 	})
@@ -250,7 +249,7 @@ func createGKECluster(t testing.NTB, name string) error {
 	cmd := exec.Command("gcloud", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Errorf("failed to create cluster %s: %v\nstdout/stderr:\n%s", name, err, string(out))
+		return fmt.Errorf("failed to create cluster %s: %v\nstdout/stderr:\n%s", name, err, string(out))
 	}
 	return listAndWaitForOperations(context.Background(), t, name)
 }
@@ -274,14 +273,14 @@ func getGKECredentials(t testing.NTB, clusterName, kubeconfig string) error {
 		kubeconfig,
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return errors.Errorf("failed to get credentials: %v\nstdout/stderr:\n%s", err, string(out))
+		return fmt.Errorf("failed to get credentials: %v\nstdout/stderr:\n%s", err, string(out))
 	}
 	cmd = withKubeConfig( // gcloud config config-helper --force-auth-refresh
 		exec.Command("gcloud", "config", "config-helper", "--force-auth-refresh"),
 		kubeconfig,
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return errors.Errorf("failed to refresh access_token: %v\nstdout/stderr:\n%s", err, string(out))
+		return fmt.Errorf("failed to refresh access_token: %v\nstdout/stderr:\n%s", err, string(out))
 	}
 	// after getting credentials, wait for any running operations to complete
 	// before handing over this cluster to the test environment
@@ -305,7 +304,7 @@ func clusterExistsGKE(t testing.NTB, clusterName string) (bool, error) {
 	cmd := exec.Command("gcloud", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, errors.Errorf("failed to list cluster (%s): %v\nstdout/stderr:\n%s",
+		return false, fmt.Errorf("failed to list cluster (%s): %v\nstdout/stderr:\n%s",
 			clusterName, err, string(out))
 	}
 	clusters := strings.Fields(string(out))

--- a/e2e/nomostest/clusters/kind.go
+++ b/e2e/nomostest/clusters/kind.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/e2e/nomostest/docker"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
@@ -126,7 +125,7 @@ func (c *KindCluster) Delete() error {
 	// callbacks such as this are not executed.
 	err := c.provider.Delete(c.Name, c.KubeConfigPath)
 	if err != nil {
-		return errors.Errorf("deleting Kind cluster %q: %v", c.Name, err)
+		return fmt.Errorf("deleting Kind cluster %q: %v", c.Name, err)
 	}
 	return nil
 }
@@ -144,7 +143,7 @@ func asKindVersion(version string) (KindVersion, error) {
 	if ok {
 		return kindVersion, nil
 	}
-	return "", errors.Errorf("Unrecognized Kind version: %q", version)
+	return "", fmt.Errorf("Unrecognized Kind version: %q", version)
 }
 
 func createKindCluster(p *cluster.Provider, name, kcfgPath string, version KindVersion) error {

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -16,6 +16,7 @@ package nomostest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1103,7 +1103,7 @@ func SetDependencies(obj client.Object, dependencies ...client.Object) error {
 		deps = append(deps, applier.ObjMetaFromObject(dep))
 	}
 	if err := setDependsOnAnnotation(obj, deps); err != nil {
-		return errors.Wrapf(err, "failed to set dependencies on %T %s", obj, client.ObjectKeyFromObject(obj))
+		return fmt.Errorf("failed to set dependencies on %T %s: %w", obj, client.ObjectKeyFromObject(obj), err)
 	}
 	return nil
 }

--- a/e2e/nomostest/docker.go
+++ b/e2e/nomostest/docker.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/e2e/nomostest/docker"
 	"kpt.dev/configsync/e2e/nomostest/retry"
@@ -90,14 +89,14 @@ func VersionFromManifest(t testing.NTB) string {
 func imageTagFromManifest(name string) (string, error) {
 	bytes, err := os.ReadFile(configSyncManifest)
 	if err != nil {
-		return "", errors.Errorf("failed to read %s: %s", configSyncManifest, err)
+		return "", fmt.Errorf("failed to read %s: %s", configSyncManifest, err)
 	}
 	re := regexp.MustCompile(
 		fmt.Sprintf(`(image: )(.*\/%s:.*)`, name),
 	)
 	match := re.FindStringSubmatch(string(bytes))
 	if match == nil || len(match) != 3 {
-		return "", errors.Errorf("failed to find image %s in %s", name, configSyncManifest)
+		return "", fmt.Errorf("failed to find image %s in %s", name, configSyncManifest)
 	}
 	return match[2], nil
 }
@@ -106,7 +105,7 @@ func checkImage(image string) error {
 	url := fmt.Sprintf("http://%s", image)
 	resp, err := http.Get(url)
 	if err != nil {
-		return errors.Errorf("Failed to check for image %s in registry: %s", image, err)
+		return fmt.Errorf("Failed to check for image %s in registry: %s", image, err)
 	}
 
 	defer func() {
@@ -114,7 +113,7 @@ func checkImage(image string) error {
 	}()
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Errorf("Failed to read response for image %s in registry: %s", image, err)
+		return fmt.Errorf("Failed to read response for image %s in registry: %s", image, err)
 	}
 	return nil
 }

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -41,7 +41,6 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -424,18 +423,18 @@ func applyAutoPilotKeepAlive(nt *NT) error {
 	yamlPath := "../testdata/autopilot-keepalive/deployment.yaml"
 	yamlBytes, err := os.ReadFile(yamlPath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read file %q", yamlPath)
+		return fmt.Errorf("failed to read file %q: %w", yamlPath, err)
 	}
 	uObj := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal(yamlBytes, uObj); err != nil {
-		return errors.Wrapf(err, "failed to decode %q as yaml", yamlPath)
+		return fmt.Errorf("failed to decode %q as yaml: %w", yamlPath, err)
 	}
 	// Apply with nt.KubeClient.Client directly, not nt.KubeClient.Apply
 	// to avoid adding the test label, to avoid deletion during cleanup
 	nt.Logger.Infof("applying %s", yamlPath)
 	patchOpts := []client.PatchOption{client.FieldOwner(FieldManager), client.ForceOwnership}
 	if err := nt.KubeClient.Client.Patch(nt.Context, uObj, client.Apply, patchOpts...); err != nil {
-		return errors.Wrapf(err, "failed to apply %s", kinds.ObjectSummary(uObj))
+		return fmt.Errorf("failed to apply %s: %w", kinds.ObjectSummary(uObj), err)
 	}
 	return nil
 }

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
@@ -118,7 +117,7 @@ func Reset(nt *NT) error {
 	protectedNamespacesWithTestLabel, nsListItems := filterNamespaces(nsList.Items,
 		protectedNamespaces...)
 	if len(protectedNamespacesWithTestLabel) > 0 {
-		return errors.Errorf("protected namespace(s) modified by test: %+v",
+		return fmt.Errorf("protected namespace(s) modified by test: %+v",
 			protectedNamespacesWithTestLabel)
 	}
 	if err := ResetNamespaces(nt, nsListItems); err != nil {
@@ -163,7 +162,7 @@ func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
 			if !IsDeletionPropagationEnabled(rs) {
 				// If you go this error, make sure your test cleanup ensures
 				// that the managed RootSync has deletion propagation enabled.
-				return errors.Errorf("RootSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+				return fmt.Errorf("RootSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
 			}
 			continue
 		}
@@ -235,7 +234,7 @@ func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
 			if !IsDeletionPropagationEnabled(rs) {
 				// If you go this error, make sure your test cleanup ensures
 				// that the managed RepoSync has deletion propagation enabled.
-				return errors.Errorf("RepoSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
+				return fmt.Errorf("RepoSync %s managed by %q does NOT have deletion propagation enabled: test reset incomplete", rsNN, manager)
 			}
 			continue
 		}

--- a/e2e/nomostest/retry/retry.go
+++ b/e2e/nomostest/retry/retry.go
@@ -16,9 +16,9 @@ package retry
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -56,7 +56,7 @@ func Retry(timeout time.Duration, fn func() error) (time.Duration, error) {
 func WithContext(ctx context.Context, fn func() error) (time.Duration, error) {
 	start := time.Now()
 	err := func() error {
-		lastError := errors.Errorf("retry.WithContext function never ran")
+		lastError := fmt.Errorf("retry.WithContext function never ran")
 		for {
 			select {
 			case <-ctx.Done():

--- a/e2e/nomostest/testkubeclient/client.go
+++ b/e2e/nomostest/testkubeclient/client.go
@@ -25,7 +25,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/retry"
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -53,7 +52,7 @@ func fmtObj(obj client.Object) string {
 func (tc *KubeClient) ObjectTypeMustExist(o client.Object) error {
 	gvks, _, _ := tc.Client.Scheme().ObjectKinds(o)
 	if len(gvks) == 0 {
-		return errors.Errorf("unknown type %T %v. Add it to nomostest.newScheme().", o, o.GetObjectKind().GroupVersionKind())
+		return fmt.Errorf("unknown type %T %v. Add it to nomostest.newScheme().", o, o.GetObjectKind().GroupVersionKind())
 	}
 	return nil
 }
@@ -74,7 +73,7 @@ func (tc *KubeClient) Get(name, namespace string, obj client.Object) error {
 		//
 		// If this is due to a retry loop, remember to create a new instance to
 		// populate for each loop.
-		return errors.Errorf("called .Get on already-populated object %v: %v", obj.GetObjectKind().GroupVersionKind(), obj)
+		return fmt.Errorf("called .Get on already-populated object %v: %v", obj.GetObjectKind().GroupVersionKind(), obj)
 	}
 	return tc.Client.Get(tc.Context, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 }
@@ -166,11 +165,11 @@ func (tc *KubeClient) GetDeploymentPod(deploymentName, namespace string, retrytT
 		// AvailableReplicas too, which respects MinReadySeconds.
 		// We're choosing to use ReadyReplicas here instead because it's faster.
 		if deployment.Status.UpdatedReplicas != 1 {
-			return errors.Errorf("deployment has %d updated pods, expected 1: %s",
+			return fmt.Errorf("deployment has %d updated pods, expected 1: %s",
 				deployment.Status.UpdatedReplicas, deploymentNN)
 		}
 		if deployment.Status.ReadyReplicas != 1 {
-			return errors.Errorf("deployment has %d ready pods, expected 1: %s",
+			return fmt.Errorf("deployment has %d ready pods, expected 1: %s",
 				deployment.Status.ReadyReplicas, deploymentNN)
 		}
 		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
@@ -178,7 +177,7 @@ func (tc *KubeClient) GetDeploymentPod(deploymentName, namespace string, retrytT
 			return err
 		}
 		if selector.Empty() {
-			return errors.Errorf("deployment has no label selectors: %s", deploymentNN)
+			return fmt.Errorf("deployment has no label selectors: %s", deploymentNN)
 		}
 		pods := &corev1.PodList{}
 		err = tc.List(pods, client.InNamespace(deploymentNN.Namespace),
@@ -187,12 +186,12 @@ func (tc *KubeClient) GetDeploymentPod(deploymentName, namespace string, retrytT
 			return err
 		}
 		if len(pods.Items) != 1 {
-			return errors.Errorf("deployment has %d pods, expected 1: %s",
+			return fmt.Errorf("deployment has %d pods, expected 1: %s",
 				len(pods.Items), deploymentNN)
 		}
 		pod = pods.Items[0].DeepCopy()
 		if pod.Status.Phase != corev1.PodRunning {
-			return errors.Errorf("pod has status %q, want %q: %s",
+			return fmt.Errorf("pod has status %q, want %q: %s",
 				pod.Status.Phase, corev1.PodRunning, client.ObjectKeyFromObject(pod))
 		}
 		return nil

--- a/e2e/nomostest/testshell/shell.go
+++ b/e2e/nomostest/testshell/shell.go
@@ -16,6 +16,7 @@ package testshell
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,8 +25,6 @@ import (
 
 	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
-
-	"github.com/pkg/errors"
 )
 
 // TestShell is a helper utility to execute shell commands in a test.

--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -234,7 +233,7 @@ func (nt *NT) WatchForSync(
 	}
 	sha1, err := sha1Func(nt, nn)
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve sha1")
+		return fmt.Errorf("failed to retrieve sha1: %w", err)
 	}
 
 	predicates := []testpredicates.Predicate{
@@ -251,7 +250,7 @@ func (nt *NT) WatchForSync(
 
 	err = nt.Watcher.WatchObject(gvk, name, namespace, predicates, opts...)
 	if err != nil {
-		return errors.Wrap(err, "waiting for sync")
+		return fmt.Errorf("waiting for sync: %w", err)
 	}
 	nt.T.Logf("%s %s/%s is synced", gvk.Kind, namespace, name)
 	return nil
@@ -367,7 +366,7 @@ func (nt *NT) WaitForRepoSourceError(code string, opts ...WaitOption) {
 			}
 			errs := obj.Status.Source.Errors
 			if len(errs) == 0 {
-				return errors.Errorf("no errors present")
+				return fmt.Errorf("no errors present")
 			}
 			var codes []string
 			for _, e := range errs {
@@ -376,7 +375,7 @@ func (nt *NT) WaitForRepoSourceError(code string, opts ...WaitOption) {
 				}
 				codes = append(codes, e.Code)
 			}
-			return errors.Errorf("error %s not present, got %s", code, strings.Join(codes, ", "))
+			return fmt.Errorf("error %s not present, got %s", code, strings.Join(codes, ", "))
 		},
 		opts...,
 	)
@@ -399,7 +398,7 @@ func (nt *NT) WaitForRepoSourceErrorClear(opts ...WaitOption) {
 			for _, e := range errs {
 				messages = append(messages, e.ErrorMessage)
 			}
-			return errors.Errorf("got errors %s", strings.Join(messages, ", "))
+			return fmt.Errorf("got errors %s", strings.Join(messages, ", "))
 		},
 		opts...,
 	)
@@ -416,7 +415,7 @@ func (nt *NT) WaitForRepoImportErrorCode(code string, opts ...WaitOption) {
 			}
 			errs := obj.Status.Import.Errors
 			if len(errs) == 0 {
-				return errors.Errorf("no errors present")
+				return fmt.Errorf("no errors present")
 			}
 			var codes []string
 			for _, e := range errs {
@@ -425,7 +424,7 @@ func (nt *NT) WaitForRepoImportErrorCode(code string, opts ...WaitOption) {
 				}
 				codes = append(codes, e.Code)
 			}
-			return errors.Errorf("error %s not present, got %s", code, strings.Join(codes, ", "))
+			return fmt.Errorf("error %s not present, got %s", code, strings.Join(codes, ", "))
 		},
 		opts...,
 	)

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -16,11 +16,11 @@ package e2e
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/metrics"

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -15,13 +15,13 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -576,7 +576,7 @@ func hasRule(name string) testpredicates.Predicate {
 				return nil
 			}
 		}
-		return errors.Errorf("missing ValidatingWebhook %q", name)
+		return fmt.Errorf("missing ValidatingWebhook %q", name)
 	}
 }
 

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -467,7 +466,7 @@ func getUpdatedRootSync(nt *nomostest.NT, name string, namespace string) *v1beta
 // validateRootSyncRepoState verifies the output from getRootSyncCommitStatusErrorSummary is as expected.
 func validateRootSyncRepoState(expectedCommit string, commit string, expectedStatus string, status string, errorSummary string) error {
 	if expectedCommit != commit || expectedStatus != status {
-		return errors.Errorf("Error: rootSync does not match expected. Got: commit: %v, status: %v\nError Summary: %v\nExpected: commit: %v, status: %v\n",
+		return fmt.Errorf("Error: rootSync does not match expected. Got: commit: %v, status: %v\nError Summary: %v\nExpected: commit: %v, status: %v\n",
 			commit, status, errorSummary, expectedCommit, expectedStatus)
 	}
 	return nil

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/slices"
 	"kpt.dev/configsync/e2e"
@@ -63,33 +62,33 @@ func setDefaultArgs() {
 func validateArgs() error {
 	var errs error
 	if len(*e2e.ClusterNames) == 0 && *e2e.CreateClusters == e2e.CreateClustersDisabled {
-		errs = multierr.Append(errs, errors.Errorf("At least one of CLUSTER_NAMES or CREATE_CLUSTERS is required"))
+		errs = multierr.Append(errs, fmt.Errorf("At least one of CLUSTER_NAMES or CREATE_CLUSTERS is required"))
 	}
 	if !slices.Contains(e2e.CreateClustersAllowedValues, *e2e.CreateClusters) {
 		errs = multierr.Append(errs,
-			errors.Errorf("Unrecognized value %s for CREATE_CLUSTERS. Allowed values: [%s]",
+			fmt.Errorf("Unrecognized value %s for CREATE_CLUSTERS. Allowed values: [%s]",
 				*e2e.CreateClusters, strings.Join(e2e.CreateClustersAllowedValues, ", ")))
 	}
 	if !slices.Contains(e2e.DestroyClustersAllowedValues, *e2e.DestroyClusters) {
 		errs = multierr.Append(errs,
-			errors.Errorf("Unrecognized value %s for DESTROY_CLUSTERS. Allowed values: [%s]",
+			fmt.Errorf("Unrecognized value %s for DESTROY_CLUSTERS. Allowed values: [%s]",
 				*e2e.DestroyClusters, strings.Join(e2e.DestroyClustersAllowedValues, ", ")))
 	}
 	if *e2e.TestCluster == e2e.GKE { // required vars for GKE
 		if *e2e.GCPProject == "" {
-			errs = multierr.Append(errs, errors.Errorf("Environment variable GCP_PROJECT is required for GKE clusters"))
+			errs = multierr.Append(errs, fmt.Errorf("Environment variable GCP_PROJECT is required for GKE clusters"))
 		}
 		if *e2e.GCPRegion == "" && *e2e.GCPZone == "" {
-			errs = multierr.Append(errs, errors.Errorf("One of GCP_REGION or GCP_ZONE is required for GKE clusters"))
+			errs = multierr.Append(errs, fmt.Errorf("One of GCP_REGION or GCP_ZONE is required for GKE clusters"))
 		}
 		if *e2e.GCPRegion != "" && *e2e.GCPZone != "" {
-			errs = multierr.Append(errs, errors.Errorf("At most one of GCP_ZONE or GCP_REGION may be specified"))
+			errs = multierr.Append(errs, fmt.Errorf("At most one of GCP_ZONE or GCP_REGION may be specified"))
 		}
 		if *e2e.GKEAutopilot && *e2e.GCPRegion == "" {
-			errs = multierr.Append(errs, errors.Errorf("Autopilot clusters must be created with a region"))
+			errs = multierr.Append(errs, fmt.Errorf("Autopilot clusters must be created with a region"))
 		}
 		if *e2e.GKEAutopilot && *e2e.GceNode {
-			errs = multierr.Append(errs, errors.Errorf("Cannot run gcenode tests on autopilot clusters"))
+			errs = multierr.Append(errs, fmt.Errorf("Cannot run gcenode tests on autopilot clusters"))
 		}
 	}
 	return errs

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -261,7 +260,7 @@ func waitForResourcesCurrent(nt *nomostest.NT, gvk schema.GroupVersionKind, labe
 		return err
 	}
 	if len(list.Items) != expectedCount {
-		return errors.Errorf("expected %d reconciler %s(s), got %d",
+		return fmt.Errorf("expected %d reconciler %s(s), got %d",
 			expectedCount, gvk.Kind, len(list.Items))
 	}
 	tg := taskgroup.New()
@@ -890,7 +889,7 @@ func roleHasRules(wantRules []rbacv1.PolicyRule) testpredicates.Predicate {
 		}
 
 		if diff := cmp.Diff(wantRules, r.Rules); diff != "" {
-			return errors.Errorf("Pod Role .rules diff: %s", diff)
+			return fmt.Errorf("Pod Role .rules diff: %s", diff)
 		}
 		return nil
 	}

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -15,9 +15,9 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -483,7 +483,7 @@ func hasV1Subjects(subjects ...string) func(o client.Object) error {
 			return testpredicates.WrongTypeErr(o, r)
 		}
 		if len(r.Subjects) != len(subjects) {
-			return errors.Wrapf(testpredicates.ErrFailedPredicate, "want %v subjects; got %v", subjects, r.Subjects)
+			return fmt.Errorf("want %v subjects; got %v: %w", subjects, r.Subjects, testpredicates.ErrFailedPredicate)
 		}
 
 		found := make(map[string]bool)
@@ -492,7 +492,7 @@ func hasV1Subjects(subjects ...string) func(o client.Object) error {
 		}
 		for _, name := range subjects {
 			if !found[name] {
-				return errors.Wrapf(testpredicates.ErrFailedPredicate, "missing subject %q", name)
+				return fmt.Errorf("missing subject %q: %w", name, testpredicates.ErrFailedPredicate)
 			}
 		}
 
@@ -510,7 +510,7 @@ func hasV1Beta1Subjects(subjects ...string) func(o client.Object) error {
 			return testpredicates.WrongTypeErr(o, r)
 		}
 		if len(r.Subjects) != len(subjects) {
-			return errors.Wrapf(testpredicates.ErrFailedPredicate, "want %v subjects; got %v", subjects, r.Subjects)
+			return fmt.Errorf("want %v subjects; got %v: %w", subjects, r.Subjects, testpredicates.ErrFailedPredicate)
 		}
 
 		found := make(map[string]bool)
@@ -519,7 +519,7 @@ func hasV1Beta1Subjects(subjects ...string) func(o client.Object) error {
 		}
 		for _, name := range subjects {
 			if !found[name] {
-				return errors.Wrapf(testpredicates.ErrFailedPredicate, "missing subject %q", name)
+				return fmt.Errorf("missing subject %q: %w", name, testpredicates.ErrFailedPredicate)
 			}
 		}
 

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -24,7 +24,6 @@ import (
 	monitoringv2 "cloud.google.com/go/monitoring/apiv3/v2"
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
@@ -391,7 +390,7 @@ func metricDoesNotHaveLabel(label string) metricValidatorFunc {
 	return func(m *metric.Metric, r *monitoredres.MonitoredResource) error {
 		labels := r.GetLabels()
 		if value, found := labels[label]; found {
-			return errors.Errorf("expected metric to not have label, but found %s=%s", label, value)
+			return fmt.Errorf("expected metric to not have label, but found %s=%s", label, value)
 		}
 		return nil
 	}
@@ -417,9 +416,7 @@ func validateMetricInGCM(nt *nomostest.NT, it *monitoringv2.TimeSeriesIterator, 
 			if labels["cluster_name"] == clusterName {
 				for _, valFn := range valFns {
 					if err := valFn(metric, resource); err != nil {
-						return errors.Wrapf(err,
-							"GCM metric %s failed validation (cluster_name=%s)",
-							metricType, nt.ClusterName)
+						return fmt.Errorf("GCM metric %s failed validation (cluster_name=%s): %w", metricType, nt.ClusterName, err)
 					}
 				}
 				return nil

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
@@ -210,12 +209,12 @@ func validateRoleRefs(nt *nomostest.NT, syncKind string, rsRef types.NamespacedN
 	}
 	totalBindings := len(roleBindings) + len(clusterRoleBindings)
 	if len(expected) != totalBindings {
-		return errors.Errorf("expected %d bindings but found %d",
+		return fmt.Errorf("expected %d bindings but found %d",
 			len(expected), totalBindings)
 	}
 	for _, roleRef := range expected {
 		if actualRoleRefCount[roleRef] != 1 {
-			return errors.Errorf("expected to find one binding mapping to %s, found %d",
+			return fmt.Errorf("expected to find one binding mapping to %s, found %d",
 				roleRef, actualRoleRefCount[roleRef])
 		}
 	}

--- a/e2e/testcases/preserve_fields_test.go
+++ b/e2e/testcases/preserve_fields_test.go
@@ -15,12 +15,12 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -529,7 +529,7 @@ func hasTargetPort(want int) testpredicates.Predicate {
 		}
 		got := service.Spec.Ports[0].TargetPort.IntValue()
 		if want != got {
-			return errors.Errorf("port %d synced, want %d", got, want)
+			return fmt.Errorf("port %d synced, want %d", got, want)
 		}
 		return nil
 	}

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -16,10 +16,10 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -849,7 +848,7 @@ func truncateSourceErrors() testpredicates.Predicate {
 				return nil
 			}
 		}
-		return errors.Errorf("the source errors should be truncated")
+		return fmt.Errorf("the source errors should be truncated")
 	}
 }
 

--- a/e2e/testcases/sync_ordering_test.go
+++ b/e2e/testcases/sync_ordering_test.go
@@ -15,10 +15,10 @@
 package e2e
 
 import (
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/open-policy-agent/cert-controller v0.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/spf13/cobra v1.6.1
@@ -121,6 +120,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -16,6 +16,7 @@ package applier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/kpt/pkg/live"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/client/restconfig/config.go
+++ b/pkg/client/restconfig/config.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -51,7 +50,7 @@ func KubeConfigPath() (string, error) {
 	}
 	curentUser, err := userCurrentTestHook()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get current user")
+		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
 	path := filepath.Join(curentUser.HomeDir, kubectlConfigPath)
 	return path, nil
@@ -62,14 +61,14 @@ func KubeConfigPath() (string, error) {
 func newRawConfigWithRules() (*clientcmdapi.Config, *clientcmd.ClientConfigLoadingRules, error) {
 	configPath, err := KubeConfigPath()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "while getting config path")
+		return nil, nil, fmt.Errorf("while getting config path: %w", err)
 	}
 
 	rules := &clientcmd.ClientConfigLoadingRules{Precedence: filepath.SplitList(configPath)}
 	clientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
 	apiCfg, err := clientCfg.RawConfig()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "while building client config")
+		return nil, nil, fmt.Errorf("while building client config: %w", err)
 	}
 
 	return &apiCfg, rules, nil

--- a/pkg/client/restconfig/restconfig.go
+++ b/pkg/client/restconfig/restconfig.go
@@ -16,10 +16,10 @@ package restconfig
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,13 +43,13 @@ func NewRestConfig(timeout time.Duration) (*rest.Config, error) {
 		// Build from k8s downward API
 		cfg, err = NewFromInClusterConfig()
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to build rest config: kubeconfig not found: reading in-cluster config")
+			return nil, fmt.Errorf("failed to build rest config: kubeconfig not found: reading in-cluster config: %w", err)
 		}
 	} else {
 		// Build from local config file
 		cfg, err = NewFromConfigFile(path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to build rest config: reading local kubeconfig")
+			return nil, fmt.Errorf("failed to build rest config: reading local kubeconfig: %w", err)
 		}
 	}
 	// Set timeout, if specified.
@@ -65,7 +65,7 @@ func NewRestConfig(timeout time.Duration) (*rest.Config, error) {
 func NewFromConfigFile(path string) (*rest.Config, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading REST config from %q", path)
+		return nil, fmt.Errorf("loading REST config from %q: %w", path, err)
 	}
 	setDefaults(config)
 	return config, nil
@@ -76,7 +76,7 @@ func NewFromConfigFile(path string) (*rest.Config, error) {
 func NewFromInClusterConfig() (*rest.Config, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading REST config from K8s downward API")
+		return nil, fmt.Errorf("loading REST config from K8s downward API: %w", err)
 	}
 	setDefaults(config)
 	return config, nil

--- a/pkg/declared/namespace_safeguard_test.go
+++ b/pkg/declared/namespace_safeguard_test.go
@@ -15,9 +15,9 @@
 package declared
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -26,7 +26,6 @@ import (
 	setnamespace "github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-namespace/transformer"
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	semverrange "github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -164,7 +163,7 @@ func (h *Hydrator) getChartVersion(ctx context.Context) error {
 	}
 	out, err := h.helm(ctx, args...)
 	if err != nil {
-		return errors.Wrapf(err, "getting helm chart version")
+		return fmt.Errorf("getting helm chart version: %w", err)
 	}
 	var parsedOut map[string]interface{}
 	if err := yaml.Unmarshal(out, &parsedOut); err != nil {
@@ -256,7 +255,7 @@ func (h *Hydrator) helm(ctx context.Context, args ...string) ([]byte, error) {
 	}
 	out, err := exec.CommandContext(ctx, "helm", allArgs...).CombinedOutput()
 	if err != nil {
-		return out, errors.Wrapf(err, "invoking helm: %s", string(out))
+		return out, fmt.Errorf("invoking helm: %s: %w", string(out), err)
 	}
 	return out, nil
 }
@@ -268,7 +267,7 @@ func (h *Hydrator) registryLogin(ctx context.Context) error {
 			return err
 		}
 		if _, err := h.helm(ctx, args...); err != nil {
-			return errors.Wrapf(err, "failed to authenticate to helm registry")
+			return fmt.Errorf("failed to authenticate to helm registry: %w", err)
 		}
 	}
 	return nil
@@ -315,7 +314,7 @@ func (h *Hydrator) HelmTemplate(ctx context.Context) error {
 	}
 	out, err := h.helm(ctx, args...)
 	if err != nil {
-		return errors.Wrapf(err, "rendering helm chart")
+		return fmt.Errorf("rendering helm chart: %w", err)
 	}
 
 	// Create the repo/chart directory, in case the chart is empty.

--- a/pkg/hydrate/print.go
+++ b/pkg/hydrate/print.go
@@ -16,11 +16,11 @@ package hydrate
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/cmd/nomos/flags"
@@ -55,7 +55,7 @@ func PrintDirectoryOutput(output, extension string, fileObjects []ast.FileObject
 	for _, obj := range fileObjects {
 		u, err := toUnstructured(obj.Unstructured)
 		if err != nil {
-			return errors.Wrapf(err, "failed to convert the object %s/%s/%s to unstructured format", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+			return fmt.Errorf("failed to convert the object %s/%s/%s to unstructured format: %w", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName(), err)
 		}
 		files[obj.SlashPath()] = append(files[obj.SlashPath()], u)
 	}
@@ -63,7 +63,7 @@ func PrintDirectoryOutput(output, extension string, fileObjects []ast.FileObject
 	for file, objects := range files {
 		err := PrintFile(filepath.Join(output, file), extension, objects)
 		if err != nil {
-			return errors.Wrap(err, "failed to print file")
+			return fmt.Errorf("failed to print file: %w", err)
 		}
 	}
 	return nil

--- a/pkg/importer/filesystem/cmpath/absolute.go
+++ b/pkg/importer/filesystem/cmpath/absolute.go
@@ -15,11 +15,11 @@
 package cmpath
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/importer/id"
 )
 
@@ -34,7 +34,7 @@ var _ id.Path = Absolute("")
 // It is an error to pass a non-absolute path.
 func AbsoluteSlash(p string) (Absolute, error) {
 	if !filepath.IsAbs(p) {
-		return "", errors.Errorf("not an absolute path")
+		return "", fmt.Errorf("not an absolute path")
 	}
 	return Absolute(path.Clean(p)), nil
 }

--- a/pkg/importer/reader/parse_file_test.go
+++ b/pkg/importer/reader/parse_file_test.go
@@ -15,11 +15,11 @@
 package reader
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
@@ -202,7 +202,7 @@ metadata:
 				}
 				return
 			} else if err != nil {
-				t.Fatal(errors.Wrap(err, "unexpected error"))
+				t.Fatal(fmt.Errorf("unexpected error: %w", err))
 			}
 
 			for _, a := range actual {
@@ -362,7 +362,7 @@ func TestParseJsonFile(t *testing.T) {
 				}
 				return
 			} else if err != nil {
-				t.Fatal(errors.Wrap(err, "unexpected error"))
+				t.Fatal(fmt.Errorf("unexpected error: %w", err))
 			}
 
 			if diff := cmp.Diff(tc.expected, actual, cmpopts.EquateEmpty()); diff != "" {
@@ -447,7 +447,7 @@ inventory:
 				}
 				return
 			} else if err != nil {
-				t.Fatal(errors.Wrap(err, "unexpected error"))
+				t.Fatal(fmt.Errorf("unexpected error: %w", err))
 			}
 			for _, a := range actual {
 				if a.GetLabels() == nil {

--- a/pkg/importer/reader/reader.go
+++ b/pkg/importer/reader/reader.go
@@ -15,11 +15,11 @@
 package reader
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -221,7 +221,7 @@ func validateMetadata(u runtime.Unstructured, oid *unstructured.Unstructured) st
 	if annotations, hasAnnotations := metadata["annotations"]; hasAnnotations {
 		invalidAnnotations, err := getInvalidKeys(annotations)
 		if err != nil {
-			err = errors.Wrap(err, "validating annotations")
+			err = fmt.Errorf("validating annotations: %w", err)
 			return status.ResourceErrorBuilder.Wrap(err).BuildWithResources(oid)
 		}
 		if len(invalidAnnotations) > 0 {
@@ -232,7 +232,7 @@ func validateMetadata(u runtime.Unstructured, oid *unstructured.Unstructured) st
 	if labels, hasLabels := metadata["labels"]; hasLabels {
 		invalidLabels, err := getInvalidKeys(labels)
 		if err != nil {
-			err = errors.Wrap(err, "validating labels")
+			err = fmt.Errorf("validating labels: %w", err)
 			return status.ResourceErrorBuilder.Wrap(err).BuildWithResources(oid)
 		}
 		if len(invalidLabels) > 0 {
@@ -322,7 +322,7 @@ func parseString(content map[string]interface{}, fields ...string) (string, erro
 		return "", e
 	}
 	if !hasField || value == "" {
-		return "", errors.Errorf("missing field %q", strings.Join(fields, "."))
+		return "", fmt.Errorf("missing field %q", strings.Join(fields, "."))
 	}
 	return value, nil
 }

--- a/pkg/kinds/cast.go
+++ b/pkg/kinds/cast.go
@@ -15,7 +15,8 @@
 package kinds
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,7 +26,7 @@ import (
 func ObjectAsClientObject(rObj runtime.Object) (client.Object, error) {
 	cObj, ok := rObj.(client.Object)
 	if !ok {
-		return nil, errors.Errorf("unsupported resource type (%s): failed to cast to client.Object",
+		return nil, fmt.Errorf("unsupported resource type (%s): failed to cast to client.Object",
 			ObjectSummary(rObj))
 	}
 	return cObj, nil
@@ -36,7 +37,7 @@ func ObjectAsClientObject(rObj runtime.Object) (client.Object, error) {
 func ObjectAsClientObjectList(rObj runtime.Object) (client.ObjectList, error) {
 	cObj, ok := rObj.(client.ObjectList)
 	if !ok {
-		return nil, errors.Errorf("unsupported resource type (%s): failed to cast to client.ObjectList",
+		return nil, fmt.Errorf("unsupported resource type (%s): failed to cast to client.ObjectList",
 			ObjectSummary(rObj))
 	}
 	return cObj, nil

--- a/pkg/kinds/convert_test.go
+++ b/pkg/kinds/convert_test.go
@@ -15,10 +15,10 @@
 package kinds
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,9 +66,11 @@ func TestToTypedObject(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"unsupported resource type (v1.Service): %w",
 					runtime.NewNotRegisteredErrForKind(emptyScheme.Name(), Service()),
-					"unsupported resource type (v1.Service)")),
+				),
+			),
 		},
 		{
 			name: "unstructured pre-populated GVK in scheme",
@@ -141,10 +143,10 @@ func TestToTypedObject(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -213,10 +215,10 @@ func TestToTypedObject(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",
@@ -402,10 +404,10 @@ func TestToUnstructured(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -478,10 +480,10 @@ func TestToUnstructured(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",

--- a/pkg/kinds/lists.go
+++ b/pkg/kinds/lists.go
@@ -15,9 +15,9 @@
 package kinds
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,14 +71,14 @@ func NewUnstructuredListForItemGVK(itemGVK schema.GroupVersionKind) *unstructure
 func ExtractClientObjectList(objList client.ObjectList) ([]client.Object, error) {
 	items, err := meta.ExtractList(objList)
 	if err != nil {
-		return nil, errors.Errorf("unsupported resource list type (%s)",
+		return nil, fmt.Errorf("unsupported resource list type (%s)",
 			ObjectSummary(objList))
 	}
 	cObjList := make([]client.Object, len(items))
 	for i := range items {
 		cObj, err := ObjectAsClientObject(items[i])
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid resource list item[%d]", i)
+			return nil, fmt.Errorf("invalid resource list item[%d]: %w", i, err)
 		}
 		cObjList[i] = cObj
 	}

--- a/pkg/kinds/lookup.go
+++ b/pkg/kinds/lookup.go
@@ -15,7 +15,8 @@
 package kinds
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -26,7 +27,7 @@ import (
 func Lookup(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
-		return schema.GroupVersionKind{}, errors.Wrap(err, "failed to lookup object type")
+		return schema.GroupVersionKind{}, fmt.Errorf("failed to lookup object type: %w", err)
 	}
 	return gvk, nil
 }

--- a/pkg/kinds/lookup_test.go
+++ b/pkg/kinds/lookup_test.go
@@ -15,10 +15,10 @@
 package kinds
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -119,10 +119,10 @@ func TestLookup(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -171,10 +171,10 @@ func TestLookup(t *testing.T) {
 			},
 			scheme: emptyScheme,
 			expectedError: testutil.EqualError(
-				errors.Wrap(
+				fmt.Errorf(
+					"failed to lookup object type: %w",
 					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})),
-					"failed to lookup object type")),
+						reflect.TypeOf(corev1.Service{})))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",

--- a/pkg/kinds/new.go
+++ b/pkg/kinds/new.go
@@ -15,7 +15,8 @@
 package kinds
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,8 +28,7 @@ import (
 func NewObjectForGVK(gvk schema.GroupVersionKind, scheme *runtime.Scheme) (runtime.Object, error) {
 	rObj, err := scheme.New(gvk)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unsupported resource type (%s)",
-			GVKToString(gvk))
+		return nil, fmt.Errorf("unsupported resource type (%s): %w", GVKToString(gvk), err)
 	}
 	return rObj, nil
 }

--- a/pkg/parse/repository_scope_test.go
+++ b/pkg/parse/repository_scope_test.go
@@ -15,10 +15,10 @@
 package parse
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -506,7 +505,7 @@ func (p *root) addImplicitNamespaces(objs []ast.FileObject) ([]ast.FileObject, s
 		existingNs := &corev1.Namespace{}
 		err := p.Client.Get(context.Background(), types.NamespacedName{Name: ns}, existingNs)
 		if err != nil && !apierrors.IsNotFound(err) {
-			errs = status.Append(errs, errors.Wrapf(err, "unable to check the existence of the implicit namespace %q", ns))
+			errs = status.Append(errs, fmt.Errorf("unable to check the existence of the implicit namespace %q: %w", ns, err))
 			continue
 		}
 

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -16,13 +16,13 @@ package parse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/declared"
@@ -555,7 +554,7 @@ func setSyncStatus(ctx context.Context, p Parser, state *reconcilerState, syncin
 	}
 	// Report conflict errors to the remote manager, if it's a RootSync.
 	if err := reportRootSyncConflicts(ctx, p.K8sClient(), conflictErrs); err != nil {
-		return errors.Wrapf(err, "failed to report remote conflicts")
+		return fmt.Errorf("failed to report remote conflicts: %w", err)
 	}
 	return nil
 }
@@ -606,7 +605,7 @@ func reportRootSyncConflicts(ctx context.Context, k8sClient client.Client, confl
 			// Report the conflict to the other RootSync to make it easier to detect.
 			klog.Infof("Detected conflict with RootSync manager %q", conflictingManager)
 			if err := prependRootSyncRemediatorStatus(ctx, k8sClient, name, conflictErrors, defaultDenominator); err != nil {
-				return errors.Wrapf(err, "failed to update RootSync %q to prepend remediator conflicts", name)
+				return fmt.Errorf("failed to update RootSync %q to prepend remediator conflicts: %w", name, err)
 			}
 		} else {
 			// RepoSync applier uses PolicyAdoptIfNoInventory.

--- a/pkg/parse/source.go
+++ b/pkg/parse/source.go
@@ -16,11 +16,11 @@ package parse
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -95,7 +95,7 @@ func (o *Files) readConfigFiles(state *sourceState) status.Error {
 	var err error
 	fileList, err = listFiles(syncDir, map[string]bool{".git": true})
 	if err != nil {
-		return status.PathWrapError(errors.Wrap(err, "listing files in the configs directory"), syncDir.OSPath())
+		return status.PathWrapError(fmt.Errorf("listing files in the configs directory: %w", err), syncDir.OSPath())
 	}
 
 	newCommit, err := hydrate.ComputeCommit(o.SourceDir)
@@ -208,7 +208,7 @@ func listFiles(dir cmpath.Absolute, ignore map[string]bool) ([]cmpath.Absolute, 
 func hydratedError(errorFile, label string) hydrate.HydrationError {
 	content, err := os.ReadFile(errorFile)
 	if err != nil {
-		return hydrate.NewInternalError(errors.Errorf("Unable to load %s: %v. Please check %s logs for more info: kubectl logs -n %s -l %s -c %s",
+		return hydrate.NewInternalError(fmt.Errorf("Unable to load %s: %v. Please check %s logs for more info: kubectl logs -n %s -l %s -c %s",
 			errorFile, err, reconcilermanager.HydrationController, configsync.ControllerNamespace, label, reconcilermanager.HydrationController))
 	}
 	if len(content) == 0 {

--- a/pkg/reconciler/finalizer/controller.go
+++ b/pkg/reconciler/finalizer/controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -129,12 +128,12 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// Object being deleted.
 		if controllerutil.ContainsFinalizer(rs, metadata.ReconcilerFinalizer) {
 			if err := c.Finalizer.Finalize(ctx, rs); err != nil {
-				return result, errors.Wrapf(err, "finalizing")
+				return result, fmt.Errorf("finalizing: %w", err)
 			}
 		}
 	} else {
 		if err := c.reconcileFinalizer(ctx, rs); err != nil {
-			return result, errors.Wrapf(err, "reconciling finalizer")
+			return result, fmt.Errorf("reconciling finalizer: %w", err)
 		}
 	}
 	return result, nil

--- a/pkg/reconciler/finalizer/reposync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -124,9 +123,9 @@ func TestRepoSyncFinalize(t *testing.T) {
 				return obj
 			}(),
 			destroyErrs: status.APIServerError(fmt.Errorf("destroy error"), "example message"),
-			expectedError: errors.Wrap(
-				status.APIServerError(fmt.Errorf("destroy error"), "example message"),
-				"deleting managed objects"),
+			expectedError: fmt.Errorf(
+				"deleting managed objects: %w",
+				status.APIServerError(fmt.Errorf("destroy error"), "example message")),
 			expectedStopped: true,
 			expectedRsyncAfterFinalize: func() client.Object {
 				obj := repoSync1.DeepCopy()
@@ -250,18 +249,22 @@ func TestRepoSyncFinalize(t *testing.T) {
 				// delete RepoSync to cause update error
 				return fakeClient.Delete(ctx, rs)
 			},
-			expectedError: errors.Wrapf(
-				errors.Wrapf(
+			expectedError: fmt.Errorf(
+				"setting Finalizing condition: %w",
+				fmt.Errorf(
+					"failed to set ReconcilerFinalizing condition: %w",
 					status.APIServerErrorWrap(
-						errors.Wrapf(
+						fmt.Errorf(
+							"failed to update object status: %s: %w",
+							kinds.ObjectSummary(repoSync1),
 							apierrors.NewNotFound(
 								schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
 								"example/repo-sync-1"),
-							"failed to update object status: %s",
-							kinds.ObjectSummary(repoSync1)),
-						repoSync1.DeepCopy()),
-					"failed to set ReconcilerFinalizing condition"),
-				"setting Finalizing condition"),
+						),
+						repoSync1.DeepCopy(),
+					),
+				),
+			),
 			expectedStopped:            true,
 			expectedRsyncAfterFinalize: nil,
 		},
@@ -408,16 +411,17 @@ func TestRepoSyncAddFinalizer(t *testing.T) {
 				// delete RepoSync to cause update error
 				return fakeClient.Delete(ctx, rs)
 			},
-			expectedError: errors.Wrapf(
+			expectedError: fmt.Errorf(
+				"failed to add finalizer: %w",
 				status.APIServerErrorWrap(
-					errors.Wrapf(
+					fmt.Errorf(
+						"failed to update object: %s: %w",
+						kinds.ObjectSummary(repoSync1),
 						apierrors.NewNotFound(
 							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
-							"example/repo-sync-1"),
-						"failed to update object: %s",
-						kinds.ObjectSummary(repoSync1)),
+							"example/repo-sync-1")),
 					repoSync1.DeepCopy()),
-				"failed to add finalizer"),
+			),
 			expectedUpdated: false,
 			expectedRsync:   nil,
 		},
@@ -552,16 +556,17 @@ func TestRepoSyncRemoveFinalizer(t *testing.T) {
 				// delete RepoSync to cause update error
 				return fakeClient.Delete(ctx, rs)
 			},
-			expectedError: errors.Wrapf(
+			expectedError: fmt.Errorf(
+				"failed to remove finalizer: %w",
 				status.APIServerErrorWrap(
-					errors.Wrapf(
+					fmt.Errorf(
+						"failed to update object: %s: %w",
+						kinds.ObjectSummary(repoSync1),
 						apierrors.NewNotFound(
 							schema.GroupResource{Group: "configsync.gke.io", Resource: "RepoSync"},
-							"example/repo-sync-1"),
-						"failed to update object: %s",
-						kinds.ObjectSummary(repoSync1)),
+							"example/repo-sync-1")),
 					repoSync1.DeepCopy()),
-				"failed to remove finalizer"),
+			),
 			expectedUpdated: false,
 			expectedRsync:   nil,
 		},

--- a/pkg/reconciler/finalizer/rootsync_finalizer.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer.go
@@ -16,8 +16,8 @@ package finalizer
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
@@ -55,7 +55,7 @@ type RootSyncFinalizer struct {
 func (f *RootSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object) error {
 	rs, ok := syncObj.(*v1beta1.RootSync)
 	if !ok {
-		return errors.Errorf("invalid syncObj type: expected *v1beta1.RootSync, but got %T", syncObj)
+		return fmt.Errorf("invalid syncObj type: expected *v1beta1.RootSync, but got %T", syncObj)
 	}
 
 	// Stop the parser & remediator
@@ -67,20 +67,20 @@ func (f *RootSyncFinalizer) Finalize(ctx context.Context, syncObj client.Object)
 	klog.Info("Finalizer executing: Parser & Remediator stopped")
 
 	if _, err := f.setFinalizingCondition(ctx, rs); err != nil {
-		return errors.Wrap(err, "setting Finalizing condition")
+		return fmt.Errorf("setting Finalizing condition: %w", err)
 	}
 
 	if err := f.deleteManagedObjects(ctx, rs); err != nil {
-		return errors.Wrap(err, "deleting managed objects")
+		return fmt.Errorf("deleting managed objects: %w", err)
 	}
 	klog.Infof("Deletion of managed objects successful")
 
 	// TODO: optimize by combining these updates into a single update
 	if _, err := f.removeFinalizingCondition(ctx, rs); err != nil {
-		return errors.Wrap(err, "removing Finalizing condition")
+		return fmt.Errorf("removing Finalizing condition: %w", err)
 	}
 	if _, err := f.RemoveFinalizer(ctx, rs); err != nil {
-		return errors.Wrap(err, "removing finalizer")
+		return fmt.Errorf("removing finalizer: %w", err)
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func (f *RootSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Obj
 		return nil
 	})
 	if err != nil {
-		return updated, errors.Wrapf(err, "failed to add finalizer")
+		return updated, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 	if updated {
 		klog.Info("Finalizer injection successful")
@@ -121,7 +121,7 @@ func (f *RootSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.
 		return nil
 	})
 	if err != nil {
-		return updated, errors.Wrapf(err, "failed to remove finalizer")
+		return updated, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 	if updated {
 		klog.Info("Finalizer removal successful")
@@ -142,7 +142,7 @@ func (f *RootSyncFinalizer) setFinalizingCondition(ctx context.Context, syncObj 
 		return nil
 	})
 	if err != nil {
-		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizing condition")
+		return updated, fmt.Errorf("failed to set ReconcilerFinalizing condition: %w", err)
 	}
 	if updated {
 		klog.Info("ReconcilerFinalizing condition update successful")
@@ -163,7 +163,7 @@ func (f *RootSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncO
 		return nil
 	})
 	if err != nil {
-		return updated, errors.Wrapf(err, "failed to remove ReconcilerFinalizing condition")
+		return updated, fmt.Errorf("failed to remove ReconcilerFinalizing condition: %w", err)
 	}
 	if updated {
 		klog.Info("ReconcilerFinalizing condition removal successful")
@@ -179,7 +179,7 @@ func (f *RootSyncFinalizer) deleteManagedObjects(ctx context.Context, syncObj *v
 	destroyErrs := f.Destroyer.Destroy(ctx)
 	// Update the FinalizerFailure condition whether the destroy succeeded or failed
 	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
-		updateErr = errors.Wrap(updateErr, "updating FinalizerFailure condition")
+		updateErr = fmt.Errorf("updating FinalizerFailure condition: %w", updateErr)
 		if destroyErrs != nil {
 			return status.Append(destroyErrs, updateErr)
 		}
@@ -209,7 +209,7 @@ func (f *RootSyncFinalizer) updateFailureCondition(ctx context.Context, syncObj 
 		return nil
 	})
 	if err != nil {
-		return updated, errors.Wrapf(err, "failed to set ReconcilerFinalizerFailure condition")
+		return updated, fmt.Errorf("failed to set ReconcilerFinalizerFailure condition: %w", err)
 	}
 	if updated {
 		klog.Info("ReconcilerFinalizerFailure condition update successful")

--- a/pkg/reconcilermanager/controllers/create_or_update.go
+++ b/pkg/reconcilermanager/controllers/create_or_update.go
@@ -16,8 +16,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +70,7 @@ func mutateWrapper(f controllerutil.MutateFn, key client.ObjectKey, obj client.O
 		return err
 	}
 	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
-		return errors.Errorf("MutateFn cannot mutate object name or namespace (before: %q, after: %q)",
+		return fmt.Errorf("MutateFn cannot mutate object name or namespace (before: %q, after: %q)",
 			key, newKey)
 	}
 	return nil

--- a/pkg/reconcilermanager/controllers/hash.go
+++ b/pkg/reconcilermanager/controllers/hash.go
@@ -15,20 +15,20 @@
 package controllers
 
 import (
+	"fmt"
 	"hash/fnv"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
 func hash(allData interface{}) ([]byte, error) {
 	data, err := json.Marshal(allData)
 	if err != nil {
-		return nil, errors.Errorf("failed to marshal ConfigMaps data, error: %v", err)
+		return nil, fmt.Errorf("failed to marshal ConfigMaps data, error: %v", err)
 	}
 	h := fnv.New128()
 	if n, err := h.Write(data); n < len(data) {
-		return nil, errors.Errorf("failed to write configmap data, error: %v", err)
+		return nil, fmt.Errorf("failed to write configmap data, error: %v", err)
 	}
 	return h.Sum(nil), nil
 }

--- a/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -292,7 +291,7 @@ func TestReconcileRepoSyncLifecycleValidToInvalid(t *testing.T) {
 			return nil
 		}
 		// keep watching
-		return errors.Errorf("reconciler deployment %s", event.Type)
+		return fmt.Errorf("reconciler deployment %s", event.Type)
 	})
 	require.NoError(t, err)
 	if reconcilerObj == nil {
@@ -375,7 +374,7 @@ func TestRepoSyncReconcilerDeploymentDriftProtection(t *testing.T) {
 		newValue := newObj.Spec.Template.Spec.ServiceAccountName
 		if newValue != oldValue {
 			// keep watching
-			return errors.Errorf("spec.template.spec.serviceAccountName expected to be %q, but found %q",
+			return fmt.Errorf("spec.template.spec.serviceAccountName expected to be %q, but found %q",
 				oldValue, newValue)
 		}
 		newRV, err := parseResourceVersion(newObj)
@@ -388,7 +387,7 @@ func TestRepoSyncReconcilerDeploymentDriftProtection(t *testing.T) {
 			return err
 		}
 		if newRV <= oldRV {
-			return errors.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
+			return fmt.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
 				newRV, oldRV)
 		}
 		// success - change reverted
@@ -419,7 +418,7 @@ func TestRepoSyncReconcilerServiceAccountDriftProtection(t *testing.T) {
 		newValue := newObj.Labels[metadata.SyncKindLabel]
 		if newValue != oldValue {
 			// keep watching
-			return errors.Errorf("spec.metadata.labels[%q] expected to be %q, but found %q",
+			return fmt.Errorf("spec.metadata.labels[%q] expected to be %q, but found %q",
 				metadata.SyncKindLabel, oldValue, newValue)
 		}
 		newRV, err := parseResourceVersion(newObj)
@@ -432,7 +431,7 @@ func TestRepoSyncReconcilerServiceAccountDriftProtection(t *testing.T) {
 			return err
 		}
 		if newRV <= oldRV {
-			return errors.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
+			return fmt.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
 				newRV, oldRV)
 		}
 		// success - change reverted
@@ -466,7 +465,7 @@ func TestRepoSyncReconcilerRoleBindingDriftProtection(t *testing.T) {
 		newValue := newObj.RoleRef.Name
 		if newValue != oldValue {
 			// keep watching
-			return errors.Errorf("roleRef.name expected to be %q, but found %q",
+			return fmt.Errorf("roleRef.name expected to be %q, but found %q",
 				oldValue, newValue)
 		}
 		newRV, err := parseResourceVersion(newObj)
@@ -479,7 +478,7 @@ func TestRepoSyncReconcilerRoleBindingDriftProtection(t *testing.T) {
 			return err
 		}
 		if newRV <= oldRV {
-			return errors.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
+			return fmt.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
 				newRV, oldRV)
 		}
 		// success - change reverted
@@ -514,7 +513,7 @@ func TestRepoSyncReconcilerAuthSecretDriftProtection(t *testing.T) {
 		newValue := string(newObj.Data[string(configsync.AuthSSH)])
 		if newValue != oldValue {
 			// keep watching
-			return errors.Errorf("data[%q] expected to be %q, but found %q",
+			return fmt.Errorf("data[%q] expected to be %q, but found %q",
 				configsync.AuthSSH, oldValue, newValue)
 		}
 		newRV, err := parseResourceVersion(newObj)
@@ -527,7 +526,7 @@ func TestRepoSyncReconcilerAuthSecretDriftProtection(t *testing.T) {
 			return err
 		}
 		if newRV <= oldRV {
-			return errors.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
+			return fmt.Errorf("watch event with resourceVersion %d predates expected update with resourceVersion %d",
 				newRV, oldRV)
 		}
 		// success - change reverted

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1682,7 +1681,7 @@ func validateReconcilerClusterRoleBindings(fakeClient *syncerFake.Client, rootSy
 		return err
 	}
 	if len(want) != len(got.Items) {
-		return errors.Errorf("want %d ClusterRoleBindings, got %d", len(want), len(got.Items))
+		return fmt.Errorf("want %d ClusterRoleBindings, got %d", len(want), len(got.Items))
 	}
 	gotCRBMap := make(map[v1beta1.RootSyncRoleRef]rbacv1.ClusterRoleBinding)
 	for idx, crb := range got.Items {
@@ -1695,11 +1694,11 @@ func validateReconcilerClusterRoleBindings(fakeClient *syncerFake.Client, rootSy
 	for roleRef, wantCRB := range want {
 		gotCRB, ok := gotCRBMap[roleRef]
 		if !ok {
-			return errors.Errorf("ClusterRoleBinding for roleRef %v not found", roleRef)
+			return fmt.Errorf("ClusterRoleBinding for roleRef %v not found", roleRef)
 		}
 		wantCRB.Name = gotCRB.Name
 		if diff := cmp.Diff(wantCRB, gotCRB, cmpopts.EquateEmpty()); diff != "" {
-			return errors.Errorf("ClusterRoleBinding[%s] diff: %s", wantCRB.Name, diff)
+			return fmt.Errorf("ClusterRoleBinding[%s] diff: %s", wantCRB.Name, diff)
 		}
 	}
 	return nil
@@ -1718,7 +1717,7 @@ func validateReconcilerRoleBindings(fakeClient *syncerFake.Client, syncKind stri
 		return err
 	}
 	if len(want) != len(got.Items) {
-		return errors.Errorf("want %d RoleBindings, got %d", len(want), len(got.Items))
+		return fmt.Errorf("want %d RoleBindings, got %d", len(want), len(got.Items))
 	}
 	gotRBMap := make(map[v1beta1.RootSyncRoleRef]rbacv1.RoleBinding)
 	for idx, rb := range got.Items {
@@ -1732,11 +1731,11 @@ func validateReconcilerRoleBindings(fakeClient *syncerFake.Client, syncKind stri
 	for roleRef, wantRB := range want {
 		gotRB, ok := gotRBMap[roleRef]
 		if !ok {
-			return errors.Errorf("ClusterRoleBinding for roleRef %v not found", roleRef)
+			return fmt.Errorf("ClusterRoleBinding for roleRef %v not found", roleRef)
 		}
 		wantRB.Name = gotRB.Name
 		if diff := cmp.Diff(wantRB, gotRB, cmpopts.EquateEmpty()); diff != "" {
-			return errors.Errorf("ClusterRoleBinding[%s] diff: %s", wantRB.Name, diff)
+			return fmt.Errorf("ClusterRoleBinding[%s] diff: %s", wantRB.Name, diff)
 		}
 	}
 	return nil

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
@@ -380,8 +379,7 @@ func PollingPeriod(envName string, defaultValue time.Duration) time.Duration {
 	if present {
 		pollingFreq, err := time.ParseDuration(val)
 		if err != nil {
-			panic(errors.Wrapf(err, "failed to parse environment variable %q,"+
-				"got value: %v, want err: nil", envName, pollingFreq))
+			panic(fmt.Errorf("failed to parse environment variable %q, got value: %v, want err: nil: %w", envName, pollingFreq, err))
 		}
 		return pollingFreq
 	}

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -16,9 +16,9 @@ package reconcile
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -16,9 +16,9 @@ package remediator
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -110,7 +110,7 @@ func New(scope declared.Scope, syncName string, cfg *rest.Config, applier syncer
 
 	watchMgr, err := watch.NewManager(scope, syncName, cfg, q, decls, nil, conflictHandler)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating watch manager")
+		return nil, fmt.Errorf("creating watch manager: %w", err)
 	}
 
 	remediator.watchMgr = watchMgr

--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -16,11 +16,11 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"

--- a/pkg/resourcegroup/controllers/watch/manager_test.go
+++ b/pkg/resourcegroup/controllers/watch/manager_test.go
@@ -16,11 +16,11 @@ package watch
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -37,7 +37,7 @@ func fakeRunnable(ctx context.Context) Runnable {
 }
 
 func fakeError(gvk schema.GroupVersionKind) error {
-	return errors.Errorf("failed error for %q", gvk)
+	return fmt.Errorf("failed error for %q", gvk)
 }
 
 func testRunnables(_ context.Context, errOnType map[schema.GroupVersionKind]bool) func(context.Context, watcherConfig) (Runnable, error) {

--- a/pkg/status/multierror.go
+++ b/pkg/status/multierror.go
@@ -15,11 +15,11 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"

--- a/pkg/status/multierror_test.go
+++ b/pkg/status/multierror_test.go
@@ -15,12 +15,12 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 )
 
 var undocumentedErrFoo = UndocumentedError("foo")

--- a/pkg/syncer/client/client.go
+++ b/pkg/syncer/client/client.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -112,7 +111,7 @@ func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.D
 		klog.V(2).Infof("Not found during attempted delete %s", description)
 		err = nil
 	default:
-		err = errors.Wrapf(err, "delete failed for %s", description)
+		err = fmt.Errorf("delete failed for %s: %w", description, err)
 	}
 
 	c.recordLatency(start, "delete", metrics.StatusLabel(err))

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -16,9 +16,9 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"kpt.dev/configsync/pkg/core"

--- a/pkg/syncer/decode/decode.go
+++ b/pkg/syncer/decode/decode.go
@@ -18,7 +18,6 @@ package decode
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -66,7 +65,7 @@ func (d *genericResourceDecoder) DecodeResources(genericResources []v1.GenericRe
 					var err error
 					o, _, err = d.decoder.Decode(genericObject.Raw, &gvk, u)
 					if err != nil {
-						return nil, errors.Wrapf(err, "could not decode client.Object from %q RawExtension bytes", gvk)
+						return nil, fmt.Errorf("could not decode client.Object from %q RawExtension bytes: %w", gvk, err)
 					}
 				}
 				au, ok := o.(*unstructured.Unstructured)

--- a/pkg/syncer/syncertest/fake/client.go
+++ b/pkg/syncer/syncertest/fake/client.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -135,7 +134,7 @@ func (c *Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...cli
 	options.ApplyOptions(opts)
 	listObj, ok := obj.(client.ObjectList)
 	if !ok {
-		return errors.Errorf("failed to convert %T to client.ObjectList", obj)
+		return fmt.Errorf("failed to convert %T to client.ObjectList", obj)
 	}
 	return c.storage.DeleteAllOf(ctx, listObj, options)
 }

--- a/pkg/syncer/syncertest/fake/dynamic_client.go
+++ b/pkg/syncer/syncertest/fake/dynamic_client.go
@@ -16,9 +16,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -151,12 +151,12 @@ func (dc *DynamicClient) create(action clienttesting.Action) (bool, runtime.Obje
 	createAction := action.(clienttesting.CreateAction)
 	if createAction.GetSubresource() != "" {
 		// TODO: add support for subresource create, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.create: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.create: resource=%q subresource=%q: not yet implemented",
 			createAction.GetResource().Resource, createAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(createAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	rObj := createAction.GetObject()
 	uObj, err := kinds.ToUnstructured(rObj, dc.scheme)
@@ -164,11 +164,11 @@ func (dc *DynamicClient) create(action clienttesting.Action) (bool, runtime.Obje
 		return true, nil, err
 	}
 	if uObj.GetNamespace() != "" && uObj.GetNamespace() != createAction.GetNamespace() {
-		return true, nil, errors.Errorf("invalid metadata.namespace: expected %q but found %q",
+		return true, nil, fmt.Errorf("invalid metadata.namespace: expected %q but found %q",
 			createAction.GetNamespace(), uObj.GetNamespace())
 	}
 	if gvk != uObj.GroupVersionKind() {
-		return true, nil, errors.Errorf("invalid GVK for resource %q: expected %q but found %q",
+		return true, nil, fmt.Errorf("invalid GVK for resource %q: expected %q but found %q",
 			createAction.GetResource(),
 			gvk, uObj.GroupVersionKind())
 	}
@@ -180,12 +180,12 @@ func (dc *DynamicClient) get(action clienttesting.Action) (bool, runtime.Object,
 	getAction := action.(clienttesting.GetAction)
 	if getAction.GetSubresource() != "" {
 		// TODO: add support for subresource get, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.get: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.get: resource=%q subresource=%q: not yet implemented",
 			getAction.GetResource().Resource, getAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(getAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	id := genID(getAction.GetNamespace(), getAction.GetName(), gvk.GroupKind())
 	uObj := &unstructured.Unstructured{}
@@ -197,7 +197,7 @@ func (dc *DynamicClient) list(action clienttesting.Action) (bool, runtime.Object
 	listAction := action.(clienttesting.ListAction)
 	if listAction.GetSubresource() != "" {
 		// TODO: add support for subresource list, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.list: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.list: resource=%q subresource=%q: not yet implemented",
 			listAction.GetResource().Resource, listAction.GetSubresource())
 	}
 	restrictions := listAction.GetListRestrictions()
@@ -208,7 +208,7 @@ func (dc *DynamicClient) list(action clienttesting.Action) (bool, runtime.Object
 	}
 	gvk, err := dc.mapper.KindFor(listAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	uObjList := kinds.NewUnstructuredListForItemGVK(gvk)
 	err = dc.storage.List(context.Background(), uObjList, opts)
@@ -219,12 +219,12 @@ func (dc *DynamicClient) update(action clienttesting.Action) (bool, runtime.Obje
 	updateAction := action.(clienttesting.UpdateAction)
 	if updateAction.GetSubresource() != "" {
 		// TODO: add support for subresource updates, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.update: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.update: resource=%q subresource=%q: not yet implemented",
 			updateAction.GetResource().Resource, updateAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(updateAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	rObj := updateAction.GetObject()
 	uObj, err := kinds.ToUnstructured(rObj, dc.scheme)
@@ -232,11 +232,11 @@ func (dc *DynamicClient) update(action clienttesting.Action) (bool, runtime.Obje
 		return true, nil, err
 	}
 	if uObj.GetNamespace() != "" && uObj.GetNamespace() != updateAction.GetNamespace() {
-		return true, nil, errors.Errorf("invalid metadata.namespace: expected %q but found %q",
+		return true, nil, fmt.Errorf("invalid metadata.namespace: expected %q but found %q",
 			updateAction.GetNamespace(), uObj.GetNamespace())
 	}
 	if gvk != uObj.GroupVersionKind() {
-		return true, nil, errors.Errorf("invalid GVK for resource %q: expected %q but found %q",
+		return true, nil, fmt.Errorf("invalid GVK for resource %q: expected %q but found %q",
 			updateAction.GetResource(),
 			gvk, uObj.GroupVersionKind())
 	}
@@ -248,12 +248,12 @@ func (dc *DynamicClient) patch(action clienttesting.Action) (bool, runtime.Objec
 	patchAction := action.(clienttesting.PatchAction)
 	if patchAction.GetSubresource() != "" {
 		// TODO: add support for subresource patch, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.patch: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.patch: resource=%q subresource=%q: not yet implemented",
 			patchAction.GetResource().Resource, patchAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(patchAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	uObj := &unstructured.Unstructured{}
 	uObj.SetGroupVersionKind(gvk)
@@ -268,12 +268,12 @@ func (dc *DynamicClient) delete(action clienttesting.Action) (bool, runtime.Obje
 	deleteAction := action.(clienttesting.DeleteAction)
 	if deleteAction.GetSubresource() != "" {
 		// TODO: add support for subresource delete, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.delete: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.delete: resource=%q subresource=%q: not yet implemented",
 			deleteAction.GetResource().Resource, deleteAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(deleteAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	uObj := &unstructured.Unstructured{}
 	uObj.SetGroupVersionKind(gvk)
@@ -287,7 +287,7 @@ func (dc *DynamicClient) deleteAllOf(action clienttesting.Action) (bool, runtime
 	deleteAction := action.(clienttesting.DeleteCollectionAction)
 	if deleteAction.GetSubresource() != "" {
 		// TODO: add support for subresource delete-collection, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.deleteAllOf: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.deleteAllOf: resource=%q subresource=%q: not yet implemented",
 			deleteAction.GetResource().Resource, deleteAction.GetSubresource())
 	}
 	restrictions := deleteAction.GetListRestrictions()
@@ -300,7 +300,7 @@ func (dc *DynamicClient) deleteAllOf(action clienttesting.Action) (bool, runtime
 	}
 	gvk, err := dc.mapper.KindFor(deleteAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	uObjList := kinds.NewUnstructuredListForItemGVK(gvk)
 	err = dc.storage.DeleteAllOf(context.Background(), uObjList, opts)
@@ -311,12 +311,12 @@ func (dc *DynamicClient) watch(action clienttesting.Action) (bool, watch.Interfa
 	watchAction := action.(clienttesting.WatchAction)
 	if watchAction.GetSubresource() != "" {
 		// TODO: add support for subresource watch, if needed
-		return true, nil, errors.Errorf("fake.DynamicClient.watch: resource=%q subresource=%q: not yet implemented",
+		return true, nil, fmt.Errorf("fake.DynamicClient.watch: resource=%q subresource=%q: not yet implemented",
 			watchAction.GetResource().Resource, watchAction.GetSubresource())
 	}
 	gvk, err := dc.mapper.KindFor(watchAction.GetResource())
 	if err != nil {
-		return true, nil, errors.Wrapf(err, "failed to lookup kind for resource")
+		return true, nil, fmt.Errorf("failed to lookup kind for resource: %w", err)
 	}
 	listGVK := kinds.ListGVKForItemGVK(gvk)
 	restrictions := watchAction.GetWatchRestrictions()

--- a/pkg/syncer/syncertest/fake/subresource_storage.go
+++ b/pkg/syncer/syncertest/fake/subresource_storage.go
@@ -16,8 +16,9 @@ package fake
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
@@ -86,7 +87,7 @@ func (ss *SubresourceStorage) Update(ctx context.Context, obj client.Object, opt
 
 	// TODO: Figure out how to check if the resource in the scheme has this sub-resource.
 	if !hasSubresource {
-		return errors.Errorf("the %s object %s does not have a %q sub-resource field",
+		return fmt.Errorf("the %s object %s does not have a %q sub-resource field",
 			id.GroupKind, id.ObjectKey, ss.Field)
 	}
 
@@ -107,7 +108,7 @@ func (ss *SubresourceStorage) Update(ctx context.Context, obj client.Object, opt
 
 	err = incrementResourceVersion(updatedObj)
 	if err != nil {
-		return errors.Wrap(err, "failed to increment resourceVersion")
+		return fmt.Errorf("failed to increment resourceVersion: %w", err)
 	}
 
 	// Assume status doesn't affect generation (don't increment).
@@ -131,7 +132,7 @@ func (ss *SubresourceStorage) Update(ctx context.Context, obj client.Object, opt
 	}
 	// Copy everything back to input object, even if no diff
 	if err := ss.Storage.scheme.Convert(cachedObj, obj, nil); err != nil {
-		return errors.Wrap(err, "failed to update input object")
+		return fmt.Errorf("failed to update input object: %w", err)
 	}
 	// TODO: Remove GVK from typed objects
 	obj.GetObjectKind().SetGroupVersionKind(cachedObj.GroupVersionKind())

--- a/pkg/syncer/syncertest/fake/watcher.go
+++ b/pkg/syncer/syncertest/fake/watcher.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -29,7 +30,6 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/util/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/kind/pkg/errors"
 )
 
 type eventWithKind struct {
@@ -257,8 +257,7 @@ func (fw *Watcher) handleEvents(ctx context.Context) {
 				// parse ResourceVersion as int
 				newRV, err := strconv.Atoi(obj.GetResourceVersion())
 				if err != nil {
-					err = errors.Wrapf(err, "invalid ResourceVersion %q for object %s",
-						obj.GetResourceVersion(), kinds.ObjectSummary(obj))
+					err = fmt.Errorf("invalid ResourceVersion %q for object %s: %w", obj.GetResourceVersion(), kinds.ObjectSummary(obj), err)
 					fw.sendEvent(ctx, watch.Event{
 						Type:   watch.Error,
 						Object: &apierrors.NewInternalError(err).ErrStatus,

--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -15,7 +15,8 @@
 package discovery
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
@@ -67,7 +68,7 @@ func toGVKs(lists ...*metav1.APIResourceList) ([]schema.GroupVersionKind, status
 	for _, list := range lists {
 		groupVersion, err := schema.ParseGroupVersion(list.GroupVersion)
 		if err != nil {
-			errs = status.Append(errs, errors.Wrapf(err, "discovery client returned invalid GroupVersion: %q", list.GroupVersion))
+			errs = status.Append(errs, fmt.Errorf("discovery client returned invalid GroupVersion: %q: %w", list.GroupVersion, err))
 			continue
 		}
 		for _, resource := range list.APIResources {

--- a/pkg/util/discovery/scoper_test.go
+++ b/pkg/util/discovery/scoper_test.go
@@ -15,10 +15,10 @@
 package discovery
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/kinds"

--- a/pkg/util/discovery/server_resourcer.go
+++ b/pkg/util/discovery/server_resourcer.go
@@ -15,7 +15,8 @@
 package discovery
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"

--- a/pkg/util/watch/delete.go
+++ b/pkg/util/watch/delete.go
@@ -16,9 +16,9 @@ package watch
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,7 +136,7 @@ func DeleteAndWait(ctx context.Context, c client.WithWatch, obj client.Object, r
 		// will be client.Object.
 		cObj, ok := lastKnownObj.(client.Object)
 		if !ok {
-			return false, errors.Errorf("unexpected watch cache object %T for object %s %s: %+v",
+			return false, fmt.Errorf("unexpected watch cache object %T for object %s %s: %+v",
 				lastKnownObj, id.Kind, id.ObjectKey, lastKnownObj)
 		}
 		// Check if the object was already deleted but still terminating
@@ -185,7 +185,7 @@ func DeleteAndWait(ctx context.Context, c client.WithWatch, obj client.Object, r
 		return false, nil
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to watch for deletion of %s: %s", id.Kind, id.ObjectKey)
+		return fmt.Errorf("failed to watch for deletion of %s: %s: %w", id.Kind, id.ObjectKey, err)
 	}
 	klog.V(1).Infof("Object delete confirmed %q=%q, %q=%q",
 		logFieldObjectRef, id.ObjectKey.String(),

--- a/pkg/util/watch/dynamic_lister_watcher.go
+++ b/pkg/util/watch/dynamic_lister_watcher.go
@@ -16,8 +16,8 @@ package watch
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,15 +57,15 @@ var _ cache.ListerWatcher = &DynamicListerWatcher{}
 func (dlw *DynamicListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
 	mapping, err := dlw.RESTMapper.RESTMapping(dlw.ItemGVK.GroupKind(), dlw.ItemGVK.Version)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing")
+		return nil, fmt.Errorf("listing: %w", err)
 	}
 	cOpts, err := ConvertListOptions(&options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+		return nil, fmt.Errorf("failed to convert metav1.ListOptions to client.ListOptions: %w", err)
 	}
 	cOpts, err = MergeListOptions(cOpts, dlw.DefaultListOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge list options")
+		return nil, fmt.Errorf("failed to merge list options: %w", err)
 	}
 	mOpts := cOpts.AsListOptions()
 	klog.V(5).Infof("Listing %s: %+v", dlw.ItemGVK.GroupKind(), cOpts)
@@ -79,15 +79,15 @@ func (dlw *DynamicListerWatcher) List(options metav1.ListOptions) (runtime.Objec
 func (dlw *DynamicListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
 	mapping, err := dlw.RESTMapper.RESTMapping(dlw.ItemGVK.GroupKind(), dlw.ItemGVK.Version)
 	if err != nil {
-		return nil, errors.Wrap(err, "watching")
+		return nil, fmt.Errorf("watching: %w", err)
 	}
 	cOpts, err := ConvertListOptions(&options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+		return nil, fmt.Errorf("failed to convert metav1.ListOptions to client.ListOptions: %w", err)
 	}
 	cOpts, err = MergeListOptions(cOpts, dlw.DefaultListOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge list options")
+		return nil, fmt.Errorf("failed to merge list options: %w", err)
 	}
 	mOpts := cOpts.AsListOptions()
 	klog.V(5).Infof("Watching %s: %+v", dlw.ItemGVK.GroupKind(), cOpts)

--- a/pkg/util/watch/options.go
+++ b/pkg/util/watch/options.go
@@ -15,7 +15,8 @@
 package watch
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -92,7 +93,7 @@ func MergeListOptions(a, b *client.ListOptions) (*client.ListOptions, error) {
 	switch {
 	case a.Namespace != "" && b.Namespace != "":
 		if a.Namespace != b.Namespace {
-			return nil, errors.Errorf("cannot merge two different namespaces: %s & %s",
+			return nil, fmt.Errorf("cannot merge two different namespaces: %s & %s",
 				a.Namespace, b.Namespace)
 		}
 		c.Namespace = a.Namespace
@@ -105,7 +106,7 @@ func MergeListOptions(a, b *client.ListOptions) (*client.ListOptions, error) {
 	switch {
 	case a.Limit > 0 && b.Limit > 0:
 		if a.Limit != b.Limit {
-			return nil, errors.Errorf("cannot merge two different limits: %d & %d",
+			return nil, fmt.Errorf("cannot merge two different limits: %d & %d",
 				a.Limit, b.Limit)
 		}
 		c.Limit = a.Limit
@@ -118,7 +119,7 @@ func MergeListOptions(a, b *client.ListOptions) (*client.ListOptions, error) {
 	switch {
 	case a.Continue != "" && b.Continue != "":
 		if a.Continue != b.Continue {
-			return nil, errors.Errorf("cannot merge two different continue tokens: %s & %s",
+			return nil, fmt.Errorf("cannot merge two different continue tokens: %s & %s",
 				a.Continue, b.Continue)
 		}
 		c.Continue = a.Continue
@@ -136,7 +137,7 @@ func MergeListOptions(a, b *client.ListOptions) (*client.ListOptions, error) {
 		// with UntilDeletedWithSync, which merges client.ListOptions from
 		// the ClientListerWatcher with metav1.ListOptions from the Reflector
 		// used by the Informer built by UntilWithoutRetry.
-		return nil, errors.Errorf("not yet implemented: merging two different raw ListOptions: %+v & %+v",
+		return nil, fmt.Errorf("not yet implemented: merging two different raw ListOptions: %+v & %+v",
 			a.Raw, b.Raw)
 	case a.Raw != nil:
 		c.Raw = a.Raw
@@ -159,14 +160,14 @@ func ConvertListOptions(mOpts *metav1.ListOptions) (*client.ListOptions, error) 
 	if mOpts.LabelSelector != "" {
 		ls, err := labels.Parse(mOpts.LabelSelector)
 		if err != nil {
-			return &cOpts, errors.Wrap(err, "failed to parse LabelSelector")
+			return &cOpts, fmt.Errorf("failed to parse LabelSelector: %w", err)
 		}
 		cOpts.LabelSelector = ls
 	}
 	if mOpts.FieldSelector != "" {
 		fs, err := fields.ParseSelector(mOpts.FieldSelector)
 		if err != nil {
-			return &cOpts, errors.Wrap(err, "failed to parse FieldSelector")
+			return &cOpts, fmt.Errorf("failed to parse FieldSelector: %w", err)
 		}
 		cOpts.FieldSelector = fs
 	}

--- a/pkg/util/watch/options_test.go
+++ b/pkg/util/watch/options_test.go
@@ -15,12 +15,12 @@
 package watch
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/pkg/util/watch/typed_lister_watcher.go
+++ b/pkg/util/watch/typed_lister_watcher.go
@@ -16,8 +16,8 @@ package watch
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -67,11 +67,11 @@ func (fw *TypedListerWatcher) List(options metav1.ListOptions) (runtime.Object, 
 	}
 	cOpts, err := ConvertListOptions(&options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+		return nil, fmt.Errorf("failed to convert metav1.ListOptions to client.ListOptions: %w", err)
 	}
 	cOpts, err = MergeListOptions(cOpts, fw.DefaultListOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge list options")
+		return nil, fmt.Errorf("failed to merge list options: %w", err)
 	}
 	optsList := UnrollListOptions(cOpts)
 	klog.V(5).Infof("Listing %T %s: %v", objList, objList.GetObjectKind().GroupVersionKind().Kind, optsList)
@@ -87,11 +87,11 @@ func (fw *TypedListerWatcher) Watch(options metav1.ListOptions) (watch.Interface
 	}
 	cOpts, err := ConvertListOptions(&options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert metav1.ListOptions to client.ListOptions")
+		return nil, fmt.Errorf("failed to convert metav1.ListOptions to client.ListOptions: %w", err)
 	}
 	cOpts, err = MergeListOptions(cOpts, fw.DefaultListOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge list options")
+		return nil, fmt.Errorf("failed to merge list options: %w", err)
 	}
 	optsList := UnrollListOptions(cOpts)
 	klog.V(5).Infof("Watching %T %s: %v", objList, objList.GetObjectKind().GroupVersionKind().Kind, optsList)

--- a/pkg/validate/raw/validate/crd_name_test.go
+++ b/pkg/validate/raw/validate/crd_name_test.go
@@ -15,10 +15,10 @@
 package validate
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/validate/raw/validate/management_annotation_test.go
+++ b/pkg/validate/raw/validate/management_annotation_test.go
@@ -15,9 +15,9 @@
 package validate
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"

--- a/pkg/vet/api_resources_test.go
+++ b/pkg/vet/api_resources_test.go
@@ -15,9 +15,9 @@
 package vet
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/util/discovery"

--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -199,13 +198,13 @@ func convertObjects(req admission.Request) (client.Object, client.Object, error)
 		var err error
 		oldObj, err = kinds.ObjectAsClientObject(req.OldObject.Object)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to convert old object")
+			return nil, nil, fmt.Errorf("failed to convert old object: %w", err)
 		}
 	case req.OldObject.Raw != nil:
 		// We got raw JSON bytes instead of an object.
 		oldU := &unstructured.Unstructured{}
 		if err := oldU.UnmarshalJSON(req.OldObject.Raw); err != nil {
-			return nil, nil, errors.Wrap(err, "failed to decode old object from JSON")
+			return nil, nil, fmt.Errorf("failed to decode old object from JSON: %w", err)
 		}
 		oldObj = oldU
 	}
@@ -217,13 +216,13 @@ func convertObjects(req admission.Request) (client.Object, client.Object, error)
 		var err error
 		newObj, err = kinds.ObjectAsClientObject(req.Object.Object)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to convert new object")
+			return nil, nil, fmt.Errorf("failed to convert new object: %w", err)
 		}
 	case req.Object.Raw != nil:
 		// We got raw JSON bytes instead of an object.
 		newU := &unstructured.Unstructured{}
 		if err := newU.UnmarshalJSON(req.Object.Raw); err != nil {
-			return nil, nil, errors.Wrap(err, "failed to decode new object from JSON")
+			return nil, nil, fmt.Errorf("failed to decode new object from JSON: %w", err)
 		}
 		newObj = newU
 	}


### PR DESCRIPTION
codebase leaned on a package that is no longer maintained.  This is a cleanup task.

Instead of a massive replace there was a thought to create our own proxy for error reporting, but I think this would be a tax we'd have to maintain for a long while so it's probably better to just do the replacement right now.