### PR TITLE
Test errors more strictly

### DIFF
--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -479,8 +479,8 @@ func TestProcessPruneEvent(t *testing.T) {
 	}
 
 	err := eh.processPruneEvent(ctx, formPruneEvent(event.PruneFailed, deploymentObj, fmt.Errorf("test error")).PruneEvent, s.PruneEvent, objStatusMap)
-	expectedError := ErrorForResource(fmt.Errorf("test error"), idFrom(deploymentID))
-	testutil.AssertEqual(t, expectedError, err, "expected processPruneEvent to error on prune %s", event.PruneFailed)
+	expectedError := PruneErrorForResource(fmt.Errorf("test error"), idFrom(deploymentID))
+	testerrors.AssertEqual(t, expectedError, err, "expected processPruneEvent to error on prune %s", event.PruneFailed)
 
 	err = eh.processPruneEvent(ctx, formPruneEvent(event.PruneSuccessful, testObj, nil).PruneEvent, s.PruneEvent, objStatusMap)
 	assert.Nil(t, err, "expected processPruneEvent NOT to error on prune %s", event.PruneSuccessful)

--- a/pkg/hydrate/controller.go
+++ b/pkg/hydrate/controller.go
@@ -356,7 +356,7 @@ func SourceCommitAndDir(sourceType v1beta1.SourceType, sourceRevDir cmpath.Absol
 		// the path doesn't exist, or other OS failures. The root cause is
 		// probably because the *-sync container is not ready yet, so retry until
 		// it becomes ready.
-		return "", "", util.NewRetriableError(fmt.Errorf("failed to check the status of the source root directory %q: %v", sourceRoot, err))
+		return "", "", util.NewRetriableError(fmt.Errorf("failed to check the status of the source root directory %q: %w", sourceRoot, err))
 	}
 	// Check if the source configs are pulled successfully.
 	errFilePath := filepath.Join(sourceRoot, ErrorFile)

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -17,9 +17,11 @@ package parse
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -42,6 +44,7 @@ import (
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"kpt.dev/configsync/pkg/util"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
@@ -160,6 +163,7 @@ func TestRun(t *testing.T) {
 			t.Error(err)
 		}
 	})
