### PR TITLE
[chore] Bump otelcontribcol to 0.99.0-gke.1

### DIFF
--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.9
+        image: gcr.io/config-management-release/otelcontribcol:v0.99.0-gke.1
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -161,7 +161,7 @@ data:
                - ALL
              runAsUser: 65533
          - name: otel-agent
-           image: gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.9
+           image: gcr.io/config-management-release/otelcontribcol:v0.99.0-gke.1
            command:
            - /otelcontribcol
            args:

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -63,7 +63,7 @@ spec:
               name: reconciler-manager
               optional: true  # Currently nothing mandatory in the ConfigMap
       - name: otel-agent
-        image: gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.9
+        image: gcr.io/config-management-release/otelcontribcol:v0.99.0-gke.1
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -266,7 +266,7 @@ spec:
               fieldPath: metadata.labels['configsync.gke.io/deployment-name']
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
-        image: gcr.io/config-management-release/otelcontribcol:v0.91.0-gke.9
+        image: gcr.io/config-management-release/otelcontribcol:v0.99.0-gke.1
         name: otel-agent
         ports:
         - containerPort: 55678


### PR DESCRIPTION
Change log https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.99.0

No breaking change applied to components used by Config Sync since 0.91.0.

Enhancements found for opencensusreceiver, filterprocessor, resourcedetectionprocessor.