### PR TITLE
chore: filter vulnerability status by the analysis type

### DIFF
--- a/scripts/vulnerabilities.sh
+++ b/scripts/vulnerabilities.sh
@@ -46,7 +46,7 @@ echo -n "Scanning" >&2
 for image in "${images[@]}"; do
   echo -n "."
   results=$(gcloud beta container images describe --show-package-vulnerability --format json --verbosity error "${image}")
-  status=$(echo "${results}" | jq -r '.discovery_summary.discovery[].discovery.analysisStatus')
+  status=$(echo "${results}" | jq -r '.discovery_summary.discovery[] | select(.noteName == "projects/goog-analysis/notes/PACKAGE_VULNERABILITY") | .discovery.analysisStatus')
   if [[ "${status}" != "FINISHED_SUCCESS" ]]; then
     vuln_map[${image}]="${status}"
     scan_failure_total=$((scan_failure_total + 1))


### PR DESCRIPTION
The 'gcloud container images describe' command returns two entries for the discovery_summary field. We only need the status from 'projects/goog-analysis/notes/PACKAGE_VULNERABILITY'. This commit adds a filter to ignore the COMPLIANCE scan result.

Example output:
```
{
  "discovery_summary": {
    "discovery": [
      {
        "createTime": "2024-05-27T01:18:40.728858Z",
        "discovery": {
          "analysisStatus": "FINISHED_SUCCESS",
          "continuousAnalysis": "ACTIVE"
        },
        "kind": "DISCOVERY",
        "name": "projects/config-management-release/occurrences/400738d4-d91e-46cc-abae-8bfb265a8f2e",
        "noteName": "projects/goog-analysis/notes/COMPLIANCE",
        "resourceUri": "https://gcr.io/config-management-release/otelcontribcol@sha256:2f93890991d10870bf0a04586522db3ced65a152ca3f0f30aa9961f82d72aea7",
        "updateTime": "2024-05-27T08:58:38.638961Z"
      },
      {
        "createTime": "2024-05-27T01:18:40.873202Z",
        "discovery": {
          "analysisStatus": "FINISHED_SUCCESS",
          "continuousAnalysis": "ACTIVE",
          "lastScanTime": "2024-05-28T15:17:14.544092857Z"
        },
        "kind": "DISCOVERY",
        "name": "projects/config-management-release/occurrences/7272fdba-beee-4812-9c96-2bf7cae7732e",
        "noteName": "projects/goog-analysis/notes/PACKAGE_VULNERABILITY",
        "resourceUri": "https://gcr.io/config-management-release/otelcontribcol@sha256:2f93890991d10870bf0a04586522db3ced65a152ca3f0f30aa9961f82d72aea7",
        "updateTime": "2024-05-28T15:17:14.613273Z"
      }
    ]
  },
  "image_summary": {
    "digest": "sha256:2f93890991d10870bf0a04586522db3ced65a152ca3f0f30aa9961f82d72aea7",
    "fully_qualified_digest": "gcr.io/config-management-release/otelcontribcol@sha256:2f93890991d10870bf0a04586522db3ced65a152ca3f0f30aa9961f82d72aea7",
    "registry": "gcr.io",
    "repository": "config-management-release/otelcontribcol"
  },
  "package_vulnerability_summary": {
    "not_fixed_vulnerability_count": 0,
    "total_vulnerability_found": 0,
    "vulnerabilities": {}
  }
}
```

b/342954704