### PR TITLE
test: fix test failures caused by sub tests running in parallel

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -750,6 +750,7 @@ func TestNomosHydrateAndVetDryRepos(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tw, opts := nomostest.NewTestWrapper(t, nomostesting.NomosCLI)
 			tmpDir := opts.TmpDir


### PR DESCRIPTION
TestNomosHydrateAndVetDryRepos uses the table driven format and the test wrapper to setup the tests. The test wrapper enables parallel exection with `t.Parallel()`. A go routine is created for each sub test. However, when it launches the go routines, the test case variables (the tc variable in the for loop iterator) are evaluated when the go routines run. Hence, by the time the go routine is actually executed, the for loop has completed, and each test ends up using the variables for the last test case.

To fix this issue, this commit rebinds the tc variable inside the loop. This creates a copy for the variable and go routine uses the local copy for execution.