### PR TITLE
base image update for golang and debian bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,11 @@ OUTPUT_DIR := $(abspath .output)
 GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
-GOLANG_IMAGE := golang:1.21.5-bookworm
+GOLANG_IMAGE := golang:1.21.8-bookworm
 # Base image used for debian containers
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.1-gke.1
+# When updating you can use this command: 
+# gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.2-gke.0
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options


### PR DESCRIPTION
```
mikebz-ct src/kpt-config-sync λ make vulnerability-scan
./scripts/vulnerabilities.sh
++++ Parsing image tags from rendered manifests at: .output/staging
Scanning............
IMAGE                                                                                     VULNERABILITIES
gcr.io/config-management-release/git-sync:v4.2.1-gke.3__linux_amd64                       0
gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.9                             0
gcr.io/mikebz-ex1/configsync/admission-webhook:v1.17.0-104-gb68be116-dirty                0
gcr.io/mikebz-ex1/configsync/gcenode-askpass-sidecar:v1.17.0-104-gb68be116-dirty          0
gcr.io/mikebz-ex1/configsync/helm-sync:v1.17.0-104-gb68be116-dirty                        0
gcr.io/mikebz-ex1/configsync/hydration-controller:v1.17.0-104-gb68be116-dirty             0
gcr.io/mikebz-ex1/configsync/hydration-controller-with-shell:v1.17.0-104-gb68be116-dirty  0
gcr.io/mikebz-ex1/configsync/nomos:v1.17.0-104-gb68be116-dirty                            0
gcr.io/mikebz-ex1/configsync/oci-sync:v1.17.0-104-gb68be116-dirty                         0
gcr.io/mikebz-ex1/configsync/reconciler-manager:v1.17.0-104-gb68be116-dirty               0
gcr.io/mikebz-ex1/configsync/reconciler:v1.17.0-104-gb68be116-dirty                       0
gcr.io/mikebz-ex1/configsync/resource-group-controller:v1.17.0-104-gb68be116-dirty        0
```
