### PR TITLE
Dedupe management conflict errors

### DIFF
--- a/pkg/applier/management_conflict_err.go
+++ b/pkg/applier/management_conflict_err.go
@@ -15,7 +15,9 @@
 package applier
 
 import (
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/remediator/conflict"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -24,9 +26,10 @@ import (
 // declared in multiple repositories.
 // TODO: merge with status.ManagementConflictError if cli-utils supports reporting the conflicting manager in InventoryOverlapError.
 func KptManagementConflictError(resource client.Object) status.Error {
+	newManager := core.GetAnnotation(resource, metadata.ResourceManagerKey)
 	return status.ManagementConflictErrorBuilder.
 		Sprintf("The %q reconciler cannot manage resources declared in another repository. "+
 			"Remove the declaration for this resource from either the current repository, or the managed repository.",
-			resource.GetAnnotations()[metadata.ResourceManagerKey]).
-		BuildWithResources(resource)
+			newManager).
+		BuildWithConflictingManagers(resource, newManager, conflict.UnknownManager)
 }

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -318,7 +318,7 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, newStatus sync
 // validation errors, applier errors, and watch update errors.
 // SyncErrors implements the Parser interface
 func (p *namespace) SyncErrors() status.MultiError {
-	return p.Errors()
+	return p.SyncErrorCache.Errors()
 }
 
 // Syncing returns true if the updater is running.

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -551,7 +551,7 @@ func (p *root) addImplicitNamespaces(objs []ast.FileObject) ([]ast.FileObject, s
 // validation errors, applier errors, and watch update errors.
 // SyncErrors implements the Parser interface
 func (p *root) SyncErrors() status.MultiError {
-	return p.Errors()
+	return p.SyncErrorCache.Errors()
 }
 
 // Syncing returns true if the updater is running.

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -44,8 +44,10 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
+	"kpt.dev/configsync/pkg/remediator/conflict"
 	remediatorfake "kpt.dev/configsync/pkg/remediator/fake"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
 	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
@@ -478,10 +480,11 @@ func TestRoot_Parse(t *testing.T) {
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Converter:          converter,
 					Updater: Updater{
-						Scope:      declared.RootScope,
-						Resources:  &declared.Resources{},
-						Remediator: &remediatorfake.Remediator{},
-						Applier:    fakeApplier,
+						Scope:          declared.RootScope,
+						Resources:      &declared.Resources{},
+						Remediator:     &remediatorfake.Remediator{},
+						Applier:        fakeApplier,
+						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -692,10 +695,11 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					Converter:          converter,
 					WebhookEnabled:     tc.webhookEnabled,
 					Updater: Updater{
-						Scope:      declared.RootScope,
-						Resources:  &declared.Resources{},
-						Remediator: &remediatorfake.Remediator{},
-						Applier:    fakeApplier,
+						Scope:          declared.RootScope,
+						Resources:      &declared.Resources{},
+						Remediator:     &remediatorfake.Remediator{},
+						Applier:        fakeApplier,
+						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -944,10 +948,11 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					DiscoveryInterface: tc.discoveryClient,
 					Converter:          converter,
 					Updater: Updater{
-						Scope:      declared.RootScope,
-						Resources:  &declared.Resources{},
-						Remediator: &remediatorfake.Remediator{},
-						Applier:    fakeApplier,
+						Scope:          declared.RootScope,
+						Resources:      &declared.Resources{},
+						Remediator:     &remediatorfake.Remediator{},
+						Applier:        fakeApplier,
+						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -1028,10 +1033,11 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Updater: Updater{
-						Scope:      declared.RootScope,
-						Resources:  &declared.Resources{},
-						Remediator: &remediatorfake.Remediator{},
-						Applier:    fakeApplier,
+						Scope:          declared.RootScope,
+						Resources:      &declared.Resources{},
+						Remediator:     &remediatorfake.Remediator{},
+						Applier:        fakeApplier,
+						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 				},
 				RootOptions: &RootOptions{
@@ -1109,10 +1115,11 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 				Options: &Options{
 					Parser: fakeConfigParser,
 					Updater: Updater{
-						Scope:      declared.RootScope,
-						Resources:  &declared.Resources{},
-						Remediator: &remediatorfake.Remediator{},
-						Applier:    fakeApplier,
+						Scope:          declared.RootScope,
+						Resources:      &declared.Resources{},
+						Remediator:     &remediatorfake.Remediator{},
+						Applier:        fakeApplier,
+						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 					},
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -40,9 +40,11 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconciler/namespacecontroller"
+	"kpt.dev/configsync/pkg/remediator/conflict"
 	remediatorfake "kpt.dev/configsync/pkg/remediator/fake"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
@@ -83,6 +85,7 @@ func newParser(t *testing.T, fs FileSource, renderingEnabled bool, retryPeriod t
 					{}, // One Apply call, no errors
 				},
 			},
+			SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 		},
 		RenderingEnabled: renderingEnabled,
 		RetryPeriod:      retryPeriod,

--- a/pkg/parse/sync_status_cache.go
+++ b/pkg/parse/sync_status_cache.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"sync"
+
+	"kpt.dev/configsync/pkg/remediator/conflict"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
+)
+
+// SyncErrorCache is a collection of sync errors, locked for thread-safe use.
+type SyncErrorCache struct {
+	statusMux sync.RWMutex
+	// Errors from the Remediator & Updater
+	conflictHandler conflict.Handler
+	// Errors from the Remediator
+	fightHandler fight.Handler
+	// Errors from the Updater
+	validationErrs status.MultiError
+	applyErrs      status.MultiError
+	watchErrs      status.MultiError
+}
+
+// NewSyncErrorCache constructs a new SyncErrorCache with shared handlers
+func NewSyncErrorCache(conflictHandler conflict.Handler, fightHandler fight.Handler) *SyncErrorCache {
+	return &SyncErrorCache{
+		conflictHandler: conflictHandler,
+		fightHandler:    fightHandler,
+	}
+}
+
+// Errors returns the latest known set of errors from the updater and remediator.
+func (s *SyncErrorCache) Errors() status.MultiError {
+	s.statusMux.RLock()
+	defer s.statusMux.RUnlock()
+
+	// Ordering here is important. It needs to be the same as Updater.Update.
+	var errs status.MultiError
+	for _, conflictErr := range s.conflictHandler.ConflictErrors() {
+		errs = status.Append(errs, conflictErr)
+	}
+	for _, fightErr := range s.fightHandler.FightErrors() {
+		errs = status.Append(errs, fightErr)
+	}
+	errs = status.Append(errs, s.validationErrs)
+	errs = status.Append(errs, s.applyErrs)
+	errs = status.Append(errs, s.watchErrs)
+	return errs
+}
+
+// SetValidationErrs replaces the cached validation errors
+func (s *SyncErrorCache) SetValidationErrs(errs status.MultiError) {
+	s.statusMux.Lock()
+	defer s.statusMux.Unlock()
+	s.validationErrs = errs
+}
+
+// AddConflictError adds a conflict error to the map of cached conflict errors.
+// Conflict errors are de-duped by ConflictingObjectID.
+func (s *SyncErrorCache) AddConflictError(err status.ManagementConflictError) {
+	s.statusMux.Lock()
+	defer s.statusMux.Unlock()
+	s.conflictHandler.AddConflictError(err.ConflictingObjectID(), err)
+}
+
+// AddApplyError adds an apply error to the list of cached apply errors.
+func (s *SyncErrorCache) AddApplyError(err status.Error) {
+	s.statusMux.Lock()
+	defer s.statusMux.Unlock()
+	s.applyErrs = status.Append(s.applyErrs, err)
+}
+
+// ResetApplyErrors deletes all cached apply errors.
+func (s *SyncErrorCache) ResetApplyErrors() {
+	s.statusMux.Lock()
+	defer s.statusMux.Unlock()
+	s.applyErrs = nil
+}
+
+// SetWatchErrs replaces the cached watch errors.
+// These come from updating the watches, not watch event errors.
+func (s *SyncErrorCache) SetWatchErrs(errs status.MultiError) {
+	s.statusMux.Lock()
+	defer s.statusMux.Unlock()
+	s.watchErrs = errs
+}

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -92,11 +92,18 @@ var _ Interface = &Remediator{}
 //
 // It is safe for decls to be modified after they have been passed into the
 // Remediator.
-func New(scope declared.Scope, syncName string, cfg *rest.Config, applier syncerreconcile.Applier, decls *declared.Resources, numWorkers int) (*Remediator, error) {
+func New(
+	scope declared.Scope,
+	syncName string,
+	cfg *rest.Config,
+	applier syncerreconcile.Applier,
+	conflictHandler conflict.Handler,
+	fightHandler fight.Handler,
+	decls *declared.Resources,
+	numWorkers int,
+) (*Remediator, error) {
 	q := queue.New(scope.String())
 	workers := make([]*reconcile.Worker, numWorkers)
-	fightHandler := fight.NewHandler()
-	conflictHandler := conflict.NewHandler()
 	for i := 0; i < numWorkers; i++ {
 		workers[i] = reconcile.NewWorker(scope, syncName, applier, q, decls, fightHandler)
 	}

--- a/pkg/status/management_conflict_error.go
+++ b/pkg/status/management_conflict_error.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,6 +33,8 @@ var ManagementConflictErrorBuilder = NewErrorBuilder(ManagementConflictErrorCode
 // ManagementConflictError indicates that the passed resource is illegally
 // declared in multiple repositories.
 type ManagementConflictError interface {
+	// ConflictingObjectID returns the ID of the object with the management conflict.
+	ConflictingObjectID() core.ID
 	// ConflictingManager returns the annotation value of the other conflicting manager.
 	ConflictingManager() string
 	// CurrentManagerError returns the error that will be surfaced to the current manager.
@@ -121,4 +124,8 @@ func (m *managementConflictErrorImpl) Is(target error) bool {
 		return false
 	}
 	return m.underlying.Is(target)
+}
+
+func (m managementConflictErrorImpl) ConflictingObjectID() core.ID {
+	return core.IDOf(m.resource)
 }


### PR DESCRIPTION
- Update KptManagementConflictError to use an "UNKNOWN" old manager so it can return a ManagementConflictError. The UNKNOWN string is not shown to users. It just acts as a placeholder to return from the ConflictingManager() method. The previously added de-dupe code in conflict.Handler prefers errors with real manager values. So when the remediator and updater return similar errors, only the one with both managers is reported in the RSync status.
- Share the conflict.Handler between the Remediator & Updater so it can handle deduping at runtime, instead of when updating the status.