+	sourceDir0 := filepath.Join(tempDir, "0", "source")
 
 	testCases := []struct {
 		id                         string
@@ -176,7 +180,7 @@ func TestRun(t *testing.T) {
 		needRetry                  bool
 		expectedMsg                string
 		expectedErrorSourceRefs    []v1beta1.ErrorSource
-		expectedErrors             string
+		expectedErrors             status.MultiError
 		expectedStateSourceErrs    status.MultiError
 		expectedStateRenderingErrs status.MultiError
 	}{
@@ -188,8 +192,16 @@ func TestRun(t *testing.T) {
 			needRetry:               true,
 			expectedMsg:             "Source",
 			expectedErrorSourceRefs: []v1beta1.ErrorSource{v1beta1.SourceError},
-			expectedErrors:          fmt.Sprintf("1 error(s)\n\n\n[1] KNV2004: failed to check the status of the source root directory \"%s/0/source\": stat %s/0/source: no such file or directory\n\nFor more information, see https://g.co/cloud/acm-errors#knv2004\n", tempDir, tempDir),
-			expectedStateSourceErrs: status.SourceError.Sprintf("KNV2004: failed to check the status of the source root directory \"%s/0/source\": stat %s/0/source: no such file or directory\n\nFor more information, see https://g.co/cloud/acm-errors#knv2004\n", tempDir, tempDir).Build(),
+			expectedErrors: status.SourceError.Wrap(
+				util.NewRetriableError(
+					fmt.Errorf("failed to check the status of the source root directory %q: %w", sourceDir0,
+						&fs.PathError{Op: "stat", Path: sourceDir0, Err: syscall.Errno(2)}))).
+				Build(),
+			expectedStateSourceErrs: status.SourceError.Wrap(
+				util.NewRetriableError(
+					fmt.Errorf("failed to check the status of the source root directory %q: %w", sourceDir0,
+						&fs.PathError{Op: "stat", Path: sourceDir0, Err: syscall.Errno(2)}))).
+				Build(),
 		},
 		{
 			id:                   "1",
@@ -200,12 +212,19 @@ func TestRun(t *testing.T) {
 			expectedMsg:          "Sync Completed",
 		},
 		{
-			id:                      "2",
-			name:                    "source error",
-			sourceError:             "git sync permission issue",
-			needRetry:               true,
-			expectedErrors:          "1 error(s)\n\n\n[1] KNV2004: error in the git-sync container: git sync permission issue\n\nFor more information, see https://g.co/cloud/acm-errors#knv2004\n",
-			expectedStateSourceErrs: status.SourceError.Sprint("error in the git-sync container: git sync permission issue").Build(),
+			id:          "2",
+			name:        "source error",
+			sourceError: "git sync permission issue",
+			needRetry:   true,
+			expectedErrors: status.SourceError.Wrap(
+				fmt.Errorf("error in the git-sync container: %w",
+					fmt.Errorf("git sync permission issue"))).
+				Build(),
+			expectedStateSourceErrs: status.SourceError.Wrap(
+				util.NewRetriableError(
+					fmt.Errorf("error in the git-sync container: %w",
+						fmt.Errorf("git sync permission issue")))).
+				Build(),
 			// source error is exposed to the RootSync status
 			expectedMsg:             "Source",
 			expectedErrorSourceRefs: []v1beta1.ErrorSource{v1beta1.SourceError},
@@ -228,7 +247,7 @@ func TestRun(t *testing.T) {
 			hydratedError:              `{"code": "1068", "error": "rendering error"}`,
 			needRetry:                  true,
 			expectedMsg:                "Rendering failed",
-			expectedErrors:             "1 error(s)\n\n\n[1] KNV1068: rendering error\n\nFor more information, see https://g.co/cloud/acm-errors#knv1068\n",
+			expectedErrors:             status.HydrationError(status.ActionableHydrationErrorCode, fmt.Errorf("rendering error")),
 			expectedStateRenderingErrs: status.HydrationError(status.ActionableHydrationErrorCode, fmt.Errorf("rendering error")),
 			// rendering error is exposed to the RootSync status
 			expectedErrorSourceRefs: []v1beta1.ErrorSource{v1beta1.RenderingError},
@@ -261,7 +280,7 @@ func TestRun(t *testing.T) {
 			needRetry:                  true,
 			expectedMsg:                "Rendering not required but is currently enabled",
 			expectedErrorSourceRefs:    []v1beta1.ErrorSource{v1beta1.RenderingError},
-			expectedErrors:             "1 error(s)\n\n\n[1] KNV2016: sync source contains only wet configs and hydration-controller is running\n\nFor more information, see https://g.co/cloud/acm-errors#knv2016\n",
+			expectedErrors:             status.HydrationError(status.TransientErrorCode, fmt.Errorf("sync source contains only wet configs and hydration-controller is running")),
 			expectedStateRenderingErrs: status.HydrationError(status.TransientErrorCode, fmt.Errorf("sync source contains only wet configs and hydration-controller is running")),
 		},
 		{
@@ -274,7 +293,7 @@ func TestRun(t *testing.T) {
 			needRetry:                  true,
 			expectedMsg:                "Rendering required but is currently disabled",
 			expectedErrorSourceRefs:    []v1beta1.ErrorSource{v1beta1.RenderingError},
-			expectedErrors:             "1 error(s)\n\n\n[1] KNV2016: sync source contains dry configs and hydration-controller is not running\n\nFor more information, see https://g.co/cloud/acm-errors#knv2016\n",
+			expectedErrors:             status.HydrationError(status.TransientErrorCode, fmt.Errorf("sync source contains dry configs and hydration-controller is not running")),
 			expectedStateRenderingErrs: status.HydrationError(status.TransientErrorCode, fmt.Errorf("sync source contains dry configs and hydration-controller is not running")),
 		},
 	}
@@ -372,14 +391,9 @@ func TestRun(t *testing.T) {
 			run(context.Background(), parser, triggerReimport, state)
 
 			assert.Equal(t, tc.needRetry, state.cache.needToRetry)
-			if tc.expectedErrors == "" {
-				assert.Nil(t, state.cache.errs)
-			} else {
-				assert.Equal(t, tc.expectedErrors, state.cache.errs.Error())
-			}
-
-			testutil.AssertEqual(t, tc.expectedStateSourceErrs, state.sourceStatus.errs, "[%s] unexpected state.sourceStatus.errs return", tc.name)
-			testutil.AssertEqual(t, tc.expectedStateRenderingErrs, state.renderingStatus.errs, "[%s] unexpected state.renderingStatus.errs return", tc.name)
+			testerrors.AssertEqual(t, tc.expectedErrors, state.cache.errs, "[%s] unexpected state.cache.errs return", tc.name)
+			testerrors.AssertEqual(t, tc.expectedStateSourceErrs, state.sourceStatus.errs, "[%s] unexpected state.sourceStatus.errs return", tc.name)
+			testerrors.AssertEqual(t, tc.expectedStateRenderingErrs, state.renderingStatus.errs, "[%s] unexpected state.renderingStatus.errs return", tc.name)
 
 			rs := &v1beta1.RootSync{}
 			if err = parser.options().Client.Get(context.Background(), rootsync.ObjectKey(parser.options().SyncName), rs); err != nil {

--- a/pkg/reconciler/finalizer/reposync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer_test.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -305,15 +306,7 @@ func TestRepoSyncFinalize(t *testing.T) {
 			}
 
 			err := finalizer.Finalize(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual is too lenient on APIServerError, because
-				// baseErrorImpl.Is only checks the error code.
-				// So check the error message and type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedStopped, stopped)
 			var expectedObjs []client.Object
@@ -442,15 +435,7 @@ func TestRepoSyncAddFinalizer(t *testing.T) {
 			}
 
 			updated, err := finalizer.AddFinalizer(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedUpdated, updated)
 			var expectedObjs []client.Object
@@ -587,15 +572,7 @@ func TestRepoSyncRemoveFinalizer(t *testing.T) {
 			}
 
 			updated, err := finalizer.RemoveFinalizer(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedUpdated, updated)
 			var expectedObjs []client.Object

--- a/pkg/reconciler/finalizer/rootsync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer_test.go
@@ -34,6 +34,7 @@ import (
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -311,15 +312,7 @@ func TestRootSyncFinalize(t *testing.T) {
 			}
 
 			err := finalizer.Finalize(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual is too lenient on APIServerError, because
-				// baseErrorImpl.Is only checks the error code.
-				// So check the error message and type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedStopped, stopped)
 			var expectedObjs []client.Object
@@ -449,15 +442,7 @@ func TestRootSyncAddFinalizer(t *testing.T) {
 			}
 
 			updated, err := finalizer.AddFinalizer(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedUpdated, updated)
 			var expectedObjs []client.Object
@@ -595,15 +580,7 @@ func TestRootSyncRemoveFinalizer(t *testing.T) {
 			}
 
 			updated, err := finalizer.RemoveFinalizer(ctx, tc.rsync)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 
 			assert.Equal(t, tc.expectedUpdated, updated)
 			var expectedObjs []client.Object

--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
 func fakeRunnable() Runnable {
@@ -148,11 +149,9 @@ func TestManager_Update(t *testing.T) {
 			}
 			m.watcherMap = tc.watcherMap
 
-			gotErr := m.UpdateWatches(context.Background(), tc.gvks)
+			err = m.UpdateWatches(context.Background(), tc.gvks)
+			testerrors.AssertEqual(t, tc.wantErr, err)
 
-			if !errors.Is(tc.wantErr, gotErr) {
-				t.Errorf("got UpdateWatches() error = %v, want %v", gotErr, tc.wantErr)
-			}
 			if diff := cmp.Diff(tc.wantWatchedTypes, m.watchedGVKs(), cmpopts.SortSlices(sortGVKs)); diff != "" {
 				t.Error(diff)
 			}

--- a/pkg/status/multierror_test.go
+++ b/pkg/status/multierror_test.go
@@ -260,26 +260,26 @@ func TestSortErrors(t *testing.T) {
 		want []Error
 	}{
 		{
-			"nil error",
-			nil,
-			nil,
+			name: "nil error",
+			errs: nil,
+			want: nil,
 		},
 		{
-			"three errors in sorted order already",
-			[]Error{apiServerErrBar, undocumentedErrFoo, undocumentedErrBaz},
-			[]Error{apiServerErrBar, undocumentedErrFoo, undocumentedErrBaz},
+			name: "three errors in sorted order already",
+			errs: []Error{apiServerErrBar, undocumentedErrBaz, undocumentedErrFoo},
+			want: []Error{apiServerErrBar, undocumentedErrBaz, undocumentedErrFoo},
 		},
 		{
-			"three errors not in sorted order",
-			[]Error{undocumentedErrFoo, undocumentedErrBaz, apiServerErrBar},
-			[]Error{apiServerErrBar, undocumentedErrFoo, undocumentedErrBaz},
+			name: "three errors not in sorted order",
+			errs: []Error{undocumentedErrFoo, undocumentedErrBaz, apiServerErrBar},
+			want: []Error{apiServerErrBar, undocumentedErrBaz, undocumentedErrFoo},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sortErrors(tc.errs)
 			sortIncorrectly := false
 			for i := range tc.errs {
-				if !errors.Is(tc.errs[i], tc.want[i]) {
+				if tc.errs[i] != tc.want[i] {
 					sortIncorrectly = true
 				}
 			}

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -26,6 +26,7 @@ import (
 	syncerclient "kpt.dev/configsync/pkg/syncer/client"
 	syncertestfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,14 +49,16 @@ func TestClient_Create(t *testing.T) {
 			client: syncertestfake.NewClient(t, core.Scheme,
 				fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			),
-			wantErr: syncerclient.ConflictCreateAlreadyExists(errors.New("some error"),
-				fake.RoleObject()),
+			wantErr: syncerclient.ConflictCreateAlreadyExists(
+				apierrors.NewAlreadyExists(rbacv1.Resource("Role"), "billing/admin"),
+				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic APIServerError if other error",
 			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some API server error")),
-			wantErr:  status.APIServerError(errors.New("some error"), "could not create"),
+			wantErr: status.APIServerError(errors.New("some API server error"), "failed to create object",
+				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 	}
 
@@ -64,9 +67,7 @@ func TestClient_Create(t *testing.T) {
 			sc := syncerclient.New(tc.client, nil)
 
 			err := sc.Create(context.Background(), tc.declared)
-			if !errors.Is(tc.wantErr, err) {
-				t.Fatalf("got err %v, want err %v", err, tc.wantErr)
-			}
+			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}
 }
@@ -81,17 +82,19 @@ func TestClient_Apply(t *testing.T) {
 		{
 			name:     "Conflict error if not found",
 			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
-			client: syncertestfake.NewErrorClient(apierrors.NewNotFound(
-				rbacv1.Resource("Role"), "admin")),
-			wantErr: syncerclient.ConflictUpdateDoesNotExist(errors.New("not found"),
+			client: syncertestfake.NewErrorClient(
+				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin")),
+			wantErr: syncerclient.ConflictUpdateDoesNotExist(
+				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin"),
 				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic error if other error",
 			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some error")),
-			wantErr: status.ResourceWrap(errors.New("some error"), "message",
-				fake.RoleObject()),
+			wantErr: status.ResourceWrap(errors.New("some error"),
+				"failed to get object to update",
+				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "No error if client does not return error",
@@ -106,9 +109,7 @@ func TestClient_Apply(t *testing.T) {
 			sc := syncerclient.New(tc.client, nil)
 
 			_, err := sc.Apply(context.Background(), tc.declared, noOpUpdate)
-			if !errors.Is(tc.wantErr, err) {
-				t.Fatalf("got err %v, want err %v", err, tc.wantErr)
-			}
+			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}
 }
@@ -125,17 +126,18 @@ func TestClient_Update(t *testing.T) {
 		{
 			name:     "Conflict error if not found",
 			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
-			client: syncertestfake.NewErrorClient(apierrors.NewNotFound(
-				rbacv1.Resource("Role"), "admin")),
-			wantErr: syncerclient.ConflictUpdateDoesNotExist(errors.New("not found"),
+			client: syncertestfake.NewErrorClient(
+				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin")),
+			wantErr: syncerclient.ConflictUpdateDoesNotExist(
+				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin"),
 				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic error if other error",
 			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some error")),
-			wantErr: status.ResourceWrap(errors.New("some error"), "message",
-				fake.RoleObject()),
+			wantErr: status.ResourceWrap(errors.New("some error"), "failed to update",
+				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "No error if client does not return error",
@@ -150,9 +152,7 @@ func TestClient_Update(t *testing.T) {
 			sc := syncerclient.New(tc.client, nil)
 
 			err := sc.Update(context.Background(), tc.declared)
-			if !errors.Is(tc.wantErr, err) {
-				t.Fatalf("got err %v, want err %v", err, tc.wantErr)
-			}
+			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}
 }

--- a/pkg/util/clusterconfig/crd_test.go
+++ b/pkg/util/clusterconfig/crd_test.go
@@ -15,7 +15,7 @@
 package clusterconfig
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,9 +24,11 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/decode"
 	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"kpt.dev/configsync/testing/testoutput"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -120,28 +122,20 @@ func TestAsCRD(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "mal-formed CRD",
-			obj:     generateMalformedCRD(t),
-			wantErr: malformedCRDErrorBuilder.Build(),
+			name: "mal-formed CRD",
+			obj:  generateMalformedCRD(t),
+			wantErr: MalformedCRDError(
+				fmt.Errorf("unable to convert unstructured object to %v: %v",
+					kinds.CustomResourceDefinition().WithVersion("v1beta1"),
+					fmt.Errorf("unrecognized type: string")),
+				generateMalformedCRD(t)),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := AsCRD(tc.obj)
-			if tc.wantErr == nil {
-				if err != nil {
-					t.Errorf("got error %v, want nil", err)
-				}
-			} else {
-				if err == nil {
-					t.Errorf("got nil, want %v", tc.wantErr)
-				} else {
-					if !errors.Is(err, tc.wantErr) {
-						t.Errorf("got error %v, want %v", err, tc.wantErr)
-					}
-				}
-			}
+			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}
 }

--- a/pkg/util/mutate/mutate_test.go
+++ b/pkg/util/mutate/mutate_test.go
@@ -31,7 +31,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -181,15 +181,7 @@ func TestStatus(t *testing.T) {
 			fakeClient := fake.NewClient(t, scheme, tc.existingObjs...)
 			ctx := context.Background()
 			updated, err := Status(ctx, fakeClient, tc.obj, tc.mutateFunc)
-			if tc.expectedError != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectedUpdated, updated)
 			fakeClient.Check(t, tc.expectedObj)
 		})
@@ -383,15 +375,7 @@ func TestSpec(t *testing.T) {
 			fakeClient = fake.NewClient(t, scheme, tc.existingObjs...)
 			ctx := context.Background()
 			updated, err := Spec(ctx, fakeClient, tc.obj, tc.mutateFunc)
-			if tc.expectedError != nil && err != nil {
-				// AssertEqual doesn't work well on APIServerError, because the
-				// Error.Is impl is too lenient. So check the error message and
-				// type, instead.
-				assert.Equal(t, tc.expectedError.Error(), err.Error())
-				assert.IsType(t, tc.expectedError, err)
-			} else {
-				testutil.AssertEqual(t, tc.expectedError, err)
-			}
+			testerrors.AssertEqual(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectedUpdated, updated)
 			fakeClient.Check(t, tc.expectedObj)
 		})

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -42,6 +43,18 @@ func NewRetriableError(err error) error {
 // Error implements the Error function of the interface.
 func (r *RetriableError) Error() string {
 	return r.err.Error()
+}
+
+// Is makes RetriableErrors comparable.
+func (r *RetriableError) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+	re, ok := target.(*RetriableError)
+	if !ok {
+		return false
+	}
+	return errors.Is(r.err, re.err)
 }
 
 var _ error = &RetriableError{}


### PR DESCRIPTION
- Use testutil.AssertEqual in more places to validate both the error type and the error message.
- Update test expectations with more correct errors
- Fix a case of error wrapping with %v instead of %w
- Remove TestRoot_ParseErrorsMetricValidation, which used to test a metric that has been removed.
- Fix TestSortErrors which was expecting an incorrect ordering.
- Simplify status.Append to only allocate a slice and multiError when necessary.
- Add RetriableError.Is to make errors.Is work