### PR TITLE
feat: add OSS migration logic

### DIFF
--- a/cmd/nomos/migrate/configmanagement.go
+++ b/cmd/nomos/migrate/configmanagement.go
@@ -1,0 +1,208 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kpt.dev/configsync/cmd/nomos/status"
+	"kpt.dev/configsync/cmd/nomos/util"
+	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+func migrateConfigManagement(ctx context.Context, cc *status.ClusterClient, kubeCtx string) error {
+	isOSS, err := util.IsOssInstallation(ctx, cc.ConfigManagement, cc.Client, cc.K8sClient)
+	if err != nil {
+		return err
+	}
+	if isOSS {
+		printNotice("The cluster is already running as an OSS installation.")
+		return nil
+	}
+
+	fmt.Printf("Removing ConfigManagement on cluster %q ...\n", kubeCtx)
+	cmYamlFile, err := saveConfigManagementOperatorYaml(ctx, cc, kubeCtx)
+	if err != nil {
+		return err
+	}
+	printHint(`Resources for the ConfigManagement operator have been saved in a temp folder. If the migration process is terminated, it can be recovered manually by running the following commands:
+  kubectl delete deployment -n config-management-system config-management-operator --ignore-not-found --cascade=foreground && \
+  (kubectl patch configmanagement config-management --type="merge" -p '{"metadata":{"finalizers":[]}}' ; \
+  kubectl delete configmanagement config-management --cascade=orphan --ignore-not-found) && \
+  kubectl delete -f %s --ignore-not-found`, cmYamlFile)
+
+	if dryRun {
+		dryrunConfigManagement()
+		return nil
+	}
+	if err := executeConfigManagementMigration(ctx, cc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func dryrunConfigManagement() {
+	printInfo(deletingConfigManagement)
+}
+
+// getOperatorObjects returns a list of objects associated with the ConfigManagement
+// operator installation. The objects are returned in the order in which they
+// should be applied. They should be deleted in the reverse order.
+func getOperatorObjects() []*unstructured.Unstructured {
+	var objs []*unstructured.Unstructured
+
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(kinds.CustomResourceDefinitionV1())
+	crd.SetName(util.ConfigManagementCRDName)
+	objs = append(objs, crd)
+
+	cm := &unstructured.Unstructured{}
+	cm.SetGroupVersionKind(kinds.ConfigManagement())
+	cm.SetName(util.ConfigManagementName)
+	objs = append(objs, cm)
+
+	sa := &unstructured.Unstructured{}
+	sa.SetGroupVersionKind(kinds.ServiceAccount())
+	sa.SetName(util.ACMOperatorDeployment)
+	sa.SetNamespace(configmanagement.ControllerNamespace)
+	objs = append(objs, sa)
+
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(kinds.ClusterRole())
+	cr.SetName(util.ACMOperatorDeployment)
+	objs = append(objs, cr)
+
+	crb := &unstructured.Unstructured{}
+	crb.SetGroupVersionKind(kinds.ClusterRoleBinding())
+	crb.SetName(util.ACMOperatorDeployment)
+	objs = append(objs, crb)
+
+	dep := &unstructured.Unstructured{}
+	dep.SetGroupVersionKind(kinds.Deployment())
+	dep.SetName(util.ACMOperatorDeployment)
+	dep.SetNamespace(configmanagement.ControllerNamespace)
+	objs = append(objs, dep)
+
+	return objs
+}
+
+// executeConfigManagementMigration performs the migration from ConfigManagement
+// installation to a standalone OSS Config Sync installation. It's assumed that
+// the ConfigManagement installation is already running in the multi-repo mode.
+func executeConfigManagementMigration(ctx context.Context, sc *status.ClusterClient) error {
+	printInfo(waitingForConfigSyncCRDs)
+	if err := waitForMultiRepoCRDsToBeEstablished(ctx, sc.Client); err != nil {
+		return err
+	}
+	printInfo("The following CRDs have been established: %s", configSyncCRDs)
+
+	printInfo(waitingForReconcilerManager)
+	if err := waitForPodToBeRunning(ctx, sc.K8sClient, configmanagement.ControllerNamespace, "app=reconciler-manager"); err != nil {
+		return err
+	}
+	printInfo("The reconciler-manager Pod is running")
+
+	printInfo(waitingForRGManager)
+	if err := waitForPodToBeRunning(ctx, sc.K8sClient, configmanagement.RGControllerNamespace, "configsync.gke.io/deployment-name=resource-group-controller-manager"); err != nil {
+		return err
+	}
+	printInfo("The resource-group-controller-manager Pod is running")
+
+	// Delete the config-management-operator objects in the reverse order in which
+	// they must be established.
+	printInfo("Deleting the ConfigManagement operator")
+	operatorObjects := getOperatorObjects()
+	for idx := range operatorObjects {
+		obj := operatorObjects[len(operatorObjects)-1-idx]
+		printInfo("deleting object: %s %s/%s",
+			obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+		propPolicy := client.PropagationPolicy(metav1.DeletePropagationForeground)
+		if obj.GetObjectKind().GroupVersionKind() == kinds.ConfigManagement() {
+			// The operator adds ownerReferences pointing to the ConfigManagement object,
+			// so "Orphan" must be specified to avoid deleting the managed objects.
+			propPolicy = client.PropagationPolicy(metav1.DeletePropagationOrphan)
+			if err := sc.ConfigManagement.RemoveFinalizers(ctx); err != nil {
+				return err
+			}
+		}
+		if err := sc.Client.Delete(ctx, obj, propPolicy); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		key := client.ObjectKeyFromObject(obj)
+		// wait for object to be not found
+		err := recheck(func() error {
+			err := sc.Client.Get(ctx, key, obj)
+			if apierrors.IsNotFound(err) {
+				return nil
+			} else if err == nil {
+				return fmt.Errorf("expected %s object %s to be NotFound, but still exists",
+					obj.GroupVersionKind(), key)
+			}
+			return err
+		})
+		if err != nil {
+			return err
+		}
+	}
+	printInfo("The ConfigManagement Operator is deleted")
+	return nil
+}
+
+// saveConfigManagementOperatorYaml saves the original config-management-operator
+// yaml to a file. The migration will uninstall the operator, so this will enable
+// users to reinstall if they want to revert the migration.
+func saveConfigManagementOperatorYaml(ctx context.Context, sc *status.ClusterClient, context string) (string, error) {
+	dir := filepath.Join(os.TempDir(), configManagementMigrateDir, context)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return "", err
+	}
+	operatorObjects := getOperatorObjects()
+	// Fetch original cluster objects, so they can be saved to a file
+	for _, obj := range operatorObjects {
+		key := client.ObjectKeyFromObject(obj)
+		if err := sc.Client.Get(ctx, key, obj); err != nil {
+			return "", fmt.Errorf("reading object %s from cluster: %w", key, err)
+		}
+	}
+
+	var content []byte
+	for idx, uObj := range operatorObjects {
+		if idx != 0 { // concatenate yaml using "---" separator
+			content = append(content, []byte("---\n")...)
+		}
+		yamlObj, err := yaml.Marshal(uObj)
+		if err != nil {
+			return "", err
+		}
+		content = append(content, yamlObj...)
+	}
+	yamlFile := filepath.Join(dir, cmOperatorYAMLFile)
+	if err := os.WriteFile(yamlFile, content, 0644); err != nil {
+		return yamlFile, err
+	}
+	printInfo("The original ConfigManagement Operator objects are saved in %q", yamlFile)
+	return yamlFile, nil
+}

--- a/cmd/nomos/migrate/monorepo.go
+++ b/cmd/nomos/migrate/monorepo.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"kpt.dev/configsync/cmd/nomos/status"
+)
+
+func migrateMonoRepo(ctx context.Context, cc *status.ClusterClient, kubeCtx string) error {
+	isMulti, err := cc.ConfigManagement.IsMultiRepo(ctx)
+	if err != nil {
+		return err
+	}
+	if isMulti != nil && *isMulti {
+		// already using multi-repo
+		printNotice("The cluster is already running in the multi-repo mode. No RootSync will be created.")
+		return nil
+	}
+
+	fmt.Printf("Enabling the multi-repo mode on cluster %q ...\n", kubeCtx)
+	rootSync, rsYamlFile, err := saveRootSyncYAML(ctx, cc.ConfigManagement, kubeCtx)
+	if err != nil {
+		return err
+	}
+	cm, cmYamlFile, err := saveConfigManagementYAML(ctx, cc.ConfigManagement, kubeCtx)
+	if err != nil {
+		return err
+	}
+	printHint(`Resources for the multi-repo mode have been saved in a temp folder. If the migration process is terminated, it can be recovered manually by running the following commands:
+  kubectl apply -f %s && \
+  kubectl wait --for condition=established crd rootsyncs.configsync.gke.io && \
+  kubectl apply -f %s`, cmYamlFile, rsYamlFile)
+
+	if dryRun {
+		dryrun()
+		return nil
+	}
+	if err := executeMonoRepoMigration(ctx, cc, cm, rootSync); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/nomos/status/client.go
+++ b/cmd/nomos/status/client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -200,8 +200,8 @@ func parseConfigSyncManifests(nt *NT) ([]client.Object, error) {
 	return objs, nil
 }
 
-// installConfigSync installs ConfigSync on the test cluster
-func installConfigSync(nt *NT) error {
+// InstallConfigSync installs ConfigSync on the test cluster
+func InstallConfigSync(nt *NT) error {
 	nt.T.Log("[SETUP] Installing Config Sync")
 	objs, err := parseConfigSyncManifests(nt)
 	if err != nil {

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -379,7 +379,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		return setupRegistry(nt)
 	})
 	tg.Go(func() error {
-		return installConfigSync(nt)
+		return InstallConfigSync(nt)
 	})
 	tg.Go(func() error {
 		return installPrometheus(nt)

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -957,7 +957,7 @@ func gitCommitFromSpec(nt *NT, gitSpec *v1beta1.Git) (string, error) {
 		return "", errors.New("spec.git.repo is empty")
 	}
 	// revision specified
-	if gitSpec.Revision != "" {
+	if gitSpec.Revision != "" && gitSpec.Revision != "HEAD" {
 		return gitSpec.Revision, nil
 	}
 	var pattern string

--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -1141,6 +1141,27 @@ func RootSyncHasCondition(expected *v1beta1.RootSyncCondition) Predicate {
 	}
 }
 
+// RootSyncSpecEquals returns a Predicate that errors if the RootSync does not
+// have the specified RootSyncCondition. Fields such as timestamps are ignored.
+func RootSyncSpecEquals(expected v1beta1.RootSyncSpec) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		rs, ok := o.(*v1beta1.RootSync)
+		if !ok {
+			return WrongTypeErr(rs, &v1beta1.RootSync{})
+		}
+		spec := rs.Spec
+		if !equality.Semantic.DeepEqual(expected, spec) {
+			diff := cmp.Diff(expected, spec)
+			return fmt.Errorf("expected RootSync to have spec:\n%sbut got:\n%s\n%s",
+				log.AsYAML(expected), log.AsYAML(spec), diff)
+		}
+		return nil
+	}
+}
+
 func validateRootSyncCondition(actual *v1beta1.RootSyncCondition, expected *v1beta1.RootSyncCondition) error {
 	e := expected.DeepCopy()
 	e.LastUpdateTime = actual.LastUpdateTime

--- a/e2e/testdata/configmanagement/1.18.0/config-management-operator.yaml
+++ b/e2e/testdata/configmanagement/1.18.0/config-management-operator.yaml
@@ -1,0 +1,484 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  name: configmanagements.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: ConfigManagement
+    listKind: ConfigManagementList
+    plural: configmanagements
+    singular: configmanagement
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConfigManagement is the Schema for the ConfigManagement API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: config-management
+                type: string
+            type: object
+          spec:
+            description: ConfigManagementSpec defines the desired state of ConfigManagement.
+            properties:
+              ConfigSyncDisableFSWatcher:
+                description: ConfigSyncDisableFSWatcher provides the ability to disable
+                  the fs-watcher process.  This field is intentionally left hidden/undocumented
+                  since it is only meant to be used by customers who have very large
+                  repositories. Optional.
+                type: boolean
+              ConfigSyncLogLevel:
+                description: ConfigSyncLogLevel overrides the logging verbosity for
+                  all ConfigSync pods. This field is intentionally left hidden/undocumented
+                  since it is really only used to gather extra logs for support cases.
+                type: integer
+              binauthz:
+                description: 'Deprecated: Does nothing. binauthz can no longer be
+                  enabled/disabled with the ConfigManagement resource; the software
+                  is available as a standalone: https://cloud.google.com/binary-authorization'
+                properties:
+                  enabled:
+                    description: 'Enable or disable BinAuthz.  Default: false.'
+                    type: boolean
+                  policyRef:
+                    description: PolicyRef is a reference to the BinAuthz policy which
+                      will be evaluated. Required if BinAuthz is enabled.
+                    properties:
+                      gkeCluster:
+                        description: BinAuthz policy associated with this GKE-on-GCP
+                          cluster.
+                        properties:
+                          location:
+                            description: Location of this cluster
+                            type: string
+                          name:
+                            description: The name of this cluster according to GKE.
+                              This is not necessarily the same as the hub membership
+                              name.
+                            type: string
+                          project:
+                            description: The name of the GCP project containing this
+                              cluster
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              channel:
+                description: 'Channel specifies a channel that can be used to resolve
+                  a specific addon, eg: stable It will be ignored if Version is specified'
+                type: string
+              clusterName:
+                description: ClusterName, if defined, sets the name for this cluster.  If
+                  unset, the cluster is considered to be unnamed, and cannot use ClusterSelectors.
+                type: string
+              configConnector:
+                description: 'Deprecated: Does nothing.  ConfigConnector can no longer
+                  be enabled/disabled with the ConfigManagement resource; the software
+                  is available as a standalone: https://cloud.google.com/config-connector'
+                properties:
+                  enabled:
+                    description: 'Enable or disable the Config Connector.  Default:
+                      false.'
+                    type: boolean
+                type: object
+              enableLegacyFields:
+                description: EnableLegacyFields instructs the operator to use spec.git
+                  for generating a RootSync resource in MultiRepo mode. Note that
+                  this should only be set to true if spec.enableMultiRepo is set to
+                  true.
+                type: boolean
+              enableMultiRepo:
+                description: EnableMultiRepo instructs the operator to enable Multi
+                  Repo mode for Config Sync.
+                type: boolean
+              git:
+                description: Git contains configuration specific to importing policies
+                  from a Git repo.
+                properties:
+                  gcpServiceAccountEmail:
+                    description: 'GCPServiceAccountEmail specifies the GCP service
+                      account used to annotate the Config Sync Kubernetes Service
+                      Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    type: string
+                  policyDir:
+                    description: 'PolicyDir is the absolute path of the directory
+                      that contains the local policy.  Default: the root directory
+                      of the repo.'
+                    type: string
+                  proxy:
+                    description: Proxy is a struct that contains options for configuring
+                      access to the Git repo via a proxy. Only has an effect when
+                      secretType is one of ("cookiefile", "none").  Optional.
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy defines a HTTP_PROXY env variable used
+                          to access the Git repo.  If both HTTPProxy and HTTPSProxy
+                          are specified, HTTPProxy will be ignored. Optional.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy defines a HTTPS_PROXY env variable
+                          used to access the Git repo.  If both HTTPProxy and HTTPSProxy
+                          are specified, HTTPProxy will be ignored. Optional.
+                        type: string
+                    type: object
+                  secretType:
+                    description: SecretType is the type of secret configured for access
+                      to the Git repo. Must be one of ssh, cookiefile, gcenode, token,
+                      gcpserviceaccount or none. Required. The validation of this
+                      is case-sensitive.
+                    pattern: ^(ssh|cookiefile|gcenode|gcpserviceaccount|token|none)$
+                    type: string
+                  syncBranch:
+                    description: 'SyncBranch is the branch to sync from.  Default:
+                      "master".'
+                    type: string
+                  syncRepo:
+                    pattern: ^(((https?|git|ssh):\/\/)|git@)
+                    type: string
+                  syncRev:
+                    description: 'SyncRev is the git revision (tag or hash) to check
+                      out. Default: HEAD.'
+                    type: string
+                  syncWait:
+                    description: 'SyncWaitSeconds is the time duration in seconds
+                      between consecutive syncs.  Default: 15 seconds. Note that SyncWaitSecs
+                      is not a time.Duration on purpose. This provides a reminder
+                      to developers that customers specify this value using using
+                      integers like "3" in their ConfigManagement YAML. However, time.Duration
+                      is at a nanosecond granularity, and it''s easy to introduce
+                      a bug where it looks like the code is dealing with seconds but
+                      its actually nanoseconds (or vice versa).'
+                    type: integer
+                type: object
+              hierarchyController:
+                description: Hierarchy Controller enables HierarchyController components
+                  as recognized by the "hierarchycontroller.configmanagement.gke.io"
+                  label set to "true".
+                properties:
+                  enableHierarchicalResourceQuota:
+                    description: 'HierarchicalResourceQuota enforces resource quota
+                      in a hierarchical fashion: a resource quota set for one namespace
+                      provides constraints that limit aggregate resource consumption
+                      for that namespace and all its descendants. Disabling this will
+                      not delete user created hrq CRs, but will delete all the intermediate
+                      resources created by HRQ (specifically the resource quota singletons),
+                      which are labeled with hierarchycontroller.configmanagement.gke.io/hrq
+                      for easier cleanup.'
+                    type: boolean
+                  enablePodTreeLabels:
+                    description: PodTreeLabels copies the tree labels from namespaces
+                      to pods, allowing any system that uses pod logs (such as Stackdriver
+                      logging) to inspect the hierarchy.
+                    type: boolean
+                  enabled:
+                    description: 'Enable or disable the Hierarchy Controller.  Default:
+                      false.'
+                    type: boolean
+                type: object
+              importer:
+                description: Importer allows one to override the existing resource
+                  requirements for the importer pod
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              metricsGCPServiceAccountEmail:
+                description: MetricsGCPServiceAccountEmail specifies a Google Service
+                  Account (GSA) Email with the Monitoring Metric Writer (roles/monitoring.metricWriter)
+                  IAM role. This GSA Email is used to annotate the `default` Kubernetes
+                  ServiceAccount under the `config-management-monitoring` namespace,
+                  which allows Config Sync to export metrics to Cloud Monitoring.
+                type: string
+              patches:
+                items:
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+              policyController:
+                description: 'Deprecated: Does nothing. Policy Controller can no longer
+                  be enabled/disabled with the ConfigManagement resource; see https://cloud.google.com/anthos-config-management/docs/how-to/installing-policy-controller
+                  for supported ways of enabling Policy Controller.'
+                properties:
+                  auditIntervalSeconds:
+                    description: AuditIntervalSeconds. The number of seconds between
+                      audit runs. Defaults to 60 seconds. To disable audit, set this
+                      to 0.
+                    format: int64
+                    type: integer
+                  enabled:
+                    description: 'Enable or disable the Policy Controller.  Default:
+                      false.'
+                    type: boolean
+                  exemptableNamespaces:
+                    description: ExemptableNamespaces. The namespaces in this list
+                      are able to have the admission.gatekeeper.sh/ignore label set.
+                      When the label is set, Policy Controller will not be called
+                      for that namespace or any resources contained in it. `gatekeeper-system`
+                      is always exempted.
+                    items:
+                      type: string
+                    type: array
+                  logDeniesEnabled:
+                    description: 'LogDeniesEnabled.  If true, Policy Controller will
+                      log all denies and dryrun failures.  No effect unless policyController
+                      is enabled.  Default: false.'
+                    type: boolean
+                  monitoring:
+                    description: Monitoring specifies the configuration of monitoring.
+                    properties:
+                      backends:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mutation:
+                    description: Mutation specifies the configuration of mutation.
+                      This is a preview feature and may change before becoming generally
+                      available.
+                    properties:
+                      enabled:
+                        description: 'Enable or disable mutation in policy controller.
+                          If true, mutation CRDs, webhook and controller will be deployed
+                          to the cluster. Default: false.'
+                        type: boolean
+                    type: object
+                  referentialRulesEnabled:
+                    description: 'ReferentialRulesEnabled.  If true, Policy Controller
+                      will allow `data.inventory` references in the contents of ConstraintTemplate
+                      Rego.  No effect unless policyController is enabled.  Default:
+                      false.'
+                    type: boolean
+                  templateLibraryInstalled:
+                    description: 'TemplateLibraryInstalled.  If true, a set of default
+                      ConstraintTemplates will be deployed to the cluster. ConstraintTemplates
+                      will not be deployed if this is explicitly set to false or if
+                      policyController is not enabled. Default: true.'
+                    type: boolean
+                type: object
+              preventDrift:
+                description: 'preventDrift, if set to `true`, enables the Config Sync
+                  admission webhook to prevent drifts. If set to `false`, disables
+                  the Config Sync admission webhook and does not prevent drifts. Default:
+                  false. Config Sync always corrects drifts no matter the value of
+                  preventDrift.'
+                type: boolean
+              sourceFormat:
+                description: "SourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do. \n Must
+                  be one of hierarchy, unstructured. Optional. Set to hierarchy if
+                  not specified. \n The validation of this is case-sensitive."
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              syncer:
+                description: Syncer allows one to override the existing resource requirements
+                  for the syncer pod
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              version:
+                description: Version specifies the exact addon version to be deployed,
+                  eg 1.2.3 It should not be specified if Channel is specified
+                type: string
+            type: object
+          status:
+            description: ConfigManagementStatus defines the observed state of ConfigManagement.
+            properties:
+              configManagementVersion:
+                description: ConfigManagementVersion is the semantic version number
+                  of the config management system enforced by the currently running
+                  config management operator.
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              phase:
+                type: string
+            required:
+            - healthy
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: config-management-system
+  labels:
+    configmanagement.gke.io/system: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: config-management-monitoring
+  labels:
+    configmanagement.gke.io/system: "true"
+---
+# The Nomos system creates RBAC rules, so it requires
+# full cluster-admin access. Thus, the operator needs
+# to be able to grant tha permission to the installed
+# Nomos components.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: config-management-operator
+subjects:
+- kind: ServiceAccount
+  name: config-management-operator
+  namespace: config-management-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+  namespace: config-management-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-management-operator
+  namespace: config-management-system
+  labels:
+    k8s-app: config-management-operator
+spec:
+  # specifying replicas explicitly would help to enforce the intended
+  # value when the file is applied.
+  replicas: 1
+  strategy:
+    type: Recreate
+    # must be null due to 3-way merge, as
+    # rollingUpdate added to the resource by default by the APIServer
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      k8s-app: config-management-operator
+      component: config-management-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: config-management-operator
+        component: config-management-operator
+    spec:
+      containers:
+      - command:
+        - /manager
+        - --private-registry=
+        name: manager
+        image: gcr.io/config-management-release/config-management-operator:v1.18.0-rc.1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        envFrom:
+        - configMapRef:
+            name: operator-environment-options
+            optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+      serviceAccount: config-management-operator
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -45,6 +45,8 @@ const (
 	RootSyncCRDName = "rootsyncs.configsync.gke.io"
 	// RepoSyncCRDName is the name of RepoSync CRD
 	RepoSyncCRDName = "reposyncs.configsync.gke.io"
+	// ResourceGroupCRDName is the name of the ResourceGroup CRD
+	ResourceGroupCRDName = "resourcegroups.kpt.dev"
 )
 
 const (

--- a/pkg/kinds/kinds.go
+++ b/pkg/kinds/kinds.go
@@ -48,6 +48,11 @@ func Sync() schema.GroupVersionKind {
 	return v1.SchemeGroupVersion.WithKind(configmanagement.SyncKind)
 }
 
+// ConfigManagement returns the canonical ConfigManagement GroupVersionKind.
+func ConfigManagement() schema.GroupVersionKind {
+	return v1.SchemeGroupVersion.WithKind(configmanagement.OperatorKind)
+}
+
 // RoleBinding returns the canonical RoleBinding GroupVersionKind.
 func RoleBinding() schema.GroupVersionKind {
 	return rbacv1.SchemeGroupVersion.WithKind("RoleBinding")


### PR DESCRIPTION
This change updates the nomos migrate command to support migrating from a ConfigManagement installation to a standalone Config Sync installation. This builds on the existing logic, such that first it will migrate from mono-repo to multi-repo if applicable.