### PR TITLE
test: log the repo creation timestamp

### DIFF
--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -431,6 +431,7 @@ func initRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedN
 		if err := repo.Create(); err != nil {
 			nt.T.Fatal(err)
 		}
+		nt.T.Logf("Successfully created repo '%s'", repo.RemoteRepoName)
 		nt.RemoteRepositories[nn] = repo
 	}
 	if err := repo.Init(); err != nil {


### PR DESCRIPTION
https://community.atlassian.com/t5/Bitbucket-questions/Re-Re-Unable-to-delete-Git-repositories-due-to-Reposit/qaq-p/2719161/comment-id/104918#M104918 suggests creating repos incrementally rather than all at once.

This commit logs the creation timestamp to confirm whether these test repos are created all around the same time.