### PR TITLE
Revert "fix: multiple sync status update bugs (#1283)"

### DIFF
--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -321,6 +321,12 @@ func (p *namespace) SyncErrors() status.MultiError {
 	return p.SyncErrorCache.Errors()
 }
 
+// Syncing returns true if the updater is running.
+// SyncErrors implements the Parser interface
+func (p *namespace) Syncing() bool {
+	return p.Updating()
+}
+
 // K8sClient implements the Parser interface
 func (p *namespace) K8sClient() client.Client {
 	return p.Client

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -96,6 +96,8 @@ type Parser interface {
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.
 	SyncErrors() status.MultiError
+	// Syncing returns true if the updater is running.
+	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 	// setRequiresRendering sets the requires-rendering annotation on the RSync

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -554,6 +554,12 @@ func (p *root) SyncErrors() status.MultiError {
 	return p.SyncErrorCache.Errors()
 }
 
+// Syncing returns true if the updater is running.
+// SyncErrors implements the Parser interface
+func (p *root) Syncing() bool {
+	return p.Updating()
+}
+
 // K8sClient implements the Parser interface
 func (p *root) K8sClient() client.Client {
 	return p.Client

--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -30,7 +30,6 @@ type Remediator struct {
 	ManagementConflictOutput bool
 	Watches                  map[schema.GroupVersionKind]struct{}
 	UpdateWatchesError       status.MultiError
-	Watching                 bool
 	Paused                   bool
 
 	needsUpdate bool
@@ -46,11 +45,6 @@ func (r *Remediator) NeedsUpdate() bool {
 	return r.needsUpdate
 }
 
-// Remediating returns true if not paused
-func (r *Remediator) Remediating() bool {
-	return r.Watching && !r.Paused
-}
-
 // Pause fakes remediator.Remediator.Pause
 func (r *Remediator) Pause() {
 	r.Paused = true
@@ -63,7 +57,6 @@ func (r *Remediator) Resume() {
 
 // UpdateWatches fakes remediator.Remediator.UpdateWatches
 func (r *Remediator) UpdateWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
-	r.Watching = true
 	r.Watches = watches
 	r.needsUpdate = false
 	return r.UpdateWatchesError

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -43,7 +43,7 @@ type Remediator struct {
 
 	// lifecycleMux guards start/stop/add/remove of the workers, as well as
 	// updates to queue, parentContext, doneCh, and stopFn.
-	lifecycleMux sync.RWMutex
+	lifecycleMux sync.Mutex
 	// workers pull objects from the queue and remediate them
 	workers []*reconcile.Worker
 	// objectQueue is a queue of objects that have received watch events and
@@ -57,9 +57,6 @@ type Remediator struct {
 	doneCh chan struct{}
 	// stopFn cancels the internal context, stopping the workers.
 	stopFn context.CancelFunc
-	// running is true if Start has been called and the remediator is not
-	// currently paused.
-	running bool
 
 	conflictHandler conflict.Handler
 	fightHandler    fight.Handler
@@ -70,8 +67,6 @@ type Remediator struct {
 //
 // Placed here to make discovering the production implementation (above) easier.
 type Interface interface {
-	// Remediating returns true if workers are running and watchers are watching.
-	Remediating() bool
 	// Pause the Remediator by stopping the workers and waiting for them to be done.
 	Pause()
 	// Resume the Remediator by starting the workers.
@@ -156,10 +151,6 @@ func (r *Remediator) Start(ctx context.Context) <-chan struct{} {
 // startWorkers starts the workers and sets doneCh & stopFn.
 // This should always be called while lifecycleMux is locked.
 func (r *Remediator) startWorkers() {
-	if r.running {
-		return
-	}
-
 	ctx, cancel := context.WithCancel(r.parentContext)
 
 	doneCh := make(chan struct{})
@@ -179,26 +170,6 @@ func (r *Remediator) startWorkers() {
 
 	r.doneCh = doneCh
 	r.stopFn = cancel
-	r.running = true
-}
-
-// stopWorkers stops the workers and waits for them to exit.
-// This should always be called while lifecycleMux is locked.
-func (r *Remediator) stopWorkers() {
-	if !r.running {
-		return
-	}
-
-	r.stopFn() // tell the workers to stop
-	<-r.doneCh // wait until workers are done (if running)
-	r.running = false
-}
-
-// Remediating returns true if workers are running and watchers are watching.
-func (r *Remediator) Remediating() bool {
-	r.lifecycleMux.RLock()
-	defer r.lifecycleMux.RUnlock()
-	return r.running && r.watchMgr.Watching()
 }
 
 // Pause the Remediator by stopping the workers and waiting for them to be done.
@@ -207,7 +178,8 @@ func (r *Remediator) Pause() {
 	defer r.lifecycleMux.Unlock()
 
 	klog.V(1).Info("Remediator pausing...")
-	r.stopWorkers()
+	r.stopFn() // tell the workers to stop
+	<-r.doneCh // wait until workers are done (if running)
 	klog.V(3).Info("Remediator paused")
 }
 


### PR DESCRIPTION
This reverts commit 3e0915218d44dc238bb3a7b21e66c9e999e50821.

Reason for revert: This introduced frequent test failures for:
- TestHydrateKustomizeComponentsChanges
- TestHydrateHelmOverlay