### PR TITLE
ci: tag all infra images with proper prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,13 @@ OLD_REGISTRY ?= $(REGISTRY)
 # Registry which hosts images related to test infrastructure
 TEST_INFRA_PROJECT ?= kpt-config-sync-ci-artifacts
 TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-infra
+INFRA_IMAGE_PREFIX := infrastructure-public-image
 
 # Docker image used for build and test. This image does not support CGO.
 # When upgrading this tag, the image will be rebuilt locally during presubmits.
 # After the change is submitted, a postsubmit job will publish the new tag.
 # There is no need to manually publish this image.
-BUILDENV_IMAGE ?= $(TEST_INFRA_REGISTRY)/buildenv:v0.3.2
+BUILDENV_IMAGE := $(TEST_INFRA_REGISTRY)/buildenv:$(INFRA_IMAGE_PREFIX)-v0.3.2
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler

--- a/Makefile.build
+++ b/Makefile.build
@@ -199,7 +199,7 @@ config-sync-manifest-local: docker-registry config-sync-manifest
 # e2e/nomostest/git-server.go to reflect the version change
 GIT_SERVER_DOCKER := $(OUTPUT_DIR)/git-server-docker
 GIT_SERVER_RELEASE := v1.0.0
-GIT_SERVER_IMAGE := $(TEST_INFRA_REGISTRY)/git-server:$(GIT_SERVER_RELEASE)-$(shell git rev-parse --short HEAD)
+GIT_SERVER_IMAGE := $(TEST_INFRA_REGISTRY)/git-server:$(INFRA_IMAGE_PREFIX)-$(GIT_SERVER_RELEASE)-$(shell git rev-parse --short HEAD)
 # Creates docker image for the test git-server from github source
 .PHONY: build-git-server
 build-git-server:
@@ -223,7 +223,7 @@ push-git-server:
 
 # NOTE: when updating the git-server version, update
 # e2e/nomostest/git-server.go to reflect the version change
-E2E_TEST_IMAGE_HTTP_GIT_SERVER_TAG := v1.0.0-$(shell git rev-parse --short HEAD)
+E2E_TEST_IMAGE_HTTP_GIT_SERVER_TAG := $(INFRA_IMAGE_PREFIX)-v1.0.0-$(shell git rev-parse --short HEAD)
 E2E_TEST_IMAGE_HTTP_GIT_SERVER := $(TEST_INFRA_REGISTRY)/http-git-server:$(E2E_TEST_IMAGE_HTTP_GIT_SERVER_TAG)
 # Builds the container used by e2e tests to test git over HTTPS.
 .PHONY: build-http-git-server
@@ -240,7 +240,7 @@ push-http-git-server:
 	@docker push $(E2E_TEST_IMAGE_HTTP_GIT_SERVER)
 
 # Used by the vulnerability scanning periodic prow job.
-VULNERABILITY_SCANNER_VERSION := v1.0.0-$(shell git rev-parse --short HEAD)
+VULNERABILITY_SCANNER_VERSION := $(INFRA_IMAGE_PREFIX)-v1.0.0-$(shell git rev-parse --short HEAD)
 VULNERABILITY_SCANNER_IMAGE_TAG := $(TEST_INFRA_REGISTRY)/vulnerability-scanner:$(VULNERABILITY_SCANNER_VERSION)
 .PHONY: build-vulnerability-scanner
 build-vulnerability-scanner:

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -8,11 +8,18 @@
 test-e2e-gke-ci: pull-postsubmit-retry test-e2e-gke-nobuild
 
 POSTSUBMIT_GCS_PREFIX ?= gs://kpt-config-sync-ci-postsubmit
-POSTSUBMIT_REGISTRY ?= us-docker.pkg.dev/kpt-config-sync-ci-artifacts/postsubmit
+POSTSUBMIT_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/postsubmit
 
 .PHONY: postsubmit
-postsubmit: build-cli
+postsubmit:
 	$(MAKE) config-sync-manifest REGISTRY=$(POSTSUBMIT_REGISTRY)
+	$(MAKE) retag-images \
+		REGISTRY=$(POSTSUBMIT_REGISTRY) \
+		OLD_IMAGE_TAG=$(IMAGE_TAG) \
+		IMAGE_TAG=$(INFRA_IMAGE_PREFIX)-$(IMAGE_TAG)
+	$(MAKE) push-images \
+		REGISTRY=$(POSTSUBMIT_REGISTRY) \
+		IMAGE_TAG=$(INFRA_IMAGE_PREFIX)-$(IMAGE_TAG)
 	$(MAKE) publish-gcs GCS_PREFIX=$(POSTSUBMIT_GCS_PREFIX)
 	$(MAKE) publish-buildenv
 

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -21,7 +21,7 @@
 # clusters rather than kind, so we don't need docker in docker.
 # Note: nothing builds this, if you update the version, you will need to rebuild manually.
 # TODO: setup postsubmit job to build this image
-GKE_E2E_TAG := v1.0.0-$(shell git rev-parse --short HEAD)
+GKE_E2E_TAG := $(INFRA_IMAGE_PREFIX)-v1.0.0-$(shell git rev-parse --short HEAD)
 GKE_E2E_IMAGE := $(TEST_INFRA_REGISTRY)/gke-e2e:$(GKE_E2E_TAG)
 .PHONY: build-gke-e2e
 build-gke-e2e:


### PR DESCRIPTION
The infrastructure-public-image prefix advertises that these images are intended for use by end to end testing infrastrucutre.