### PR TITLE
e2e: Add registry login/logout to test setup

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -459,6 +459,10 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 	if *e2e.OCIProvider == e2e.Local || *e2e.HelmProvider == e2e.Local {
 		nt.portForwardRegistryServer()
 	}
+	// Setup registry authentication
+	if err := setupRegistryClient(nt, opts); err != nil {
+		nt.T.Fatalf("configuring registry client: %v", err)
+	}
 	// Images created by the tests should not be persisted after the test finishes.
 	// Cleanup all images before the port forward gets torn down.
 	nt.T.Cleanup(func() {

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -46,6 +46,12 @@ type MultiRepo struct {
 	// Default: 5m.
 	ReconcileTimeout *time.Duration
 
+	// RequireOCIProvider will enable GitProvider Login & Logout.
+	RequireOCIProvider bool
+
+	// RequireHelmProvider will enable HelmProvider Login & Logout.
+	RequireHelmProvider bool
+
 	// RequireLocalGitProvider will skip the test if run with a GitProvider type other than local.
 	RequireLocalGitProvider bool
 
@@ -79,19 +85,33 @@ func RootRepo(name string) func(opt *New) {
 	}
 }
 
+// RequireOCIProvider will enable OCI repo client login and logout
+func RequireOCIProvider(opt *New) {
+	opt.RequireOCIProvider = true
+}
+
+// RequireHelmProvider will enable Helm repo client login and logout
+func RequireHelmProvider(opt *New) {
+	opt.RequireHelmProvider = true
+}
+
 // RequireLocalGitProvider will skip the test with non-local GitProvider types
 func RequireLocalGitProvider(opt *New) {
 	opt.RequireLocalGitProvider = true
 }
 
-// RequireLocalOCIProvider will skip the test with non-local OCIProvider types
+// RequireLocalOCIProvider will skip the test with non-local OCIProvider types.
+// RequireLocalOCIProvider implies RequireOCIProvider.
 func RequireLocalOCIProvider(opt *New) {
 	opt.RequireLocalOCIProvider = true
+	opt.RequireOCIProvider = true
 }
 
-// RequireLocalHelmProvider will skip the test with non-local HelmProvider types
+// RequireLocalHelmProvider will skip the test with non-local HelmProvider types.
+// RequireLocalHelmProvider implies RequireHelmProvider.
 func RequireLocalHelmProvider(opt *New) {
 	opt.RequireLocalHelmProvider = true
+	opt.RequireHelmProvider = true
 }
 
 // WithDelegatedControl will specify the Delegated Control Pattern.

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -101,20 +101,26 @@ func RequireKind(t testing.NTB) Opt {
 	return func(opt *New) {}
 }
 
-// RequireHelmArtifactRegistry requires the --helm-provider flag to be set to gar
+// RequireHelmArtifactRegistry requires the --helm-provider flag to be set to `gar`.
+// RequireHelmArtifactRegistry implies RequireHelmProvider.
 func RequireHelmArtifactRegistry(t testing.NTB) Opt {
 	if *e2e.HelmProvider != e2e.ArtifactRegistry {
 		t.Skip("The --helm-provider flag must be set to `gar` to run this test.")
 	}
-	return func(opt *New) {}
+	return func(opts *New) {
+		opts.RequireHelmProvider = true
+	}
 }
 
-// RequireOCIArtifactRegistry requires the --oci-provider flag to be set to gar
+// RequireOCIArtifactRegistry requires the --oci-provider flag to be set to `gar`.
+// RequireOCIArtifactRegistry implies RequireOCIProvider.
 func RequireOCIArtifactRegistry(t testing.NTB) Opt {
 	if *e2e.OCIProvider != e2e.ArtifactRegistry {
 		t.Skip("The --oci-provider flag must be set to `gar` to run this test.")
 	}
-	return func(opt *New) {}
+	return func(opts *New) {
+		opts.RequireOCIProvider = true
+	}
 }
 
 // WithInitialCommit creates the initialCommit before the first sync

--- a/e2e/nomostest/registryproviders/artifact_registry.go
+++ b/e2e/nomostest/registryproviders/artifact_registry.go
@@ -119,7 +119,8 @@ type ArtifactRegistryOCIProvider struct {
 	ArtifactRegistryProvider
 }
 
-func (a *ArtifactRegistryOCIProvider) registryLogin() error {
+// Login to the registry with the crane client
+func (a *ArtifactRegistryOCIProvider) Login() error {
 	var err error
 	authCmd := a.shell.Command("gcloud", "auth", "print-access-token")
 	loginCmd := a.shell.Command("crane", "auth", "login",
@@ -141,11 +142,17 @@ func (a *ArtifactRegistryOCIProvider) registryLogin() error {
 	return nil
 }
 
+// Logout of the registry with the crane client
+func (a *ArtifactRegistryOCIProvider) Logout() error {
+	_, err := a.shell.ExecWithDebug("crane", "auth", "logout", a.registryHost())
+	if err != nil {
+		return fmt.Errorf("running logout command: %w", err)
+	}
+	return nil
+}
+
 // Setup performs setup
 func (a *ArtifactRegistryOCIProvider) Setup() error {
-	if err := a.registryLogin(); err != nil {
-		return err
-	}
 	return a.createRepository()
 }
 
@@ -167,7 +174,8 @@ type ArtifactRegistryHelmProvider struct {
 	ArtifactRegistryProvider
 }
 
-func (a *ArtifactRegistryHelmProvider) registryLogin() error {
+// Login to the registry with the helm client
+func (a *ArtifactRegistryHelmProvider) Login() error {
 	var err error
 	authCmd := a.shell.Command("gcloud", "auth", "print-access-token")
 	loginCmd := a.shell.Command("helm", "registry", "login",
@@ -189,12 +197,18 @@ func (a *ArtifactRegistryHelmProvider) registryLogin() error {
 	return nil
 }
 
+// Logout of the registry with the helm client
+func (a *ArtifactRegistryHelmProvider) Logout() error {
+	_, err := a.shell.ExecWithDebug("helm", "registry", "logout", a.registryHost())
+	if err != nil {
+		return fmt.Errorf("running logout: %w", err)
+	}
+	return nil
+}
+
 // Setup performs required setup for the helm AR provider.
 // This requires setting up authentication for the helm CLI.
 func (a *ArtifactRegistryHelmProvider) Setup() error {
-	if err := a.registryLogin(); err != nil {
-		return err
-	}
 	return a.createRepository()
 }
 

--- a/e2e/nomostest/registryproviders/local.go
+++ b/e2e/nomostest/registryproviders/local.go
@@ -56,6 +56,16 @@ func (l *LocalProvider) Teardown() error {
 	return nil
 }
 
+// Login to the local registry (no-op)
+func (l *LocalProvider) Login() error {
+	return nil
+}
+
+// Logout of the local registry (no-op)
+func (l *LocalProvider) Logout() error {
+	return nil
+}
+
 // localAddress returns the local port forwarded address that proxies to the
 // in-cluster git server. For use from the test framework to push to the registry.
 func (l *LocalProvider) localAddress(name string) (string, error) {

--- a/e2e/nomostest/registryproviders/registry_provider.go
+++ b/e2e/nomostest/registryproviders/registry_provider.go
@@ -41,6 +41,10 @@ type RegistryProvider interface {
 	// Teardown is used to perform cleanup of the RegistryProvider after test
 	// completion.
 	Teardown() error
+	// Login to the registry with the client
+	Login() error
+	// Logout of the registry with the client
+	Logout() error
 	// deleteImage is used to delegate image deletion to the RegistryProvider
 	// implementation. This is needed because the delete interface varies by
 	// provider.

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -402,6 +402,7 @@ func TestHelmDefaultNamespace(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource,
 		ntopts.Unstructured,
+		ntopts.RequireHelmProvider,
 	)
 
 	chart, err := nt.BuildAndPushHelmPackage(nomostest.RootSyncNN(configsync.RootSyncName),
@@ -450,6 +451,7 @@ func TestHelmLatestVersion(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.WorkloadIdentity,
 		ntopts.Unstructured,
+		ntopts.RequireHelmProvider,
 	)
 
 	newVersion := "1.0.0"
@@ -526,7 +528,7 @@ func TestHelmVersionRange(t *testing.T) {
 // Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
 func TestHelmNamespaceRepo(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
 
@@ -571,7 +573,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 // Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
 func TestHelmConfigMapNamespaceRepo(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()),
 		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
 	cmName := "helm-cm-ns-repo-1"
@@ -671,7 +673,8 @@ func TestHelmConfigMapNamespaceRepo(t *testing.T) {
 //   - `roles/artifactregistry.reader` for access image in Artifact Registry.
 func TestHelmGCENode(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
-		ntopts.RequireGKE(t), ntopts.GCENodeTest, ntopts.RequireHelmArtifactRegistry(t))
+		ntopts.RequireGKE(t), ntopts.GCENodeTest,
+		ntopts.RequireHelmArtifactRegistry(t))
 
 	if err := workloadidentity.ValidateDisabled(nt); err != nil {
 		nt.T.Fatal(err)
@@ -780,6 +783,7 @@ func TestHelmEmptyChart(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource,
 		ntopts.Unstructured,
+		ntopts.RequireHelmProvider,
 	)
 
 	chart, err := nt.BuildAndPushHelmPackage(nomostest.RootSyncNN(configsync.RootSyncName))

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -112,7 +112,8 @@ func TestPublicOCI(t *testing.T) {
 //   - `roles/containerregistry.ServiceAgent` for access image in Container Registry.
 func TestGCENodeOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
-		ntopts.RequireGKE(t), ntopts.GCENodeTest, ntopts.RequireOCIArtifactRegistry(t))
+		ntopts.RequireGKE(t), ntopts.GCENodeTest,
+		ntopts.RequireOCIArtifactRegistry(t))
 
 	if err := workloadidentity.ValidateDisabled(nt); err != nil {
 		nt.T.Fatal(err)
@@ -158,6 +159,7 @@ func TestGCENodeOCI(t *testing.T) {
 func TestSwitchFromGitToOciCentralized(t *testing.T) {
 	namespace := testNs
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+		ntopts.RequireOCIProvider,
 		ntopts.NamespaceRepo(namespace, configsync.RepoSyncName),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount
@@ -222,7 +224,7 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 func TestSwitchFromGitToOciDelegated(t *testing.T) {
 	namespace := testNs
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
-		ntopts.WithDelegatedControl,
+		ntopts.WithDelegatedControl, ntopts.RequireOCIProvider,
 		ntopts.NamespaceRepo(namespace, configsync.RepoSyncName),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -467,7 +467,7 @@ func TestStressMemoryUsageGit(t *testing.T) {
 // 7. IAM for the test runner to write to Artifact Registry repo
 func TestStressMemoryUsageOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.Unstructured,
-		ntopts.StressTest,
+		ntopts.StressTest, ntopts.RequireOCIProvider,
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 
 	if err := workloadidentity.ValidateEnabled(nt); err != nil {
@@ -572,7 +572,7 @@ func TestStressMemoryUsageOCI(t *testing.T) {
 // 8. gcloud & helm
 func TestStressMemoryUsageHelm(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.Unstructured,
-		ntopts.StressTest,
+		ntopts.StressTest, ntopts.RequireHelmProvider,
 		ntopts.WithReconcileTimeout(30*time.Second))
 
 	if err := workloadidentity.ValidateEnabled(nt); err != nil {


### PR DESCRIPTION
The gcloud auth token only lasts 1 hour, so we need to re-auth for each test that uses helm or oci.