### PR TITLE
Add e2e NT.ClusterVersion detection

### DIFF
--- a/e2e/nomostest/clusterversion/cluster_version.go
+++ b/e2e/nomostest/clusterversion/cluster_version.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterversion
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+const clusterVersionPattern = `^(v?([0-9]+)(\.([0-9]+))?(\.([0-9]+))?([+-_].*)?)$`
+
+// ClusterVersion represents the parts of a Kubernetes cluster version.
+type ClusterVersion struct {
+	Major  int
+	Minor  int
+	Patch  int
+	Suffix string
+}
+
+// String returns the canonical string representation of a ClusterVersion.
+func (cv ClusterVersion) String() string {
+	if cv.Suffix != "" {
+		return fmt.Sprintf("v%d.%d.%d%s",
+			cv.Major, cv.Minor, cv.Patch, cv.Suffix)
+	}
+	return fmt.Sprintf("v%d.%d.%d", cv.Major, cv.Minor, cv.Patch)
+}
+
+// ParseClusterVersion parses the string "gitVersion" of a Kubernetes cluster.
+func ParseClusterVersion(version string) (ClusterVersion, error) {
+	re := regexp.MustCompile(clusterVersionPattern)
+	match := re.FindStringSubmatch(version)
+	cv := ClusterVersion{}
+	if match == nil {
+		return cv, fmt.Errorf("invalid cluster version: %q does not match version regex: %q", version, clusterVersionPattern)
+	}
+	var err error
+	cv.Major, err = strconv.Atoi(match[2])
+	if err != nil {
+		return cv, fmt.Errorf("invalid regex result: major version must be an integer: %v", err)
+	}
+	if len(match) > 4 && match[4] != "" {
+		cv.Minor, err = strconv.Atoi(match[4])
+		if err != nil {
+			return cv, fmt.Errorf("Invalid regex result: minor version must be an integer: %v", err)
+		}
+	}
+	if len(match) > 6 && match[6] != "" {
+		cv.Patch, err = strconv.Atoi(match[6])
+		if err != nil {
+			return cv, fmt.Errorf("Invalid regex result: patch version must be an integer: %v", err)
+		}
+	}
+	if len(match) > 7 && match[7] != "" {
+		cv.Suffix = match[7]
+	}
+	return cv, nil
+}

--- a/e2e/nomostest/clusterversion/cluster_version_test.go
+++ b/e2e/nomostest/clusterversion/cluster_version_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterversion
+
+import (
+	"testing"
+
+	"kpt.dev/configsync/pkg/testing/testerrors"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestParseClusterVersion(t *testing.T) {
+	testcases := []struct {
+		name                   string
+		input                  string
+		expectedClusterVersion ClusterVersion
+		expectedError          error
+		expectedString         string
+	}{
+		{
+			name:  "GKE patch",
+			input: "v1.27.11-gke.1062001",
+			expectedClusterVersion: ClusterVersion{
+				Major:  1,
+				Minor:  27,
+				Patch:  11,
+				Suffix: "-gke.1062001",
+			},
+			expectedString: "v1.27.11-gke.1062001",
+		},
+		{
+			name:  "semver",
+			input: "v1.27.11",
+			expectedClusterVersion: ClusterVersion{
+				Major: 1,
+				Minor: 27,
+				Patch: 11,
+			},
+			expectedString: "v1.27.11",
+		},
+		{
+			name:  "semver without prefix",
+			input: "1.27.11",
+			expectedClusterVersion: ClusterVersion{
+				Major: 1,
+				Minor: 27,
+				Patch: 11,
+			},
+			expectedString: "v1.27.11",
+		},
+		{
+			name:  "major minor",
+			input: "v1.27",
+			expectedClusterVersion: ClusterVersion{
+				Major: 1,
+				Minor: 27,
+			},
+			expectedString: "v1.27.0",
+		},
+		{
+			name:  "major",
+			input: "v1",
+			expectedClusterVersion: ClusterVersion{
+				Major: 1,
+			},
+			expectedString: "v1.0.0",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv, err := ParseClusterVersion(tc.input)
+			testutil.AssertEqual(t, tc.expectedClusterVersion, cv)
+			testerrors.AssertEqual(t, tc.expectedError, err)
+			testutil.AssertEqual(t, tc.expectedString, cv.String())
+		})
+	}
+}

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -186,6 +186,8 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		OCIClient:               sharedNt.OCIClient,
 	}
 
+	nt.detectClusterVersion()
+
 	if opts.SkipConfigSyncInstall {
 		return nt
 	}
@@ -276,6 +278,8 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		HelmClient:              helmClient,
 		OCIClient:               ociClient,
 	}
+
+	nt.detectClusterVersion()
 
 	// TODO: Try speeding up the reconciler and hydration polling.
 	// It seems that speeding them up too much can cause failures in

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -118,13 +118,10 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 }
 func TestMustRemoveCustomResourceWithDefinitionV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
