### PR TITLE
[metric] Reset declared_resource to 0 when commit updates with test fix (#1232)

### DIFF
--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -285,7 +285,7 @@ func TestGCMMetrics(t *testing.T) {
 		rgmetrics.ResourceCountName,
 		rgmetrics.ReadyResourceCountName,
 	}
-	_, err = retry.Retry(120*time.Second, func() error {
+	_, err = retry.Retry(nt.DefaultWaitTimeout, func() error {
 		var err error
 		for _, metricType := range resourceMetrics {
 			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
@@ -306,7 +306,7 @@ func TestGCMMetrics(t *testing.T) {
 	}
 
 	nt.T.Log("Checking resource related metrics after removing test resource")
-	_, err = retry.Retry(120*time.Second, func() error {
+	_, err = retry.Retry(nt.DefaultWaitTimeout, func() error {
 		var err error
 		for _, metricType := range resourceMetrics {
 			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -280,19 +280,10 @@ func TestGCMMetrics(t *testing.T) {
 	}
 
 	nt.T.Log("Checking resource related metrics after adding test resource")
-	resourceMetrics := []string{
-		csmetrics.DeclaredResourcesName,
-		rgmetrics.ResourceCountName,
-		rgmetrics.ReadyResourceCountName,
-	}
 	_, err = retry.Retry(nt.DefaultWaitTimeout, func() error {
-		var err error
-		for _, metricType := range resourceMetrics {
-			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
-			it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
-			err = multierr.Append(err, validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasValue(3)))
-		}
-		return err
+		descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, csmetrics.DeclaredResourcesName)
+		it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
+		return validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasValue(3))
 	})
 	if err != nil {
 		nt.T.Fatal(err)
@@ -307,13 +298,9 @@ func TestGCMMetrics(t *testing.T) {
 
 	nt.T.Log("Checking resource related metrics after removing test resource")
 	_, err = retry.Retry(nt.DefaultWaitTimeout, func() error {
-		var err error
-		for _, metricType := range resourceMetrics {
-			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
-			it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
-			err = multierr.Append(err, validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasLastestValue(2)))
-		}
-		return err
+		descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, csmetrics.DeclaredResourcesName)
+		it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
+		return validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasLatestValue(2))
 	})
 	if err != nil {
 		nt.T.Fatal(err)
@@ -511,7 +498,7 @@ func metricHasValue(value int64) metricValidatorFunc {
 	}
 }
 
-func metricHasLastestValue(value int64) metricValidatorFunc {
+func metricHasLatestValue(value int64) metricValidatorFunc {
 	return func(series *monitoringpb.TimeSeries) error {
 		points := series.GetPoints()
 		lastPoint := points[len(points)-1]

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -258,12 +258,60 @@ func TestGCMMetrics(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	_, err = retry.Retry(60*time.Second, func() error {
+	_, err = retry.Retry(120*time.Second, func() error {
 		var err error
 		for _, metricType := range GCMMetricTypes {
 			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
 			it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
 			err = multierr.Append(err, validateMetricInGCM(nt, it, descriptor, nt.ClusterName))
+		}
+		return err
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Adding test namespace")
+	namespace := fake.NamespaceObject("foo")
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding foo namespace"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Checking resource related metrics after adding test resource")
+	resourceMetrics := []string{
+		csmetrics.DeclaredResourcesName,
+		rgmetrics.ResourceCountName,
+		rgmetrics.ReadyResourceCountName,
+	}
+	_, err = retry.Retry(120*time.Second, func() error {
+		var err error
+		for _, metricType := range resourceMetrics {
+			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
+			it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
+			err = multierr.Append(err, validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasValue(3)))
+		}
+		return err
+	})
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Remove the test resource")
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/ns.yaml"))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the test namespace"))
+	if err := nt.WatchForAllSyncs(); err != nil {
+		nt.T.Fatal(err)
+	}
+
+	nt.T.Log("Checking resource related metrics after removing test resource")
+	_, err = retry.Retry(120*time.Second, func() error {
+		var err error
+		for _, metricType := range resourceMetrics {
+			descriptor := fmt.Sprintf("%s/%s", GCMMetricPrefix, metricType)
+			it := listMetricInGCM(ctx, nt, client, startTime, descriptor)
+			err = multierr.Append(err, validateMetricInGCM(nt, it, descriptor, nt.ClusterName, metricHasLastestValue(2)))
 		}
 		return err
 	})
@@ -448,6 +496,29 @@ func metricDoesNotHaveLabel(label string) metricValidatorFunc {
 			return fmt.Errorf("expected metric to not have label, but found %s=%s", label, value)
 		}
 		return nil
+	}
+}
+
+func metricHasValue(value int64) metricValidatorFunc {
+	return func(series *monitoringpb.TimeSeries) error {
+		points := series.GetPoints()
+		for _, point := range points {
+			if point.GetValue().GetInt64Value() == value {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected metric to have value %v but did not find in response", value)
+	}
+}
+
+func metricHasLastestValue(value int64) metricValidatorFunc {
+	return func(series *monitoringpb.TimeSeries) error {
+		points := series.GetPoints()
+		lastPoint := points[len(points)-1]
+		if lastPoint.GetValue().GetInt64Value() == value {
+			return nil
+		}
+		return fmt.Errorf("expected metric to have latest value %v but did not find in response", value)
 	}
 }
 


### PR DESCRIPTION
The current OpenCensus library keeps a metric stream that is uniquely identified by commit alive even though no new values are issued.

This makes the Otel Collector metricstransform processor receives all time value when calculating the max and gives false output.

The temporary work around is to reset the stream of previous commit to 0 when parser sees new commit.

The cherry-pick was modified to accommodate the data structure of Resources that v1.18 currently has.

b/321875474