### PR TITLE
ci: omit nomos migrate output from test logs

### DIFF
--- a/cmd/junit-report/resetfailure/reset_failure.go
+++ b/cmd/junit-report/resetfailure/reset_failure.go
@@ -53,7 +53,7 @@ func ResetFailure(path string) error {
 
 	testSuites := &junit.Testsuites{}
 	if err = xml.Unmarshal(bytes, testSuites); err != nil {
-		return err
+		return fmt.Errorf("unmarshalling xml: %w", err)
 	}
 
 	failureTestSuite := junit.Testsuite{

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1348,8 +1348,9 @@ func TestNomosMigrate(t *testing.T) {
 	}
 
 	nt.T.Log("Running nomos migrate to migrate from ConfigManagement to OSS install")
-	out, err := nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
-	nt.T.Log(string(out))
+	_, err = nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
+	// TODO: this breaks the XML parsing of the junit report
+	//nt.T.Log(string(out))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -1526,8 +1527,9 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Running nomos migrate to migrate from ConfigManagement to OSS install")
-	out, err := nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
-	nt.T.Log(string(out))
+	_, err = nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
+	// TODO: this breaks the XML parsing of the junit report
+	//nt.T.Log(string(out))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -42,6 +42,7 @@ if [[ -n "${ARTIFACTS}" && -d "${ARTIFACTS}" ]]; then
   sed -i -e 's/=== NAME/=== CONT/g' test_results.txt
   go-junit-report --subtest-mode=exclude-parents < test_results.txt > "${ARTIFACTS}/junit_report.xml"
   if [ "$exit_code" -eq 0 ]; then
+    echo "Running junit-report post processor"
     # build our in-repo junit report post-processor binary
     go install ./cmd/junit-report
     junit-report reset-failure --path="${ARTIFACTS}/junit_report.xml"


### PR DESCRIPTION
The output currently breaks the XML parser used by the junit reporting.