-	if support {
-		mustRemoveCustomResourceWithDefinition(nt, anvilV1Beta1CRD())
-	}
+	mustRemoveCustomResourceWithDefinition(nt, anvilV1Beta1CRD())
 }
 
 func TestMustRemoveCustomResourceWithDefinitionV1(t *testing.T) {
@@ -215,13 +212,10 @@ func TestAddAndRemoveCustomResourceV1(t *testing.T) {
 
 func TestAddAndRemoveCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
-	if support {
-		addAndRemoveCustomResource(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
-	}
+	addAndRemoveCustomResource(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
 }
 
 func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string) {
@@ -292,13 +286,10 @@ func TestMustRemoveUnManagedCustomResourceV1(t *testing.T) {
 
 func TestMustRemoveUnManagedCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
-	if support {
-		mustRemoveUnManagedCustomResource(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
-	}
+	mustRemoveUnManagedCustomResource(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
 }
 
 func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
@@ -384,13 +375,10 @@ func TestAddUpdateRemoveClusterScopedCRDV1(t *testing.T) {
 
 func TestAddUpdateRemoveClusterScopedCRDV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
-	if support {
-		addUpdateRemoveClusterScopedCRD(nt, "v1beta1_crds", "clusteranvil-crd-v1.yaml")
-	}
+	addUpdateRemoveClusterScopedCRD(nt, "v1beta1_crds", "clusteranvil-crd-v1.yaml")
 }
 
 func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
@@ -493,13 +481,10 @@ func TestAddUpdateNamespaceScopedCRDV1(t *testing.T) {
 
 func TestAddUpdateNamespaceScopedCRDV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
-	if support {
-		addUpdateNamespaceScopedCRD(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
-	}
+	addUpdateNamespaceScopedCRD(nt, "v1beta1_crds", "anvil-crd-v1.yaml")
 }
 
 func TestLargeCRD(t *testing.T) {

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -40,18 +40,13 @@ import (
 func TestCRDDeleteBeforeRemoveCustomResourceV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
 
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
-	}
-	// Skip this test if v1beta1 CRD is not supported in the testing cluster.
-	if !support {
-		return
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
 
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", "v1beta1_crds", "anvil-crd.yaml")
 	clusterFile := filepath.Join(".", "..", "testdata", "customresources", "v1beta1_crds", "clusteranvil-crd.yaml")
-	_, err = nt.Shell.Kubectl("apply", "-f", crdFile)
+	_, err := nt.Shell.Kubectl("apply", "-f", crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -284,17 +279,13 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 
 func TestSyncUpdateCustomResource(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
-	}
-	// Skip this test if v1beta1 CRD is not supported in the testing cluster.
-	if !support {
-		return
+
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
 
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", "v1beta1_crds", "anvil-crd-structural-v1.yaml")
-	_, err = nt.Shell.Kubectl("apply", "-f", crdFile)
+	_, err := nt.Shell.Kubectl("apply", "-f", crdFile)
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -38,13 +38,9 @@ import (
 func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	support, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
-	}
-	// Skip this test when v1beta1 CRD is not supported in the testing cluster.
-	if !support {
-		return
+
+	if !nt.SupportV1Beta1CRDAndRBAC() {
+		nt.T.Skip("Kubernetes v1.22 and later do not support the v1beta1 CRD API")
 	}
 
 	// Add the Anvil CRD.
@@ -68,7 +64,7 @@ func TestMultipleVersions_CustomResourceV1Beta1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("first", "foo", anvilCR("v1", "", 0))
+	err := nt.Validate("first", "foo", anvilCR("v1", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -313,10 +309,8 @@ func anvilGVK(version string) schema.GroupVersionKind {
 func TestMultipleVersions_RoleBinding(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	supportV1beta1, err := nt.SupportV1Beta1CRDAndRBAC()
-	if err != nil {
-		nt.T.Fatal("failed to check the supported CRD versions")
-	}
+
+	supportV1beta1 := nt.SupportV1Beta1CRDAndRBAC()
 
 	rbV1 := fake.RoleBindingObject(core.Name("v1user"))
 	rbV1.RoleRef = rbacv1.RoleRef{
@@ -354,7 +348,7 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("v1user", "foo", &rbacv1.RoleBinding{},
+	err := nt.Validate("v1user", "foo", &rbacv1.RoleBinding{},
 		hasV1Subjects("v1user@acme.com"))
 	if err != nil {
 		nt.T.Fatal(err)


### PR DESCRIPTION
- Get the cluster version from the discovery client, parse it, and save it in the NT environment for use by tests.
- Update the v1beta1 CRD/RBAC check to use NT.ClusterVersion
- Update tests using the v1beta1 check to skip their test, not just return as successful.
- In the future, we can use the cluster version to check for autopilot resource bursting. But since resource bursting is temporarily disabled by default, we can't validate it today.