### PR TITLE
Improvements for the NamespaceSelector dynamic mode

### DIFF
--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -73,11 +73,15 @@ type RootOptions struct {
 	// DynamicNSSelectorEnabled represents whether the NamespaceSelector's dynamic
 	// mode is enabled. If it is enabled, NamespaceSelector will also select
 	// resources matching the on-cluster Namespaces.
+	// Only Root reconciler may have dynamic NamespaceSelector enabled because
+	// RepoSync can't manage NamespaceSelectors.
 	DynamicNSSelectorEnabled bool
 
 	// NSControllerState stores whether the Namespace Controller schedules a sync
 	// event for the reconciler thread, along with the cached NamespaceSelector
 	// and selected namespaces.
+	// Only Root reconciler may have Namespace Controller state because
+	// RepoSync can't manage NamespaceSelectors.
 	NSControllerState *namespacecontroller.State
 }
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -257,13 +257,19 @@ func Run(opts Options) {
 		}
 	}
 
-	nsControllerState := namespacecontroller.NewState()
+	var nsControllerState *namespacecontroller.State
 	if opts.ReconcilerScope == declared.RootReconciler {
 		rootOpts := &parse.RootOptions{
 			SourceFormat:             opts.SourceFormat,
 			NamespaceStrategy:        opts.NamespaceStrategy,
 			DynamicNSSelectorEnabled: opts.DynamicNSSelectorEnabled,
-			NSControllerState:        nsControllerState,
+		}
+		if opts.DynamicNSSelectorEnabled {
+			// Only set nsControllerState when dynamic NamespaceSelector is enabled on
+			// RootSyncs.
+			// RepoSync can't manage NamespaceSelectors.
+			nsControllerState = namespacecontroller.NewState()
+			rootOpts.NSControllerState = nsControllerState
 		}
 		parser = parse.NewRootRunner(parseOpts, rootOpts)
 	} else {

--- a/pkg/validate/scoped/hydrate/namespace_hydrator.go
+++ b/pkg/validate/scoped/hydrate/namespace_hydrator.go
@@ -143,7 +143,7 @@ func buildSelectorMap(ctx context.Context, c client.Client, objs *objects.Scoped
 		var selectedNamespaces []string
 		// Select dynamic/on-cluster Namespaces that match the NamespaceSelector's labels.
 		for _, ns := range nsList.Items {
-			if selector.Matches(labels.Set(ns.GetLabels())) {
+			if ns.Status.Phase != corev1.NamespaceTerminating && selector.Matches(labels.Set(ns.GetLabels())) {
 				selectedNamespaces = append(selectedNamespaces, ns.GetName())
 				// selectedNamespaceMap only stores dynamic Namespaces.
 				selectedNamespaceMap[ns.GetName()] = append(selectedNamespaceMap[ns.GetName()], selector)


### PR DESCRIPTION
- It only initializes `nsControllerState` when dynamicNSSelectorEnabled is true, so that pkg/parse/run.go can stop `nsEventTimer` when nsControllerState is nil.
- When namespace_hydrator selects dynamic/on-cluster Namespaces, it filters out terminating Namespaces because Kubernetes doesn't allow creating new content in terminating Namespaces.