### PR TITLE
test: fix CI failures when running with --git-provider=csr

### DIFF
--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -162,8 +162,7 @@ func TestComposition(t *testing.T) {
 	nt.T.Log("Validating synced objects are reconciled...")
 	validateStatusCurrent(nt, lvl0Repo.MustGetAll(nt.T, lvl0SubDir, true)...)
 
-	nt.T.Logf("Creating Secret for RepoSync: %s", lvl2NN)
-	nt.Must(nomostest.CreateNamespaceSecret(nt, lvl2NN.Namespace))
+	nt.Must(nomostest.CreateNamespaceSecretForNonCSR(nt, lvl2NN.Namespace))
 
 	// lvl1 RootSync
 	lvl1Path := filepath.Join(lvl0SubDir, fmt.Sprintf("rootsync-%s.yaml", lvl1NN.Name))

--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/e2e/nomostest"
-	"kpt.dev/configsync/e2e/nomostest/gitproviders"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -41,22 +40,13 @@ func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", fake.NamespaceObject("hello")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace"))
 
-	nt.T.Logf("Mitigation: set spec.git.branch to HEAD to pull the latest commit")
-	nomostest.SetGitBranch(nt, configsync.RootSyncName, "HEAD")
+	nt.T.Logf("Verify git-sync can pull the latest commit with the default branch and revision")
 	// WatchForAllSyncs validates RootSync's lastSyncedCommit is updated to the
 	// local HEAD with the DefaultRootSha1Fn function.
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 	if err := nt.Validate("hello", "", &corev1.Namespace{}); err != nil {
-		nt.T.Fatal(err)
-	}
-
-	nt.T.Logf("Verify git-sync can pull the latest commit with the default branch and revision")
-	nomostest.SetGitBranch(nt, configsync.RootSyncName, gitproviders.MainBranch)
-	// WatchForAllSyncs validates RootSync's lastSyncedCommit is updated to the
-	// local HEAD with the DefaultRootSha1Fn function.
-	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -27,6 +27,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -55,6 +56,9 @@ func TestSyncingThroughAProxy(t *testing.T) {
 	nt.T.Log("Set auth type to cookiefile")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "cookiefile"}}}`)
 	nt.T.Log("Verify the secretRef error")
+	if err = nomostest.SetupFakeSSHCreds(nt, rs.Kind, nomostest.RootSyncNN(rs.Name), configsync.AuthCookieFile, controllers.GitCredentialVolume); err != nil {
+		nt.T.Fatal(err)
+	}
 	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", `git secretType was set as "cookiefile" but cookie_file key is not present`)
 
 	nt.T.Log("Set auth type to token")

--- a/e2e/testinfra/terraform/modules/service_account/service_account.tf
+++ b/e2e/testinfra/terraform/modules/service_account/service_account.tf
@@ -24,15 +24,58 @@ resource "google_service_account" "gcp_sa" {
 }
 
 resource "google_service_account_iam_member" "k8s_sa_binding" {
+  for_each = toset([
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler]", # The default RootSync used in e2e test.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns]", # The default RepoSync used in e2e test.
+    # RootSync and RepoSync used in TestNomosStatusNameFilter.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-crontab-sync]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-bookinfo-bookinfo-repo-sync-18]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-bookinfo-crontab-sync-12]",
+    # RootSync and RepoSync used in TestMultiSyncs_Unstructured_MixedControl.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-rr1]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-rr2]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-rr3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-nr1-3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-nr2-3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-nr3-3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-nr4-3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-nr5-3]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-ns-2-nr1-3]",
+    # RootSync used in TestConflictingDefinitions_RootToRoot.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-root-test]",
+    # RepoSync used in TestConflictingDefinitions_RootToRoot.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-rs-test-1-9]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-rs-test-2-9]",
+    # RepoSync used in TestNamespaceRepo_Delegated, TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1, TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1, TestManageSelfRepoSync, TestDeleteNamespaceReconcilerDeployment, TestReconcilerManagerRootSyncCRDMissing.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-bookstore]",
+    # RepoSync used in TestNoSSLVerifyV1Alpha1, TestNoSSLVerifyV1Beta1, TestOverrideGitSyncDepthV1Alpha1, TestOverrideGitSyncDepthV1Beta1, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-backend]",
+    # RepoSync used in TestOverrideRepoSyncLogLevel, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-frontend]",
+    # RootSync used in TestRootSyncRoleRefs, TestNamespaceStrategyMultipleRootSyncs.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-a]",
+    # RepoSync used in TestReconcilerFinalizer_MultiLevelForeground, TestReconcilerFinalizer_MultiLevelMixed.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-rs-test-7]",
+    # RootSync used in TestReconcileFinalizerReconcileTimeout.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-nested-root-sync]",
+    # RepoSync used in TestReconcilerManagerNormalTeardown.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-teardown]",
+    # RepoSync used in TestReconcilerManagerTeardownInvalidRSyncs.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-invalid-teardown]",
+    # RepoSync used in TestReconcilerManagerTeardownRepoSyncWithReconcileTimeout.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-reconcile-timeout]",
+    # RootSync used in TestNamespaceStrategyMultipleRootSyncs.
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-x]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-y]",
+    # RootSync and RepoSync used in TestComposition
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-level-1]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-level-1-7]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-test-ns-level-2-7]",
+    "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-test-ns-level-3-7]",
+  ])
   service_account_id = google_service_account.gcp_sa.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler]"
-}
-
-resource "google_service_account_iam_member" "k8s_sa_ns_binding" {
-  service_account_id = google_service_account.gcp_sa.name
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns]"
+  member             = each.value
 }
 
 resource "google_project_iam_member" "gcp_sa_role" {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2228 changes the default git provider from local to csr, which also changes the defalt git auth from ssh to gcpserviceaccount, which causes a bunch of testing failures and missing permissions.

This commit updates the tests to set the secret for non-csr git providers and also adds the missing IAM bindings.