### PR TITLE
refactor: parametrize git-sync and otel version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ HELM_VERSION := v3.14.4-gke.1
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
+GIT_SYNC_VERSION := v4.2.1-gke.10__linux_amd64
+GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
+
+OTELCONTRIBCOL_VERSION := v0.102.0-gke.4
+OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
+
 # Keep KIND_VERSION in sync with the version defined in go.mod
 # When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
 KIND_VERSION := v0.20.0

--- a/Makefile.build
+++ b/Makefile.build
@@ -142,6 +142,8 @@ build-manifests-oss: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(call gen_image_tag,$(RECONCILER_MANAGER_IMAGE))|g" \
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
+			-e "s|GIT_SYNC_IMAGE_NAME|$(GIT_SYNC_IMAGE_NAME)|g" \
+			-e "s|OTELCONTRIBCOL_IMAGE_NAME|$(OTELCONTRIBCOL_IMAGE_NAME)|g" \
 		> $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(ADDLICENSE)" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 
@@ -168,6 +170,8 @@ build-manifests-operator: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|WEBHOOK_IMAGE_NAME|$(call gen_image_tag,$(ADMISSION_WEBHOOK_IMAGE))|g" \
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
+			-e "s|GIT_SYNC_IMAGE_NAME|$(GIT_SYNC_IMAGE_NAME)|g" \
+			-e "s|OTELCONTRIBCOL_IMAGE_NAME|$(OTELCONTRIBCOL_IMAGE_NAME)|g" \
 		> $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(ADDLICENSE)" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -104,7 +104,7 @@ data:
                - ALL
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v4.2.1-gke.10__linux_amd64
+           image: GIT_SYNC_IMAGE_NAME
            args: ["--root=/repo/source", "--link=rev", "--max-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo
@@ -164,7 +164,7 @@ data:
                - ALL
              runAsUser: 65533
          - name: otel-agent
-           image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+           image: OTELCONTRIBCOL_IMAGE_NAME
            command:
            - /otelcontribcol
            args:

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -63,7 +63,7 @@ spec:
               name: reconciler-manager
               optional: true  # Currently nothing mandatory in the ConfigMap
       - name: otel-agent
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -266,7 +266,7 @@ spec:
               fieldPath: metadata.labels['configsync.gke.io/deployment-name']
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         name: otel-agent
         ports:
         - containerPort: 55678


### PR DESCRIPTION
This moves the image definitions for git-sync and otelcontribcol to the Makefile, such that all sub-dependency versions defined in one place.