### PR TITLE
test: rename test-e2e-kind targets and dev docs

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -9,7 +9,13 @@ GOTOPT2_BINARY := docker run -i -u $(UID):$(GID) $(BUILDENV_IMAGE) /bin/gotopt2
 
 GCP_ZONE ?= us-central1-a
 GKE_E2E_TIMEOUT ?= 6h
+# Configurable timeout for running the e2e tests on kind clusters.
+# The fewer clusters being used, the higher the timeout needs to be.
 KIND_E2E_TIMEOUT ?= 60m
+# Configurable number of kind clusters to run the tests against.
+# A higher number will lead to a faster test execution, but may cause stability
+# issues depending on the size of the host machine.
+KIND_NUM_CLUSTERS ?= 15
 
 E2E_CREATE_CLUSTERS ?= "true"
 E2E_DESTROY_CLUSTERS ?= "true"
@@ -70,10 +76,10 @@ build-kind-e2e: "$(KIND)" "$(KUSTOMIZE)" "$(HELM)" "$(CRANE)"
 		-t $(KIND_IMAGE) \
 		$(DOCKER_BUILD_ARGS)
 
-# This target runs all the e2e tests with the multi-repo mode.
+# This target runs all the e2e tests on kind clusters.
 # This is the target used by the presubmits.
-.PHONY: test-e2e-kind-multi-repo
-test-e2e-kind-multi-repo: config-sync-manifest-local build-kind-e2e
+.PHONY: test-e2e-kind
+test-e2e-kind: config-sync-manifest-local build-kind-e2e
 	kind delete clusters --all
 	docker run \
 		$(DOCKER_INTERACTIVE) \
@@ -88,20 +94,34 @@ test-e2e-kind-multi-repo: config-sync-manifest-local build-kind-e2e
 			--share-test-env \
 			--timeout $(KIND_E2E_TIMEOUT) \
 			--test.v -v \
-			--num-clusters 15 \
+			--num-clusters $(KIND_NUM_CLUSTERS) \
 			$(E2E_ARGS)
 
-# This target runs the first group of e2e tests with the multi-repo mode.
+# This target runs the first group of e2e tests.
+.PHONY: test-e2e-kind-test-group1
+test-e2e-kind-test-group1:
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=acm-controller,selector,lifecycle,nomos-cli" test-e2e-kind
+
+# This target runs the second group of e2e tests.
+.PHONY: test-e2e-kind-test-group2
+test-e2e-kind-test-group2:
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1,drift-control" test-e2e-kind
+
+# This target runs the third group of e2e tests.
+.PHONY: test-e2e-kind-test-group3
+test-e2e-kind-test-group3:
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=reconciliation-2,multi-repos,override-api,hydration" test-e2e-kind
+
+# Legacy aliases to support backwards compatibility for CI
+# These can be removed once CI uses the newly named targets
+.PHONY: test-e2e-kind-multi-repo
+test-e2e-kind-multi-repo: test-e2e-kind
+
 .PHONY: test-e2e-kind-multi-repo-test-group1
-test-e2e-kind-multi-repo-test-group1:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=acm-controller,selector,lifecycle,nomos-cli" test-e2e-kind-multi-repo
+test-e2e-kind-multi-repo-test-group1: test-e2e-kind-test-group1
 
-# This target runs the second group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group2
-test-e2e-kind-multi-repo-test-group2:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1,drift-control" test-e2e-kind-multi-repo
+test-e2e-kind-multi-repo-test-group2: test-e2e-kind-test-group2
 
-# This target runs the third group of e2e tests with the multi-repo mode.
 .PHONY: test-e2e-kind-multi-repo-test-group3
-test-e2e-kind-multi-repo-test-group3:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=reconciliation-2,multi-repos,override-api,hydration" test-e2e-kind-multi-repo
+test-e2e-kind-multi-repo-test-group3: test-e2e-kind-test-group3

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,8 @@ go test ./e2e/... --usage
 
 Below is a non-exhaustive list of some useful arguments for running the e2e tests.
 These can be provided on the command line with `go test` or with program arguments in your IDE.
+The test output can be very verbose, so running the tests in an IDE can help with
+parsing the output using the IDE frontend.
 
 - `--usage` - If true, print usage and exit.
 - `--e2e` - If true, run end-to-end tests. (required to run the e2e tests).
@@ -56,13 +58,16 @@ make install-kind
 
 #### Running E2E tests on kind
 
-Run all of the tests (this will take a while):
+Build everything and run all e2e tests. This will take a long time, but can be
+tuned using `KIND_E2E_TIMEOUT` and `KIND_NUM_CLUSTERS`.
 ```
-make test-e2e-go-multirepo
+make test-e2e-kind KIND_E2E_TIMEOUT=5h KIND_NUM_CLUSTERS=5
 ```
 
-To execute e2e multi-repo tests locally with kind, build and push the Config Sync
-images to the local kind registry and then execute tests using go test.
+To execute e2e tests locally with kind, build and push the Config Sync
+images to the local kind registry and then execute tests using `go test`.
+Running the tests directly using `go test` gives more flexibility with the
+test parameters and allows running smaller subsets of tests.
 ```shell
 make config-sync-manifest-local
 go test ./e2e/... --e2e --debug --test.v --test.run (test name regexp)


### PR DESCRIPTION
This simplifies the naming of some of the e2e-kind test targets and updates the dev/testing docs with the current entrypoints.