### PR TITLE
Use field managers for all K8s API calls

### DIFF
--- a/cmd/nomos/hydrate/hydrate.go
+++ b/cmd/nomos/hydrate/hydrate.go
@@ -103,6 +103,7 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 		if err != nil {
 			return err
 		}
+		validateOpts.FieldManager = util.FieldManager
 
 		if sourceFormat == filesystem.SourceFormatHierarchy {
 			files = filesystem.FilterHierarchyFiles(rootDir, files)

--- a/cmd/nomos/util/constants.go
+++ b/cmd/nomos/util/constants.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "kpt.dev/configsync/pkg/api/configsync"
+
+const (
+	// FieldManager is the field manager name used by the nomos CLI.
+	// This avoids conflicts with the reconciler and reconciler-manager.
+	FieldManager = configsync.ConfigSyncPrefix + "nomos-cli"
+)

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -89,6 +89,7 @@ func runVet(ctx context.Context, namespace string, sourceFormat filesystem.Sourc
 	if err != nil {
 		return err
 	}
+	validateOpts.FieldManager = util.FieldManager
 
 	switch sourceFormat {
 	case filesystem.SourceFormatHierarchy:

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -23,7 +23,8 @@ const (
 	// ConfigSyncPrefix is the prefix for all ConfigSync annotations and labels.
 	ConfigSyncPrefix = GroupName + "/"
 
-	// FieldManager is the field manager name for server-side apply.
+	// FieldManager is the field manager name used by the reconciler.
+	// This avoids conflicts between the reconciler and reconciler-manager.
 	FieldManager = GroupName
 
 	// ControllerNamespace is the Namespace used for Nomos controllers

--- a/pkg/applier/utils.go
+++ b/pkg/applier/utils.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
@@ -140,7 +141,7 @@ func annotateStatusMode(ctx context.Context, c client.Client, u *unstructured.Un
 	}
 	annotations[StatusModeKey] = statusMode
 	u.SetAnnotations(annotations)
-	return c.Update(ctx, u)
+	return c.Update(ctx, u, client.FieldOwner(configsync.FieldManager))
 }
 
 func refsFromIDs(ids ...core.ID) []mutation.ResourceReference {

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -469,12 +469,13 @@ func TestRoot_Parse(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
+			tc.existingObjects = append(tc.existingObjects, fake.RootSyncObjectV1Beta1(rootSyncName))
 			parser := &root{
 				Options: &Options{
 					Parser:             fakeConfigParser,
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, tc.existingObjects...),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Converter:          converter,
 					Updater: Updater{
@@ -489,11 +490,6 @@ func TestRoot_Parse(t *testing.T) {
 					SourceFormat:      tc.format,
 					NamespaceStrategy: tc.namespaceStrategy,
 				},
-			}
-			for _, o := range tc.existingObjects {
-				if err := parser.Client.Create(context.Background(), o); err != nil {
-					t.Fatal(err)
-				}
 			}
 			files := []cmpath.Absolute{
 				"example.yaml",
@@ -687,12 +683,13 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
+			tc.existingObjects = append(tc.existingObjects, fake.RootSyncObjectV1Beta1(rootSyncName))
 			parser := &root{
 				Options: &Options{
 					Parser:             fakeConfigParser,
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, tc.existingObjects...),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Converter:          converter,
 					WebhookEnabled:     tc.webhookEnabled,
@@ -708,12 +705,6 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					SourceFormat:      filesystem.SourceFormatUnstructured,
 					NamespaceStrategy: configsync.NamespaceStrategyExplicit,
 				},
-			}
-			for _, o := range tc.existingObjects {
-				t.Log("creating obj", o.GetObjectKind().GroupVersionKind().Kind)
-				if err := parser.Client.Create(context.Background(), o); err != nil {
-					t.Fatal(err)
-				}
 			}
 			state := &reconcilerState{}
 			if err := parseAndUpdate(context.Background(), parser, triggerReimport, state); err != nil {

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
@@ -491,7 +492,8 @@ func parseSource(ctx context.Context, p Parser, trigger string, state *reconcile
 	state.cache.setParserResult(objs, sourceErrs)
 
 	if !status.HasBlockingErrors(sourceErrs) && p.options().WebhookEnabled {
-		err := webhookconfiguration.Update(ctx, p.options().k8sClient(), p.options().discoveryClient(), objs)
+		err := webhookconfiguration.Update(ctx, p.options().k8sClient(), p.options().discoveryClient(), objs,
+			client.FieldOwner(configsync.FieldManager))
 		if err != nil {
 			// Don't block if updating the admission webhook fails.
 			// Return an error instead if we remove the remediator as otherwise we

--- a/pkg/reconciler/finalizer/reposync_finalizer.go
+++ b/pkg/reconciler/finalizer/reposync_finalizer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/reposync"
@@ -96,7 +97,7 @@ func (f *RepoSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Obj
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to add finalizer: %w", err)
 	}
@@ -119,7 +120,7 @@ func (f *RepoSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
@@ -140,7 +141,7 @@ func (f *RepoSyncFinalizer) setFinalizingCondition(ctx context.Context, syncObj 
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to set ReconcilerFinalizing condition: %w", err)
 	}
@@ -161,7 +162,7 @@ func (f *RepoSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncO
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to remove ReconcilerFinalizing condition: %w", err)
 	}
@@ -207,7 +208,7 @@ func (f *RepoSyncFinalizer) updateFailureCondition(ctx context.Context, syncObj 
 			}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to set ReconcilerFinalizerFailure condition: %w", err)
 	}

--- a/pkg/reconciler/finalizer/rootsync_finalizer.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/rootsync"
@@ -96,7 +97,7 @@ func (f *RootSyncFinalizer) AddFinalizer(ctx context.Context, syncObj client.Obj
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to add finalizer: %w", err)
 	}
@@ -119,7 +120,7 @@ func (f *RootSyncFinalizer) RemoveFinalizer(ctx context.Context, syncObj client.
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
@@ -140,7 +141,7 @@ func (f *RootSyncFinalizer) setFinalizingCondition(ctx context.Context, syncObj 
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to set ReconcilerFinalizing condition: %w", err)
 	}
@@ -161,7 +162,7 @@ func (f *RootSyncFinalizer) removeFinalizingCondition(ctx context.Context, syncO
 			return &mutate.NoUpdateError{}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to remove ReconcilerFinalizing condition: %w", err)
 	}
@@ -207,7 +208,7 @@ func (f *RootSyncFinalizer) updateFailureCondition(ctx context.Context, syncObj 
 			}
 		}
 		return nil
-	})
+	}, client.FieldOwner(configsync.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("failed to set ReconcilerFinalizerFailure condition: %w", err)
 	}

--- a/pkg/reconciler/finalizer/rootsync_finalizer_test.go
+++ b/pkg/reconciler/finalizer/rootsync_finalizer_test.go
@@ -615,7 +615,7 @@ func updateToRemoveFinalizers(ctx context.Context, fakeClient *fake.Client, obj 
 		return err
 	}
 	obj.SetFinalizers(nil)
-	return fakeClient.Update(ctx, obj)
+	return fakeClient.Update(ctx, obj, client.FieldOwner(fake.FieldManager))
 }
 
 type fakeDestroyer struct {

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -14,9 +14,15 @@
 
 package reconcilermanager
 
+import "kpt.dev/configsync/pkg/api/configsync"
+
 const (
 	// ManagerName is the name of the controller which creates reconcilers.
 	ManagerName = "reconciler-manager"
+
+	// FieldManager is the field manager used by the reconciler-manager.
+	// This avoids conflicts between the reconciler and reconciler-manager.
+	FieldManager = configsync.ConfigSyncPrefix + ManagerName
 )
 
 const (

--- a/pkg/reconcilermanager/controllers/create_or_update.go
+++ b/pkg/reconcilermanager/controllers/create_or_update.go
@@ -20,6 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"kpt.dev/configsync/pkg/reconcilermanager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -43,7 +44,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 		if err := mutateWrapper(f, key, obj); err != nil {
 			return controllerutil.OperationResultNone, err
 		}
-		if err := c.Create(ctx, obj); err != nil {
+		if err := c.Create(ctx, obj, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 			return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationCreate, key)
 		}
 		return controllerutil.OperationResultCreated, nil
@@ -58,7 +59,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 		return controllerutil.OperationResultNone, nil
 	}
 
-	if err := c.Update(ctx, obj); err != nil {
+	if err := c.Update(ctx, obj, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return controllerutil.OperationResultNone, NewObjectOperationErrorWithKey(err, obj, OperationUpdate, key)
 	}
 	return controllerutil.OperationResultUpdated, nil

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -169,7 +169,7 @@ func (r *RepoSyncReconciler) deleteSharedRoleBinding(ctx context.Context, reconc
 		// Delete the whole RB
 		return r.cleanup(ctx, rb)
 	}
-	if err := r.client.Update(ctx, rb); err != nil {
+	if err := r.client.Update(ctx, rb, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return NewObjectOperationError(err, rb, OperationUpdate)
 	}
 	return nil
@@ -261,7 +261,7 @@ func (r *RootSyncReconciler) deleteSharedClusterRoleBinding(ctx context.Context,
 		// No change
 		return nil
 	}
-	if err := r.client.Update(ctx, crb); err != nil {
+	if err := r.client.Update(ctx, crb, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return NewObjectOperationError(err, crb, OperationUpdate)
 	}
 	return nil

--- a/pkg/reconcilermanager/controllers/otel_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
@@ -191,7 +192,7 @@ func updateDeploymentAnnotation(ctx context.Context, c client.Client, annotation
 		return nil
 	}
 
-	return c.Patch(ctx, dep, patch)
+	return c.Patch(ctx, dep, patch, client.FieldOwner(configsync.FieldManager))
 }
 
 // Register otel controller with reconciler-manager.

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/reconcilermanager"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
@@ -345,7 +346,7 @@ func TestOtelSAReconciler(t *testing.T) {
 
 	// Change the GCPSAAnnotationKey annotation
 	core.SetAnnotation(sa, GCPSAAnnotationKey, test2GSAEmail)
-	if err := fakeClient.Update(ctx, sa); err != nil {
+	if err := fakeClient.Update(ctx, sa, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the default service account: %v", err)
 	}
 	// Reconcile the default service account under the config-management-monitoring namespace.
@@ -360,7 +361,7 @@ func TestOtelSAReconciler(t *testing.T) {
 
 	// Resets the annotations of the default SA
 	sa.SetAnnotations(map[string]string{})
-	if err := fakeClient.Update(ctx, sa); err != nil {
+	if err := fakeClient.Update(ctx, sa, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the default service account: %v", err)
 	}
 	// Reconcile the default service account under the config-management-monitoring namespace.

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -593,7 +593,7 @@ func (r *reconcilerBase) setupOrTeardown(ctx context.Context, syncObj client.Obj
 			// The object is new and doesn't have our finalizer yet.
 			// Add our finalizer and update the object.
 			controllerutil.AddFinalizer(syncObj, metadata.ReconcilerManagerFinalizer)
-			if err := r.client.Update(ctx, syncObj); err != nil {
+			if err := r.client.Update(ctx, syncObj, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 				err = status.APIServerError(err,
 					fmt.Sprintf("failed to update %s to add finalizer", r.syncKind))
 				r.logger(ctx).Error(err, "Finalizer injection failed")
@@ -642,7 +642,7 @@ func (r *reconcilerBase) setupOrTeardown(ctx context.Context, syncObj client.Obj
 
 		// Remove our finalizer and update the object.
 		controllerutil.RemoveFinalizer(syncObj, metadata.ReconcilerManagerFinalizer)
-		if err := r.client.Update(ctx, syncObj); err != nil {
+		if err := r.client.Update(ctx, syncObj, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 			err = status.APIServerError(err,
 				fmt.Sprintf("failed to update %s to remove the reconciler-manager finalizer", r.syncKind))
 			r.logger(ctx).Error(err, "Removal of reconciler-manager finalizer failed")
@@ -684,7 +684,7 @@ func (r *reconcilerBase) updateRBACBinding(ctx context.Context, reconcilerRef, r
 	if equality.Semantic.DeepEqual(existingBinding, binding) {
 		return nil
 	}
-	if err := r.client.Update(ctx, binding); err != nil {
+	if err := r.client.Update(ctx, binding, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return err
 	}
 	bindingNN := types.NamespacedName{

--- a/pkg/reconcilermanager/controllers/reconciler_base_test.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base_test.go
@@ -580,7 +580,7 @@ func TestCompareDeploymentsToCreatePatchData(t *testing.T) {
 			testCurrent := tc.current.DeepCopy()
 			fakeClient := syncerFake.NewClient(t, core.Scheme)
 			if tc.isAutopilot {
-				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject())
+				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject(), client.FieldOwner(syncerFake.FieldManager))
 				require.NoError(t, err)
 			}
 			r := &reconcilerBase{
@@ -698,7 +698,7 @@ func TestCompareDeploymentsToCreatePatchDataResourceLimits(t *testing.T) {
 			}
 			fakeClient := syncerFake.NewClient(t, core.Scheme)
 			if tc.isAutopilot {
-				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject())
+				err := fakeClient.Create(context.Background(), util.FakeAutopilotWebhookObject(), client.FieldOwner(syncerFake.FieldManager))
 				require.NoError(t, err)
 			}
 			r := &reconcilerBase{

--- a/pkg/reconcilermanager/controllers/reconciler_finalizer_handler.go
+++ b/pkg/reconcilermanager/controllers/reconciler_finalizer_handler.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -85,7 +86,7 @@ func (r nsReconcilerFinalizerHandler) handleReconcilerFinalizer(ctx context.Cont
 		r.logger(ctx).Info("Reconciler finalizer not found")
 		return true, nil
 	}
-	if err := r.client.Update(ctx, syncObj); err != nil {
+	if err := r.client.Update(ctx, syncObj, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		err = status.APIServerError(err, "failed to update RepoSync to remove the reconciler finalizer")
 		r.logger(ctx).Error(err, "Removal of reconciler finalizer removal failed")
 		return false, err

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -1103,7 +1103,7 @@ func (r *RepoSyncReconciler) updateSyncStatus(ctx context.Context, rs *v1beta1.R
 					cmp.Diff(before.Status, rs.Status)))
 		}
 		return nil
-	})
+	}, client.FieldOwner(reconcilermanager.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("Sync status update failed: %w", err)
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -306,7 +306,7 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 
 	ctx := context.Background()
 	for _, obj := range objs {
-		err := cs.Client.Create(ctx, obj)
+		err := cs.Client.Create(ctx, obj, client.FieldOwner(reconcilermanager.FieldManager))
 		if err != nil {
 			t.Fatalf("Failed to create object: %v", err)
 		}
@@ -419,7 +419,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 			Resources: overrideReconcilerCPUAndGitSyncMemResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -457,7 +457,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -565,7 +565,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 			Resources: overrideReconcilerAndGitSyncResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -623,7 +623,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 			Resources: overrideReconcilerResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -673,7 +673,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 			Resources: overrideGitSyncResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -710,7 +710,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -842,7 +842,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionFalse, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -869,7 +869,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionTrue, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -887,7 +887,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.NoSSLVerify = false
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -913,7 +913,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.NoSSLVerify = true
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -956,7 +956,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionFalse, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -982,7 +982,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionTrue, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -1017,7 +1017,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.NoSSLVerify = false
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1038,7 +1038,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionFalse, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -1082,7 +1082,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 		*newDeploymentCondition(appsv1.DeploymentAvailable, corev1.ConditionTrue, "unused", "unused"),
 		*newDeploymentCondition(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "unused"),
 	)
-	if err := fakeClient.Status().Update(ctx, deployment); err != nil {
+	if err := fakeClient.Status().Update(ctx, deployment, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the reconciler deployment status: %v", err)
 	}
 
@@ -1182,7 +1182,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.CACertSecretRef = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1200,7 +1200,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1231,7 +1231,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.CACertSecretRef = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1294,7 +1294,7 @@ func TestRepoSyncReconcileAdmissionWebhook(t *testing.T) {
 
 			for _, o := range tc.existingObjects {
 				t.Log("creating obj", o.GetObjectKind().GroupVersionKind().Kind)
-				if err := fakeClient.Create(context.Background(), o); err != nil {
+				if err := fakeClient.Create(context.Background(), o, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1452,7 +1452,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	var depth int64 = 5
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1485,7 +1485,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	depth = 0
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1517,7 +1517,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SafeOverride().GitSyncDepth = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1548,7 +1548,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1640,7 +1640,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1672,7 +1672,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1703,7 +1703,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1792,7 +1792,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().APIServerTimeout = &reconcileTimeout
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1824,7 +1824,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SafeOverride().APIServerTimeout = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1855,7 +1855,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1934,7 +1934,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	}
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: reposyncSSHKey}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -1966,7 +1966,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 	}
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -2051,7 +2051,9 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 	}
 	_, err = fakeDynamicClient.Resource(kinds.DeploymentResource()).
 		Namespace(repoDeployment.Namespace).
-		Patch(ctx, repoDeployment.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+		Patch(ctx, repoDeployment.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{
+			FieldManager: reconcilermanager.FieldManager,
+		})
 	if err != nil {
 		t.Fatalf("failed to update the deployment, got error: %v, want error: nil", err)
 	}
@@ -2181,7 +2183,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("ServiceAccount, RoleBinding, Deployment successfully created")
 
 	// Test reconciler rs2: repo-sync
-	if err := fakeClient.Create(ctx, rs2); err != nil {
+	if err := fakeClient.Create(ctx, rs2, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName2); err != nil {
@@ -2242,7 +2244,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and RoleBindings successfully created")
 
 	// Test reconciler rs3: my-rs-3
-	if err := fakeClient.Create(ctx, rs3); err != nil {
+	if err := fakeClient.Create(ctx, rs3, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName3); err != nil {
@@ -2299,10 +2301,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and RoleBindings successfully created")
 
 	// Test reconciler rs4: my-rs-4
-	if err := fakeClient.Create(ctx, rs4); err != nil {
+	if err := fakeClient.Create(ctx, rs4, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
-	if err := fakeClient.Create(ctx, secret4); err != nil {
+	if err := fakeClient.Create(ctx, secret4, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName4); err != nil {
@@ -2359,10 +2361,10 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and RoleBindings successfully created")
 
 	// Test reconciler rs5: my-rs-5
-	if err := fakeClient.Create(ctx, rs5); err != nil {
+	if err := fakeClient.Create(ctx, rs5, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
-	if err := fakeClient.Create(ctx, secret5); err != nil {
+	if err := fakeClient.Create(ctx, secret5, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName5); err != nil {
@@ -2424,7 +2426,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs1.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs1); err != nil {
+	if err := fakeClient.Update(ctx, rs1, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -2460,7 +2462,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs2.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs2); err != nil {
+	if err := fakeClient.Update(ctx, rs2, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -2496,7 +2498,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs3.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs3); err != nil {
+	if err := fakeClient.Update(ctx, rs3, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -3089,7 +3091,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	}
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: reposyncSSHKey}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -3122,7 +3124,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 	}
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -3211,7 +3213,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	existing := rs.DeepCopy()
 	rs.Spec.Helm.Auth = configsync.AuthNone
 	rs.Spec.Helm.SecretRef = nil
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3243,7 +3245,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	existing = rs.DeepCopy()
 	rs.Spec.Helm.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Helm.GCPServiceAccountEmail = gcpSAEmail
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3321,7 +3323,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	// Test 5: Migrate from GSA to KSA for authentication using Fleet WI.
 	existing = rs.DeepCopy()
 	rs.Spec.Helm.Auth = configsync.AuthK8sServiceAccount
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3372,7 +3374,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 			Resources: overrideHelmSyncResources,
 		},
 	}
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3460,7 +3462,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	t.Log("Test updating RepoSync resources with gcenode auth type.")
 	existing := rs.DeepCopy()
 	rs.Spec.Oci.Auth = configsync.AuthGCENode
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3495,7 +3497,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	existing = rs.DeepCopy()
 	rs.Spec.Oci.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Oci.GCPServiceAccountEmail = gcpSAEmail
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3575,7 +3577,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 	// test 5: Migrate from GSA to KSA for authentication using Fleet WI.
 	existing = rs.DeepCopy()
 	rs.Spec.Oci.Auth = configsync.AuthK8sServiceAccount
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -3631,7 +3633,7 @@ func TestRepoSyncWithOCI(t *testing.T) {
 			Resources: overrideOciSyncResources,
 		},
 	}
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -3683,7 +3685,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.GitSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3698,7 +3700,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3713,7 +3715,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3729,7 +3731,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3745,7 +3747,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3762,7 +3764,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3778,7 +3780,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3794,7 +3796,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3812,12 +3814,12 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage, Auth: configsync.AuthNone}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	// Clear the stalled condition
 	rs.Status = v1beta1.RepoSyncStatus{}
-	if err := fakeClient.Status().Update(ctx, rs); err != nil {
+	if err := fakeClient.Status().Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3838,12 +3840,12 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart, Auth: configsync.AuthNone}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	// Clear the stalled condition
 	rs.Status = v1beta1.RepoSyncStatus{}
-	if err := fakeClient.Status().Update(ctx, rs); err != nil {
+	if err := fakeClient.Status().Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3912,7 +3914,7 @@ func TestRepoSyncReconcileStaleClientCache(t *testing.T) {
 	require.NoError(t, err, "unexpected Get error")
 	rs.Spec.SourceType = string(v1beta1.GitSource)
 	rs.ResourceVersion = "2" // doesn't need to be increasing or even numeric
-	err = fakeClient.Update(ctx, rs)
+	err = fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager))
 	require.NoError(t, err, "unexpected Update error")
 
 	// Reconcile should succeed and update the RepoSync
@@ -4121,7 +4123,7 @@ func TestUpdateNamespaceReconcilerLogLevelWithOverride(t *testing.T) {
 			LogLevels: overrideLogLevel,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -4221,7 +4223,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverrideOnAutopilot(t *testing.T)
 			Resources: overrideReconcilerCPUAndGitSyncMemResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -4259,7 +4261,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverrideOnAutopilot(t *testing.T)
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
 	rs.Spec.Override = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 
@@ -4365,7 +4367,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	}
 	rs.Spec.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret2Name}
 	rs.Spec.SecretRef = &v1beta1.SecretReference{Name: gitSecret2Name}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4385,7 +4387,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	rs.Spec.CACertSecretRef = nil
 	rs.Spec.SecretRef = nil
 	rs.Spec.Auth = configsync.AuthNone
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4403,7 +4405,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	// Verify Secret garbage collection behavior with OCI source type
 	rs = repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone),
 		reposyncCACert(v1beta1.OciSource, caCertSecret1Name))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4417,7 +4419,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	// Switch secret reference to a different Secret
 	rs = repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone),
 		reposyncCACert(v1beta1.OciSource, caCertSecret2Name))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4430,7 +4432,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Remove CA cert secret ref
 	rs = repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4446,7 +4448,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	// Verify Secret garbage collection behavior with helm source type
 	rs = repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone),
 		reposyncCACert(v1beta1.HelmSource, caCertSecret1Name))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4460,7 +4462,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	// Switch secret reference to a different Secret
 	rs = repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone),
 		reposyncCACert(v1beta1.HelmSource, caCertSecret2Name))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4473,7 +4475,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Remove CA cert secret ref
 	rs = repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone))
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -1093,7 +1093,7 @@ func (r *RootSyncReconciler) createRBACBinding(ctx context.Context, reconcilerRe
 	binding.SetGenerateName(fmt.Sprintf("%s-", reconcilerRef.Name))
 	binding.SetLabels(ManagedObjectLabelMap(r.syncKind, rsRef))
 
-	if err := r.client.Create(ctx, binding); err != nil {
+	if err := r.client.Create(ctx, binding, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return client.ObjectKey{}, err
 	}
 	rbRef := client.ObjectKey{
@@ -1138,7 +1138,7 @@ func (r *RootSyncReconciler) updateSyncStatus(ctx context.Context, rs *v1beta1.R
 					cmp.Diff(before.Status, rs.Status)))
 		}
 		return nil
-	})
+	}, client.FieldOwner(reconcilermanager.FieldManager))
 	if err != nil {
 		return updated, fmt.Errorf("Sync status update failed: %w", err)
 	}

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -193,7 +193,7 @@ func setupRootReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 
 	ctx := context.Background()
 	for _, obj := range objs {
-		err := cs.Client.Create(ctx, obj)
+		err := cs.Client.Create(ctx, obj, client.FieldOwner(reconcilermanager.FieldManager))
 		if err != nil {
 			t.Fatalf("Failed to create object: %v", err)
 		}
@@ -459,7 +459,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 			Resources: overrideSelectedResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -492,7 +492,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
 	rs.Spec.Override = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -592,7 +592,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 			Resources: overrideAllContainerResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -648,7 +648,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 			Resources: overrideReconcilerAndHydrationResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -694,7 +694,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 			Resources: overrideGitSyncResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -728,7 +728,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.RootSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -837,7 +837,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	// Set rs.Spec.NoSSLVerify to false
 	rs.Spec.NoSSLVerify = false
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -858,7 +858,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	// Set rs.Spec.NoSSLVerify to true
 	rs.Spec.NoSSLVerify = true
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -891,7 +891,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 	}
 	// Set rs.Spec.NoSSLVerify to false
 	rs.Spec.NoSSLVerify = false
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1009,7 +1009,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	// Unset rs.Spec.CACertSecretRef
 	rs.Spec.CACertSecretRef = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1027,7 +1027,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	// Set rs.Spec.CACertSecretRef
 	rs.Spec.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1060,7 +1060,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	}
 	// Unset rs.Spec.CACertSecretRef
 	rs.Spec.CACertSecretRef = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1123,7 +1123,7 @@ func TestRootSyncReconcileAdmissionWebhook(t *testing.T) {
 
 			for _, o := range tc.existingObjects {
 				t.Log("creating obj", o.GetObjectKind().GroupVersionKind().Kind)
-				if err := fakeClient.Create(context.Background(), o); err != nil {
+				if err := fakeClient.Create(context.Background(), o, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1285,7 +1285,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	// Test overriding the git sync depth to a positive value
 	var depth int64 = 5
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1317,7 +1317,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	// Test overriding the git sync depth to 0
 	depth = 0
 	rs.Spec.SafeOverride().GitSyncDepth = &depth
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1351,7 +1351,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	// Set rs.Spec.Override.GitSyncDepth to nil.
 	rs.Spec.SafeOverride().GitSyncDepth = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1384,7 +1384,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.RootSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -1480,7 +1480,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	// Test overriding the reconcile timeout to 50s
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1514,7 +1514,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	// Set rs.Spec.Override.ReconcileTimeout to nil.
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1547,7 +1547,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.RootSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1639,7 +1639,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	// Test overriding the reconcile timeout to 50s
 	reconcileTimeout := metav1.Duration{Duration: 50 * time.Second}
 	rs.Spec.SafeOverride().ReconcileTimeout = &reconcileTimeout
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1669,7 +1669,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	// Set rs.Spec.Override.ReconcileTimeout to nil.
 	rs.Spec.SafeOverride().ReconcileTimeout = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1699,7 +1699,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 	}
 	// Clear rs.Spec.Override
 	rs.Spec.Override = &v1beta1.RootSyncOverrideSpec{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -1865,7 +1865,7 @@ func TestRootSyncCreateWithOverrideRoleRefs(t *testing.T) {
 	}
 
 	rs.Spec.SafeOverride().RoleRefs = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("Failed to update RootSync: %q", err)
 	}
 	t.Log("RootSync updated to remove RoleRefs override")
@@ -2007,7 +2007,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	// Test updating RootSync resources with SSH auth type.
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: rootsyncSSHKey}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -2041,7 +2041,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 	// Test updating RootSync resources with None auth type.
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -2120,7 +2120,9 @@ func TestRootSyncReconcilerRestart(t *testing.T) {
 	t.Logf("Applying Patch: %s", string(patchData))
 	_, err = fakeDynamicClient.Resource(kinds.DeploymentResource()).
 		Namespace(rootDeployment.Namespace).
-		Patch(ctx, rootDeployment.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+		Patch(ctx, rootDeployment.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{
+			FieldManager: reconcilermanager.FieldManager,
+		})
 	if err != nil {
 		t.Fatalf("failed to patch the deployment: %v", err)
 	}
@@ -2248,7 +2250,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	t.Log("ServiceAccount, ClusterRoleBinding and Deployment successfully created")
 
 	// Test reconciler rs2: root-sync
-	if err := fakeClient.Create(ctx, rs2); err != nil {
+	if err := fakeClient.Create(ctx, rs2, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName2); err != nil {
@@ -2309,7 +2311,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and ClusterRoleBindings successfully created")
 
 	// Test reconciler rs3: my-rs-3
-	if err := fakeClient.Create(ctx, rs3); err != nil {
+	if err := fakeClient.Create(ctx, rs3, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName3); err != nil {
@@ -2371,10 +2373,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and ClusterRoleBindings successfully created")
 
 	// Test reconciler rs4: my-rs-4
-	if err := fakeClient.Create(ctx, rs4); err != nil {
+	if err := fakeClient.Create(ctx, rs4, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
-	if err := fakeClient.Create(ctx, secret4); err != nil {
+	if err := fakeClient.Create(ctx, secret4, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName4); err != nil {
@@ -2436,10 +2438,10 @@ func TestMultipleRootSyncs(t *testing.T) {
 	t.Log("Deployments, ServiceAccounts, and ClusterRoleBindings successfully created")
 
 	// Test reconciler rs5: my-rs-5
-	if err := fakeClient.Create(ctx, rs5); err != nil {
+	if err := fakeClient.Create(ctx, rs5, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
-	if err := fakeClient.Create(ctx, secret5); err != nil {
+	if err := fakeClient.Create(ctx, secret5, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName5); err != nil {
@@ -2506,7 +2508,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	// Test updating Deployment resources for rs1: my-root-sync
 	rs1.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs1); err != nil {
+	if err := fakeClient.Update(ctx, rs1, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -2548,7 +2550,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	}
 	// Test updating Deployment resources for rs2: root-sync
 	rs2.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs2); err != nil {
+	if err := fakeClient.Update(ctx, rs2, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v, want error: nil", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName2); err != nil {
@@ -2590,7 +2592,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	// Test updating  Deployment resources for rs3: my-rs-3
 	rs3.Spec.Git.Revision = gitUpdatedRevision
 	rs3.Spec.Git.Revision = gitUpdatedRevision
-	if err := fakeClient.Update(ctx, rs3); err != nil {
+	if err := fakeClient.Update(ctx, rs3, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName3); err != nil {
@@ -2963,7 +2965,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 	// Test updating RootSync resources with SSH auth type.
 	rs.Spec.Auth = configsync.AuthSSH
 	rs.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: rootsyncSSHKey}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -2997,7 +2999,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 	// Test updating RootSync resources with None auth type.
 	rs.Spec.Auth = configsync.AuthNone
 	rs.Spec.SecretRef = &v1beta1.SecretReference{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -3092,7 +3094,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 	// Test 2: updating RootSync resources with None auth type.
 	rs.Spec.Helm.Auth = configsync.AuthNone
 	rs.Spec.Helm.SecretRef = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3124,7 +3126,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 	existing := rs.DeepCopy()
 	rs.Spec.Helm.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Helm.GCPServiceAccountEmail = gcpSAEmail
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3201,7 +3203,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 	// Test 5: Migrate from GSA to KSA for authentication using Fleet WI.
 	existing = rs.DeepCopy()
 	rs.Spec.Helm.Auth = configsync.AuthK8sServiceAccount
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3253,7 +3255,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 			Resources: overrideHelmSyncResources,
 		},
 	}
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -3343,7 +3345,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 	// test 2: switch to authenticate with `gcenode` type.
 	t.Log("Test updating RootSync resources with gcenode auth type.")
 	rs.Spec.Oci.Auth = configsync.AuthGCENode
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3377,7 +3379,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 	existing := rs.DeepCopy()
 	rs.Spec.Oci.Auth = configsync.AuthGCPServiceAccount
 	rs.Spec.Oci.GCPServiceAccountEmail = gcpSAEmail
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3454,7 +3456,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 	// test 5: Migrate from GSA to KSA for authentication using Fleet WI.
 	existing = rs.DeepCopy()
 	rs.Spec.Oci.Auth = configsync.AuthK8sServiceAccount
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3506,7 +3508,7 @@ func TestRootSyncWithOCI(t *testing.T) {
 			Resources: overrideOciSyncResources,
 		},
 	}
-	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing)); err != nil {
+	if err := fakeClient.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 
@@ -3560,7 +3562,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.GitSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3575,7 +3577,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3590,7 +3592,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3606,7 +3608,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3622,7 +3624,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.OciSource)
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3639,7 +3641,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{}
 	rs.Spec.Oci = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3655,7 +3657,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3671,7 +3673,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	}
 	rs.Spec.SourceType = string(v1beta1.HelmSource)
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3689,12 +3691,12 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage, Auth: configsync.AuthNone}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	// Clear the stalled condition
 	rs.Status = v1beta1.RootSyncStatus{}
-	if err := fakeClient.Status().Update(ctx, rs); err != nil {
+	if err := fakeClient.Status().Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3715,12 +3717,12 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart, Auth: configsync.AuthNone}}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	// Clear the stalled condition
 	rs.Status = v1beta1.RootSyncStatus{}
-	if err := fakeClient.Status().Update(ctx, rs); err != nil {
+	if err := fakeClient.Status().Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3790,7 +3792,7 @@ func TestRootSyncReconcileStaleClientCache(t *testing.T) {
 	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
 	require.NoError(t, err, "unexpected Get error")
 	rs.Spec.SourceType = string(v1beta1.GitSource)
-	err = fakeClient.Update(ctx, rs)
+	err = fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager))
 	require.NoError(t, err, "unexpected Update error")
 
 	// Reconcile should succeed and update the RootSync
@@ -4005,7 +4007,7 @@ func TestUpdateRootReconcilerLogLevelWithOverride(t *testing.T) {
 			LogLevels: overrideLogLevel,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4095,7 +4097,7 @@ func TestCreateAndUpdateRootReconcilerWithOverrideOnAutopilot(t *testing.T) {
 			Resources: overrideSelectedResources,
 		},
 	}
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 
@@ -4128,7 +4130,7 @@ func TestCreateAndUpdateRootReconcilerWithOverrideOnAutopilot(t *testing.T) {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
 	rs.Spec.Override = nil
-	if err := fakeClient.Update(ctx, rs); err != nil {
+	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
 

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -243,7 +243,7 @@ func TestRemediator_Reconcile(t *testing.T) {
 			// Simulate the Parser having already parsed the resource and recorded it.
 			d := makeDeclared(t, "unused", tc.declared)
 
-			r := newReconciler(declared.RootReconciler, configsync.RootSyncName, c.Applier(), d, testingfake.NewFightHandler())
+			r := newReconciler(declared.RootReconciler, configsync.RootSyncName, c.Applier(configsync.FieldManager), d, testingfake.NewFightHandler())
 
 			// Get the triggering object for the reconcile event.
 			var obj client.Object
@@ -360,7 +360,7 @@ func TestRemediator_Reconcile_Metrics(t *testing.T) {
 			// Simulate the Parser having already parsed the resource and recorded it.
 			d := makeDeclared(t, "abc123", tc.declared)
 
-			fakeApplier := &testingfake.Applier{Client: fakeClient}
+			fakeApplier := &testingfake.Applier{Client: fakeClient, FieldManager: configsync.FieldManager}
 			fakeApplier.CreateError = tc.createError
 			fakeApplier.UpdateError = tc.updateError
 			fakeApplier.DeleteError = tc.deleteError

--- a/pkg/resourcegroup/controllers/resourcegroup/constants.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/constants.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegroup
+
+import "kpt.dev/configsync/pkg/api/configsync"
+
+const (
+	// FieldManager is the field manager name used by the resource-group controller.
+	// This avoids conflicts with the reconciler and reconciler-manager.
+	FieldManager = configsync.ConfigSyncPrefix + "resource-group-controller"
+)

--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
@@ -177,7 +177,7 @@ func (r *reconciler) updateStatusKptGroup(ctx context.Context, resgroup *v1alpha
 		}
 		resgroup.Status = newStatus
 		// Use `r.Status().Update()` here instead of `r.Update()` to update only resgroup.Status.
-		return r.Status().Update(ctx, resgroup)
+		return r.Status().Update(ctx, resgroup, client.FieldOwner(FieldManager))
 	})
 }
 

--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcemap"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/typeresolver"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -92,7 +93,7 @@ func TestReconcile(t *testing.T) {
 			Resources: resources,
 		},
 	}
-	err = c.Create(ctx, resgroupKpt)
+	err = c.Create(ctx, resgroupKpt, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 	// Wait 5 seconds before querying resgroup from API server
 	time.Sleep(5 * time.Second)
@@ -140,7 +141,7 @@ func TestReconcile(t *testing.T) {
 		Resources: resources,
 	}
 
-	err = c.Update(ctx, updatedResgroupKpt)
+	err = c.Update(ctx, updatedResgroupKpt, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
@@ -188,7 +189,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	err = c.Create(ctx, pod2)
+	err = c.Create(ctx, pod2, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 
@@ -206,7 +207,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}
-	err = c.Create(ctx, ns1)
+	err = c.Create(ctx, ns1, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 	time.Sleep(2 * time.Second)
 
@@ -254,7 +255,7 @@ func TestReconcile(t *testing.T) {
 	updatedResgroupKpt.Spec = v1alpha1.ResourceGroupSpec{
 		Resources: resources,
 	}
-	err = c.Update(ctx, updatedResgroupKpt)
+	err = c.Update(ctx, updatedResgroupKpt, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 	time.Sleep(5 * time.Second)
 

--- a/pkg/resourcegroup/controllers/root/root_controller.go
+++ b/pkg/resourcegroup/controllers/root/root_controller.go
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileDisabledResourceGroup(ctx context.Context, req ctr
 		}
 		resgroup.Status = emptyStatus
 		// Use `r.Status().Update()` here instead of `r.Update()` to update only resgroup.Status.
-		return r.Status().Update(ctx, resgroup)
+		return r.Status().Update(ctx, resgroup, client.FieldOwner(resourcegroup.FieldManager))
 	})
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcemap"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/typeresolver"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
 )
 
 const contextRootControllerKey = contextKey("root-controller")
@@ -75,7 +76,7 @@ func TestRootReconciler(t *testing.T) {
 		},
 	}
 
-	err = c.Create(ctx, resourceGroupKpt)
+	err = c.Create(ctx, resourceGroupKpt, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 
 	// Create triggers an reconciliation,
@@ -138,7 +139,7 @@ func TestRootReconciler(t *testing.T) {
 		Resources: resources,
 	}
 	// Update the resource group
-	err = c.Update(ctx, resourceGroupKpt)
+	err = c.Update(ctx, resourceGroupKpt, client.FieldOwner(fake.FieldManager))
 	assert.NoError(t, err)
 
 	// The update triggers another reconcile

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -66,7 +66,7 @@ func TestClient_Create(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sc := syncerclient.New(tc.client, nil)
 
-			err := sc.Create(context.Background(), tc.declared)
+			err := sc.Create(context.Background(), tc.declared, client.FieldOwner(syncertestfake.FieldManager))
 			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}
@@ -151,7 +151,7 @@ func TestClient_Update(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sc := syncerclient.New(tc.client, nil)
 
-			err := sc.Update(context.Background(), tc.declared)
+			err := sc.Update(context.Background(), tc.declared, client.FieldOwner(syncertestfake.FieldManager))
 			testerrors.AssertEqual(t, tc.wantErr, err)
 		})
 	}

--- a/pkg/syncer/reconcile/apply.go
+++ b/pkg/syncer/reconcile/apply.go
@@ -212,7 +212,7 @@ func (c *clientApplier) create(ctx context.Context, obj *unstructured.Unstructur
 		return status.ResourceWrap(err, "could not generate apply annotation on create", obj)
 	}
 
-	return c.client.Create(ctx, obj)
+	return c.client.Create(ctx, obj, client.FieldOwner(configsync.FieldManager))
 }
 
 // clientFor returns the client which may interact with the passed object.
@@ -380,7 +380,9 @@ func attemptPatch(ctx context.Context, resClient dynamic.ResourceInterface, name
 	}
 
 	start := time.Now()
-	_, err := resClient.Patch(ctx, name, patchType, patch, metav1.PatchOptions{})
+	_, err := resClient.Patch(ctx, name, patchType, patch, metav1.PatchOptions{
+		FieldManager: configsync.FieldManager,
+	})
 	duration := time.Since(start).Seconds()
 	metrics.APICallDuration.WithLabelValues("update", metrics.StatusLabel(err)).Observe(duration)
 	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), start)

--- a/pkg/syncer/syncertest/fake/client.go
+++ b/pkg/syncer/syncertest/fake/client.go
@@ -72,7 +72,7 @@ func NewClient(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) *Cli
 	StartWatchSupervisor(t, watchSupervisor)
 
 	for _, o := range objs {
-		err := result.Create(context.Background(), o)
+		err := result.Create(context.Background(), o, client.FieldOwner(FieldManager))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -228,8 +228,8 @@ func (c *Client) Watch(ctx context.Context, exampleList client.ObjectList, opts 
 
 // Applier returns a fake.Applier wrapping this fake.Client. Callers using the
 // resulting Applier will read from/write to the original fake.Client.
-func (c *Client) Applier() reconcile.Applier {
-	return &Applier{Client: c}
+func (c *Client) Applier(fieldManager string) reconcile.Applier {
+	return &Applier{Client: c, FieldManager: fieldManager}
 }
 
 // Codecs returns the CodecFactory.

--- a/pkg/syncer/syncertest/fake/dynamic_client.go
+++ b/pkg/syncer/syncertest/fake/dynamic_client.go
@@ -172,7 +172,10 @@ func (dc *DynamicClient) create(action clienttesting.Action) (bool, runtime.Obje
 			createAction.GetResource(),
 			gvk, uObj.GroupVersionKind())
 	}
-	err = dc.storage.Create(context.Background(), uObj, &client.CreateOptions{})
+	err = dc.storage.Create(context.Background(), uObj, &client.CreateOptions{
+		// TODO: Pass through FieldManager from CreateOption (requires client-go & client-gen changes)
+		FieldManager: FieldManager,
+	})
 	return true, uObj, err
 }
 
@@ -240,7 +243,10 @@ func (dc *DynamicClient) update(action clienttesting.Action) (bool, runtime.Obje
 			updateAction.GetResource(),
 			gvk, uObj.GroupVersionKind())
 	}
-	err = dc.storage.Update(context.Background(), uObj, &client.UpdateOptions{})
+	err = dc.storage.Update(context.Background(), uObj, &client.UpdateOptions{
+		// TODO: Pass through FieldManager from UpdateOption (requires client-go & client-gen changes)
+		FieldManager: FieldManager,
+	})
 	return true, uObj, err
 }
 
@@ -260,7 +266,10 @@ func (dc *DynamicClient) patch(action clienttesting.Action) (bool, runtime.Objec
 	uObj.SetNamespace(patchAction.GetNamespace())
 	uObj.SetName(patchAction.GetName())
 	patch := client.RawPatch(patchAction.GetPatchType(), patchAction.GetPatch())
-	err = dc.storage.Patch(context.Background(), uObj, patch, &client.PatchOptions{})
+	err = dc.storage.Patch(context.Background(), uObj, patch, &client.PatchOptions{
+		// TODO: Pass through FieldManager from PatchOptions (requires client-go & client-gen changes)
+		FieldManager: FieldManager,
+	})
 	return true, uObj, err
 }
 

--- a/pkg/util/mutate/mutate.go
+++ b/pkg/util/mutate/mutate.go
@@ -58,8 +58,9 @@ func RetriableOrConflict(err error) bool {
 // unnecessary (`NoUpdateError` from the `mutate.Func`). Retries are quick, with
 // no backoff.
 // Returns an error if the status update fails OR if the mutate func fails.
-func Spec(ctx context.Context, c client.Client, obj client.Object, mutateFn Func) (bool, error) {
-	return withRetry(ctx, &specClient{client: c}, obj, mutateFn)
+func Spec(ctx context.Context, c client.Client, obj client.Object, mutateFn Func, opts ...client.UpdateOption) (bool, error) {
+	client := &specClient{client: c, updateOptions: opts}
+	return withRetry(ctx, client, obj, mutateFn)
 }
 
 // Status attempts to update the status of an object until successful or update
@@ -67,7 +68,7 @@ func Spec(ctx context.Context, c client.Client, obj client.Object, mutateFn Func
 // quick, with no backoff.
 // Returns an error if the status update fails OR if the mutate func fails OR if
 // the generation changes before the status update succeeds.
-func Status(ctx context.Context, c client.Client, obj client.Object, mutateFn Func) (bool, error) {
+func Status(ctx context.Context, c client.Client, obj client.Object, mutateFn Func, opts ...client.UpdateOption) (bool, error) {
 	oldGen := obj.GetGeneration()
 	mutateFn2 := func() error {
 		newGen := obj.GetGeneration()
@@ -79,7 +80,8 @@ func Status(ctx context.Context, c client.Client, obj client.Object, mutateFn Fu
 		}
 		return mutateFn()
 	}
-	return withRetry(ctx, &statusClient{client: c}, obj, mutateFn2)
+	client := &statusClient{client: c, updateOptions: convertUpdateOptions(opts)}
+	return withRetry(ctx, client, obj, mutateFn2)
 }
 
 // withRetry attempts to update an object until successful or update becomes
@@ -169,7 +171,8 @@ type updater interface {
 }
 
 type specClient struct {
-	client client.Client
+	client        client.Client
+	updateOptions []client.UpdateOption
 }
 
 // Get the current spec of the specified object.
@@ -179,7 +182,7 @@ func (c *specClient) Get(ctx context.Context, obj client.Object) error {
 
 // Update the spec of the specified object.
 func (c *specClient) Update(ctx context.Context, obj client.Object) error {
-	return c.client.Update(ctx, obj)
+	return c.client.Update(ctx, obj, c.updateOptions...)
 }
 
 // WrapError returns the specified error wrapped with extra context specific
@@ -189,7 +192,8 @@ func (c *specClient) WrapError(_ context.Context, obj client.Object, err error) 
 }
 
 type statusClient struct {
-	client client.Client
+	client        client.Client
+	updateOptions []client.SubResourceUpdateOption
 }
 
 // Get the current status of the specified object.
@@ -199,11 +203,23 @@ func (c *statusClient) Get(ctx context.Context, obj client.Object) error {
 
 // Update the status of the specified object.
 func (c *statusClient) Update(ctx context.Context, obj client.Object) error {
-	return c.client.Status().Update(ctx, obj)
+	return c.client.Status().Update(ctx, obj, c.updateOptions...)
 }
 
 // WrapError returns the specified error wrapped with extra context specific
 // to this updater.
 func (c *statusClient) WrapError(_ context.Context, obj client.Object, err error) error {
 	return fmt.Errorf("failed to update object status: %s: %w", kinds.ObjectSummary(obj), err)
+}
+
+// convertUpdateOptions converts []client.UpdateOption to []client.SubResourceUpdateOption
+func convertUpdateOptions(optList []client.UpdateOption) []client.SubResourceUpdateOption {
+	if len(optList) == 0 {
+		return nil
+	}
+	opts := &client.UpdateOptions{}
+	opts.ApplyOptions(optList)
+	return []client.SubResourceUpdateOption{
+		&client.SubResourceUpdateOptions{UpdateOptions: *opts},
+	}
 }

--- a/pkg/util/mutate/mutate_test.go
+++ b/pkg/util/mutate/mutate_test.go
@@ -180,7 +180,7 @@ func TestStatus(t *testing.T) {
 			scheme := core.Scheme
 			fakeClient := fake.NewClient(t, scheme, tc.existingObjs...)
 			ctx := context.Background()
-			updated, err := Status(ctx, fakeClient, tc.obj, tc.mutateFunc)
+			updated, err := Status(ctx, fakeClient, tc.obj, tc.mutateFunc, client.FieldOwner(fake.FieldManager))
 			testerrors.AssertEqual(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectedUpdated, updated)
 			fakeClient.Check(t, tc.expectedObj)
@@ -337,7 +337,7 @@ func TestSpec(t *testing.T) {
 				// Fake async re-create (with different UID)
 				replacementObj := obj.DeepCopy()
 				replacementObj.SetUID("2")
-				err = fakeClient.Create(context.Background(), replacementObj)
+				err = fakeClient.Create(context.Background(), replacementObj, client.FieldOwner(fake.FieldManager))
 				if err != nil {
 					return fmt.Errorf("failed to create object: %w", err)
 				}
@@ -374,7 +374,7 @@ func TestSpec(t *testing.T) {
 			scheme := core.Scheme
 			fakeClient = fake.NewClient(t, scheme, tc.existingObjs...)
 			ctx := context.Background()
-			updated, err := Spec(ctx, fakeClient, tc.obj, tc.mutateFunc)
+			updated, err := Spec(ctx, fakeClient, tc.obj, tc.mutateFunc, client.FieldOwner(fake.FieldManager))
 			testerrors.AssertEqual(t, tc.expectedError, err)
 			assert.Equal(t, tc.expectedUpdated, updated)
 			fakeClient.Check(t, tc.expectedObj)

--- a/pkg/validate/scoped/hydrate/namespace_hydrator_test.go
+++ b/pkg/validate/scoped/hydrate/namespace_hydrator_test.go
@@ -418,7 +418,7 @@ func TestNamespaceSelectors(t *testing.T) {
 			tc.objs.AllowAPICall = true
 			tc.objs.DynamicNSSelectorEnabled = tc.originalDynamicNSSelectorEnabled
 			tc.objs.NSControllerState = &namespacecontroller.State{}
-			errs := NamespaceSelectors(context.Background(), fakeClient)(tc.objs)
+			errs := NamespaceSelectors(context.Background(), fakeClient, syncerFake.FieldManager)(tc.objs)
 			if !errors.Is(errs, tc.wantErrs) {
 				t.Errorf("Got NamespaceSelectors() error %v, want %v", errs, tc.wantErrs)
 			}

--- a/pkg/validate/scoped/scoped.go
+++ b/pkg/validate/scoped/scoped.go
@@ -52,7 +52,7 @@ func Hierarchical(objs *objects.Scoped) status.MultiError {
 // Unstructured performs the second round of validation and hydration for an
 // unstructured repo against the given Scoped objects. Note that this will
 // modify the Scoped objects in-place.
-func Unstructured(ctx context.Context, c client.Client, objs *objects.Scoped) status.MultiError {
+func Unstructured(ctx context.Context, c client.Client, fieldManager string, objs *objects.Scoped) status.MultiError {
 	var errs status.MultiError
 	var validateClusterScoped objects.ObjectVisitor
 	if objs.Scope == declared.RootReconciler {
@@ -75,7 +75,7 @@ func Unstructured(ctx context.Context, c client.Client, objs *objects.Scoped) st
 	}
 
 	hydrators := []objects.ScopedVisitor{
-		hydrate.NamespaceSelectors(ctx, c),
+		hydrate.NamespaceSelectors(ctx, c, fieldManager),
 		hydrate.UnknownScope,
 	}
 	for _, hydrator := range hydrators {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -83,6 +83,8 @@ type Options struct {
 	NSControllerState *namespacecontroller.State
 	// WebhookEnabled indicates whether the admission webhook configuration is enabled
 	WebhookEnabled bool
+	// FieldManager to use when performing cluster operations
+	FieldManager string
 }
 
 // Hierarchical validates and hydrates the given FileObjects from a structured,
@@ -217,7 +219,7 @@ func Unstructured(ctx context.Context, c client.Client, objs []ast.FileObject, o
 
 	scopedObjects.Scope = opts.Scope
 	scopedObjects.SyncName = opts.SyncName
-	if errs := scoped.Unstructured(ctx, c, scopedObjects); errs != nil {
+	if errs := scoped.Unstructured(ctx, c, opts.FieldManager, scopedObjects); errs != nil {
 		return nil, status.Append(nonBlockingErrs, errs)
 	}
 

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -1341,6 +1341,7 @@ func TestUnstructured(t *testing.T) {
 			tc.options.AllowAPICall = true
 			tc.options.DynamicNSSelectorEnabled = tc.originalDynamicNSSelectorEnabled
 			tc.options.NSControllerState = &namespacecontroller.State{}
+			tc.options.FieldManager = configsync.FieldManager
 
 			s := runtime.NewScheme()
 			if err := corev1.AddToScheme(s); err != nil {

--- a/pkg/webhook/configuration/update.go
+++ b/pkg/webhook/configuration/update.go
@@ -31,7 +31,7 @@ import (
 //
 // Returns an error if the API Server returns invalid API Resource lists or
 // there is a problem updating the Configuration.
-func Update(ctx context.Context, c client.Client, dc discovery.ServerResourcer, objs []ast.FileObject) status.MultiError {
+func Update(ctx context.Context, c client.Client, dc discovery.ServerResourcer, objs []ast.FileObject, opts ...client.UpdateOption) status.MultiError {
 	if len(objs) == 0 {
 		// Nothing to do.
 		return nil
@@ -68,7 +68,7 @@ func Update(ctx context.Context, c client.Client, dc discovery.ServerResourcer, 
 	// We aren't yet concerned with removing stale rules, so just merge the two
 	// together.
 	newCfg = Merge(oldCfg, newCfg)
-	if err = c.Update(ctx, newCfg); err != nil {
+	if err = c.Update(ctx, newCfg, opts...); err != nil {
 		return status.APIServerError(err, "applying changes to admission webhook")
 	}
 	return nil


### PR DESCRIPTION
- Add component-specific field managers: configsync.gke.io/resource-group-controller configsync.gke.io/nomos-cli configsync.gke.io/reconciler-manager configsync.gke.io (reconciler uses existing field manager)
- Update the fake clients to require using one of the approved field managers, to help validate usage in unit tests.
- Add a fake.FieldManager for tests to use.
- Update all the unit tests using once of the fake clients.
- Update all Create, Update, and Patch calls to use the appropriate field manager.
- This should help distinguish between fields modified by the reconciler vs the reconciler-manager, and avoid any accidentally removed fields when using server-side apply. This is necessary to allow the reconciler-manager to start adding labels & annotations to RSyncs, whose spec may already be managed by a reconciler using composition.

Caveats:
- The kpt inventory client and cli-utils applier & destroyer do not yet allow configuring the field manager.
- The client-go FakeDynamicClient and generated client-gen clients do not support passing through client options. So the config-sync fake.DynamicClient just uses the fake.FieldManager instead for now.