### PR TITLE
Fix status errors to work with errors.Is

### DIFF
--- a/pkg/status/error_builder.go
+++ b/pkg/status/error_builder.go
@@ -82,7 +82,7 @@ type ErrorBuilder struct {
 // call with the passed unique code. Panics if there is an error code collision.
 func NewErrorBuilder(code string) ErrorBuilder {
 	register(code)
-	return ErrorBuilder{error: baseErrorImpl{
+	return ErrorBuilder{error: &baseErrorImpl{
 		code: code,
 	}}
 }
@@ -97,7 +97,7 @@ func (eb ErrorBuilder) BuildWithPaths(paths ...id.Path) PathError {
 	if len(paths) == 0 {
 		return nil
 	}
-	return pathErrorImpl{
+	return &pathErrorImpl{
 		underlying: eb.error,
 		paths:      paths,
 	}
@@ -108,7 +108,7 @@ func (eb ErrorBuilder) BuildWithResources(resources ...client.Object) ResourceEr
 	if len(resources) == 0 {
 		return nil
 	}
-	return resourceErrorImpl{
+	return &resourceErrorImpl{
 		underlying: eb.error,
 		resources:  resources,
 	}
@@ -118,7 +118,7 @@ func (eb ErrorBuilder) BuildWithResources(resources ...client.Object) ResourceEr
 // newManager is the manager annotation for the current remediator/reconciler.
 // currentManager is the manager annotation in the actual resource. It is also known as conflictingManager.
 func (eb ErrorBuilder) BuildWithConflictingManagers(resource client.Object, newManager, currentManager string) ManagementConflictError {
-	return managementConflictErrorImpl{
+	return &managementConflictErrorImpl{
 		underlying:     eb.error,
 		resource:       resource,
 		newManager:     newManager,
@@ -128,7 +128,7 @@ func (eb ErrorBuilder) BuildWithConflictingManagers(resource client.Object, newM
 
 // Sprint adds a message string into the Error inside the ErrorBuilder.
 func (eb ErrorBuilder) Sprint(message string) ErrorBuilder {
-	return ErrorBuilder{error: messageErrorImpl{
+	return ErrorBuilder{error: &messageErrorImpl{
 		underlying: eb.error,
 		message:    message,
 	}}
@@ -151,7 +151,7 @@ func (eb ErrorBuilder) Sprintf(format string, a ...interface{}) ErrorBuilder {
 		// a stack overflow.
 		reportMisuse("improperly formatted error message: " + message)
 	}
-	return ErrorBuilder{error: messageErrorImpl{
+	return ErrorBuilder{error: &messageErrorImpl{
 		underlying: eb.error,
 		message:    message,
 	}}
@@ -167,7 +167,7 @@ func (eb ErrorBuilder) Wrap(toWrap error) ErrorBuilder {
 	if toWrap == nil {
 		return ErrorBuilder{error: nil}
 	}
-	return ErrorBuilder{error: wrappedErrorImpl{
+	return ErrorBuilder{error: &wrappedErrorImpl{
 		underlying: eb.error,
 		wrapped:    toWrap,
 	}}

--- a/pkg/status/error_impl.go
+++ b/pkg/status/error_impl.go
@@ -24,15 +24,18 @@ type baseErrorImpl struct {
 	code string
 }
 
-var _ Error = baseErrorImpl{}
+var _ Error = &baseErrorImpl{}
 
 // Error implements error.
-func (e baseErrorImpl) Error() string {
+func (e *baseErrorImpl) Error() string {
 	return format(e)
 }
 
 // Is implements Error.
-func (e baseErrorImpl) Is(target error) bool {
+func (e *baseErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	// Two errors satisfy errors.Is() if they are both status.Error and have the
 	// same KNV code.
 	if se, ok := target.(Error); ok {
@@ -42,31 +45,31 @@ func (e baseErrorImpl) Is(target error) bool {
 }
 
 // Code implements Error.
-func (e baseErrorImpl) Code() string {
+func (e *baseErrorImpl) Code() string {
 	return e.code
 }
 
 // Body implements Error.
-func (e baseErrorImpl) Body() string {
+func (e *baseErrorImpl) Body() string {
 	return ""
 }
 
 // Errors implements MultiError.
-func (e baseErrorImpl) Errors() []Error {
+func (e *baseErrorImpl) Errors() []Error {
 	return []Error{e}
 }
 
 // ToCME implements Error.
-func (e baseErrorImpl) ToCME() v1.ConfigManagementError {
+func (e *baseErrorImpl) ToCME() v1.ConfigManagementError {
 	return fromError(e)
 }
 
 // ToCSE implements Error.
-func (e baseErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (e *baseErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	return cseFromError(e)
 }
 
 // Cause implements causer.
-func (e baseErrorImpl) Cause() error {
+func (e *baseErrorImpl) Cause() error {
 	return nil
 }

--- a/pkg/status/management_conflict_error.go
+++ b/pkg/status/management_conflict_error.go
@@ -64,19 +64,19 @@ type managementConflictErrorImpl struct {
 	currentManager string
 }
 
-var _ ManagementConflictError = managementConflictErrorImpl{}
+var _ ManagementConflictError = &managementConflictErrorImpl{}
 
-func (m managementConflictErrorImpl) ConflictingManager() string {
+func (m *managementConflictErrorImpl) ConflictingManager() string {
 	return m.currentManager
 }
 
-func (m managementConflictErrorImpl) CurrentManagerError() ManagementConflictError {
+func (m *managementConflictErrorImpl) CurrentManagerError() ManagementConflictError {
 	return ManagementConflictErrorBuilder.
 		Sprint(currentErrorMsg(m.newManager, m.newManager)).
 		BuildWithConflictingManagers(m.resource, m.newManager, m.currentManager)
 }
 
-func (m managementConflictErrorImpl) ConflictingManagerError() ManagementConflictError {
+func (m *managementConflictErrorImpl) ConflictingManagerError() ManagementConflictError {
 	return ManagementConflictErrorBuilder.
 		Sprintf("The %q reconciler detects a management conflict for a resource declared in another repository. "+
 			"Remove the declaration for this resource from either the current repository, or the repository managed by %q.",
@@ -84,38 +84,41 @@ func (m managementConflictErrorImpl) ConflictingManagerError() ManagementConflic
 		BuildWithConflictingManagers(m.resource, m.newManager, m.currentManager)
 }
 
-func (m managementConflictErrorImpl) Cause() error {
+func (m *managementConflictErrorImpl) Cause() error {
 	return m.underlying.Cause()
 }
 
-func (m managementConflictErrorImpl) Error() string {
+func (m *managementConflictErrorImpl) Error() string {
 	return format(m)
 }
 
-func (m managementConflictErrorImpl) Errors() []Error {
+func (m *managementConflictErrorImpl) Errors() []Error {
 	return []Error{m}
 }
 
-func (m managementConflictErrorImpl) ToCME() v1.ConfigManagementError {
+func (m *managementConflictErrorImpl) ToCME() v1.ConfigManagementError {
 	cme := fromError(m)
 	cme.ErrorResources = append(cme.ErrorResources, toErrorResource(m.resource))
 	return cme
 }
 
-func (m managementConflictErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (m *managementConflictErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	cse := cseFromError(m)
 	cse.Resources = append(cse.Resources, toResourceRef(m.resource))
 	return cse
 }
 
-func (m managementConflictErrorImpl) Code() string {
+func (m *managementConflictErrorImpl) Code() string {
 	return m.underlying.Code()
 }
 
-func (m managementConflictErrorImpl) Body() string {
+func (m *managementConflictErrorImpl) Body() string {
 	return formatBody(m.underlying.Body(), "\n\n", formatResources(m.resource))
 }
 
-func (m managementConflictErrorImpl) Is(target error) bool {
+func (m *managementConflictErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	return m.underlying.Is(target)
 }

--- a/pkg/status/message_error_impl.go
+++ b/pkg/status/message_error_impl.go
@@ -24,44 +24,47 @@ type messageErrorImpl struct {
 	message    string
 }
 
-var _ Error = messageErrorImpl{}
+var _ Error = &messageErrorImpl{}
 
 // Error implements error.
-func (m messageErrorImpl) Error() string {
+func (m *messageErrorImpl) Error() string {
 	return format(m)
 }
 
 // Is implements Error.
-func (m messageErrorImpl) Is(target error) bool {
+func (m *messageErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	return m.underlying.Is(target)
 }
 
 // Code implements Error.
-func (m messageErrorImpl) Code() string {
+func (m *messageErrorImpl) Code() string {
 	return m.underlying.Code()
 }
 
 // Body implements Error.
-func (m messageErrorImpl) Body() string {
+func (m *messageErrorImpl) Body() string {
 	return formatBody(m.message, ": ", m.underlying.Body())
 }
 
 // Errors implements MultiError.
-func (m messageErrorImpl) Errors() []Error {
+func (m *messageErrorImpl) Errors() []Error {
 	return []Error{m}
 }
 
 // ToCME implements Error.
-func (m messageErrorImpl) ToCME() v1.ConfigManagementError {
+func (m *messageErrorImpl) ToCME() v1.ConfigManagementError {
 	return fromError(m)
 }
 
 // ToCSE implements Error.
-func (m messageErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (m *messageErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	return cseFromError(m)
 }
 
 // Cause implements causer.
-func (m messageErrorImpl) Cause() error {
+func (m *messageErrorImpl) Cause() error {
 	return m.underlying.Cause()
 }

--- a/pkg/status/path_error_impl.go
+++ b/pkg/status/path_error_impl.go
@@ -29,50 +29,53 @@ type pathErrorImpl struct {
 	paths      []id.Path
 }
 
-var _ PathError = pathErrorImpl{}
+var _ PathError = &pathErrorImpl{}
 
 // Error implements error.
-func (p pathErrorImpl) Error() string {
+func (p *pathErrorImpl) Error() string {
 	return format(p)
 }
 
 // Is implements Error.
-func (p pathErrorImpl) Is(target error) bool {
+func (p *pathErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	return p.underlying.Is(target)
 }
 
 // Code implements Error.
-func (p pathErrorImpl) Code() string {
+func (p *pathErrorImpl) Code() string {
 	return p.underlying.Code()
 }
 
 // Body implements Error.
-func (p pathErrorImpl) Body() string {
+func (p *pathErrorImpl) Body() string {
 	return formatBody(p.underlying.Body(), "\n\n", formatPaths(p.paths))
 }
 
 // Errors implements MultiError.
-func (p pathErrorImpl) Errors() []Error {
+func (p *pathErrorImpl) Errors() []Error {
 	return []Error{p}
 }
 
 // RelativePaths implements PathError.
-func (p pathErrorImpl) RelativePaths() []id.Path {
+func (p *pathErrorImpl) RelativePaths() []id.Path {
 	return p.paths
 }
 
 // Cause implements causer.
-func (p pathErrorImpl) Cause() error {
+func (p *pathErrorImpl) Cause() error {
 	return p.underlying.Cause()
 }
 
 // ToCME implements Error.
-func (p pathErrorImpl) ToCME() v1.ConfigManagementError {
+func (p *pathErrorImpl) ToCME() v1.ConfigManagementError {
 	return fromPathError(p)
 }
 
 // ToCSE implements Error.
-func (p pathErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (p *pathErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	return cseFromPathError(p)
 }
 

--- a/pkg/status/resource_error_impl.go
+++ b/pkg/status/resource_error_impl.go
@@ -31,50 +31,53 @@ type resourceErrorImpl struct {
 	resources  []client.Object
 }
 
-var _ ResourceError = resourceErrorImpl{}
+var _ ResourceError = &resourceErrorImpl{}
 
 // Error implements error.
-func (r resourceErrorImpl) Error() string {
+func (r *resourceErrorImpl) Error() string {
 	return format(r)
 }
 
 // Is implements Error.
-func (r resourceErrorImpl) Is(target error) bool {
+func (r *resourceErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	return r.underlying.Is(target)
 }
 
 // Code implements Error.
-func (r resourceErrorImpl) Code() string {
+func (r *resourceErrorImpl) Code() string {
 	return r.underlying.Code()
 }
 
 // Body implements Error.
-func (r resourceErrorImpl) Body() string {
+func (r *resourceErrorImpl) Body() string {
 	return formatBody(r.underlying.Body(), "\n\n", formatResources(r.resources...))
 }
 
 // Errors implements MultiError.
-func (r resourceErrorImpl) Errors() []Error {
+func (r *resourceErrorImpl) Errors() []Error {
 	return []Error{r}
 }
 
 // Resources implements ResourceError.
-func (r resourceErrorImpl) Resources() []client.Object {
+func (r *resourceErrorImpl) Resources() []client.Object {
 	return r.resources
 }
 
 // ToCME implements Error.
-func (r resourceErrorImpl) ToCME() v1.ConfigManagementError {
+func (r *resourceErrorImpl) ToCME() v1.ConfigManagementError {
 	return fromResourceError(r)
 }
 
 // ToCSE implements Error.
-func (r resourceErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (r *resourceErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	return cseFromResourceError(r)
 }
 
 // Cause implements causer.
-func (r resourceErrorImpl) Cause() error {
+func (r *resourceErrorImpl) Cause() error {
 	return r.underlying.Cause()
 }
 

--- a/pkg/status/wrapped_error_impl.go
+++ b/pkg/status/wrapped_error_impl.go
@@ -26,25 +26,28 @@ type wrappedErrorImpl struct {
 	wrapped    error
 }
 
-var _ Error = wrappedErrorImpl{}
+var _ Error = &wrappedErrorImpl{}
 
 // Error implements error.
-func (w wrappedErrorImpl) Error() string {
+func (w *wrappedErrorImpl) Error() string {
 	return format(w)
 }
 
 // Is implements Error.
-func (w wrappedErrorImpl) Is(target error) bool {
+func (w *wrappedErrorImpl) Is(target error) bool {
+	if target == nil {
+		return false
+	}
 	return w.underlying.Is(target)
 }
 
 // Code implements Error.
-func (w wrappedErrorImpl) Code() string {
+func (w *wrappedErrorImpl) Code() string {
 	return w.underlying.Code()
 }
 
 // Body implements Error.
-func (w wrappedErrorImpl) Body() string {
+func (w *wrappedErrorImpl) Body() string {
 	var sb strings.Builder
 	body := w.underlying.Body()
 	wrapped := w.wrapped.Error()
@@ -57,21 +60,21 @@ func (w wrappedErrorImpl) Body() string {
 }
 
 // Errors implements MultiError.
-func (w wrappedErrorImpl) Errors() []Error {
+func (w *wrappedErrorImpl) Errors() []Error {
 	return []Error{w}
 }
 
 // ToCME implements Error.
-func (w wrappedErrorImpl) ToCME() v1.ConfigManagementError {
+func (w *wrappedErrorImpl) ToCME() v1.ConfigManagementError {
 	return fromError(w)
 }
 
 // ToCSE implements Error.
-func (w wrappedErrorImpl) ToCSE() v1beta1.ConfigSyncError {
+func (w *wrappedErrorImpl) ToCSE() v1beta1.ConfigSyncError {
 	return cseFromError(w)
 }
 
 // Cause implements causer.
-func (w wrappedErrorImpl) Cause() error {
+func (w *wrappedErrorImpl) Cause() error {
 	return w.wrapped
 }


### PR DESCRIPTION
- errors.Is performs a basic equality comparison on the input errors which panics if the errors are not comparable. This effectively requires errors to use pointers so that the pointer can be used for equality comparison.
- Update all status errors to use pointers. This has the added benefit of not repeatedly copying error field values every time an error is returned to a function caller.
- Update testerrors.AssertEqual to support asymetric equality comparison, which is performed by go-cmp.Equal when using the EquateErrors option.