### PR TITLE
Fix sync status lost on reconciler pod replacement

### DIFF
--- a/pkg/parse/cache.go
+++ b/pkg/parse/cache.go
@@ -34,7 +34,7 @@ import (
 type cacheForCommit struct {
 	// source tracks the state of the source repo.
 	// This field is only set after the reconciler successfully reads all the source files.
-	source sourceState
+	source *sourceState
 
 	// hasParserResult indicates whether the cache includes the parser result.
 	hasParserResult bool

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -93,7 +93,8 @@ type Options struct {
 
 // Parser represents a parser that can be pointed at and continuously parse a source.
 type Parser interface {
-	parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError)
+	parseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError)
+	ReconcilerStatusFromCluster(ctx context.Context) (*ReconcilerStatus, error)
 	setSourceStatus(ctx context.Context, newStatus *SourceStatus) error
 	setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error
 	SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -100,6 +100,7 @@ func TestReadConfigFiles(t *testing.T) {
 			}()
 
 			srcState := &sourceState{
+				spec:    nil, // TODO: Add tests for behavior when spec is non-nil
 				commit:  originCommit,
 				syncDir: cmpath.Absolute(sourceCommitDir),
 				files:   nil,
@@ -262,6 +263,7 @@ func TestReadHydratedDirWithRetry(t *testing.T) {
 			}()
 
 			srcState := &sourceState{
+				spec:   nil, // TODO: Add tests for behavior when spec is non-nil
 				commit: originCommit,
 			}
 
@@ -278,14 +280,14 @@ func TestReadHydratedDirWithRetry(t *testing.T) {
 				},
 			}
 
-			wantState := sourceState{
+			wantState := &sourceState{
 				commit:  tc.commit,
 				syncDir: cmpath.Absolute(filepath.Join(parserCommitDir, syncDir)),
 			}
 
 			t.Logf("start calling readHydratedDirWithRetry at %v", time.Now())
 			hydrationState, hydrationErr := parser.readHydratedDirWithRetry(backoff,
-				cmpath.Absolute(hydratedRoot), parser.ReconcilerName, *srcState)
+				cmpath.Absolute(hydratedRoot), parser.ReconcilerName, srcState)
 
 			if tc.expectedErrMsg == "" {
 				assert.Nil(t, hydrationErr)


### PR DESCRIPTION
- Fix reconciler ignoring/erasing status from previous reconciler
  instances by priming the in-memory cache from the RSyncs status.
  Example: status.sync.commit
  Exception: errors are not parsable and may still be lost.

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1283
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1280
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1282
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1290
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1296
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1299