### PR TITLE
test: fix registry cleanup to delete images after

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -809,22 +809,6 @@ func (nt *NT) portForwardRegistryServer(helmTest, ociTest bool) {
 		TestRegistryServer,
 		portForwarder,
 	)
-	// Register Cleanup to Reset the providers AFTER startPortForwarder, so that
-	// it runs BEFORE the Cleanup in startPortForwarder which stops the PortForwarder.
-	if provider, ok := nt.OCIProvider.(registryproviders.ProxiedRegistryProvider); ok && ociTest {
-		nt.T.Cleanup(func() {
-			if err := provider.Reset(); err != nil {
-				nt.T.Errorf("resetting proxy provider: %v", err)
-			}
-		})
-	}
-	if provider, ok := nt.HelmProvider.(registryproviders.ProxiedRegistryProvider); ok && helmTest {
-		nt.T.Cleanup(func() {
-			if err := provider.Reset(); err != nil {
-				nt.T.Errorf("resetting proxy provider: %v", err)
-			}
-		})
-	}
 }
 
 // portForwardGitServer forwards the prometheus deployment to a port.

--- a/e2e/nomostest/registry_server.go
+++ b/e2e/nomostest/registry_server.go
@@ -114,22 +114,28 @@ func setupRegistryClient(nt *NT, opts *ntopts.New) error {
 	if opts.RequireOCIProvider && *e2e.OCIProvider == e2e.Local || opts.RequireHelmProvider && *e2e.HelmProvider == e2e.Local {
 		nt.portForwardRegistryServer(opts.RequireHelmProvider, opts.RequireOCIProvider)
 	}
-	// For non-local registries, just login before each test and logout after.
-	if opts.RequireOCIProvider && *e2e.OCIProvider != e2e.Local {
+	// Login before each test, then reset the registry and logout after the test.
+	if opts.RequireOCIProvider {
 		if err := nt.OCIProvider.Login(); err != nil {
 			return err
 		}
 		nt.T.Cleanup(func() {
+			if err := nt.OCIProvider.Reset(); err != nil {
+				nt.T.Error(err)
+			}
 			if err := nt.OCIProvider.Logout(); err != nil {
 				nt.T.Error(err)
 			}
 		})
 	}
-	if opts.RequireHelmProvider && *e2e.HelmProvider != e2e.Local {
+	if opts.RequireHelmProvider {
 		if err := nt.HelmProvider.Login(); err != nil {
 			return err
 		}
 		nt.T.Cleanup(func() {
+			if err := nt.HelmProvider.Reset(); err != nil {
+				nt.T.Error(err)
+			}
 			if err := nt.HelmProvider.Logout(); err != nil {
 				nt.T.Error(err)
 			}

--- a/e2e/nomostest/registryproviders/local.go
+++ b/e2e/nomostest/registryproviders/local.go
@@ -165,7 +165,7 @@ func (l *LocalOCIProvider) Restore(proxyAddress string) error {
 	return nil
 }
 
-// Reset the proxy and flush the cache of pushed images.
+// Reset the state of the registry by deleting images pushed during the test.
 func (l *LocalOCIProvider) Reset() error {
 	// Delete all charts & images pushed during the test.
 	for _, image := range l.pushedImages {
@@ -174,8 +174,7 @@ func (l *LocalOCIProvider) Reset() error {
 		}
 	}
 	l.pushedImages = nil
-	// Logout to reset the local client credentials.
-	return l.Logout()
+	return nil
 }
 
 // PushImage pushes the local tarball as an OCI image to the remote registry.
@@ -210,7 +209,12 @@ func (l *LocalOCIProvider) DeleteImage(imageName, digest string) error {
 	if err != nil {
 		return err
 	}
-	return deleteOCIImage(l.OCIClient, imageLocalAddress, digest)
+	if err := deleteOCIImage(l.OCIClient, imageLocalAddress, digest); err != nil {
+		return err
+	}
+	imageID := fmt.Sprintf("%s@%s", imageName, digest)
+	delete(l.pushedImages, imageID)
+	return nil
 }
 
 // LocalHelmProvider provides methods for interacting with the test registry-server
@@ -273,7 +277,7 @@ func (l *LocalHelmProvider) Restore(proxyAddress string) error {
 	return nil
 }
 
-// Reset the proxy and flush the cache of pushed images.
+// Reset the state of the registry by deleting images pushed during the test.
 func (l *LocalHelmProvider) Reset() error {
 	// Delete all charts & images pushed during the test.
 	for _, image := range l.pushedPackages {
@@ -282,8 +286,7 @@ func (l *LocalHelmProvider) Reset() error {
 		}
 	}
 	l.pushedPackages = nil
-	// Logout to reset the local client credentials.
-	return l.Logout()
+	return nil
 }
 
 // PushPackage pushes the local helm chart as an OCI image to the remote registry.

--- a/e2e/nomostest/registryproviders/registry_provider.go
+++ b/e2e/nomostest/registryproviders/registry_provider.go
@@ -37,6 +37,9 @@ type RegistryProvider interface {
 	Login() error
 	// Logout of the registry with the client
 	Logout() error
+
+	// Reset the state of the registry by deleting images pushed during the test.
+	Reset() error
 }
 
 // ProxiedRegistryProvider is a registry provider with a proxy that needs to
@@ -52,8 +55,6 @@ type ProxiedRegistryProvider interface {
 	// Restore takes the new proxy address to avoid deadlocks trying to ask
 	// PortForwarder.LocalPort(), which blocks until after restore is done.
 	Restore(proxyAddress string) error
-	// Reset the proxy and flush the cache of pushed images.
-	Reset() error
 }
 
 // OCIRegistryProvider abstracts remote OCI registry providers for use by OCI clients.
@@ -82,7 +83,7 @@ type HelmRegistryProvider interface {
 	// For pulling with RSync's `.spec.helm.repo`
 	RepositoryRemoteURL() (string, error)
 
-	// PushImage pushes a local helm chart as an OCI image to the remote registry.
+	// PushPackage pushes a local helm chart as an OCI image to the remote registry.
 	PushPackage(localChartTgzPath string) (*HelmPackage, error)
 	// DeletePackage deletes the helm chart OCI image from the remote registry,
 	// including all versions and tags.


### PR DESCRIPTION
A recent refactor updated the cleanup logic to only delete images in cleanup for local registries. The registry state needs to be reset regardless of the registry type.