### PR TITLE
fix: update git-sync to v4.2.1 to fix a pulling issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 # Base image used for all golang containers
 GOLANG_IMAGE := golang:1.21.5-bookworm
 # Base image used for debian containers
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.1-gke.0
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.1-gke.1
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -101,7 +101,7 @@ data:
                - ALL
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v4.1.0-gke.7__linux_amd64
+           image: gcr.io/config-management-release/git-sync:v4.2.1-gke.1__linux_amd64
            args: ["--root=/repo/source", "--link=rev", "--max-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo


### PR DESCRIPTION
There is a bug in git-sync v4.1.0. When branches in different remotes
are out of sync, `git-sync` fetches the commit SHA from the last line,
which may not be the latest. This leads to an issue that Config Sync
couldn't pull the latest commit from HEAD.

The issue was fixed in v4.2.0 by
https://github.com/kubernetes/git-sync/pull/845.
This commit updates git-sync to v4.2.1 to include the fix.

It also bumps the debian-base to latest version for CVE fixes.

b/325341042