### PR TITLE
test: use a new Bitbucket workspace

### DIFF
--- a/e2e/nomostest/gitproviders/bitbucket.go
+++ b/e2e/nomostest/gitproviders/bitbucket.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	bitbucketWorkspace = "config-sync-ci"
+	bitbucketWorkspace = "config-sync-ci-20240328"
 	bitbucketProject   = "CSCI"
 
 	// PrivateSSHKey is secret name of the private SSH key stored in the Cloud Secret Manager.


### PR DESCRIPTION
Bitbucket failed to delete Git repositories in the old workspace: https://community.atlassian.com/t5/Bitbucket-questions/Unable-to-delete-Git-repositories-due-to-Repository-currently/qaq-p/2654436.

As a workaround, we created a new workspace. This commit updates the CI to create repos in the new workspace.