### PR TITLE
Remove unused annotation webhook-configuration-update

### DIFF
--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -116,15 +116,6 @@ const (
 	// This annotation is set by Config Sync on a managed namespace resource.
 	OriginalHNCManagedByValue = configsync.ConfigSyncPrefix + "original-hnc-managed-by-value"
 
-	// WebhookconfigurationKey annotation declares if the webhook configuration
-	// should be updated.
-	// This annotation is set by Config Sync users on the Config Sync ValidatingWebhookConfiguration object.
-	WebhookconfigurationKey = configsync.ConfigSyncPrefix + "webhook-configuration-update"
-
-	// WebhookConfigurationUpdateDisabled is the value for WebhookConfigurationKey
-	// to disable updating the webhook configuration.
-	WebhookConfigurationUpdateDisabled = "disabled"
-
 	// UnknownScopeAnnotationKey is the annotation that indicates the scope of a resource is unknown.
 	// This annotation is set by Config Sync on a managed resource whose scope is unknown.
 	UnknownScopeAnnotationKey = configsync.ConfigSyncPrefix + "unknown-scope"

--- a/pkg/webhook/configuration/update.go
+++ b/pkg/webhook/configuration/update.go
@@ -20,9 +20,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
-	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,10 +65,6 @@ func Update(ctx context.Context, c client.Client, dc discovery.ServerResourcer, 
 		return status.APIServerError(err, "getting admission webhook from API Server")
 	}
 
-	// skip updating the webhook configuration if the update is disabled.
-	if core.GetAnnotation(oldCfg, metadata.WebhookconfigurationKey) == metadata.WebhookConfigurationUpdateDisabled {
-		return nil
-	}
 	// We aren't yet concerned with removing stale rules, so just merge the two
 	// together.
 	newCfg = Merge(oldCfg, newCfg)


### PR DESCRIPTION
The annotation was added as a workaround to disable updating webhook configuration before preventDrift field was made available.

Users who might be relying on this annotation can switch to using the [preventDrift field](https://cloud.google.com/anthos-config-management/docs/how-to/prevent-config-drift).