### PR TITLE
test: update e2e test to fix gitlab push error

### DIFF
--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -35,7 +35,7 @@ func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 	}
 
 	nt.T.Log("Create an extra remote tracking branch")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Push("HEAD:refs/remotes/upstream/main"))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Push("HEAD:upstream/main"))
 
 	nt.T.Logf("Update the remote main branch by adding a test namespace")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", fake.NamespaceObject("hello")))


### PR DESCRIPTION
Gitlab doesn't allow pushing a branch with `refs/remotes/upstream/*`. It failed with a `deny updating a hidden ref` error. This commit changes the remote branch to just `upstream/main`, which is `refs/heads/upstream/main`.