### PR TITLE
fix: remediator error reporting after new commit

### DIFF
--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -321,12 +321,6 @@ func (p *namespace) SyncErrors() status.MultiError {
 	return p.SyncErrorCache.Errors()
 }
 
-// Syncing returns true if the updater is running.
-// SyncErrors implements the Parser interface
-func (p *namespace) Syncing() bool {
-	return p.Updating()
-}
-
 // K8sClient implements the Parser interface
 func (p *namespace) K8sClient() client.Client {
 	return p.Client

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -96,8 +96,6 @@ type Parser interface {
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.
 	SyncErrors() status.MultiError
-	// Syncing returns true if the updater is running.
-	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 	// setRequiresRendering sets the requires-rendering annotation on the RSync

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -554,12 +554,6 @@ func (p *root) SyncErrors() status.MultiError {
 	return p.SyncErrorCache.Errors()
 }
 
-// Syncing returns true if the updater is running.
-// SyncErrors implements the Parser interface
-func (p *root) Syncing() bool {
-	return p.Updating()
-}
-
 // K8sClient implements the Parser interface
 func (p *root) K8sClient() client.Client {
 	return p.Client

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -183,14 +183,13 @@ func Run(ctx context.Context, p Parser, nsControllerState *namespacecontroller.S
 
 		// Update the sync status to report management conflicts (from the remediator).
 		case <-statusUpdateTimer.C:
-			// Skip sync status update if the .status.sync.commit is out of date.
-			// This avoids overwriting a newer Syncing condition with the status
-			// from an older commit.
-			if state.syncStatus.commit == state.sourceStatus.commit &&
-				state.syncStatus.commit == state.renderingStatus.commit {
-
+			// Publish the sync status periodically to update remediator errors.
+			// Skip updates if the remediator is not running yet, paused, or watches haven't been updated yet.
+			// This implies that this reconciler has successfully parsed, rendered, validated, and synced.
+			if p.options().Remediating() {
 				klog.V(3).Info("Updating sync status (periodic while not syncing)")
-				if err := setSyncStatus(ctx, p, state, p.Syncing(), p.SyncErrors()); err != nil {
+				// Don't update the sync spec or commit.
+				if err := setSyncStatus(ctx, p, state, false, state.syncStatus.commit, p.SyncErrors()); err != nil {
 					klog.Warningf("failed to update sync status: %v", err)
 				}
 			}
@@ -551,7 +550,7 @@ func parseAndUpdate(ctx context.Context, p Parser, trigger string, state *reconc
 	// SyncErrors include errors from both the Updater and Remediator
 	klog.V(3).Info("Updating sync status (after sync)")
 	syncErrs := p.SyncErrors()
-	if err := setSyncStatus(ctx, p, state, false, syncErrs); err != nil {
+	if err := setSyncStatus(ctx, p, state, false, state.cache.source.commit, syncErrs); err != nil {
 		syncErrs = status.Append(syncErrs, err)
 	}
 
@@ -562,11 +561,11 @@ func parseAndUpdate(ctx context.Context, p Parser, trigger string, state *reconc
 // setSyncStatus updates `.status.sync` and the Syncing condition, if needed,
 // as well as `state.syncStatus` and `state.syncingConditionLastUpdate` if
 // the update is successful.
-func setSyncStatus(ctx context.Context, p Parser, state *reconcilerState, syncing bool, syncErrs status.MultiError) error {
+func setSyncStatus(ctx context.Context, p Parser, state *reconcilerState, syncing bool, commit string, syncErrs status.MultiError) error {
 	// Update the RSync status, if necessary
 	newSyncStatus := syncStatus{
 		syncing:    syncing,
-		commit:     state.cache.source.commit,
+		commit:     commit,
 		errs:       syncErrs,
 		lastUpdate: metav1.Now(),
 	}
@@ -610,7 +609,7 @@ func updateSyncStatusPeriodically(ctx context.Context, p Parser, state *reconcil
 
 		case <-updateTimer.C:
 			klog.V(3).Info("Updating sync status (periodic while syncing)")
-			if err := setSyncStatus(ctx, p, state, true, p.SyncErrors()); err != nil {
+			if err := setSyncStatus(ctx, p, state, true, state.cache.source.commit, p.SyncErrors()); err != nil {
 				klog.Warningf("failed to update sync status: %v", err)
 			}
 

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -51,7 +51,6 @@ type Updater struct {
 	SyncErrorCache *SyncErrorCache
 
 	updateMux sync.RWMutex
-	updating  bool
 }
 
 func (u *Updater) needToUpdateWatch() bool {
@@ -62,9 +61,9 @@ func (u *Updater) managementConflict() bool {
 	return u.Remediator.ManagementConflict()
 }
 
-// Updating returns true if the Update method is running.
-func (u *Updater) Updating() bool {
-	return u.updating
+// Remediating returns true if the Remediator is remediating.
+func (u *Updater) Remediating() bool {
+	return u.Remediator.Remediating()
 }
 
 // declaredCRDs returns the list of CRDs which are present in the updater's
@@ -98,11 +97,7 @@ func (u *Updater) declaredCRDs() ([]*v1beta1.CustomResourceDefinition, status.Mu
 // another reconciler.
 func (u *Updater) Update(ctx context.Context, cache *cacheForCommit) status.MultiError {
 	u.updateMux.Lock()
-	u.updating = true
-	defer func() {
-		u.updating = false
-		u.updateMux.Unlock()
-	}()
+	defer u.updateMux.Unlock()
 
 	return u.update(ctx, cache)
 }

--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -32,6 +32,7 @@ type Remediator struct {
 	ManagementConflictOutput bool
 	Watches                  map[schema.GroupVersionKind]struct{}
 	UpdateWatchesError       status.MultiError
+	Watching                 bool
 	Paused                   bool
 
 	needsUpdate bool
@@ -57,6 +58,11 @@ func (r *Remediator) NeedsUpdate() bool {
 	return r.needsUpdate
 }
 
+// Remediating returns true if not paused
+func (r *Remediator) Remediating() bool {
+	return r.Watching && !r.Paused
+}
+
 // Pause fakes remediator.Remediator.Pause
 func (r *Remediator) Pause() {
 	r.Paused = true
@@ -69,6 +75,7 @@ func (r *Remediator) Resume() {
 
 // UpdateWatches fakes remediator.Remediator.UpdateWatches
 func (r *Remediator) UpdateWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
+	r.Watching = true
 	r.Watches = watches
 	r.needsUpdate = false
 	return r.UpdateWatchesError

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -43,7 +43,7 @@ type Remediator struct {
 
 	// lifecycleMux guards start/stop/add/remove of the workers, as well as
 	// updates to queue, parentContext, doneCh, and stopFn.
-	lifecycleMux sync.Mutex
+	lifecycleMux sync.RWMutex
 	// workers pull objects from the queue and remediate them
 	workers []*reconcile.Worker
 	// objectQueue is a queue of objects that have received watch events and
@@ -57,6 +57,9 @@ type Remediator struct {
 	doneCh chan struct{}
 	// stopFn cancels the internal context, stopping the workers.
 	stopFn context.CancelFunc
+	// running is true if Start has been called and the remediator is not
+	// currently paused.
+	running bool
 
 	conflictHandler conflict.Handler
 	fightHandler    fight.Handler
@@ -67,6 +70,8 @@ type Remediator struct {
 //
 // Placed here to make discovering the production implementation (above) easier.
 type Interface interface {
+	// Remediating returns true if workers are running and watchers are watching.
+	Remediating() bool
 	// Pause the Remediator by stopping the workers and waiting for them to be done.
 	Pause()
 	// Resume the Remediator by starting the workers.
@@ -155,6 +160,10 @@ func (r *Remediator) Start(ctx context.Context) <-chan struct{} {
 // startWorkers starts the workers and sets doneCh & stopFn.
 // This should always be called while lifecycleMux is locked.
 func (r *Remediator) startWorkers() {
+	if r.running {
+		return
+	}
+
 	ctx, cancel := context.WithCancel(r.parentContext)
 
 	doneCh := make(chan struct{})
@@ -174,6 +183,26 @@ func (r *Remediator) startWorkers() {
 
 	r.doneCh = doneCh
 	r.stopFn = cancel
+	r.running = true
+}
+
+// stopWorkers stops the workers and waits for them to exit.
+// This should always be called while lifecycleMux is locked.
+func (r *Remediator) stopWorkers() {
+	if !r.running {
+		return
+	}
+
+	r.stopFn() // tell the workers to stop
+	<-r.doneCh // wait until workers are done (if running)
+	r.running = false
+}
+
+// Remediating returns true if workers are running and watchers are watching.
+func (r *Remediator) Remediating() bool {
+	r.lifecycleMux.RLock()
+	defer r.lifecycleMux.RUnlock()
+	return r.running && r.watchMgr.Watching()
 }
 
 // Pause the Remediator by stopping the workers and waiting for them to be done.
@@ -182,8 +211,7 @@ func (r *Remediator) Pause() {
 	defer r.lifecycleMux.Unlock()
 
 	klog.V(1).Info("Remediator pausing...")
-	r.stopFn() // tell the workers to stop
-	<-r.doneCh // wait until workers are done (if running)
+	r.stopWorkers()
 	klog.V(3).Info("Remediator paused")
 }
 

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -50,7 +50,9 @@ type Manager struct {
 	watcherFactory watcherFactory
 
 	// The following fields are guarded by the mutex.
-	mux sync.Mutex
+	mux sync.RWMutex
+	// watching is true if UpdateWatches has been called
+	watching bool
 	// watcherMap maps GVKs to their associated watchers
 	watcherMap map[schema.GroupVersionKind]Runnable
 	// needsUpdate indicates if the Manager's watches need to be updated.
@@ -99,10 +101,17 @@ func NewManager(scope declared.Scope, syncName string, cfg *rest.Config,
 	}, nil
 }
 
+// Watching returns true if UpdateWatches has been called, starting the watchers. This function is threadsafe.
+func (m *Manager) Watching() bool {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+	return m.watching
+}
+
 // NeedsUpdate returns true if the Manager's watches need to be updated. This function is threadsafe.
 func (m *Manager) NeedsUpdate() bool {
-	m.mux.Lock()
-	defer m.mux.Unlock()
+	m.mux.RLock()
+	defer m.mux.RUnlock()
 	return m.needsUpdate
 }
 
@@ -135,6 +144,7 @@ func (m *Manager) ManagementConflict() bool {
 func (m *Manager) UpdateWatches(ctx context.Context, gvkMap map[schema.GroupVersionKind]struct{}) status.MultiError {
 	m.mux.Lock()
 	defer m.mux.Unlock()
+	m.watching = true
 
 	klog.V(3).Infof("UpdateWatches(%v)", gvkMap)
 


### PR DESCRIPTION
- Fix remediator error updates not being published after parsing has started for a new commit. Normally parsing is quick, but if there was an error, this state would often continue until the error was fixed by the user in the source.
- Modify setSyncStatus to take a commit, so we can avoid reverting the status.sync.commit after parsing has started and modified state.cache.source.commit.
- Add Remediator.Remediating() to avoid updating the sync status before syncing has succeeded or while remediating is paused during a sync attempt.