### PR TITLE
test: properly skip tests that use test wrapper

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -366,7 +366,7 @@ func newSharedNT(name string) error {
 	newSNT := mySharedNTs.newNT(fakeNTB)
 	// Create the actual test environment that will be reused by tests.
 	wrapper := testing.NewShared(fakeNTB)
-	opts := newOptStruct(name, tmpDir, wrapper)
+	opts := newOptStruct(name, tmpDir)
 	newSNT.sharedNT = FreshTestEnv(wrapper, opts)
 	return nil
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -24,7 +24,7 @@ set +e
 
 echo "Starting e2e tests"
 start_time=$(date +%s)
-go test ./e2e/... --p 1 --e2e --test.v "$@" | tee test_results.txt
+go test ./e2e/testcases/... --p 1 --e2e --test.v "$@" | tee test_results.txt
 exit_code=$?
 end_time=$(date +%s)
 echo "Tests took $(( end_time - start_time )) seconds"


### PR DESCRIPTION
The tests that use the test wrapper directly instead of the nomostest entrypoint were not properly being skipped. This moves the skip logic to the shared entrypoint.