### PR TITLE
chore: Bump otelcontribcol to 0.102.0-gke.4

### DIFF
--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.2
+        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -164,7 +164,7 @@ data:
                - ALL
              runAsUser: 65533
          - name: otel-agent
-           image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.2
+           image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
            command:
            - /otelcontribcol
            args:

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -63,7 +63,7 @@ spec:
               name: reconciler-manager
               optional: true  # Currently nothing mandatory in the ConfigMap
       - name: otel-agent
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.2
+        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -266,7 +266,7 @@ spec:
               fieldPath: metadata.labels['configsync.gke.io/deployment-name']
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.2
+        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
         name: otel-agent
         ports:
         - containerPort: 55678


### PR DESCRIPTION
For CVE fixes.