### PR TITLE
fix: deadlock in Updater.Errors()

### DIFF
--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -73,7 +73,7 @@ func (u *Updater) Errors() status.MultiError {
 	errs = status.Append(errs, u.conflictErrors())
 	errs = status.Append(errs, u.fightErrors())
 	errs = status.Append(errs, u.validationErrs)
-	errs = status.Append(errs, u.applyErrors())
+	errs = status.Append(errs, u.applyErrs)
 	errs = status.Append(errs, u.watchErrs)
 	return errs
 }
@@ -102,12 +102,6 @@ func (u *Updater) setValidationErrs(errs status.MultiError) {
 	u.statusMux.Lock()
 	defer u.statusMux.Unlock()
 	u.validationErrs = errs
-}
-
-func (u *Updater) applyErrors() status.MultiError {
-	u.statusMux.RLock()
-	defer u.statusMux.RUnlock()
-	return u.applyErrs
 }
 
 func (u *Updater) addApplyError(err status.Error) {


### PR DESCRIPTION
Errors() was calling applyErrors() and both were trying to lock the same mutex. Since nothing else is calling applyErrors() any more, we can just remove it.

Flaky deadlock was caused by https://github.com/GoogleContainerTools/kpt-config-sync/pull/1199, so this does not need cherry-picking to v1.18