### PR TITLE
ci: grant test runner CSR admin

### DIFF
--- a/e2e/testinfra/terraform/prow/service_accounts.tf
+++ b/e2e/testinfra/terraform/prow/service_accounts.tf
@@ -24,7 +24,7 @@ resource "google_project_iam_member" "test-runner-iam" {
     "roles/gkehub.admin",
     "roles/monitoring.viewer",
     "roles/secretmanager.admin",
-    "roles/source.reader",
+    "roles/source.admin",
   ])
 
   role    = each.value


### PR DESCRIPTION
The test runner GSA now needs permission to manage CSR repositories.