### PR TITLE
Add event handler to Applier/Destroyer

### DIFF
--- a/pkg/applier/stats/stats.go
+++ b/pkg/applier/stats/stats.go
@@ -36,6 +36,14 @@ func (s *PruneEventStats) Add(status event.PruneEventStatus) {
 	s.EventByOp[status]++
 }
 
+// Set records a total number of events
+func (s *PruneEventStats) Set(status event.PruneEventStatus, count uint64) {
+	if s.EventByOp == nil {
+		s.EventByOp = map[event.PruneEventStatus]uint64{}
+	}
+	s.EventByOp[status] = count
+}
+
 // String returns the stats as a human readable string.
 func (s PruneEventStats) String() string {
 	var strs []string
@@ -75,6 +83,14 @@ func (s *DeleteEventStats) Add(status event.DeleteEventStatus) {
 		s.EventByOp = map[event.DeleteEventStatus]uint64{}
 	}
 	s.EventByOp[status]++
+}
+
+// Set records a total number of events
+func (s *DeleteEventStats) Set(status event.DeleteEventStatus, count uint64) {
+	if s.EventByOp == nil {
+		s.EventByOp = map[event.DeleteEventStatus]uint64{}
+	}
+	s.EventByOp[status] = count
 }
 
 // String returns the stats as a human readable string.
@@ -119,6 +135,14 @@ func (s *ApplyEventStats) Add(status event.ApplyEventStatus) {
 	s.EventByOp[status]++
 }
 
+// Set records a total number of events
+func (s *ApplyEventStats) Set(status event.ApplyEventStatus, count uint64) {
+	if s.EventByOp == nil {
+		s.EventByOp = map[event.ApplyEventStatus]uint64{}
+	}
+	s.EventByOp[status] = count
+}
+
 // String returns the stats as a human readable string.
 func (s ApplyEventStats) String() string {
 	var strs []string
@@ -159,6 +183,14 @@ func (s *WaitEventStats) Add(status event.WaitEventStatus) {
 		s.EventByOp = map[event.WaitEventStatus]uint64{}
 	}
 	s.EventByOp[status]++
+}
+
+// Set records a total number of events
+func (s *WaitEventStats) Set(status event.WaitEventStatus, count uint64) {
+	if s.EventByOp == nil {
+		s.EventByOp = map[event.WaitEventStatus]uint64{}
+	}
+	s.EventByOp[status] = count
 }
 
 // String returns the stats as a human readable string.
