### PR TITLE
Unwrap single status.MultiErrors

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -605,12 +605,14 @@ func TestNomosHydrateWithUnknownScopedObject(t *testing.T) {
 		nt.T.Error(err)
 	}
 
+	expectedErrorPrefix := `KNV1021: No CustomResourceDefinition is defined for the type "VirtualMachine.kubevirt.io" in the cluster.`
+
 	// Verify that `nomos vet` returns a KNV1021 error.
 	out, err = nt.Shell.Command("nomos", "vet", "--source-format=unstructured", fmt.Sprintf("--path=%s", kubevirtPath)).CombinedOutput()
 	if err == nil {
 		nt.T.Error(fmt.Errorf("`nomos vet --path=%s` expects an error, got nil", kubevirtPath))
 	} else {
-		if !strings.Contains(string(out), "Error: 1 error(s)") || !strings.Contains(string(out), "KNV1021") {
+		if !strings.HasPrefix(string(out), "Error: "+expectedErrorPrefix) {
 			nt.T.Error(fmt.Errorf("`nomos vet --path=%s` expects only one KNV1021 error, got %v", kubevirtPath, string(out)))
 		}
 	}
@@ -637,7 +639,7 @@ func TestNomosHydrateWithUnknownScopedObject(t *testing.T) {
 	if err == nil {
 		nt.T.Error(fmt.Errorf("`nomo hydrate --path=%s` expects an error, got nil", kubevirtPath))
 	} else {
-		if !strings.Contains(string(out), ": 1 error(s)") || !strings.Contains(string(out), "KNV1021") {
+		if !strings.HasPrefix(string(out), `errors for Cluster "defaultcluster": `+expectedErrorPrefix) {
 			nt.T.Error(fmt.Errorf("`nomos hydrate --path=%s` expects only one KNV1021 error, got %v", kubevirtPath, string(out)))
 		}
 	}
@@ -660,7 +662,7 @@ func TestNomosHydrateWithUnknownScopedObject(t *testing.T) {
 	if err == nil {
 		nt.T.Error(fmt.Errorf("`nomos vet --path=%s` expects an error, got nil", compiledDirWithoutAPIServerCheck))
 	} else {
-		if !strings.Contains(string(out), "Error: 1 error(s)") || !strings.Contains(string(out), "KNV1021") {
+		if !strings.HasPrefix(string(out), "Error: "+expectedErrorPrefix) {
 			nt.T.Error(fmt.Errorf("`nomos vet --path=%s` expects only one KNV1021 error, got %v", compiledDirWithoutAPIServerCheck, string(out)))
 		}
 	}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -628,11 +628,17 @@ func (a *supervisor) Errors() status.MultiError {
 	a.errorMux.RLock()
 	defer a.errorMux.RUnlock()
 
-	// Return a copy to avoid persisting caller modifications
-	return status.Append(nil, a.errs)
+	if a.errs != nil {
+		// Return a copy to avoid persisting caller modifications
+		return status.Wrap(a.errs.Errors()...)
+	}
+	return nil
 }
 
 func (a *supervisor) addError(err error) {
+	if err == nil {
+		return
+	}
 	a.errorMux.Lock()
 	defer a.errorMux.Unlock()
 

--- a/pkg/applier/applier_err_test.go
+++ b/pkg/applier/applier_err_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applier
+
+import (
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/testing/fake"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestErrorForResourceWithResource(t *testing.T) {
+	namespace := "test-namespace"
+	namespaceObj := fake.UnstructuredObject(kinds.Namespace(),
+		core.Name(namespace))
+	namespaceObjID := core.IDOf(namespaceObj)
+
+	cmObj := fake.UnstructuredObject(kinds.ConfigMap(),
+		core.Name("test-configmap"), core.Namespace(namespace))
+	cmObjID := core.IDOf(cmObj)
+
+	anvilObj := fake.UnstructuredObject(kinds.Anvil(),
+		core.Namespace(namespace), core.Name("test-anvil"),
+		core.Annotation(metadata.SourcePathAnnotationKey, "foo/anvil.yaml"))
+	anvilObjID := core.IDOf(anvilObj)
+
+	testcases := []struct {
+		name            string
+		err             error
+		id              core.ID
+		object          client.Object
+		expectedMessage string
+		expectedCSE     v1beta1.ConfigSyncError
+	}{
+		{
+			name:   "namespace-scoped object",
+			err:    errors.New("unknown type"),
+			id:     cmObjID,
+			object: cmObj,
+			expectedMessage: "KNV2009: failed to apply ConfigMap, test-namespace/test-configmap: unknown type\n\n" +
+				"namespace: test-namespace\n" +
+				"metadata.name: test-configmap\n" +
+				"group:\n" +
+				"version: v1\n" +
+				"kind: ConfigMap\n\n" +
+				"For more information, see https://g.co/cloud/acm-errors#knv2009",
+			expectedCSE: v1beta1.ConfigSyncError{
+				Code: ApplierErrorCode,
+				ErrorMessage: "KNV2009: failed to apply ConfigMap, test-namespace/test-configmap: unknown type\n\n" +
+					"namespace: test-namespace\n" +
+					"metadata.name: test-configmap\n" +
+					"group:\n" +
+					"version: v1\n" +
+					"kind: ConfigMap\n\n" +
+					"For more information, see https://g.co/cloud/acm-errors#knv2009",
+				Resources: []v1beta1.ResourceRef{
+					{
+						Name:      "test-configmap",
+						Namespace: "test-namespace",
+						GVK: metav1.GroupVersionKind{
+							Version: "v1",
+							Kind:    "ConfigMap",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "cluster-scoped object",
+			err:    errors.New("example error"),
+			id:     namespaceObjID,
+			object: namespaceObj,
+			expectedMessage: "KNV2009: failed to apply Namespace, /test-namespace: example error\n\n" +
+				"metadata.name: test-namespace\n" +
+				"group:\n" +
+				"version: v1\n" +
+				"kind: Namespace\n\n" +
+				"For more information, see https://g.co/cloud/acm-errors#knv2009",
+			expectedCSE: v1beta1.ConfigSyncError{
+				Code: ApplierErrorCode,
+				ErrorMessage: "KNV2009: failed to apply Namespace, /test-namespace: example error\n\n" +
+					"metadata.name: test-namespace\n" +
+					"group:\n" +
+					"version: v1\n" +
+					"kind: Namespace\n\n" +
+					"For more information, see https://g.co/cloud/acm-errors#knv2009",
+				Resources: []v1beta1.ResourceRef{
+					{
+						Name: "test-namespace",
+						GVK: metav1.GroupVersionKind{
+							Version: "v1",
+							Kind:    "Namespace",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "object with source path",
+			err:    errors.New("another error"),
+			id:     anvilObjID,
+			object: anvilObj,
+			expectedMessage: "KNV2009: failed to apply Anvil.acme.com, test-namespace/test-anvil: another error\n\n" +
+				"source: foo/anvil.yaml\n" +
+				"namespace: test-namespace\n" +
+				"metadata.name: test-anvil\n" +
+				"group: acme.com\n" +
+				"version: v1\n" +
+				"kind: Anvil\n\n" +
+				"For more information, see https://g.co/cloud/acm-errors#knv2009",
+			expectedCSE: v1beta1.ConfigSyncError{
+				Code: ApplierErrorCode,
+				ErrorMessage: "KNV2009: failed to apply Anvil.acme.com, test-namespace/test-anvil: another error\n\n" +
+					"source: foo/anvil.yaml\n" +
+					"namespace: test-namespace\n" +
+					"metadata.name: test-anvil\n" +
+					"group: acme.com\n" +
+					"version: v1\n" +
+					"kind: Anvil\n\n" +
+					"For more information, see https://g.co/cloud/acm-errors#knv2009",
+				Resources: []v1beta1.ResourceRef{
+					{
+						SourcePath: "foo/anvil.yaml",
+						Name:       "test-anvil",
+						Namespace:  "test-namespace",
+						GVK: metav1.GroupVersionKind{
+							Group:   "acme.com",
+							Version: "v1",
+							Kind:    "Anvil",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ErrorForResourceWithResource(tc.err, tc.id, tc.object)
+			testutil.AssertEqual(t, tc.expectedMessage, err.Error())
+			testutil.AssertEqual(t, tc.expectedCSE, err.ToCSE())
+		})
+	}
+}

--- a/pkg/diff/precedence_test.go
+++ b/pkg/diff/precedence_test.go
@@ -26,7 +26,7 @@ import (
 	"kpt.dev/configsync/pkg/diff/difftest"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	"kpt.dev/configsync/pkg/testing/fake"
-	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -178,7 +178,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "any-other-manager",
 			id:         rootSyncID,
 			operation:  admissionv1.Create,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "root-reconciler-rootsync-1" can not CREATE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-any-other-manager"`)),
+			want:       fmt.Errorf(`config sync "root-reconciler-rootsync-1" can not CREATE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-any-other-manager"`),
 		},
 		{
 			name:       "Root reconciler can not delete its own RootSync",
@@ -186,7 +186,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "any-other-manager",
 			id:         rootSyncID,
 			operation:  admissionv1.Delete,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "root-reconciler-rootsync-1" can not DELETE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-any-other-manager"`)),
+			want:       fmt.Errorf(`config sync "root-reconciler-rootsync-1" can not DELETE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-any-other-manager"`),
 		},
 		{
 			name:       "Root reconciler can not manage object with other root manager",
@@ -194,7 +194,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    ":root_test-rs",
 			id:         cmID,
 			operation:  admissionv1.Update,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "root-reconciler" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "root-reconciler-test-rs"`)),
+			want:       fmt.Errorf(`config sync "root-reconciler" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "root-reconciler-test-rs"`),
 		},
 		{
 			name:       "Root reconciler can manage object with no manager",
@@ -226,7 +226,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "any-other-manager",
 			id:         repoSyncID,
 			operation:  admissionv1.Create,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "ns-reconciler-ns-1-reposync-1-10" can not CREATE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-any-other-manager"`)),
+			want:       fmt.Errorf(`config sync "ns-reconciler-ns-1-reposync-1-10" can not CREATE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-any-other-manager"`),
 		},
 		{
 			name:       "Namespace reconciler can not delete its own RepoSync",
@@ -234,7 +234,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "any-other-manager",
 			id:         repoSyncID,
 			operation:  admissionv1.Delete,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "ns-reconciler-ns-1-reposync-1-10" can not DELETE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-any-other-manager"`)),
+			want:       fmt.Errorf(`config sync "ns-reconciler-ns-1-reposync-1-10" can not DELETE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-any-other-manager"`),
 		},
 		{
 			name:       "Namespace reconciler can not manage object with manager in different namespace",
@@ -242,7 +242,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "videostore",
 			id:         cmID,
 			operation:  admissionv1.Update,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "ns-reconciler-videostore"`)),
+			want:       fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "ns-reconciler-videostore"`),
 		},
 		{
 			name:       "Namespace reconciler can not manage object with different manager in the same namespace",
@@ -250,7 +250,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "bookstore_test-rs",
 			id:         cmID,
 			operation:  admissionv1.Update,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "ns-reconciler-bookstore-test-rs-7"`)),
+			want:       fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "ns-reconciler-bookstore-test-rs-7"`),
 		},
 		{
 			name:       "Namespace reconciler can not manage object with any root manager",
@@ -258,7 +258,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    ":root",
 			id:         cmID,
 			operation:  admissionv1.Update,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "root-reconciler"`)),
+			want:       fmt.Errorf(`config sync "ns-reconciler-bookstore" can not UPDATE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "root-reconciler"`),
 		},
 		{
 			name:       "Namespace reconciler can manage object with no manager",
@@ -290,7 +290,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "bookstore",
 			id:         rootSyncID,
 			operation:  admissionv1.Create,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "reconciler-manager" can not CREATE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-bookstore"`)),
+			want:       fmt.Errorf(`config sync "reconciler-manager" can not CREATE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
 		{
 			name:       "ReconcilerManager can not create RepoSync with a manager",
@@ -298,7 +298,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "bookstore",
 			id:         repoSyncID,
 			operation:  admissionv1.Create,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "reconciler-manager" can not CREATE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-bookstore"`)),
+			want:       fmt.Errorf(`config sync "reconciler-manager" can not CREATE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
 		{
 			name:       "ReconcilerManager can not delete RootSync with a manager",
@@ -306,7 +306,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "bookstore",
 			id:         rootSyncID,
 			operation:  admissionv1.Delete,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "reconciler-manager" can not DELETE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-bookstore"`)),
+			want:       fmt.Errorf(`config sync "reconciler-manager" can not DELETE object "RootSync.configsync.gke.io, config-management-system/rootsync-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
 		{
 			name:       "ReconcilerManager can not delete RepoSync with a manager",
@@ -314,7 +314,7 @@ func TestValidateManager(t *testing.T) {
 			manager:    "bookstore",
 			id:         repoSyncID,
 			operation:  admissionv1.Delete,
-			want:       testutil.EqualError(fmt.Errorf(`config sync "reconciler-manager" can not DELETE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-bookstore"`)),
+			want:       fmt.Errorf(`config sync "reconciler-manager" can not DELETE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
 		{
 			name:       "Importer can manage object with a root manager",
@@ -337,7 +337,7 @@ func TestValidateManager(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ValidateManager(tc.reconciler, tc.manager, tc.id, tc.operation)
-			testutil.AssertEqual(t, tc.want, got)
+			testerrors.AssertEqual(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/hydrate/controller_test.go
+++ b/pkg/hydrate/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	ft "kpt.dev/configsync/pkg/importer/filesystem/filesystemtest"
-	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
 const (
@@ -206,7 +206,7 @@ func TestRunHydrate(t *testing.T) {
 		{
 			name:      "Run hydrate when source commit is changed",
 			commit:    differentCommit,
-			wantedErr: testutil.EqualError(NewTransientError(fmt.Errorf("source commit changed while running Kustomize build, was %s, now %s. It will be retried in the next sync", originCommit, differentCommit))),
+			wantedErr: NewTransientError(fmt.Errorf("source commit changed while running Kustomize build, was %s, now %s. It will be retried in the next sync", originCommit, differentCommit)),
 		},
 	}
 
@@ -268,7 +268,7 @@ func TestRunHydrate(t *testing.T) {
 			}
 
 			err = hydrator.runHydrate(originCommit, syncDir)
-			testutil.AssertEqual(t, tc.wantedErr, err)
+			testerrors.AssertEqual(t, tc.wantedErr, err)
 		})
 	}
 }

--- a/pkg/kinds/convert_test.go
+++ b/pkg/kinds/convert_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
@@ -65,12 +66,8 @@ func TestToTypedObject(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"unsupported resource type (v1.Service): %w",
-					runtime.NewNotRegisteredErrForKind(emptyScheme.Name(), Service()),
-				),
-			),
+			expectedError: fmt.Errorf("unsupported resource type (v1.Service): %w",
+				runtime.NewNotRegisteredErrForKind(emptyScheme.Name(), Service())),
 		},
 		{
 			name: "unstructured pre-populated GVK in scheme",
@@ -142,11 +139,9 @@ func TestToTypedObject(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -214,11 +209,9 @@ func TestToTypedObject(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",
@@ -267,7 +260,7 @@ func TestToTypedObject(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := ToTypedObject(tc.object, tc.scheme)
-			testutil.AssertEqual(t, tc.expectedError, err)
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			testutil.AssertEqual(t, tc.expected, actual)
 		})
 	}
@@ -403,11 +396,9 @@ func TestToUnstructured(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -479,11 +470,9 @@ func TestToUnstructured(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",
@@ -549,7 +538,7 @@ func TestToUnstructured(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := ToUnstructured(tc.object, tc.scheme)
-			testutil.AssertEqual(t, tc.expectedError, err)
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			testutil.AssertEqual(t, tc.expected, actual)
 		})
 	}

--- a/pkg/kinds/lookup_test.go
+++ b/pkg/kinds/lookup_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
@@ -118,11 +119,9 @@ func TestLookup(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed pre-populated GVK in scheme",
@@ -170,11 +169,9 @@ func TestLookup(t *testing.T) {
 				},
 			},
 			scheme: emptyScheme,
-			expectedError: testutil.EqualError(
-				fmt.Errorf(
-					"failed to lookup object type: %w",
-					runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
-						reflect.TypeOf(corev1.Service{})))),
+			expectedError: fmt.Errorf("failed to lookup object type: %w",
+				runtime.NewNotRegisteredErrForType(emptyScheme.Name(),
+					reflect.TypeOf(corev1.Service{}))),
 		},
 		{
 			name: "typed unpopulated GVK in scheme",
@@ -203,7 +200,7 @@ func TestLookup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := Lookup(tc.object, tc.scheme)
-			testutil.AssertEqual(t, tc.expectedError, err)
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			testutil.AssertEqual(t, tc.expected, actual)
 		})
 	}

--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -150,8 +150,7 @@ func TestManager_Update(t *testing.T) {
 
 			gotErr := m.UpdateWatches(context.Background(), tc.gvks)
 
-			wantErr := status.Append(nil, tc.wantErr)
-			if !errors.Is(wantErr, gotErr) {
+			if !errors.Is(tc.wantErr, gotErr) {
 				t.Errorf("got UpdateWatches() error = %v, want %v", gotErr, tc.wantErr)
 			}
 			if diff := cmp.Diff(tc.wantWatchedTypes, m.watchedGVKs(), cmpopts.SortSlices(sortGVKs)); diff != "" {

--- a/pkg/status/multierror.go
+++ b/pkg/status/multierror.go
@@ -68,6 +68,18 @@ func NonBlockingErrors(errs MultiError) []v1beta1.ConfigSyncError {
 	return ToCSE(nonBlockingErrs)
 }
 
+// Wrap returns a MultiError composed of the specified status.Errors.
+// Returns nil if input list is empty or all inputs are nil.
+// If only one error is provided and it's a MultiError, it is returned without
+// wrapping.
+func Wrap(errs ...Error) MultiError {
+	var multiErr MultiError
+	for _, err := range errs {
+		multiErr = Append(multiErr, err)
+	}
+	return multiErr
+}
+
 // Append adds one or more errors to an existing MultiError.
 // If m, err, and errs are nil, returns nil.
 //
@@ -75,7 +87,14 @@ func NonBlockingErrors(errs MultiError) []v1beta1.ConfigSyncError {
 // There is no valid reason to call Append with exactly one argument.
 //
 // If err is a MultiError, appends all contained errors.
+//
+// If only one error is provided and it's a MultiError, it is returned without
+// wrapping.
 func Append(m MultiError, err error, errs ...error) MultiError {
+	if me, ok := err.(MultiError); ok && m == nil && len(errs) == 0 {
+		return me
+	}
+
 	result := &multiError{}
 
 	switch m.(type) {

--- a/pkg/testing/testerrors/testerrors.go
+++ b/pkg/testing/testerrors/testerrors.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testerrors
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+// AssertEqual fails the test if the actual error does not match the expected
+// error. Similar to sigs.k8s.io/cli-utils/pkg/testutil.AssertEqual, but
+// automatically wraps non-nil expected errors with testutil.EqualError to allow
+// matching by type and string value.
+//
+// This works around an issue with status.Error that breaks errors.Is(), which
+// only compares the error code. Using testerrors.Equal, the assertion is more
+// strict.
+func AssertEqual(t *testing.T, expected, actual error, msgAndArgs ...interface{}) {
+	testutil.AssertEqual(t, testableError(expected), actual, msgAndArgs...)
+}
+
+func testableError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return testutil.EqualError(err)
+}

--- a/pkg/util/watch/options_test.go
+++ b/pkg/util/watch/options_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -367,8 +368,7 @@ func TestMergeListOptions(t *testing.T) {
 			b: &client.ListOptions{
 				Namespace: "example2",
 			},
-			expectedError: testutil.EqualError(
-				errors.New("cannot merge two different namespaces: example1 & example2")),
+			expectedError: errors.New("cannot merge two different namespaces: example1 & example2"),
 		},
 		// Limit
 		{
@@ -415,8 +415,7 @@ func TestMergeListOptions(t *testing.T) {
 			b: &client.ListOptions{
 				Limit: 10,
 			},
-			expectedError: testutil.EqualError(
-				errors.New("cannot merge two different limits: 5 & 10")),
+			expectedError: errors.New("cannot merge two different limits: 5 & 10"),
 		},
 		// Continue
 		{
@@ -463,8 +462,7 @@ func TestMergeListOptions(t *testing.T) {
 			b: &client.ListOptions{
 				Continue: "123abc",
 			},
-			expectedError: testutil.EqualError(
-				errors.New("cannot merge two different continue tokens: abc123 & 123abc")),
+			expectedError: errors.New("cannot merge two different continue tokens: abc123 & 123abc"),
 		},
 		// Raw
 		{
@@ -535,10 +533,10 @@ func TestMergeListOptions(t *testing.T) {
 					ResourceVersion: "abc123",
 				},
 			},
-			expectedError: testutil.EqualError(
-				errors.New("not yet implemented: merging two different raw ListOptions: " +
-					"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,} & " +
-					"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:abc123,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,}")),
+			expectedError: errors.New("not yet implemented: " +
+				"merging two different raw ListOptions: " +
+				"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,} & " +
+				"&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:abc123,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,}"),
 		},
 		// AllTheThings!
 		{
@@ -606,14 +604,13 @@ func TestMergeListOptions(t *testing.T) {
 	}))
 
 	asserter := testutil.NewAsserter(
-		cmpopts.EquateErrors(),
 		hasTermFieldSelectorComparer,
 	)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := MergeListOptions(tc.a, tc.b)
-			asserter.Equal(t, tc.expectedError, err)
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			asserter.Equal(t, tc.expectedOpts, result)
 		})
 	}

--- a/pkg/validate/objects/tree_test.go
+++ b/pkg/validate/objects/tree_test.go
@@ -125,7 +125,7 @@ func TestBuildTree(t *testing.T) {
 				},
 			},
 			want:     nil,
-			wantErrs: status.Append(nil, validation.ShouldBeInClusterError(fake.ClusterRole())),
+			wantErrs: validation.ShouldBeInClusterError(fake.ClusterRole()),
 		},
 		{
 			name: "namespace-scoped resource in wrong directory",
@@ -139,7 +139,7 @@ func TestBuildTree(t *testing.T) {
 				},
 			},
 			want:     nil,
-			wantErrs: status.Append(nil, validation.ShouldBeInNamespacesError(fake.Role())),
+			wantErrs: validation.ShouldBeInNamespacesError(fake.Role()),
 		},
 		{
 			name: "system resource in wrong directory",
@@ -151,7 +151,7 @@ func TestBuildTree(t *testing.T) {
 				},
 			},
 			want:     nil,
-			wantErrs: status.Append(nil, validation.ShouldBeInSystemError(fake.HierarchyConfig())),
+			wantErrs: validation.ShouldBeInSystemError(fake.HierarchyConfig()),
 		},
 	}
 

--- a/pkg/validate/raw/validate/cluster_selector_validator_test.go
+++ b/pkg/validate/raw/validate/cluster_selector_validator_test.go
@@ -120,7 +120,7 @@ func TestClusterSelectorsForHierarchical(t *testing.T) {
 					fake.NamespaceSelector(legacyClusterSelectorAnnotation),
 				},
 			},
-			wantErrs: status.Append(nil,
+			wantErrs: status.Wrap(
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.Cluster(), "legacy"),
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.ClusterSelector(), "legacy"),
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.NamespaceSelector(), "legacy"),
@@ -135,7 +135,7 @@ func TestClusterSelectorsForHierarchical(t *testing.T) {
 					fake.NamespaceSelector(inlineClusterSelectorAnnotation),
 				},
 			},
-			wantErrs: status.Append(nil,
+			wantErrs: status.Wrap(
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.Cluster(), "inline"),
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.ClusterSelector(), "inline"),
 				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.NamespaceSelector(), "inline"),
@@ -149,7 +149,7 @@ func TestClusterSelectorsForHierarchical(t *testing.T) {
 					fake.ClusterSelectorAtPath("cluster/cs.yaml"),
 				},
 			},
-			wantErrs: status.Append(nil,
+			wantErrs: status.Wrap(
 				validation.ShouldBeInClusterRegistryError(fake.Cluster()),
 				validation.ShouldBeInClusterRegistryError(fake.ClusterSelector()),
 			),

--- a/pkg/validate/raw/validate/disallowed_fields_validator_test.go
+++ b/pkg/validate/raw/validate/disallowed_fields_validator_test.go
@@ -59,7 +59,7 @@ func TestDisallowedFields(t *testing.T) {
 					),
 				},
 			},
-			wantErrs: status.Append(nil,
+			wantErrs: status.Wrap(
 				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.OwnerReference),
 				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.SelfLink),
 				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.UID),


### PR DESCRIPTION
- Fix Applier/Destroyer.addError from wrapping/appending nil errors
- Add status.Wrap for wrapping status.Errors without an existing MultiError.
- Fix status.Append to avoid wrapping errors that are already a MultiError
- Add testerrors.AssertEqual to simplify testing status.Errors. Ideally we would just fix statis.Error.Is, but that would require fixing all our test assertions. This approach is a bit easier, so we can fix assertions a little at a time to make them more strict.
- Backfilled unit tests for ErrorForResourceWithResource