### PR TITLE
[WIP] Fix remediator errors causing sync failure

### DIFF
--- a/pkg/parse/cache.go
+++ b/pkg/parse/cache.go
@@ -64,9 +64,6 @@ type cacheForCommit struct {
 
 	// needToRetry indicates whether a retry is needed.
 	needToRetry bool
-
-	// errs tracks all the errors encountered during the reconciliation.
-	errs status.MultiError
 }
 
 func (c *cacheForCommit) setParserResult(objs []ast.FileObject, parserErrs status.MultiError) {

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -88,16 +88,12 @@ type Options struct {
 
 // Parser represents a parser that can be pointed at and continuously parse a source.
 type Parser interface {
+	SyncStatusUpdater
+
 	parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError)
 	setSourceStatus(ctx context.Context, newStatus sourceStatus) error
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
-	SetSyncStatus(ctx context.Context, newStatus syncStatus) error
 	options() *Options
-	// SyncErrors returns all the sync errors, including remediator errors,
-	// validation errors, applier errors, and watch update errors.
-	SyncErrors() status.MultiError
-	// Syncing returns true if the updater is running.
-	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 	// setRequiresRendering sets the requires-rendering annotation on the RSync
@@ -110,4 +106,13 @@ func (o *Options) k8sClient() client.Client {
 
 func (o *Options) discoveryClient() discovery.ServerResourcer {
 	return o.DiscoveryInterface
+}
+
+// SyncStatusUpdater allows reading and writing the status of the latest sync
+// attempt to the cluster.
+type SyncStatusUpdater interface {
+	// SetSyncStatus updates the status.sync field of the RSync
+	SetSyncStatus(ctx context.Context, newStatus syncStatus) error
+	// SyncStatus gets updates the status.sync field of the RSync
+	SyncStatus(ctx context.Context) (syncStatus, error)
 }

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -480,11 +480,12 @@ func TestRoot_Parse(t *testing.T) {
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Converter:          converter,
 					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+						Scope:              declared.RootScope,
+						Resources:          &declared.Resources{},
+						Remediator:         &remediatorfake.Remediator{},
+						Applier:            fakeApplier,
+						StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+						SyncErrorCache:     NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -695,11 +696,12 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					Converter:          converter,
 					WebhookEnabled:     tc.webhookEnabled,
 					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+						Scope:              declared.RootScope,
+						Resources:          &declared.Resources{},
+						Remediator:         &remediatorfake.Remediator{},
+						Applier:            fakeApplier,
+						StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+						SyncErrorCache:     NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -948,11 +950,12 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					DiscoveryInterface: tc.discoveryClient,
 					Converter:          converter,
 					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+						Scope:              declared.RootScope,
+						Resources:          &declared.Resources{},
+						Remediator:         &remediatorfake.Remediator{},
+						Applier:            fakeApplier,
+						StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+						SyncErrorCache:     NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -1033,11 +1036,12 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+						Scope:              declared.RootScope,
+						Resources:          &declared.Resources{},
+						Remediator:         &remediatorfake.Remediator{},
+						Applier:            fakeApplier,
+						StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+						SyncErrorCache:     NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -1108,18 +1112,19 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 			}
 			fakeApplier := &applierfake.Applier{
 				ApplyOutputs: []applierfake.ApplierOutputs{
-					{Errors: tc.applyErrors}, // One Apply call, optional errors
+					{Errors: tc.applyErrors}, // One Apply call, with optional errors
 				},
 			}
 			parser := &root{
 				Options: &Options{
 					Parser: fakeConfigParser,
 					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+						Scope:              declared.RootScope,
+						Resources:          &declared.Resources{},
+						Remediator:         &remediatorfake.Remediator{},
+						Applier:            fakeApplier,
+						StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+						SyncErrorCache:     NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/metadata"
@@ -183,14 +182,18 @@ func Run(ctx context.Context, p Parser, nsControllerState *namespacecontroller.S
 
 		// Update the sync status to report management conflicts (from the remediator).
 		case <-statusUpdateTimer.C:
+			// Skip sync status update if state.cache has been reset and not yet
+			// re-parsed. This avoids removing the last known sync status while
+			// waiting to parse a new source commit.
 			// Skip sync status update if the .status.sync.commit is out of date.
 			// This avoids overwriting a newer Syncing condition with the status
 			// from an older commit.
-			if state.syncStatus.commit == state.sourceStatus.commit &&
+			if state.cache.source.commit != "" &&
+				state.syncStatus.commit == state.sourceStatus.commit &&
 				state.syncStatus.commit == state.renderingStatus.commit {
 
 				klog.V(3).Info("Updating sync status (periodic while not syncing)")
-				if err := setSyncStatus(ctx, p, state, p.Syncing(), p.SyncErrors()); err != nil {
+				if err := p.options().Updater.SetSyncStatus(ctx, state, p); err != nil {
 					klog.Warningf("failed to update sync status: %v", err)
 				}
 			}
@@ -534,119 +537,12 @@ func parseAndUpdate(ctx context.Context, p Parser, trigger string, state *reconc
 		return sourceErrs
 	}
 
-	// Create a new context with its cancellation function.
-	ctxForUpdateSyncStatus, cancel := context.WithCancel(context.Background())
-
-	go updateSyncStatusPeriodically(ctxForUpdateSyncStatus, p, state)
-
-	klog.V(3).Info("Updater starting...")
 	start := time.Now()
-	updateErrs := p.options().Update(ctx, &state.cache)
+	updateErrs := p.options().Update(ctx, state, p)
 	metrics.RecordParserDuration(ctx, trigger, "update", metrics.StatusTagKey(updateErrs), start)
-	klog.V(3).Info("Updater stopped")
 
-	// This is to terminate `updateSyncStatusPeriodically`.
-	cancel()
-
-	// SyncErrors include errors from both the Updater and Remediator
-	klog.V(3).Info("Updating sync status (after sync)")
-	syncErrs := p.SyncErrors()
-	if err := setSyncStatus(ctx, p, state, false, syncErrs); err != nil {
-		syncErrs = status.Append(syncErrs, err)
-	}
-
-	// Return all the errors from the Parser, Updater, and Remediator
-	return status.Append(sourceErrs, syncErrs)
-}
-
-// setSyncStatus updates `.status.sync` and the Syncing condition, if needed,
-// as well as `state.syncStatus` and `state.syncingConditionLastUpdate` if
-// the update is successful.
-func setSyncStatus(ctx context.Context, p Parser, state *reconcilerState, syncing bool, syncErrs status.MultiError) error {
-	// Update the RSync status, if necessary
-	newSyncStatus := syncStatus{
-		syncing:    syncing,
-		commit:     state.cache.source.commit,
-		errs:       syncErrs,
-		lastUpdate: metav1.Now(),
-	}
-	if state.needToSetSyncStatus(newSyncStatus) {
-		if err := p.SetSyncStatus(ctx, newSyncStatus); err != nil {
-			return err
-		}
-		state.syncStatus = newSyncStatus
-		state.syncingConditionLastUpdate = newSyncStatus.lastUpdate
-	}
-
-	// Extract conflict errors from sync errors.
-	var conflictErrs []status.ManagementConflictError
-	if syncErrs != nil {
-		for _, err := range syncErrs.Errors() {
-			if conflictErr, ok := err.(status.ManagementConflictError); ok {
-				conflictErrs = append(conflictErrs, conflictErr)
-			}
-		}
-	}
-	// Report conflict errors to the remote manager, if it's a RootSync.
-	if err := reportRootSyncConflicts(ctx, p.K8sClient(), conflictErrs); err != nil {
-		return fmt.Errorf("failed to report remote conflicts: %w", err)
-	}
-	return nil
-}
-
-// updateSyncStatusPeriodically update the sync status periodically until the
-// cancellation function of the context is called.
-func updateSyncStatusPeriodically(ctx context.Context, p Parser, state *reconcilerState) {
-	klog.V(3).Info("Periodic sync status updates starting...")
-	updatePeriod := p.options().StatusUpdatePeriod
-	updateTimer := time.NewTimer(updatePeriod)
-	defer updateTimer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			// ctx.Done() is closed when the cancellation function of the context is called.
-			klog.V(3).Info("Periodic sync status updates stopped")
-			return
-
-		case <-updateTimer.C:
-			klog.V(3).Info("Updating sync status (periodic while syncing)")
-			if err := setSyncStatus(ctx, p, state, true, p.SyncErrors()); err != nil {
-				klog.Warningf("failed to update sync status: %v", err)
-			}
-
-			updateTimer.Reset(updatePeriod) // Schedule status update attempt
-		}
-	}
-}
-
-// reportRootSyncConflicts reports conflicts to the RootSync that manages the
-// conflicting resources.
-func reportRootSyncConflicts(ctx context.Context, k8sClient client.Client, conflictErrs []status.ManagementConflictError) error {
-	if len(conflictErrs) == 0 {
-		return nil
-	}
-	conflictingManagerErrors := map[string][]status.ManagementConflictError{}
-	for _, conflictError := range conflictErrs {
-		conflictingManager := conflictError.ConflictingManager()
-		err := conflictError.ConflictingManagerError()
-		conflictingManagerErrors[conflictingManager] = append(conflictingManagerErrors[conflictingManager], err)
-	}
-
-	for conflictingManager, conflictErrors := range conflictingManagerErrors {
-		scope, name := declared.ManagerScopeAndName(conflictingManager)
-		if scope == declared.RootScope {
-			// RootSync applier uses PolicyAdoptAll.
-			// So it may fight, if the webhook is disabled.
-			// Report the conflict to the other RootSync to make it easier to detect.
-			klog.Infof("Detected conflict with RootSync manager %q", conflictingManager)
-			if err := prependRootSyncRemediatorStatus(ctx, k8sClient, name, conflictErrors, defaultDenominator); err != nil {
-				return fmt.Errorf("failed to update RootSync %q to prepend remediator conflicts: %w", name, err)
-			}
-		} else {
-			// RepoSync applier uses PolicyAdoptIfNoInventory.
-			// So it won't fight, even if the webhook is disabled.
-			klog.Infof("Detected conflict with RepoSync manager %q", conflictingManager)
-		}
-	}
-	return nil
+	// Return all the errors from the Parser & Updater, but not the Remediator.
+	// Remediation errors should not cause sync failure, cache invalidation, or
+	// retry, even though they show up as sync errors in the RSync spec.
+	return status.Append(sourceErrs, updateErrs)
 }

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -110,10 +109,6 @@ func TestReadConfigFiles(t *testing.T) {
 					ReconcilerName:     rootReconcilerName,
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-					Updater: Updater{
-						Scope:     declared.RootScope,
-						Resources: &declared.Resources{},
-					},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat: filesystem.SourceFormatUnstructured,

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -112,10 +112,8 @@ func (s *reconcilerState) checkpoint() {
 		return
 	}
 	klog.Infof("Reconciler checkpoint updated to %s", applied)
-	s.cache.errs = nil
 	s.lastApplied = applied
 	s.cache.needToRetry = false
-	s.cache.errs = nil
 }
 
 // reset sets the reconciler to retry in the next second because the rendering
@@ -131,7 +129,6 @@ func (s *reconcilerState) reset() {
 // invalidate does not clean up the `s.cache`.
 func (s *reconcilerState) invalidate(errs status.MultiError) {
 	klog.Errorf("Invalidating reconciler checkpoint: %v", status.FormatSingleLine(errs))
-	s.cache.errs = errs
 	// Invalidate state on error since this could be the result of switching
 	// branches or some other operation where inverting the operation would
 	// result in repeating a previous state that was checkpointed.

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -252,11 +252,12 @@ func Run(opts Options) {
 		Files:              parse.Files{FileSource: fs},
 		WebhookEnabled:     opts.WebhookEnabled,
 		Updater: parse.Updater{
-			Scope:          opts.ReconcilerScope,
-			Resources:      decls,
-			Applier:        supervisor,
-			Remediator:     rem,
-			SyncErrorCache: parse.NewSyncErrorCache(conflictHandler, fightHandler),
+			Scope:              opts.ReconcilerScope,
+			Resources:          decls,
+			Applier:            supervisor,
+			Remediator:         rem,
+			SyncErrorCache:     parse.NewSyncErrorCache(conflictHandler, fightHandler),
+			StatusUpdatePeriod: opts.StatusUpdatePeriod,
 		},
 	}
 	// Only instantiate the converter when the webhook is enabled because the
@@ -285,9 +286,6 @@ func Run(opts Options) {
 		parser = parse.NewRootRunner(parseOpts, rootOpts)
 	} else {
 		parser = parse.NewNamespaceRunner(parseOpts)
-		if err != nil {
-			klog.Fatalf("Instantiating Namespace Repository Parser: %v", err)
-		}
 	}
 
 	// Start listening to signals


### PR DESCRIPTION
- Remove remediator errors (except watch updates) from the Updater
  errors, so that sync invalidation is not affected by remediation
  errors. But keep remediation errors as part of the RSync sync
  status and conditions.
  (Maybe at some point we can move remediation errors to its own
  status field to prevent the ambiguity here.)
- Move sync status update management into the Updater, to clean up
  the Parser.
- Extract a SyncStatusUpdater interface from the Parser, so Updater
  methods can accept it as an argument without a circular dependency.
- Fix the status.sync.commit getting erased when the reconciler
  is restarted/rescheduled. Add a check to the periodic status updates
  to only update the sync status if the source commit has been
  initialized, meaning the source step has succeeded.

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1257
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1269
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1274
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1276
- TODO: extract the remediator error fix from the sycn status update refactor