@@ -247,6 +279,49 @@ func (s SyncStats) String() string {
 // Empty returns true if no events were recorded.
 func (s *SyncStats) Empty() bool {
 	return s == nil || s.ErrorTypeEvents == 0 && s.PruneEvent.Empty() && s.DeleteEvent.Empty() && s.ApplyEvent.Empty() && s.WaitEvent.Empty() && s.DisableObjs.Empty()
+}
+
+// WithApplyEvents sets the number of times this apply event status occurred.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithApplyEvents(status event.ApplyEventStatus, count uint64) *SyncStats {
+	s.ApplyEvent.Set(status, count)
+	return s
+}
+
+// WithPruneEvents sets the number of times this prune event status occurred.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithPruneEvents(status event.PruneEventStatus, count uint64) *SyncStats {
+	s.PruneEvent.Set(status, count)
+	return s
+}
+
+// WithDeleteEvents sets the number of times this delete event status occurred.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithDeleteEvents(status event.DeleteEventStatus, count uint64) *SyncStats {
+	s.DeleteEvent.Set(status, count)
+	return s
+}
+
+// WithWaitEvent sets the number of times this wait event status occurred.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithWaitEvent(status event.WaitEventStatus, count uint64) *SyncStats {
+	s.WaitEvent.Set(status, count)
+	return s
+}
+
+// WithDisabledObjStats sets the disabled object stats.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithDisabledObjStats(total, succeeded uint64) *SyncStats {
+	s.DisableObjs.Total = total
+	s.DisableObjs.Succeeded = succeeded
+	return s
+}
+
+// WithErrorEvents sets the total number of error events.
+// Intended for easy test expectation construction.
+func (s *SyncStats) WithErrorEvents(count uint64) *SyncStats {
+	s.ErrorTypeEvents = count
+	return s
 }
 
 // NewSyncStats constructs a SyncStats with empty event maps.

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -1066,13 +1066,15 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 	testCases := []struct {
 		name            string
-		applyErrors     status.MultiError
+		applyErrors     []status.Error
 		expectedError   status.MultiError
 		expectedMetrics []*view.Row
 	}{
 		{
-			name:          "single reconciler error in sync component",
-			applyErrors:   applier.Error(errors.New("sync error")),
+			name: "single reconciler error in sync component",
+			applyErrors: []status.Error{
+				applier.Error(errors.New("sync error")),
+			},
 			expectedError: applier.Error(errors.New("sync error")),
 			expectedMetrics: []*view.Row{
 				{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{{Key: metrics.KeyComponent, Value: "source"}, {Key: metrics.KeyErrorClass, Value: "1xxx"}}},
@@ -1085,10 +1087,10 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 		},
 		{
 			name: "multiple reconciler errors in sync component",
-			applyErrors: status.Wrap(
+			applyErrors: []status.Error{
 				applier.Error(errors.New("sync error")),
 				status.InternalError("internal error"),
-			),
+			},
 			expectedError: status.Wrap(
 				applier.Error(errors.New("sync error")),
 				status.InternalError("internal error"),

--- a/pkg/reconciler/finalizer/base_finalizer.go
+++ b/pkg/reconciler/finalizer/base_finalizer.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/status"
+)
+
+type baseFinalizer struct {
+	Destroyer applier.Destroyer
+}
+
+// destroy calls Destroyer.Destroy, collects errors, and handles logging,
+// similar to Updater.apply.
+func (bf *baseFinalizer) destroy(ctx context.Context) status.MultiError {
+	var err status.MultiError
+	eventHandler := func(event applier.Event) {
+		if errEvent, ok := event.(applier.ErrorEvent); ok {
+			if err == nil {
+				err = errEvent.Error
+			} else {
+				err = status.Append(err, errEvent.Error)
+			}
+		}
+	}
+	klog.V(1).Info("Destroyer starting...")
+	// start := time.Now()
+	objStatusMap, syncStats := bf.Destroyer.Destroy(ctx, eventHandler)
+	if syncStats.Empty() {
+		klog.V(4).Info("Destroyer made no new progress")
+	} else {
+		klog.Infof("Destroyer made new progress: %s", syncStats.String())
+		objStatusMap.Log(klog.V(0))
+	}
+	// TODO: should we have a destroy duration metric?
+	// We don't have the commit here, so we can't send the apply metric.
+	// metrics.RecordApplyDuration(ctx, metrics.StatusTagKey(errs), commit, start)
+	if err != nil {
+		klog.Warningf("Failed to destroy declared resources: %v", err)
+		return err
+	}
+	klog.V(4).Info("Destroyer completed without error: all resources are deleted.")
+	klog.V(3).Info("Applier stopped")
+	return nil
+}

--- a/pkg/reconciler/finalizer/finalizer.go
+++ b/pkg/reconciler/finalizer/finalizer.go
@@ -37,14 +37,18 @@ type Finalizer interface {
 func New(scope declared.Scope, destroyer applier.Destroyer, c client.Client, stopControllers context.CancelFunc, controllersStopped <-chan struct{}) Finalizer {
 	if scope == declared.RootReconciler {
 		return &RootSyncFinalizer{
-			Destroyer:          destroyer,
+			baseFinalizer: baseFinalizer{
+				Destroyer: destroyer,
+			},
 			Client:             c,
 			StopControllers:    stopControllers,
 			ControllersStopped: controllersStopped,
 		}
 	}
 	return &RepoSyncFinalizer{
-		Destroyer:          destroyer,
+		baseFinalizer: baseFinalizer{
+			Destroyer: destroyer,
+		},
 		Client:             c,
 		StopControllers:    stopControllers,
 		ControllersStopped: controllersStopped,

--- a/pkg/reconciler/finalizer/rootsync_finalizer.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer.go
@@ -20,7 +20,6 @@ import (
 
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
-	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/mutate"
@@ -31,8 +30,10 @@ import (
 // to destroy all managed user objects previously applied from source.
 // Implements the Finalizer interface.
 type RootSyncFinalizer struct {
-	Destroyer applier.Destroyer
-	Client    client.Client
+	baseFinalizer
+
+	// Client used to update RSync spec and status.
+	Client client.Client
 
 	// StopControllers will be called by the Finalize() method to stop the Parser and Remediator.
 	StopControllers context.CancelFunc
@@ -176,7 +177,7 @@ func (f *RootSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncO
 // deleteManagedObjects uses the destroyer to delete managed objects and then
 // updates the ReconcilerFinalizerFailure condition on the specified object.
 func (f *RootSyncFinalizer) deleteManagedObjects(ctx context.Context, syncObj *v1beta1.RootSync) error {
-	destroyErrs := f.Destroyer.Destroy(ctx)
+	destroyErrs := f.destroy(ctx)
 	// Update the FinalizerFailure condition whether the destroy succeeded or failed
 	if _, updateErr := f.updateFailureCondition(ctx, syncObj, destroyErrs); updateErr != nil {
 		updateErr = fmt.Errorf("updating FinalizerFailure condition: %w", updateErr)


### PR DESCRIPTION
Use an injected event handler function to avoid needing to cache errors in the supervisor. Instead, cache errors in the Updater, which already has a lock for this.

This event handler simplifies the Applier/Destroyer API and makes it easy to add more events in the future, like for inventory updates.

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1204