### PR TITLE
Refactor parser.Options to use a normal mutex

### DIFF
--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/klog/v2"
@@ -39,7 +38,6 @@ import (
 
 // NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
 func NewNamespaceRunner(opts *Options) Parser {
-	opts.mux = &sync.Mutex{}
 	return &namespace{
 		Options: opts,
 	}

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -71,7 +71,7 @@ type Options struct {
 	Converter *declared.ValueConverter
 
 	// mux prevents status update conflicts.
-	mux *sync.Mutex
+	mux sync.Mutex
 
 	// RenderingEnabled indicates whether the hydration-controller is currently
 	// running for this reconciler.

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/elliotchance/orderedmap/v2"
 	"github.com/google/go-cmp/cmp"
@@ -53,7 +52,6 @@ import (
 
 // NewRootRunner creates a new runnable parser for parsing a Root repository.
 func NewRootRunner(opts *Options, rootOpts *RootOptions) Parser {
-	opts.mux = &sync.Mutex{}
 	return &root{
 		Options:     opts,
 		RootOptions: rootOpts,

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -484,7 +483,6 @@ func TestRoot_Parse(t *testing.T) {
 						Remediator: &remediatorfake.Remediator{},
 						Applier:    fakeApplier,
 					},
-					mux: &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat:      tc.format,
@@ -699,7 +697,6 @@ func TestRoot_DeclaredFields(t *testing.T) {
 						Remediator: &remediatorfake.Remediator{},
 						Applier:    fakeApplier,
 					},
-					mux: &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat:      filesystem.SourceFormatUnstructured,
@@ -952,7 +949,6 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 						Remediator: &remediatorfake.Remediator{},
 						Applier:    fakeApplier,
 					},
-					mux: &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat:      filesystem.SourceFormatUnstructured,
@@ -1037,7 +1033,6 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 						Remediator: &remediatorfake.Remediator{},
 						Applier:    fakeApplier,
 					},
-					mux: &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat: filesystem.SourceFormatUnstructured,
@@ -1123,7 +1118,6 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					ReconcilerName:     rootReconcilerName,
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-					mux:                &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat: filesystem.SourceFormatUnstructured,

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -20,7 +20,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -85,7 +84,6 @@ func newParser(t *testing.T, fs FileSource, renderingEnabled bool, retryPeriod t
 				},
 			},
 		},
-		mux:              &sync.Mutex{},
 		RenderingEnabled: renderingEnabled,
 		RetryPeriod:      retryPeriod,
 		ResyncPeriod:     2 * time.Second,

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -115,7 +114,6 @@ func TestReadConfigFiles(t *testing.T) {
 						Scope:     declared.RootScope,
 						Resources: &declared.Resources{},
 					},
-					mux: &sync.Mutex{},
 				},
 				RootOptions: &RootOptions{
 					SourceFormat: filesystem.SourceFormatUnstructured,


### PR DESCRIPTION
Mutexes do not need a pointer when used as a field in a struct that is used with a pointer. Mutexes also don't need initialization when not a pointer. So this makes it a little easier to construct pointer.Options.