### PR TITLE
Dedupe conflict errors with diff resource versions

### DIFF
--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -118,7 +118,7 @@ func (m *Manager) ManagementConflict() bool {
 	for _, watcher := range m.watcherMap {
 		if watcher.ManagementConflict() {
 			managementConflict = true
-			watcher.ClearManagementConflict()
+			watcher.ClearManagementConflicts()
 		}
 	}
 	return managementConflict
@@ -234,8 +234,8 @@ func (m *Manager) stopWatcher(gvk schema.GroupVersionKind) {
 
 	// Stop the watcher.
 	w.Stop()
-	// Remove all conflict errors for objects with the same GVK because the
+	// Remove all conflict errors for objects with the same GK because the
 	// objects are no longer managed by the reconciler.
-	w.removeAllManagementConflictErrorsWithGVK(gvk)
+	w.ClearManagementConflictsWithKind(gvk.GroupKind())
 	delete(m.watcherMap, gvk)
 }

--- a/pkg/syncer/syncertest/fake/conflict_handler.go
+++ b/pkg/syncer/syncertest/fake/conflict_handler.go
@@ -16,8 +16,8 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/remediator/conflict"
-	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/status"
 )
 
@@ -25,10 +25,10 @@ import (
 type ConflictHandler struct{}
 
 // AddConflictError is a fake implementation of AddConflictError of conflict.Handler.
-func (h *ConflictHandler) AddConflictError(queue.GVKNN, status.ManagementConflictError) {}
+func (h *ConflictHandler) AddConflictError(core.ID, status.ManagementConflictError) {}
 
 // RemoveConflictError is a fake implementation of the RemoveConflictError of conflict.Handler.
-func (h *ConflictHandler) RemoveConflictError(queue.GVKNN) {
+func (h *ConflictHandler) RemoveConflictError(core.ID) {
 }
 
 // ConflictErrors is a fake implementation of ConflictErrors of conflict.Handler.
@@ -36,8 +36,8 @@ func (h *ConflictHandler) ConflictErrors() []status.ManagementConflictError {
 	return nil
 }
 
-// RemoveAllConflictErrors is a fake implementation of RemoveAllConflictErrors of conflict.Handler.
-func (h *ConflictHandler) RemoveAllConflictErrors(schema.GroupVersionKind) {
+// ClearConflictErrorsWithKind is a fake implementation of ClearConflictErrorsWithKind of conflict.Handler.
+func (h *ConflictHandler) ClearConflictErrorsWithKind(schema.GroupKind) {
 }
 
 var _ conflict.Handler = &ConflictHandler{}


### PR DESCRIPTION
Since objects are indexed by ID in the inventory, we don't need to index conflict errors by GVKNN. So this change modifies the conflict handler to index by ID instead. This should have no real effect.