### PR TITLE
cleanup: remove unused methods from remediator

### DIFF
--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -27,24 +27,12 @@ import (
 // This is not in kpt.dev/configsync/pkg/testing/fake because that would cause
 // a import loop (remediator -> fake -> remediator).
 type Remediator struct {
-	ConflictErrorsOutput     []status.ManagementConflictError
-	FightErrorsOutput        []status.Error
 	ManagementConflictOutput bool
 	Watches                  map[schema.GroupVersionKind]struct{}
 	UpdateWatchesError       status.MultiError
 	Paused                   bool
 
 	needsUpdate bool
-}
-
-// ConflictErrors fakes remediator.Remediator.ConflictErrors
-func (r *Remediator) ConflictErrors() []status.ManagementConflictError {
-	return r.ConflictErrorsOutput
-}
-
-// FightErrors fakes remediator.Remediator.FightErrors
-func (r *Remediator) FightErrors() []status.Error {
-	return r.FightErrorsOutput
 }
 
 // ManagementConflict fakes remediator.Remediator.ManagementConflict

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -79,10 +79,6 @@ type Interface interface {
 	UpdateWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
 	// ManagementConflict returns true if one of the watchers noticed a management conflict.
 	ManagementConflict() bool
-	// ConflictErrors returns the errors the remediator encounters.
-	ConflictErrors() []status.ManagementConflictError
-	// FightErrors returns the fight errors (KNV2005) the remediator encounters.
-	FightErrors() []status.Error
 }
 
 var _ Interface = &Remediator{}
@@ -210,14 +206,4 @@ func (r *Remediator) UpdateWatches(ctx context.Context, gvks map[schema.GroupVer
 // ManagementConflict implements Interface.
 func (r *Remediator) ManagementConflict() bool {
 	return r.watchMgr.ManagementConflict()
-}
-
-// ConflictErrors implements Interface.
-func (r *Remediator) ConflictErrors() []status.ManagementConflictError {
-	return r.conflictHandler.ConflictErrors()
-}
-
-// FightErrors implements Interface.
-func (r *Remediator) FightErrors() []status.Error {
-	return r.fightHandler.FightErrors()
 }


### PR DESCRIPTION
The conflict and fight handlers are injected now, so these methods are unused.