### PR TITLE
refactor: use SourceType type in RSync spec

### DIFF
--- a/cmd/hydration-controller/main.go
+++ b/cmd/hydration-controller/main.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kmetrics"
@@ -111,7 +110,7 @@ func main() {
 
 	hydrator := &hydrate.Hydrator{
 		DonePath:        absDonePath,
-		SourceType:      v1beta1.SourceType(*sourceType),
+		SourceType:      configsync.SourceType(*sourceType),
 		SourceRoot:      absSourceRootDir,
 		HydratedRoot:    absHydratedRootDir,
 		SourceLink:      *sourceLinkDir,

--- a/cmd/nomos/status/cluster_state.go
+++ b/cmd/nomos/status/cluster_state.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/cmd/nomos/util"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/rootsync"
@@ -75,7 +76,7 @@ func unavailableCluster(ref string) *ClusterState {
 type RepoState struct {
 	scope             string
 	syncName          string
-	sourceType        v1beta1.SourceType
+	sourceType        configsync.SourceType
 	git               *v1beta1.Git
 	oci               *v1beta1.Oci
 	helm              *v1beta1.HelmBase
@@ -133,13 +134,13 @@ func (r *RepoState) printRows(writer io.Writer) {
 	}
 }
 
-func sourceString(sourceType v1beta1.SourceType, git *v1beta1.Git, oci *v1beta1.Oci, helm *v1beta1.HelmBase) string {
+func sourceString(sourceType configsync.SourceType, git *v1beta1.Git, oci *v1beta1.Oci, helm *v1beta1.HelmBase) string {
 	switch sourceType {
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		return ociString(oci)
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		return helmString(helm)
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		return gitString(git)
 	}
 	return gitString(git)
@@ -307,7 +308,7 @@ func namespaceRepoStatus(rs *v1beta1.RepoSync, rg *unstructured.Unstructured, sy
 	repostate := &RepoState{
 		scope:      rs.Namespace,
 		syncName:   rs.Name,
-		sourceType: v1beta1.SourceType(rs.Spec.SourceType),
+		sourceType: rs.Spec.SourceType,
 		git:        rs.Spec.Git,
 		oci:        rs.Spec.Oci,
 		helm:       reposync.GetHelmBase(rs.Spec.Helm),
@@ -409,7 +410,7 @@ func RootRepoStatus(rs *v1beta1.RootSync, rg *unstructured.Unstructured, syncing
 	repostate := &RepoState{
 		scope:      "<root>",
 		syncName:   rs.Name,
-		sourceType: v1beta1.SourceType(rs.Spec.SourceType),
+		sourceType: rs.Spec.SourceType,
 		git:        rs.Spec.Git,
 		oci:        rs.Spec.Oci,
 		helm:       rootsync.GetHelmBase(rs.Spec.Helm),

--- a/cmd/nomos/status/cluster_state_test.go
+++ b/cmd/nomos/status/cluster_state_test.go
@@ -284,7 +284,7 @@ func TestRepoState_PrintRows(t *testing.T) {
 			&RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.OciSource,
+				sourceType: configsync.OciSource,
 				oci: &v1beta1.Oci{
 					Image: "us-docker.pkg.dev/test-project/test-ar-repo/sample",
 					Dir:   "test",
@@ -301,7 +301,7 @@ func TestRepoState_PrintRows(t *testing.T) {
 			&RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.HelmSource,
+				sourceType:   configsync.HelmSource,
 				helm:         helm,
 				status:       "ERROR",
 				commit:       "abc123",
@@ -315,7 +315,7 @@ func TestRepoState_PrintRows(t *testing.T) {
 			&RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				status:       "ERROR",
 				errors:       []string{"missing Git config"},
 				errorSummary: errorSummayWithOneError,
@@ -327,7 +327,7 @@ func TestRepoState_PrintRows(t *testing.T) {
 			&RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.OciSource,
+				sourceType:   configsync.OciSource,
 				status:       "ERROR",
 				errors:       []string{"missing OCI config"},
 				errorSummary: errorSummayWithOneError,
@@ -339,7 +339,7 @@ func TestRepoState_PrintRows(t *testing.T) {
 			&RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.HelmSource,
+				sourceType:   configsync.HelmSource,
 				status:       "ERROR",
 				errors:       []string{"missing Helm config"},
 				errorSummary: errorSummayWithOneError,
@@ -508,7 +508,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		gitSpec                   *v1beta1.Git
 		ociSpec                   *v1beta1.Oci
 		helmSpec                  *v1beta1.HelmBase
-		sourceType                v1beta1.SourceType
+		sourceType                configsync.SourceType
 		conditions                []v1beta1.RepoSyncCondition
 		sourceStatus              v1beta1.SourceStatus
 		renderingStatus           v1beta1.RenderingStatus
@@ -522,7 +522,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			conditions: []v1beta1.RepoSyncCondition{stalledCondition},
 			want: &RepoState{
 				scope:        "bookstore",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				syncName:     "repo-sync",
 				git:          git,
 				status:       stalledMsg,
@@ -552,7 +552,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       stalledMsg,
 				commit:       emptyCommit,
@@ -567,7 +567,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     reconcilingMsg,
 				commit:     emptyCommit,
@@ -594,7 +594,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     reconcilingMsg,
 				commit:     emptyCommit,
@@ -607,7 +607,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				commit:     emptyCommit,
@@ -621,7 +621,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				commit:     emptyCommit,
@@ -648,7 +648,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				// This mistakenly reports an error because `nomos status` checks all errors first.
 				// The following test case shows how the status is reported correctly with the syncing condition.
@@ -680,7 +680,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     pendingMsg,
 				commit:     emptyCommit,
@@ -698,7 +698,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     util.ErrorMsg,
 				// This mistakenly reports the commit as empty because "nomos status" used
@@ -725,7 +725,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          git,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
@@ -755,7 +755,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     util.ErrorMsg,
 				// This mistakenly shows the commit because `nomos status` sets commit to `.status.sync.commit`.
@@ -792,7 +792,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       util.ErrorMsg,
 				commit:       "def456",
@@ -812,7 +812,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				// This mistakenly reports an empty commit because `nomos status` sets commit to `.status.sync.commit`.
@@ -836,7 +836,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				commit:     "abc123",
@@ -863,7 +863,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				// This mistakenly reports an error status because `nomos status` checks all errors first.
 				// The test case below shows how it is fixed with the syncing condition.
@@ -900,7 +900,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     pendingMsg,
 				commit:     "def456",
@@ -918,7 +918,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     util.ErrorMsg,
 				// This mistakenly reports an empty commit because `nomos status` sets the commit to `.status.sync.commit`.
@@ -944,7 +944,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          git,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
@@ -974,7 +974,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     util.ErrorMsg,
 				// This mistakenly reports the commit and errors because `nomos status` checks all errors first.
@@ -1011,7 +1011,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       util.ErrorMsg,
 				commit:       "def456",
@@ -1031,7 +1031,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				// This mistakenly reports the commit to be empty because `nomos status` used to set the commit to `.status.sync.commit`.
@@ -1055,7 +1055,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				commit:     "abc123",
@@ -1082,7 +1082,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				// This mistakenly reports an error status because `nomos status` used to check all errors first.
 				// The test case below shows how it is fixed with the syncing condition.
@@ -1119,7 +1119,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     pendingMsg,
 				commit:     "def456",
@@ -1142,7 +1142,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     util.ErrorMsg,
 				// This mistakenly reports the commit as empty because `nomos status` used to set the commit to `.status.sync.commit`.
@@ -1173,7 +1173,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          git,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
@@ -1203,7 +1203,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     util.ErrorMsg,
 				// This mistakenly reports the commit because `nomos status` used to set the commit to `.status.sync.commit`.
@@ -1240,7 +1240,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       util.ErrorMsg,
 				commit:       "def456",
@@ -1264,7 +1264,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				// The commit should be available because it is included in the rendering and source statuses,
@@ -1293,7 +1293,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        git,
 				status:     pendingMsg,
 				commit:     "abc123",
@@ -1320,7 +1320,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				// This mistakenly reports an error status because `nomos status` checks all errors first.
 				// The test case below shows how the status is correctly reported with the syncing condition.
@@ -1357,7 +1357,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:      "bookstore",
 				syncName:   "repo-sync",
-				sourceType: v1beta1.GitSource,
+				sourceType: configsync.GitSource,
 				git:        gitUpdated,
 				status:     pendingMsg,
 				commit:     "def456",
@@ -1385,7 +1385,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          git,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
@@ -1419,7 +1419,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          git,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
@@ -1449,7 +1449,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       util.ErrorMsg,
 				commit:       "def456",
@@ -1483,7 +1483,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:        "bookstore",
 				syncName:     "repo-sync",
-				sourceType:   v1beta1.GitSource,
+				sourceType:   configsync.GitSource,
 				git:          gitUpdated,
 				status:       util.ErrorMsg,
 				commit:       "def456",
@@ -1513,7 +1513,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			want: &RepoState{
 				scope:             "bookstore",
 				syncName:          "repo-sync",
-				sourceType:        v1beta1.GitSource,
+				sourceType:        configsync.GitSource,
 				git:               git,
 				status:            syncedMsg,
 				lastSyncTimestamp: lastSyncTimestamp,
@@ -1548,7 +1548,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:             "bookstore",
 				syncName:          "repo-sync",
 				git:               git,
-				sourceType:        v1beta1.GitSource,
+				sourceType:        configsync.GitSource,
 				status:            syncedMsg,
 				lastSyncTimestamp: lastSyncTimestamp,
 				commit:            "abc123",
@@ -1558,7 +1558,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "OCI repo has import error",
 			ociSpec:                   oci,
-			sourceType:                v1beta1.OciSource,
+			sourceType:                configsync.OciSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1573,7 +1573,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				oci:          oci,
-				sourceType:   v1beta1.OciSource,
+				sourceType:   configsync.OciSource,
 				status:       util.ErrorMsg,
 				commit:       "def456",
 				errors:       []string{"KNV2004: import error"},
@@ -1583,7 +1583,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "OCI repo has import error",
 			ociSpec:                   oci,
-			sourceType:                v1beta1.OciSource,
+			sourceType:                configsync.OciSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1598,7 +1598,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				oci:          oci,
-				sourceType:   v1beta1.OciSource,
+				sourceType:   configsync.OciSource,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
 				errors:       []string{"KNV2004: import error"},
@@ -1608,7 +1608,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "OCI repo has rendering error",
 			ociSpec:                   oci,
-			sourceType:                v1beta1.OciSource,
+			sourceType:                configsync.OciSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1633,7 +1633,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				oci:          oci,
-				sourceType:   v1beta1.OciSource,
+				sourceType:   configsync.OciSource,
 				status:       util.ErrorMsg,
 				commit:       "def456",
 				errors:       []string{"KNV2015: rendering error"},
@@ -1643,7 +1643,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "OCI repo has syncing error",
 			ociSpec:                   oci,
-			sourceType:                v1beta1.OciSource,
+			sourceType:                configsync.OciSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1667,7 +1667,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				oci:          oci,
-				sourceType:   v1beta1.OciSource,
+				sourceType:   configsync.OciSource,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
 				errors:       []string{"KNV2009: apply error"},
@@ -1677,7 +1677,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "Helm repo has import error",
 			helmSpec:                  helm,
-			sourceType:                v1beta1.HelmSource,
+			sourceType:                configsync.HelmSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1692,7 +1692,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				helm:         helm,
-				sourceType:   v1beta1.HelmSource,
+				sourceType:   configsync.HelmSource,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
 				errors:       []string{"KNV2004: import error"},
@@ -1702,7 +1702,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "Helm repo has rendering error",
 			helmSpec:                  helm,
-			sourceType:                v1beta1.HelmSource,
+			sourceType:                configsync.HelmSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1727,7 +1727,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				helm:         helm,
-				sourceType:   v1beta1.HelmSource,
+				sourceType:   configsync.HelmSource,
 				status:       util.ErrorMsg,
 				commit:       "def456",
 				errors:       []string{"KNV2015: rendering error"},
@@ -1737,7 +1737,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "Helm repo has syncing error",
 			helmSpec:                  helm,
-			sourceType:                v1beta1.HelmSource,
+			sourceType:                configsync.HelmSource,
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1761,7 +1761,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 				scope:        "bookstore",
 				syncName:     "repo-sync",
 				helm:         helm,
-				sourceType:   v1beta1.HelmSource,
+				sourceType:   configsync.HelmSource,
 				status:       util.ErrorMsg,
 				commit:       "abc123",
 				errors:       []string{"KNV2009: apply error"},
@@ -1777,9 +1777,9 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 			if tc.helmSpec != nil {
 				repoSync.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: *tc.helmSpec}
 			}
-			repoSync.Spec.SourceType = string(tc.sourceType)
+			repoSync.Spec.SourceType = tc.sourceType
 			if repoSync.Spec.SourceType == "" {
-				repoSync.Spec.SourceType = string(v1beta1.GitSource)
+				repoSync.Spec.SourceType = configsync.GitSource
 			}
 			repoSync.Status.Conditions = tc.conditions
 			repoSync.Status.Source = tc.sourceStatus
@@ -2895,7 +2895,7 @@ gke_sample-project_europe-west1-b_cluster-1
 					{
 						scope:      "<root>",
 						syncName:   "root-sync",
-						sourceType: v1beta1.GitSource,
+						sourceType: configsync.GitSource,
 						git: &v1beta1.Git{
 							Repo: "git@github.com:tester/sample",
 						},
@@ -2905,7 +2905,7 @@ gke_sample-project_europe-west1-b_cluster-1
 					{
 						scope:      "bookstore",
 						syncName:   "repos-sync",
-						sourceType: v1beta1.GitSource,
+						sourceType: configsync.GitSource,
 						git: &v1beta1.Git{
 							Repo:   "git@github.com:tester/sample",
 							Branch: "feature",
@@ -2933,7 +2933,7 @@ gke_sample-project_europe-west1-b_cluster-2
 					{
 						scope:      "<root>",
 						syncName:   "root-sync",
-						sourceType: v1beta1.OciSource,
+						sourceType: configsync.OciSource,
 						oci: &v1beta1.Oci{
 							Image: "us-docker.pkg.dev/test-project/test-ar-repo/sample",
 						},
@@ -2943,7 +2943,7 @@ gke_sample-project_europe-west1-b_cluster-2
 					{
 						scope:      "bookstore",
 						syncName:   "repos-sync",
-						sourceType: v1beta1.OciSource,
+						sourceType: configsync.OciSource,
 						oci: &v1beta1.Oci{
 							Image: "us-docker.pkg.dev/test-project/test-ar-repo/sample-repo",
 							Dir:   "test",
@@ -2971,7 +2971,7 @@ gke_sample-project_europe-west1-b_cluster-2
 					{
 						scope:      "<root>",
 						syncName:   "root-sync",
-						sourceType: v1beta1.HelmSource,
+						sourceType: configsync.HelmSource,
 						helm: &v1beta1.HelmBase{
 							Repo:  "oci://us-central1-docker.pkg.dev/your-dev-project/sample",
 							Chart: "test",
@@ -2982,7 +2982,7 @@ gke_sample-project_europe-west1-b_cluster-2
 					{
 						scope:      "bookstore",
 						syncName:   "repos-sync",
-						sourceType: v1beta1.HelmSource,
+						sourceType: configsync.HelmSource,
 						helm: &v1beta1.HelmBase{
 							Repo:    "oci://us-central1-docker.pkg.dev/your-dev-project/sample",
 							Chart:   "test",
@@ -3030,7 +3030,7 @@ func TestClusterState_PrintRowsWithNameFilter(t *testing.T) {
 					{
 						scope:      "<root>",
 						syncName:   "root-sync",
-						sourceType: v1beta1.GitSource,
+						sourceType: configsync.GitSource,
 						git: &v1beta1.Git{
 							Repo: "git@github.com:tester/sample",
 						},
@@ -3040,7 +3040,7 @@ func TestClusterState_PrintRowsWithNameFilter(t *testing.T) {
 					{
 						scope:      "<root>",
 						syncName:   "root-sync-2",
-						sourceType: v1beta1.GitSource,
+						sourceType: configsync.GitSource,
 						git: &v1beta1.Git{
 							Repo:   "git@github.com:tester/sample",
 							Branch: "feature",
@@ -3051,7 +3051,7 @@ func TestClusterState_PrintRowsWithNameFilter(t *testing.T) {
 					{
 						scope:      "<root>",
 						syncName:   "root-sync-3",
-						sourceType: v1beta1.GitSource,
+						sourceType: configsync.GitSource,
 						git: &v1beta1.Git{
 							Repo:   "git@github.com:tester/sample",
 							Branch: "dev",

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -189,7 +188,7 @@ func main() {
 		HydratedLink:             *hydratedLinkDir,
 		SourceRev:                *sourceRev,
 		SourceBranch:             *sourceBranch,
-		SourceType:               v1beta1.SourceType(*sourceType),
+		SourceType:               configsync.SourceType(*sourceType),
 		SourceRepo:               *sourceRepo,
 		SyncDir:                  relSyncDir,
 		SyncName:                 *syncName,

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -651,7 +651,7 @@ func setupDelegatedControl(nt *NT) {
 func RootSyncObjectV1Alpha1(name, repoURL string, sourceFormat filesystem.SourceFormat) *v1alpha1.RootSync {
 	rs := fake.RootSyncObjectV1Alpha1(name)
 	rs.Spec.SourceFormat = string(sourceFormat)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1alpha1.Git{
 		Repo:   repoURL,
 		Branch: gitproviders.MainBranch,
@@ -700,7 +700,7 @@ func RootSyncObjectV1Alpha1FromRootRepo(nt *NT, name string) *v1alpha1.RootSync 
 func RootSyncObjectV1Beta1(name, repoURL string, sourceFormat filesystem.SourceFormat) *v1beta1.RootSync {
 	rs := fake.RootSyncObjectV1Beta1(name)
 	rs.Spec.SourceFormat = string(sourceFormat)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo:   repoURL,
 		Branch: gitproviders.MainBranch,
@@ -772,7 +772,7 @@ func StructuredNSPath(namespace, resourceName string) string {
 // SourceFormat for RepoSync must be Unstructured (default), so it's left unspecified.
 func RepoSyncObjectV1Alpha1(nn types.NamespacedName, repoURL string) *v1alpha1.RepoSync {
 	rs := fake.RepoSyncObjectV1Alpha1(nn.Namespace, nn.Name)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1alpha1.Git{
 		Repo:   repoURL,
 		Branch: gitproviders.MainBranch,
@@ -829,7 +829,7 @@ func RepoSyncObjectV1Alpha1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1a
 func RepoSyncObjectV1Beta1(nn types.NamespacedName, repoURL string, sourceFormat filesystem.SourceFormat) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1(nn.Namespace, nn.Name)
 	rs.Spec.SourceFormat = string(sourceFormat)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo:   repoURL,
 		Branch: gitproviders.MainBranch,
@@ -864,7 +864,7 @@ func (nt *NT) RootSyncObjectOCI(name string, image *registryproviders.OCIImage) 
 	}
 
 	rs := RootSyncObjectV1Beta1FromRootRepo(nt, name)
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{
 		Image: imageURL,
 		Auth:  configsync.AuthNone,
@@ -893,7 +893,7 @@ func (nt *NT) RepoSyncObjectOCI(nn types.NamespacedName, image *registryprovider
 	}
 
 	rs := RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{
 		Image: imageURL,
 		Auth:  configsync.AuthNone,
@@ -921,7 +921,7 @@ func (nt *NT) RootSyncObjectHelm(name string, chart *registryproviders.HelmPacka
 		nt.T.Fatalf("HelmProvider.RepositoryRemoteURL: %v", err)
 	}
 	rs := RootSyncObjectV1Beta1FromRootRepo(nt, name)
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{
 		HelmBase: v1beta1.HelmBase{
 			Repo:    chartRepoURL,
@@ -954,7 +954,7 @@ func (nt *NT) RepoSyncObjectHelm(nn types.NamespacedName, chart *registryprovide
 	}
 	rs := RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
 	rs.Spec.Git = nil
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{
 		HelmBase: v1beta1.HelmBase{
 			Repo:    chartRepoURL,

--- a/e2e/nomostest/sync.go
+++ b/e2e/nomostest/sync.go
@@ -51,7 +51,7 @@ func RootSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
 					configsync.RootSyncKind, i, log.AsJSON(condition), log.AsYAML(rs))
 			}
 		}
-		err := statusHasSyncDirAndNoErrors(rs.Status.Status, v1beta1.SourceType(rs.Spec.SourceType), dir)
+		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, dir)
 		if err != nil {
 			return fmt.Errorf("%s %w:\n%s", configsync.RootSyncKind, err, log.AsYAML(rs))
 		}
@@ -82,7 +82,7 @@ func RepoSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
 					configsync.RepoSyncKind, i, log.AsJSON(condition), log.AsYAML(rs))
 			}
 		}
-		err := statusHasSyncDirAndNoErrors(rs.Status.Status, v1beta1.SourceType(rs.Spec.SourceType), dir)
+		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, dir)
 		if err != nil {
 			return fmt.Errorf("%s %w:\n%s", configsync.RepoSyncKind, err, log.AsYAML(rs))
 		}
@@ -189,7 +189,7 @@ func statusHasSyncCommitAndNoErrors(status v1beta1.Status, sha1 string) error {
 	return nil
 }
 
-func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType v1beta1.SourceType, dir string) error {
+func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType configsync.SourceType, dir string) error {
 	if status.Source.ErrorSummary != nil && status.Source.ErrorSummary.TotalCount > 0 {
 		return fmt.Errorf("status.source contains %d errors", status.Source.ErrorSummary.TotalCount)
 	}
@@ -203,7 +203,7 @@ func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType v1beta1.Sourc
 		return fmt.Errorf("status.rendering.message %q does not indicate a successful state", message)
 	}
 	switch sourceType {
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		if status.Source.Oci == nil {
 			return fmt.Errorf("status.source.oci is nil")
 		}
@@ -222,7 +222,7 @@ func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType v1beta1.Sourc
 		if ociDir := status.Rendering.Oci.Dir; ociDir != dir {
 			return fmt.Errorf("status.rendering.oci.dir %q does not match the provided directory %q", ociDir, dir)
 		}
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		if status.Source.Git == nil {
 			return fmt.Errorf("status.source.git is nil")
 		}
@@ -241,7 +241,7 @@ func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType v1beta1.Sourc
 		if gitDir := status.Rendering.Git.Dir; gitDir != dir {
 			return fmt.Errorf("status.rendering.git.dir %q does not match the provided directory %q", gitDir, dir)
 		}
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		if status.Source.Helm == nil {
 			return fmt.Errorf("status.source.helm is nil")
 		}

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1548,7 +1548,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 		},
 	}
 	expectedRootSyncSpec := v1beta1.RootSyncSpec{
-		SourceType:   string(v1beta1.GitSource),
+		SourceType:   configsync.GitSource,
 		SourceFormat: string(filesystem.SourceFormatUnstructured),
 		Override:     &v1beta1.RootSyncOverrideSpec{},
 		Git: &v1beta1.Git{

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -728,7 +728,7 @@ func TestHelmARTokenAuth(t *testing.T) {
 	nt.T.Log("Update RootSync to sync from a private Artifact Registry")
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "git": null, "helm": {"repo": "%s", "chart": "%s", "auth": "token", "version": "%s", "releaseName": "my-coredns", "namespace": "coredns", "secretRef": {"name" : "foo"}}}}`,
-		v1beta1.HelmSource, chartRepoURL, chart.Name, chart.Version))
+		configsync.HelmSource, chartRepoURL, chart.Name, chart.Version))
 	err = nt.WatchForAllSyncs(
 		nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(chart.Version)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: chart.Name}))

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -42,7 +42,7 @@ import (
 	"kpt.dev/configsync/pkg/testing/fake"
 )
 
-func caCertSecretPatch(sourceType v1beta1.SourceType, name string) string {
+func caCertSecretPatch(sourceType configsync.SourceType, name string) string {
 	return fmt.Sprintf(`{"spec": {"%s": {"caCertSecretRef": {"name": "%s"}}}}`, sourceType, name)
 }
 
@@ -101,7 +101,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	}
 
 	// Set caCertSecret for RootSync
-	nt.MustMergePatch(rootSync, caCertSecretPatch(v1beta1.GitSource, caCertSecret))
+	nt.MustMergePatch(rootSync, caCertSecretPatch(configsync.GitSource, caCertSecret))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	}
 
 	// Unset caCertSecret for RootSync
-	nt.MustMergePatch(rootSync, caCertSecretPatch(v1beta1.GitSource, ""))
+	nt.MustMergePatch(rootSync, caCertSecretPatch(configsync.GitSource, ""))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
@@ -219,7 +219,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	}
 
 	// Set caCertSecret for RootSync
-	nt.MustMergePatch(rootSync, caCertSecretPatch(v1beta1.GitSource, caCertSecret))
+	nt.MustMergePatch(rootSync, caCertSecretPatch(configsync.GitSource, caCertSecret))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	}
 
 	// Unset caCertSecret for RootSync
-	nt.MustMergePatch(rootSync, caCertSecretPatch(v1beta1.GitSource, ""))
+	nt.MustMergePatch(rootSync, caCertSecretPatch(configsync.GitSource, ""))
 	// RootSync should fail without caCertSecret
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "server certificate verification failed")
 	err = nt.Validate(nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace, &appsv1.Deployment{}, testpredicates.DeploymentMissingEnvVar(reconcilermanager.GitSync, key))
@@ -409,11 +409,11 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 
 	nt.T.Log("Set the RootSync to sync the OCI image without providing a CA cert")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "oci": {"image": "%s", "auth": "none"}, "git": null}}`,
-		v1beta1.OciSource, imageURL))
+		configsync.OciSource, imageURL))
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "tls: failed to verify certificate: x509: certificate signed by unknown authority")
 
 	nt.T.Log("Add caCertSecretRef to RootSync")
-	nt.MustMergePatch(rs, caCertSecretPatch(v1beta1.OciSource, caCertSecret))
+	nt.MustMergePatch(rs, caCertSecretPatch(configsync.OciSource, caCertSecret))
 	err = nt.WatchForAllSyncs(
 		nomostest.WithRootSha1Func(imageDigestFuncByDigest(image.Digest)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
@@ -450,7 +450,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Set the RepoSync to sync the OCI image without providing a CA cert")
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{
 		Image: imageURL,
 		Auth:  "none",
@@ -484,7 +484,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Set the RepoSync to sync from git")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		nomostest.StructuredNSPath(nn.Namespace, nn.Name), rs))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Set the RepoSync to sync from Git"))
@@ -523,11 +523,11 @@ func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 
 	nt.T.Log("Set the RootSync to sync the Helm package without providing a CA cert")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"sourceType": "%s", "helm": {"repo": "%s", "chart": "%s", "version": "%s", "auth": "none", "period": "15s"}, "git": null}}`,
-		v1beta1.HelmSource, chartRepoURL, chart.Name, chart.Version))
+		configsync.HelmSource, chartRepoURL, chart.Name, chart.Version))
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "tls: failed to verify certificate: x509: certificate signed by unknown authority")
 
 	nt.T.Log("Add caCertSecretRef to RootSync")
-	nt.MustMergePatch(rs, caCertSecretPatch(v1beta1.HelmSource, caCertSecret))
+	nt.MustMergePatch(rs, caCertSecretPatch(configsync.HelmSource, caCertSecret))
 	err = nt.WatchForAllSyncs(
 		nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(chart.Version)),
 		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
@@ -568,7 +568,7 @@ func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Set the RepoSync to sync the Helm package without providing a CA cert")
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{
 		HelmBase: v1beta1.HelmBase{
 			Repo:    chartRepoURL,
@@ -607,7 +607,7 @@ func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Set the RepoSync to sync from git")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		nomostest.StructuredNSPath(nn.Namespace, nn.Name), rs))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Set the RepoSync to sync from Git"))

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -69,7 +69,7 @@ func TestWorkloadIdentity(t *testing.T) {
 		crossProject     bool
 		rootSrcCfg       sourceConfig
 		nsSrcCfg         sourceConfig
-		sourceType       v1beta1.SourceType
+		sourceType       configsync.SourceType
 		gsaEmail         string
 		requireHelmGAR   bool
 		requireOCIGAR    bool
@@ -84,7 +84,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			crossProject: false,
 			rootSrcCfg:   sourceConfig{pkg: "hydration/kustomize-components", dir: "kustomize-components", commitFn: nomostest.RemoteRootRepoSha1Fn},
 			nsSrcCfg:     sourceConfig{pkg: "hydration/namespace-repo", dir: "namespace-repo", commitFn: nomostest.RemoteNsRepoSha1Fn},
-			sourceType:   v1beta1.GitSource,
+			sourceType:   configsync.GitSource,
 			gsaEmail:     gitproviders.CSRReaderEmail(),
 			requireCSR:   true,
 		},
@@ -94,7 +94,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			crossProject: false,
 			rootSrcCfg:   sourceConfig{pkg: "hydration/kustomize-components", dir: "kustomize-components", commitFn: nomostest.RemoteRootRepoSha1Fn},
 			nsSrcCfg:     sourceConfig{pkg: "hydration/namespace-repo", dir: "namespace-repo", commitFn: nomostest.RemoteNsRepoSha1Fn},
-			sourceType:   v1beta1.GitSource,
+			sourceType:   configsync.GitSource,
 			gsaEmail:     gitproviders.CSRReaderEmail(),
 			requireCSR:   true,
 		},
@@ -104,7 +104,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			crossProject: true,
 			rootSrcCfg:   sourceConfig{pkg: "hydration/kustomize-components", dir: "kustomize-components", commitFn: nomostest.RemoteRootRepoSha1Fn},
 			nsSrcCfg:     sourceConfig{pkg: "hydration/namespace-repo", dir: "namespace-repo", commitFn: nomostest.RemoteNsRepoSha1Fn},
-			sourceType:   v1beta1.GitSource,
+			sourceType:   configsync.GitSource,
 			gsaEmail:     gitproviders.CSRReaderEmail(),
 			requireCSR:   true,
 		},
@@ -116,7 +116,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			nsSrcCfg:         sourceConfig{pkg: "hydration/namespace-repo", dir: ".", version: "v1"},
 			newRootSrcCfg:    sourceConfig{pkg: "hydration/kustomize-components", dir: "tenant-a", version: "v1"},
 			newNSSrcCfg:      sourceConfig{pkg: "hydration/namespace-repo", dir: "test-ns", version: "v1"},
-			sourceType:       v1beta1.OciSource,
+			sourceType:       configsync.OciSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireOCIGAR:    true,
@@ -133,7 +133,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				repo:     privateGCRImage("namespace-repo"),
 				dir:      ".",
 				commitFn: imageDigestFuncByName(privateGCRImage("namespace-repo"))},
-			sourceType: v1beta1.OciSource,
+			sourceType: configsync.OciSource,
 			gsaEmail:   gsaGCRReaderEmail(),
 		},
 		{
@@ -144,7 +144,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			nsSrcCfg:         sourceConfig{pkg: "hydration/namespace-repo", dir: ".", version: "v1"},
 			newRootSrcCfg:    sourceConfig{pkg: "hydration/kustomize-components", dir: "tenant-a", version: "v1"},
 			newNSSrcCfg:      sourceConfig{pkg: "hydration/namespace-repo", dir: "test-ns", version: "v1"},
-			sourceType:       v1beta1.OciSource,
+			sourceType:       configsync.OciSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireOCIGAR:    true,
@@ -161,7 +161,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				repo:     privateGCRImage("namespace-repo"),
 				dir:      ".",
 				commitFn: imageDigestFuncByName(privateGCRImage("namespace-repo"))},
-			sourceType: v1beta1.OciSource,
+			sourceType: configsync.OciSource,
 			gsaEmail:   gsaGCRReaderEmail(),
 		},
 		{
@@ -172,7 +172,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			nsSrcCfg:         sourceConfig{pkg: "hydration/namespace-repo", dir: ".", version: "v1"},
 			newRootSrcCfg:    sourceConfig{pkg: "hydration/kustomize-components", dir: "tenant-a", version: "v1"},
 			newNSSrcCfg:      sourceConfig{pkg: "hydration/namespace-repo", dir: "test-ns", version: "v1"},
-			sourceType:       v1beta1.OciSource,
+			sourceType:       configsync.OciSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireOCIGAR:    true,
@@ -189,7 +189,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				repo:     privateGCRImage("namespace-repo"),
 				dir:      ".",
 				commitFn: imageDigestFuncByName(privateGCRImage("namespace-repo"))},
-			sourceType: v1beta1.OciSource,
+			sourceType: configsync.OciSource,
 			gsaEmail:   gsaGCRReaderEmail(),
 		},
 		{
@@ -212,7 +212,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				chart:    "simple-ns-chart",
 				version:  "1.0.0",
 				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
-			sourceType:       v1beta1.HelmSource,
+			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireHelmGAR:   true,
@@ -237,7 +237,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				chart:    "simple-ns-chart",
 				version:  "1.0.0",
 				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
-			sourceType:       v1beta1.HelmSource,
+			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireHelmGAR:   true,
@@ -262,7 +262,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				chart:    "simple-ns-chart",
 				version:  "1.0.0",
 				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
-			sourceType:       v1beta1.HelmSource,
+			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
 			requireHelmGAR:   true,
@@ -349,10 +349,10 @@ func TestWorkloadIdentity(t *testing.T) {
 			var rootChart, nsChart *registryproviders.HelmPackage
 			nt.T.Logf("Update RootSync and RepoSync to sync from %s", tc.sourceType)
 			switch tc.sourceType {
-			case v1beta1.GitSource:
+			case configsync.GitSource:
 				rootMeta = updateRSyncWithGitSourceConfig(nt, rootSync, nt.RootRepos[configsync.RootSyncName], tc.rootSrcCfg)
 				nsMeta = updateRSyncWithGitSourceConfig(nt, repoSync, nt.NonRootRepos[nsRef], tc.nsSrcCfg)
-			case v1beta1.HelmSource:
+			case configsync.HelmSource:
 				rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rsRef, tc.rootSrcCfg)
 				if err != nil {
 					nt.T.Fatal(err)
@@ -362,7 +362,7 @@ func TestWorkloadIdentity(t *testing.T) {
 					nt.T.Fatal(err)
 				}
 
-			case v1beta1.OciSource:
+			case configsync.OciSource:
 				if tc.requireOCIGAR { // OCI provider is AR
 					rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rsRef, tc.rootSrcCfg)
 					if err != nil {
@@ -383,7 +383,7 @@ func TestWorkloadIdentity(t *testing.T) {
 								"gcpServiceAccountEmail": "%s"
 							}
 						}
-					}`, v1beta1.OciSource, tc.rootSrcCfg.repo, tc.rootSrcCfg.dir, tc.gsaEmail))
+					}`, configsync.OciSource, tc.rootSrcCfg.repo, tc.rootSrcCfg.dir, tc.gsaEmail))
 					rootMeta = rsyncValidateMeta{
 						rsRef:    rsRef,
 						sha1Func: tc.rootSrcCfg.commitFn,
@@ -399,7 +399,7 @@ func TestWorkloadIdentity(t *testing.T) {
 								"gcpServiceAccountEmail": "%s"
 							}
 						}
-					}`, v1beta1.OciSource, tc.nsSrcCfg.repo, tc.nsSrcCfg.dir, tc.gsaEmail))
+					}`, configsync.OciSource, tc.nsSrcCfg.repo, tc.nsSrcCfg.dir, tc.gsaEmail))
 					nsMeta = rsyncValidateMeta{
 						rsRef:    nsRef,
 						sha1Func: tc.nsSrcCfg.commitFn,
@@ -449,7 +449,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			}
 
 			switch tc.sourceType {
-			case v1beta1.GitSource, v1beta1.OciSource:
+			case configsync.GitSource, configsync.OciSource:
 				if err = nt.WatchForAllSyncs(
 					nomostest.WithRootSha1Func(rootMeta.sha1Func),
 					nomostest.WithRepoSha1Func(nsMeta.sha1Func),
@@ -461,7 +461,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				kustomizecomponents.ValidateAllTenants(nt, string(declared.RootScope), "base", "tenant-a", "tenant-b", "tenant-c")
 				kustomizecomponents.ValidateTenant(nt, nsMeta.rsRef.Namespace, "test-ns", "base")
 
-			case v1beta1.HelmSource:
+			case configsync.HelmSource:
 				if err = nt.WatchForAllSyncs(
 					nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(rootChart.Version)),
 					nomostest.WithRepoSha1Func(nomostest.HelmChartVersionShaFn(nsChart.Version)),
@@ -604,14 +604,14 @@ func truncateStringByLength(s string, l int) string {
 
 // migrateFromGSAtoKSA tests the scenario of migrating from impersonating a GSA
 // to leveraging KSA+WI (a.k.a, BYOID/Ubermint).
-func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType v1beta1.SourceType, rsRef, nsRef types.NamespacedName, rootSC, nsSC sourceConfig) error {
+func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsync.SourceType, rsRef, nsRef types.NamespacedName, rootSC, nsSC sourceConfig) error {
 	nt.T.Log("Update RootSync auth type from gcpserviceaccount to k8sserviceaccount")
 	var err error
 	var rootMeta, nsMeta rsyncValidateMeta
 	var rootChart, nsChart *registryproviders.HelmPackage
 	// Change the source config to guarantee new resources can be reconciled with k8sserviceaccount
 	switch sourceType {
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rsRef, rootSC, func(rs *v1beta1.RootSync) {
 			rs.Spec.Helm.Auth = configsync.AuthK8sServiceAccount
 		})
@@ -624,7 +624,7 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType v1beta1.
 		if err != nil {
 			nt.T.Fatal(err)
 		}
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rsRef, rootSC, func(rs *v1beta1.RootSync) {
 			rs.Spec.Oci.Auth = configsync.AuthK8sServiceAccount
 		})
@@ -682,7 +682,7 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType v1beta1.
 	}
 
 	switch sourceType {
-	case v1beta1.GitSource, v1beta1.OciSource:
+	case configsync.GitSource, configsync.OciSource:
 		if err = nt.WatchForAllSyncs(
 			nomostest.WithRootSha1Func(rootMeta.sha1Func),
 			nomostest.WithRepoSha1Func(nsMeta.sha1Func),
@@ -700,7 +700,7 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType v1beta1.
 		}
 		kustomizecomponents.ValidateTenant(nt, nsMeta.rsRef.Namespace, "test-ns", "../base")
 
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		if err = nt.WatchForAllSyncs(
 			nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(rootChart.Version)),
 			nomostest.WithRepoSha1Func(nomostest.HelmChartVersionShaFn(nsChart.Version)),

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -92,6 +92,20 @@ const (
 	DefaultHelmReleaseNamespace = "default"
 )
 
+// SourceType specifies the type of the source of truth.
+type SourceType string
+
+const (
+	// GitSource represents the source type is Git repository.
+	GitSource SourceType = "git"
+
+	// OciSource represents the source type is OCI package.
+	OciSource SourceType = "oci"
+
+	// HelmSource represents the source type is Helm repository.
+	HelmSource SourceType = "helm"
+)
+
 // AuthType specifies the type to authenticate to a repository.
 type AuthType string
 

--- a/pkg/api/configsync/v1alpha1/reposync_types.go
+++ b/pkg/api/configsync/v1alpha1/reposync_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 // +kubebuilder:object:root=true
@@ -57,8 +58,9 @@ type RepoSyncSpec struct {
 	// Must be one of git, oci, helm. Optional. Set to git if not specified.
 	// +kubebuilder:validation:Pattern=^(git|oci|helm)$
 	// +kubebuilder:default:=git
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceType string `json:"sourceType,omitempty"`
+	SourceType configsync.SourceType `json:"sourceType,omitempty"`
 
 	// git contains configuration specific to importing resources from a Git repo.
 	// +optional

--- a/pkg/api/configsync/v1alpha1/rootsync_types.go
+++ b/pkg/api/configsync/v1alpha1/rootsync_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 // +kubebuilder:object:root=true
@@ -57,8 +58,9 @@ type RootSyncSpec struct {
 	// Must be one of git, oci, helm. Optional. Set to git if not specified.
 	// +kubebuilder:validation:Pattern=^(git|oci|helm)$
 	// +kubebuilder:default:=git
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceType string `json:"sourceType,omitempty"`
+	SourceType configsync.SourceType `json:"sourceType,omitempty"`
 
 	// git contains configuration specific to importing resources from a Git repo.
 	// +optional

--- a/pkg/api/configsync/v1alpha1/sync_types.go
+++ b/pkg/api/configsync/v1alpha1/sync_types.go
@@ -249,17 +249,3 @@ type ResourceRef struct {
 	// +optional
 	GVK metav1.GroupVersionKind `json:"gvk,omitempty"`
 }
-
-// SourceType specifies the type of the source of truth.
-type SourceType string
-
-const (
-	// GitSource represents the source type is Git repository.
-	GitSource SourceType = "git"
-
-	// OciSource represents the source type is OCI package.
-	OciSource SourceType = "oci"
-
-	// HelmSource represents the source type is Helm repository.
-	HelmSource SourceType = "helm"
-)

--- a/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
@@ -884,7 +884,7 @@ func Convert_v1beta1_RepoSyncOverrideSpec_To_v1alpha1_RepoSyncOverrideSpec(in *v
 
 func autoConvert_v1alpha1_RepoSyncSpec_To_v1beta1_RepoSyncSpec(in *RepoSyncSpec, out *v1beta1.RepoSyncSpec, s conversion.Scope) error {
 	out.SourceFormat = in.SourceFormat
-	out.SourceType = in.SourceType
+	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*v1beta1.Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*v1beta1.Oci)(unsafe.Pointer(in.Oci))
 	if in.Helm != nil {
@@ -907,7 +907,7 @@ func Convert_v1alpha1_RepoSyncSpec_To_v1beta1_RepoSyncSpec(in *RepoSyncSpec, out
 
 func autoConvert_v1beta1_RepoSyncSpec_To_v1alpha1_RepoSyncSpec(in *v1beta1.RepoSyncSpec, out *RepoSyncSpec, s conversion.Scope) error {
 	out.SourceFormat = in.SourceFormat
-	out.SourceType = in.SourceType
+	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*Oci)(unsafe.Pointer(in.Oci))
 	if in.Helm != nil {
@@ -1146,7 +1146,7 @@ func Convert_v1beta1_RootSyncRoleRef_To_v1alpha1_RootSyncRoleRef(in *v1beta1.Roo
 
 func autoConvert_v1alpha1_RootSyncSpec_To_v1beta1_RootSyncSpec(in *RootSyncSpec, out *v1beta1.RootSyncSpec, s conversion.Scope) error {
 	out.SourceFormat = in.SourceFormat
-	out.SourceType = in.SourceType
+	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*v1beta1.Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*v1beta1.Oci)(unsafe.Pointer(in.Oci))
 	if in.Helm != nil {
@@ -1169,7 +1169,7 @@ func Convert_v1alpha1_RootSyncSpec_To_v1beta1_RootSyncSpec(in *RootSyncSpec, out
 
 func autoConvert_v1beta1_RootSyncSpec_To_v1alpha1_RootSyncSpec(in *v1beta1.RootSyncSpec, out *RootSyncSpec, s conversion.Scope) error {
 	out.SourceFormat = in.SourceFormat
-	out.SourceType = in.SourceType
+	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*Oci)(unsafe.Pointer(in.Oci))
 	if in.Helm != nil {

--- a/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/api/configsync/v1beta1/reposync_types.go
+++ b/pkg/api/configsync/v1beta1/reposync_types.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 // +kubebuilder:object:root=true
@@ -58,8 +59,9 @@ type RepoSyncSpec struct {
 	// Must be one of git, oci, helm. Optional. Set to git if not specified.
 	// +kubebuilder:validation:Pattern=^(git|oci|helm)$
 	// +kubebuilder:default:=git
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceType string `json:"sourceType,omitempty"`
+	SourceType configsync.SourceType `json:"sourceType,omitempty"`
 
 	// git contains configuration specific to importing resources from a Git repo.
 	// +optional

--- a/pkg/api/configsync/v1beta1/rootsync_types.go
+++ b/pkg/api/configsync/v1beta1/rootsync_types.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 // +kubebuilder:object:root=true
@@ -58,8 +59,9 @@ type RootSyncSpec struct {
 	// Must be one of git, oci, helm. Optional. Set to git if not specified.
 	// +kubebuilder:validation:Pattern=^(git|oci|helm)$
 	// +kubebuilder:default:=git
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceType string `json:"sourceType,omitempty"`
+	SourceType configsync.SourceType `json:"sourceType,omitempty"`
 
 	// git contains configuration specific to importing resources from a Git repo.
 	// +optional

--- a/pkg/api/configsync/v1beta1/sync_types.go
+++ b/pkg/api/configsync/v1beta1/sync_types.go
@@ -249,17 +249,3 @@ type ResourceRef struct {
 	// +optional
 	GVK metav1.GroupVersionKind `json:"gvk,omitempty"`
 }
-
-// SourceType specifies the type of the source of truth.
-type SourceType string
-
-const (
-	// GitSource represents the source type is Git repository.
-	GitSource SourceType = "git"
-
-	// OciSource represents the source type is OCI package.
-	OciSource SourceType = "oci"
-
-	// HelmSource represents the source type is Helm repository.
-	HelmSource SourceType = "helm"
-)

--- a/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/api/configsync/v1beta1/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1beta1
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/hydrate/controller.go
+++ b/pkg/hydrate/controller.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -48,7 +47,7 @@ type Hydrator struct {
 	// DonePath is the absolute path to the done file under the /repo directory.
 	DonePath cmpath.Absolute
 	// SourceType is the type of the source repository, must be git or oci.
-	SourceType v1beta1.SourceType
+	SourceType configsync.SourceType
 	// SourceRoot is the absolute path to the source root directory.
 	SourceRoot cmpath.Absolute
 	// HydratedRoot is the absolute path to the hydrated root directory.
@@ -335,7 +334,7 @@ func deleteErrorFile(file string) error {
 // OCI image digest or a helm chart version), the absolute path of the sync
 // directory, and source errors.
 // It retries with the provided backoff.
-func SourceCommitAndDirWithRetry(backoff wait.Backoff, sourceType v1beta1.SourceType, sourceRevDir cmpath.Absolute, syncDir cmpath.Relative, reconcilerName string) (commit string, sourceDir cmpath.Absolute, _ status.Error) {
+func SourceCommitAndDirWithRetry(backoff wait.Backoff, sourceType configsync.SourceType, sourceRevDir cmpath.Absolute, syncDir cmpath.Relative, reconcilerName string) (commit string, sourceDir cmpath.Absolute, _ status.Error) {
 	err := util.RetryWithBackoff(backoff, func() error {
 		var err error
 		commit, sourceDir, err = SourceCommitAndDir(sourceType, sourceRevDir, syncDir, reconcilerName)
@@ -349,7 +348,7 @@ func SourceCommitAndDirWithRetry(backoff wait.Backoff, sourceType v1beta1.Source
 // SourceCommitAndDir returns the source hash (a git commit hash or an OCI image
 // digest or a helm chart version), the absolute path of the sync directory,
 // and source errors.
-func SourceCommitAndDir(sourceType v1beta1.SourceType, sourceRevDir cmpath.Absolute, syncDir cmpath.Relative, reconcilerName string) (string, cmpath.Absolute, error) {
+func SourceCommitAndDir(sourceType configsync.SourceType, sourceRevDir cmpath.Absolute, syncDir cmpath.Relative, reconcilerName string) (string, cmpath.Absolute, error) {
 	sourceRoot := path.Dir(sourceRevDir.OSPath())
 	if _, err := os.Stat(sourceRoot); err != nil {
 		// It fails to check the source root directory status, either because of
@@ -363,11 +362,11 @@ func SourceCommitAndDir(sourceType v1beta1.SourceType, sourceRevDir cmpath.Absol
 
 	var containerName string
 	switch sourceType {
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		containerName = reconcilermanager.OciSync
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		containerName = reconcilermanager.GitSync
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		containerName = reconcilermanager.HelmSync
 	}
 

--- a/pkg/hydrate/controller_test.go
+++ b/pkg/hydrate/controller_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	ft "kpt.dev/configsync/pkg/importer/filesystem/filesystemtest"
 	"kpt.dev/configsync/pkg/testing/testerrors"
@@ -175,7 +175,7 @@ func TestSourceCommitAndDirWithRetry(t *testing.T) {
 			}()
 
 			t.Logf("start calling SourceCommitAndDirWithRetry at %v", time.Now())
-			srcCommit, srcSyncDir, err := SourceCommitAndDirWithRetry(backoff, v1beta1.GitSource, cmpath.Absolute(commitDir), cmpath.RelativeOS(tc.syncDir), "root-reconciler")
+			srcCommit, srcSyncDir, err := SourceCommitAndDirWithRetry(backoff, configsync.GitSource, cmpath.Absolute(commitDir), cmpath.RelativeOS(tc.syncDir), "root-reconciler")
 			if tc.expectedErrMsg == "" {
 				assert.Nil(t, err, "got unexpected error %v", err)
 				assert.Equal(t, tc.expectedSourceCommit, srcCommit)
@@ -250,7 +250,7 @@ func TestRunHydrate(t *testing.T) {
 
 			hydrator := &Hydrator{
 				DonePath:        "",
-				SourceType:      v1beta1.HelmSource,
+				SourceType:      configsync.HelmSource,
 				SourceRoot:      cmpath.Absolute(commitDir),
 				HydratedRoot:    cmpath.Absolute(commitDir),
 				SourceLink:      "",

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -222,7 +222,7 @@ func setSourceStatusFields(source *v1beta1.SourceStatus, p Parser, newStatus sou
 	cse := status.ToCSE(newStatus.errs)
 	source.Commit = newStatus.commit
 	switch p.options().SourceType {
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		source.Git = &v1beta1.GitStatus{
 			Repo:     p.options().SourceRepo,
 			Revision: p.options().SourceRev,
@@ -231,14 +231,14 @@ func setSourceStatusFields(source *v1beta1.SourceStatus, p Parser, newStatus sou
 		}
 		source.Oci = nil
 		source.Helm = nil
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		source.Oci = &v1beta1.OciStatus{
 			Image: p.options().SourceRepo,
 			Dir:   p.options().SyncDir.SlashPath(),
 		}
 		source.Git = nil
 		source.Helm = nil
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		source.Helm = &v1beta1.HelmStatus{
 			Repo:    p.options().SourceRepo,
 			Chart:   p.options().SyncDir.SlashPath(),
@@ -338,7 +338,7 @@ func setRenderingStatusFields(rendering *v1beta1.RenderingStatus, p Parser, newS
 	cse := status.ToCSE(newStatus.errs)
 	rendering.Commit = newStatus.commit
 	switch p.options().SourceType {
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		rendering.Git = &v1beta1.GitStatus{
 			Repo:     p.options().SourceRepo,
 			Revision: p.options().SourceRev,
@@ -347,14 +347,14 @@ func setRenderingStatusFields(rendering *v1beta1.RenderingStatus, p Parser, newS
 		}
 		rendering.Oci = nil
 		rendering.Helm = nil
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		rendering.Oci = &v1beta1.OciStatus{
 			Image: p.options().SourceRepo,
 			Dir:   p.options().SyncDir.SlashPath(),
 		}
 		rendering.Git = nil
 		rendering.Helm = nil
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		rendering.Helm = &v1beta1.HelmStatus{
 			Repo:    p.options().SourceRepo,
 			Chart:   p.options().SyncDir.SlashPath(),

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -269,13 +269,13 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.RootSyncV1Beta1("test", fake.WithRootSyncSourceType(v1beta1.GitSource), gitSpec("https://github.com/test/test.git", configsync.AuthNone)),
+						fake.RootSyncV1Beta1("test", fake.WithRootSyncSourceType(configsync.GitSource), gitSpec("https://github.com/test/test.git", configsync.AuthNone)),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
 				fake.RootSyncV1Beta1("test", gitSpec("https://github.com/test/test.git", configsync.AuthNone),
-					fake.WithRootSyncSourceType(v1beta1.GitSource),
+					fake.WithRootSyncSourceType(configsync.GitSource),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1beta1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, fmt.Sprintf("namespaces/%s/test.yaml", configsync.ControllerNamespace)),

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -389,7 +389,7 @@ func TestRun(t *testing.T) {
 				RepoRoot:     cmpath.Absolute(rootDir),
 				HydratedRoot: hydratedRoot,
 				HydratedLink: symLink,
-				SourceType:   v1beta1.GitSource,
+				SourceType:   configsync.GitSource,
 				SourceRepo:   "https://github.com/test/test.git",
 				SourceBranch: "main",
 			}

--- a/pkg/parse/source.go
+++ b/pkg/parse/source.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/metadata"
@@ -46,7 +45,7 @@ type FileSource struct {
 	// SyncDir is the path to the directory of policies within the source repository.
 	SyncDir cmpath.Relative
 	// SourceType is the type of the source repository, must be git or oci.
-	SourceType v1beta1.SourceType
+	SourceType configsync.SourceType
 	// SourceRepo is the source repo to sync.
 	SourceRepo string
 	// SourceBranch is the branch of the source repo to sync.

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/core"
@@ -102,7 +101,7 @@ type Options struct {
 	// SourceRepo is the git or OCI or Helm repo being synced.
 	SourceRepo string
 	// SourceType is the type of the source repository, must be git or oci or Helm.
-	SourceType v1beta1.SourceType
+	SourceType configsync.SourceType
 	// SyncDir is the relative path to the configurations in the source.
 	SyncDir cmpath.Relative
 	// StatusMode controls the kpt applier to inject the actuation status data or not

--- a/pkg/reconcilermanager/controllers/helm_value_files.go
+++ b/pkg/reconcilermanager/controllers/helm_value_files.go
@@ -93,7 +93,7 @@ func (r *RepoSyncReconciler) getReconcilerHelmConfigMapRefs(rs *v1beta1.RepoSync
 func (r *RepoSyncReconciler) upsertHelmConfigMaps(ctx context.Context, rs *v1beta1.RepoSync, labelMap map[string]string) error {
 	rsRef := client.ObjectKeyFromObject(rs)
 	var cmNamesToKeep map[string]struct{}
-	if rs.Spec.SourceType == string(v1beta1.HelmSource) && rs.Spec.Helm != nil {
+	if rs.Spec.SourceType == configsync.HelmSource && rs.Spec.Helm != nil {
 		cmNamesToKeep = make(map[string]struct{}, len(rs.Spec.Helm.ValuesFileRefs))
 		for _, vfRef := range rs.Spec.Helm.ValuesFileRefs {
 			userCMRef := types.NamespacedName{

--- a/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_manager_test.go
@@ -52,7 +52,7 @@ func TestRepoSyncReconcilerDeploymentLifecycle(t *testing.T) {
 
 	t.Log("building RepoSync controller")
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(GitSecretConfigKeySSH), reposyncSecretRef(reposyncSSHKey))
-	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, secretObj)
 
@@ -175,7 +175,7 @@ func TestReconcileInvalidRepoSyncLifecycle(t *testing.T) {
 	t.Log("building RepoSyncReconciler")
 	// rs is an invalid RepoSync as its auth type is set to `token`, but the token key is not configured in the secret.
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthToken), reposyncSecretRef(reposyncSSHKey))
-	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
 
@@ -248,7 +248,7 @@ func TestReconcileRepoSyncLifecycleValidToInvalid(t *testing.T) {
 
 	t.Log("building RepoSyncReconciler")
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
-	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
 
@@ -539,7 +539,7 @@ func TestRepoSyncReconcilerAuthSecretDriftProtection(t *testing.T) {
 func testRepoSyncDriftProtection(t *testing.T, exampleObj client.Object, objKeyFunc func(client.ObjectKey) client.ObjectKey, modify, validate func(client.Object) error) {
 	t.Log("building RepoSyncReconciler")
 	syncObj := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
-	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(syncObj.Namespace))
+	secretObj := secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(syncObj.Namespace))
 	fakeClient, _, testReconciler := setupNSReconciler(t, secretObj)
 	testDriftProtection(t, fakeClient, testReconciler, syncObj, exampleObj, objKeyFunc, modify, validate)
 }

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -131,7 +131,7 @@ func init() {
 	helmSyncVersionPollingPeriod = filesystemPollingPeriod
 }
 
-func reposyncSourceType(sourceType string) func(*v1beta1.RepoSync) {
+func reposyncSourceType(sourceType configsync.SourceType) func(*v1beta1.RepoSync) {
 	return func(rs *v1beta1.RepoSync) {
 		rs.Spec.SourceType = sourceType
 	}
@@ -218,14 +218,14 @@ func reposyncNoSSLVerify() func(*v1beta1.RepoSync) {
 	}
 }
 
-func reposyncCACert(sourceType v1beta1.SourceType, caCertSecretRef string) func(sync *v1beta1.RepoSync) {
+func reposyncCACert(sourceType configsync.SourceType, caCertSecretRef string) func(sync *v1beta1.RepoSync) {
 	return func(rs *v1beta1.RepoSync) {
 		switch sourceType {
-		case v1beta1.GitSource:
+		case configsync.GitSource:
 			rs.Spec.Git.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
-		case v1beta1.OciSource:
+		case configsync.OciSource:
 			rs.Spec.Oci.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
-		case v1beta1.HelmSource:
+		case configsync.HelmSource:
 			rs.Spec.Helm.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
 		}
 	}
@@ -250,7 +250,7 @@ func repoSync(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSyn
 
 func repoSyncWithGit(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	addGit := func(rs *v1beta1.RepoSync) {
-		rs.Spec.SourceType = string(v1beta1.GitSource)
+		rs.Spec.SourceType = configsync.GitSource
 		rs.Spec.Git = &v1beta1.Git{
 			Repo: reposyncRepo,
 			Dir:  reposyncDir,
@@ -262,7 +262,7 @@ func repoSyncWithGit(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.
 
 func repoSyncWithOCI(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	addOci := func(rs *v1beta1.RepoSync) {
-		rs.Spec.SourceType = string(v1beta1.OciSource)
+		rs.Spec.SourceType = configsync.OciSource
 		rs.Spec.Oci = &v1beta1.Oci{
 			Image: ociImage,
 			Dir:   reposyncDir,
@@ -274,7 +274,7 @@ func repoSyncWithOCI(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.
 
 func repoSyncWithHelm(ns, name string, opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	addHelm := func(rs *v1beta1.RepoSync) {
-		rs.Spec.SourceType = string(v1beta1.HelmSource)
+		rs.Spec.SourceType = configsync.HelmSource
 		rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{
 			Repo:    helmRepo,
 			Chart:   helmChart,
@@ -356,7 +356,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH),
 		reposyncSecretRef(reposyncSSHKey), reposyncOverrideResources(overrideReconcilerAndGitSyncResourceLimits))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -496,7 +496,7 @@ func TestUpdateNamespaceReconcilerWithOverride(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -749,7 +749,7 @@ func TestRepoSyncCreateWithNoSSLVerify(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey), reposyncNoSSLVerify())
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -792,7 +792,7 @@ func TestRepoSyncUpdateNoSSLVerify(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncSourceType(gitSourceType), reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1102,11 +1102,11 @@ func TestRepoSyncCreateWithCACert(t *testing.T) {
 	caCertSecret := "foo-secret"
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch),
 		reposyncSecretType(configsync.AuthToken), reposyncSecretRef(secretName),
-		reposyncCACert(v1beta1.GitSource, caCertSecret))
+		reposyncCACert(configsync.GitSource, caCertSecret))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
 	gitSecret := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret.Data[CACertSecretKey] = []byte("test-cert")
 	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, gitSecret, certSecret)
 
@@ -1147,7 +1147,7 @@ func TestRepoSyncUpdateCACert(t *testing.T) {
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
 	gitSecret := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret.Data[CACertSecretKey] = []byte("test-cert")
 	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, gitSecret, certSecret)
 
@@ -1290,7 +1290,7 @@ func TestRepoSyncReconcileAdmissionWebhook(t *testing.T) {
 				reposyncSecretRef(reposyncSSHKey),
 			)
 			reqNamespacedName := namespacedName(repoSync.Name, repoSync.Namespace)
-			fakeClient, _, testReconciler := setupNSReconciler(t, repoSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(repoSync.Namespace)))
+			fakeClient, _, testReconciler := setupNSReconciler(t, repoSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(repoSync.Namespace)))
 
 			for _, o := range tc.existingObjects {
 				t.Log("creating obj", o.GetObjectKind().GroupVersionKind().Kind)
@@ -1317,15 +1317,15 @@ func TestRepoSyncReconcileWithInvalidCACertSecret(t *testing.T) {
 		"git": {
 			repoSync: repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch),
 				reposyncSecretType(configsync.AuthNone),
-				reposyncCACert(v1beta1.GitSource, caCertSecret)),
+				reposyncCACert(configsync.GitSource, caCertSecret)),
 		},
 		"oci": {
 			repoSync: repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone),
-				reposyncCACert(v1beta1.OciSource, caCertSecret)),
+				reposyncCACert(configsync.OciSource, caCertSecret)),
 		},
 		"helm": {
 			repoSync: repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone),
-				reposyncCACert(v1beta1.HelmSource, caCertSecret)),
+				reposyncCACert(configsync.HelmSource, caCertSecret)),
 		},
 	}
 	for name, tc := range testCases {
@@ -1383,7 +1383,7 @@ func TestRepoSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey), reposyncOverrideGitSyncDepth(5))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1418,7 +1418,7 @@ func TestRepoSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1571,7 +1571,7 @@ func TestRepoSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey), reposyncOverrideReconcileTimeout(metav1.Duration{Duration: 50 * time.Second}))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1606,7 +1606,7 @@ func TestRepoSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1726,7 +1726,7 @@ func TestRepoSyncCreateWithOverrideAPIServerTimeout(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey), reposyncOverrideAPIServerTimeout(metav1.Duration{Duration: 50 * time.Second}))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	_, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1758,7 +1758,7 @@ func TestRepoSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1878,7 +1878,7 @@ func TestRepoSyncSwitchAuthTypes(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthGCPServiceAccount), reposyncGCPSAEmail(gcpSAEmail))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources with GCPServiceAccount auth type.
 	ctx := context.Background()
@@ -2000,7 +2000,7 @@ func TestRepoSyncReconcilerRestart(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -2114,7 +2114,7 @@ func TestMultipleRepoSyncs(t *testing.T) {
 	secret5 := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs5.Namespace))
 	secret5.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
 
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs1, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs1.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs1, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs1.Namespace)))
 
 	nsReconcilerName2 := core.NsReconcilerName(rs2.Namespace, rs2.Name)
 	nsReconcilerName3 := core.NsReconcilerName(rs3.Namespace, rs3.Name)
@@ -2661,9 +2661,9 @@ func TestMapSecretToRepoSyncs(t *testing.T) {
 	rs1 := repoSyncWithGit("ns1", "rs1", reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	rs2 := repoSyncWithGit("ns1", "rs2", reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	rs3 := repoSyncWithGit("ns1", "rs3", reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(testSecretName))
-	rs4 := repoSyncWithGit("ns1", "rs4", reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthNone), reposyncCACert(v1beta1.GitSource, caCertSecret))
-	rs5 := repoSyncWithOCI("ns1", "rs5", reposyncOCIAuthType(configsync.AuthNone), reposyncCACert(v1beta1.OciSource, caCertSecret))
-	rs6 := repoSyncWithHelm("ns1", "rs6", reposyncHelmAuthType(configsync.AuthNone), reposyncCACert(v1beta1.HelmSource, caCertSecret))
+	rs4 := repoSyncWithGit("ns1", "rs4", reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthNone), reposyncCACert(configsync.GitSource, caCertSecret))
+	rs5 := repoSyncWithOCI("ns1", "rs5", reposyncOCIAuthType(configsync.AuthNone), reposyncCACert(configsync.OciSource, caCertSecret))
+	rs6 := repoSyncWithHelm("ns1", "rs6", reposyncHelmAuthType(configsync.AuthNone), reposyncCACert(configsync.HelmSource, caCertSecret))
 
 	ns1rs1ReconcilerName := core.NsReconcilerName(rs1.Namespace, rs1.Name)
 	ns1rs4ReconcilerName := core.NsReconcilerName(rs4.Namespace, rs4.Name)
@@ -3010,7 +3010,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRepoSync(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthGCPServiceAccount), reposyncGCPSAEmail(gcpSAEmail))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 	// The membership doesn't have WorkloadIdentityPool and IdentityProvider specified, so FWI creds won't be injected.
 	testReconciler.membership = &hubv1.Membership{
 		Spec: hubv1.MembershipSpec{
@@ -3162,7 +3162,7 @@ func TestRepoSyncWithHelm(t *testing.T) {
 	rs := repoSyncWithHelm(reposyncNs, reposyncName,
 		reposyncHelmAuthType(configsync.AuthToken), reposyncHelmSecretRef(secretName))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	helmSecret := secretObj(t, secretName, configsync.AuthToken, v1beta1.HelmSource, core.Namespace(rs.Namespace))
+	helmSecret := secretObj(t, secretName, configsync.AuthToken, configsync.HelmSource, core.Namespace(rs.Namespace))
 	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, helmSecret)
 
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3684,7 +3684,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
@@ -3699,7 +3699,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
@@ -3714,7 +3714,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
 	}
@@ -3729,7 +3729,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -3745,7 +3745,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -3761,7 +3761,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
@@ -3778,7 +3778,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -3794,7 +3794,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the repo sync request, got error: %v", err)
@@ -3810,7 +3810,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage, Auth: configsync.AuthNone}
@@ -3836,7 +3836,7 @@ func TestRepoSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the repo sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart, Auth: configsync.AuthNone}}
@@ -3912,7 +3912,7 @@ func TestRepoSyncReconcileStaleClientCache(t *testing.T) {
 	rs = fake.RepoSyncObjectV1Beta1(reposyncNs, reposyncName)
 	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
 	require.NoError(t, err, "unexpected Get error")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.ResourceVersion = "2" // doesn't need to be increasing or even numeric
 	err = fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager))
 	require.NoError(t, err, "unexpected Update error")
@@ -4033,7 +4033,7 @@ func TestPopulateRepoContainerEnvs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, testReconciler := setupNSReconciler(t, tc.repoSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(tc.repoSync.Namespace)))
+			_, _, testReconciler := setupNSReconciler(t, tc.repoSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(tc.repoSync.Namespace)))
 
 			env := testReconciler.populateContainerEnvs(ctx, tc.repoSync, nsReconcilerName)
 
@@ -4052,7 +4052,7 @@ func TestUpdateNamespaceReconcilerLogLevelWithOverride(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -4160,7 +4160,7 @@ func TestCreateAndUpdateNamespaceReconcilerWithOverrideOnAutopilot(t *testing.T)
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(configsync.AuthSSH),
 		reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, util.FakeAutopilotWebhookObject(), rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupNSReconciler(t, util.FakeAutopilotWebhookObject(), rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -4323,15 +4323,15 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 	rs := repoSyncWithGit(reposyncNs, reposyncName,
 		reposyncRef(gitRevision), reposyncBranch(branch),
 		reposyncSecretType(configsync.AuthToken), reposyncSecretRef(gitSecret1Name),
-		reposyncCACert(v1beta1.GitSource, caCertSecret1Name))
+		reposyncCACert(configsync.GitSource, caCertSecret1Name))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
 	gitSecret1 := secretObjWithProxy(t, gitSecret1Name, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret1.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret1 := secretObj(t, caCertSecret1Name, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret1 := secretObj(t, caCertSecret1Name, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret1.Data[CACertSecretKey] = []byte("test-cert")
 	gitSecret2 := secretObjWithProxy(t, gitSecret2Name, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret2.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret2 := secretObj(t, caCertSecret2Name, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret2 := secretObj(t, caCertSecret2Name, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret2.Data[CACertSecretKey] = []byte("test-cert")
 	fakeClient, _, testReconciler := setupNSReconciler(t, rs,
 		gitSecret1, certSecret1, gitSecret2, certSecret2)
@@ -4404,7 +4404,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Verify Secret garbage collection behavior with OCI source type
 	rs = repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone),
-		reposyncCACert(v1beta1.OciSource, caCertSecret1Name))
+		reposyncCACert(configsync.OciSource, caCertSecret1Name))
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -4418,7 +4418,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Switch secret reference to a different Secret
 	rs = repoSyncWithOCI(reposyncNs, reposyncName, reposyncOCIAuthType(configsync.AuthNone),
-		reposyncCACert(v1beta1.OciSource, caCertSecret2Name))
+		reposyncCACert(configsync.OciSource, caCertSecret2Name))
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -4447,7 +4447,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Verify Secret garbage collection behavior with helm source type
 	rs = repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone),
-		reposyncCACert(v1beta1.HelmSource, caCertSecret1Name))
+		reposyncCACert(configsync.HelmSource, caCertSecret1Name))
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -4461,7 +4461,7 @@ func TestRepoSyncGarbageCollectSecrets(t *testing.T) {
 
 	// Switch secret reference to a different Secret
 	rs = repoSyncWithHelm(reposyncNs, reposyncName, reposyncHelmAuthType(configsync.AuthNone),
-		reposyncCACert(v1beta1.HelmSource, caCertSecret2Name))
+		reposyncCACert(configsync.HelmSource, caCertSecret2Name))
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v, want error: nil", err)
 	}
@@ -4493,7 +4493,7 @@ func TestRepoReconcilerWithoutKnownHosts(t *testing.T) {
 
 	rs := repoSyncWithGit(reposyncNs, reposyncName, reposyncRef(gitRevision), reposyncBranch(branch), reposyncSecretType(GitSecretConfigKeySSH), reposyncSecretRef(reposyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	_, _, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	_, _, testReconciler := setupNSReconciler(t, rs, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test performing reconcile
 	ctx := context.Background()

--- a/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
@@ -66,7 +66,7 @@ func TestRootSyncReconcilerDeploymentLifecycle(t *testing.T) {
 
 	t.Log("building RootSync controller")
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
-	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, secretObj)
 
@@ -189,7 +189,7 @@ func TestReconcileInvalidRootSyncLifecycle(t *testing.T) {
 	t.Log("building RootSyncReconciler")
 	// rs is an invalid RootSync as its auth type is set to `token`, but the token key is not configured in the secret.
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeyToken), rootsyncSecretRef(rootsyncSSHKey))
-	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupRootReconciler(t, secretObj)
 
@@ -262,7 +262,7 @@ func TestReconcileRootSyncLifecycleValidToInvalid1(t *testing.T) {
 
 	t.Log("building RootSyncReconciler")
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
-	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace))
 
 	fakeClient, _, testReconciler := setupRootReconciler(t, secretObj)
 
@@ -500,7 +500,7 @@ func TestRootSyncReconcilerClusterRoleBindingDriftProtection(t *testing.T) {
 func testRootSyncDriftProtection(t *testing.T, exampleObj client.Object, objKeyFunc func(client.ObjectKey) client.ObjectKey, modify, validate func(client.Object) error) {
 	t.Log("building RootSyncReconciler")
 	syncObj := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
-	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(syncObj.Namespace))
+	secretObj := secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(syncObj.Namespace))
 	fakeClient, _, testReconciler := setupRootReconciler(t, secretObj)
 	testDriftProtection(t, fakeClient, testReconciler, syncObj, exampleObj, objKeyFunc, modify, validate)
 }

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -157,7 +157,7 @@ func configMapWithData(namespace, name string, data map[string]string, opts ...c
 	return result
 }
 
-func secretObj(t *testing.T, name string, auth configsync.AuthType, sourceType v1beta1.SourceType, opts ...core.MetaMutator) *corev1.Secret {
+func secretObj(t *testing.T, name string, auth configsync.AuthType, sourceType configsync.SourceType, opts ...core.MetaMutator) *corev1.Secret {
 	t.Helper()
 	result := fake.SecretObject(name, opts...)
 	result.Data = secretData(t, "test-key", auth, sourceType)
@@ -167,8 +167,8 @@ func secretObj(t *testing.T, name string, auth configsync.AuthType, sourceType v
 func secretObjWithProxy(t *testing.T, name string, auth configsync.AuthType, opts ...core.MetaMutator) *corev1.Secret {
 	t.Helper()
 	result := fake.SecretObject(name, opts...)
-	result.Data = secretData(t, "test-key", auth, v1beta1.GitSource)
-	m2 := secretData(t, "test-key", "https_proxy", v1beta1.GitSource)
+	result.Data = secretData(t, "test-key", auth, configsync.GitSource)
+	m2 := secretData(t, "test-key", "https_proxy", configsync.GitSource)
 	for k, v := range m2 {
 		result.Data[k] = v
 	}
@@ -178,7 +178,7 @@ func secretObjWithProxy(t *testing.T, name string, auth configsync.AuthType, opt
 func secretObjWithKnownHosts(t *testing.T, name string, opts ...core.MetaMutator) *corev1.Secret {
 	t.Helper()
 	result := fake.SecretObject(name, opts...)
-	result.Data = secretData(t, "test-key", configsync.AuthSSH, v1beta1.GitSource)
+	result.Data = secretData(t, "test-key", configsync.AuthSSH, configsync.GitSource)
 	result.Data[KnownHostsKey] = []byte("abc")
 	return result
 }
@@ -299,14 +299,14 @@ func rootsyncNoSSLVerify() func(*v1beta1.RootSync) {
 	}
 }
 
-func rootsyncCACert(sourceType v1beta1.SourceType, caCertSecretRef string) func(*v1beta1.RootSync) {
+func rootsyncCACert(sourceType configsync.SourceType, caCertSecretRef string) func(*v1beta1.RootSync) {
 	return func(rs *v1beta1.RootSync) {
 		switch sourceType {
-		case v1beta1.GitSource:
+		case configsync.GitSource:
 			rs.Spec.Git.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
-		case v1beta1.OciSource:
+		case configsync.OciSource:
 			rs.Spec.Oci.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
-		case v1beta1.HelmSource:
+		case configsync.HelmSource:
 			rs.Spec.Helm.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecretRef}
 		}
 	}
@@ -338,7 +338,7 @@ func rootSync(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 
 func rootSyncWithGit(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	addGit := func(rs *v1beta1.RootSync) {
-		rs.Spec.SourceType = string(v1beta1.GitSource)
+		rs.Spec.SourceType = configsync.GitSource
 		rs.Spec.Git = &v1beta1.Git{
 			Repo: rootsyncRepo,
 			Dir:  rootsyncDir,
@@ -350,7 +350,7 @@ func rootSyncWithGit(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.Root
 
 func rootSyncWithOCI(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	addOci := func(rs *v1beta1.RootSync) {
-		rs.Spec.SourceType = string(v1beta1.OciSource)
+		rs.Spec.SourceType = configsync.OciSource
 		rs.Spec.Oci = &v1beta1.Oci{
 			Image: ociImage,
 			Dir:   rootsyncDir,
@@ -362,7 +362,7 @@ func rootSyncWithOCI(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.Root
 
 func rootSyncWithHelm(name string, opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	addHelm := func(rs *v1beta1.RootSync) {
-		rs.Spec.SourceType = string(v1beta1.HelmSource)
+		rs.Spec.SourceType = configsync.HelmSource
 		rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{
 			Repo:    helmRepo,
 			Chart:   helmChart,
@@ -404,7 +404,7 @@ func TestCreateAndUpdateRootReconcilerWithOverride(t *testing.T) {
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH),
 		rootsyncSecretRef(rootsyncSSHKey), rootsyncOverrideResources(overrideAllContainerResources))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -528,7 +528,7 @@ func TestUpdateRootReconcilerWithOverride(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -764,7 +764,7 @@ func TestRootSyncCreateWithNoSSLVerify(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey), rootsyncNoSSLVerify())
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -802,7 +802,7 @@ func TestRootSyncUpdateNoSSLVerify(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -926,11 +926,11 @@ func TestRootSyncCreateWithCACertSecret(t *testing.T) {
 	caCertSecret := "foo-secret"
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch),
 		rootsyncSecretType(configsync.AuthToken), rootsyncSecretRef(secretName),
-		rootsyncCACert(v1beta1.GitSource, caCertSecret))
+		rootsyncCACert(configsync.GitSource, caCertSecret))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
 	gitSecret := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret.Data[CACertSecretKey] = []byte("test-data")
 	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, gitSecret, certSecret)
 
@@ -972,7 +972,7 @@ func TestRootSyncUpdateCACertSecret(t *testing.T) {
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
 	gitSecret := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs.Namespace))
 	gitSecret.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
-	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, v1beta1.GitSource, core.Namespace(rs.Namespace))
+	certSecret := secretObj(t, caCertSecret, GitSecretConfigKeyToken, configsync.GitSource, core.Namespace(rs.Namespace))
 	certSecret.Data[CACertSecretKey] = []byte("test-data")
 	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, gitSecret, certSecret)
 
@@ -1119,7 +1119,7 @@ func TestRootSyncReconcileAdmissionWebhook(t *testing.T) {
 				rootsyncSecretRef(rootsyncSSHKey),
 			)
 			reqNamespacedName := namespacedName(rootSync.Name, rootSync.Namespace)
-			fakeClient, _, testReconciler := setupRootReconciler(t, rootSync, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rootSync.Namespace)))
+			fakeClient, _, testReconciler := setupRootReconciler(t, rootSync, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rootSync.Namespace)))
 
 			for _, o := range tc.existingObjects {
 				t.Log("creating obj", o.GetObjectKind().GroupVersionKind().Kind)
@@ -1146,15 +1146,15 @@ func TestRootSyncReconcileWithInvalidCACertSecret(t *testing.T) {
 		"git": {
 			rootSync: rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch),
 				rootsyncSecretType(configsync.AuthNone),
-				rootsyncCACert(v1beta1.GitSource, caCertSecret)),
+				rootsyncCACert(configsync.GitSource, caCertSecret)),
 		},
 		"oci": {
 			rootSync: rootSyncWithOCI(rootsyncName, rootsyncOCIAuthType(configsync.AuthNone),
-				rootsyncCACert(v1beta1.OciSource, caCertSecret)),
+				rootsyncCACert(configsync.OciSource, caCertSecret)),
 		},
 		"helm": {
 			rootSync: rootSyncWithHelm(rootsyncName, rootsyncHelmAuthType(configsync.AuthNone),
-				rootsyncCACert(v1beta1.HelmSource, caCertSecret)),
+				rootsyncCACert(configsync.HelmSource, caCertSecret)),
 		},
 	}
 	for name, tc := range testCases {
@@ -1211,7 +1211,7 @@ func TestRootSyncCreateWithOverrideGitSyncDepth(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey), rootsyncOverrideGitSyncDepth(5))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1249,7 +1249,7 @@ func TestRootSyncUpdateOverrideGitSyncDepth(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1407,7 +1407,7 @@ func TestRootSyncCreateWithOverrideReconcileTimeout(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey), rootsyncOverrideReconcileTimeout(metav1.Duration{Duration: 50 * time.Second}))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1445,7 +1445,7 @@ func TestRootSyncUpdateOverrideReconcileTimeout(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1569,7 +1569,7 @@ func TestRootSyncCreateWithOverrideAPIServerTimeout(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey), rootsyncOverrideReconcileTimeout(metav1.Duration{Duration: 50 * time.Second}))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1604,7 +1604,7 @@ func TestRootSyncUpdateOverrideAPIServerTimeout(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -1948,7 +1948,7 @@ func TestRootSyncSwitchAuthTypes(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(configsync.AuthGCPServiceAccount), rootsyncGCPSAEmail(gcpSAEmail))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources with GCPServiceAccount auth type.
 	ctx := context.Background()
@@ -2074,7 +2074,7 @@ func TestRootSyncReconcilerRestart(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -2174,7 +2174,7 @@ func TestMultipleRootSyncs(t *testing.T) {
 	secret5 := secretObjWithProxy(t, secretName, GitSecretConfigKeyToken, core.Namespace(rs5.Namespace))
 	secret5.Data[GitSecretConfigKeyTokenUsername] = []byte("test-user")
 
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs1, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs1.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs1, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs1.Namespace)))
 
 	rootReconcilerName2 := core.RootReconcilerName(rs2.Name)
 	rootReconcilerName3 := core.RootReconcilerName(rs3.Name)
@@ -2773,9 +2773,9 @@ func TestMapSecretToRootSyncs(t *testing.T) {
 	rs1 := rootSyncWithGit("rs-1", rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	rs2 := rootSyncWithGit("rs-2", rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	rs3 := rootSyncWithGit("rs-3", rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(testSecretName))
-	rs4 := rootSyncWithGit("rs-4", rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(configsync.AuthNone), rootsyncCACert(v1beta1.GitSource, caCertSecret))
-	rs5 := rootSyncWithOCI("rs-5", rootsyncOCIAuthType(configsync.AuthNone), rootsyncCACert(v1beta1.OciSource, caCertSecret))
-	rs6 := rootSyncWithHelm("rs-6", rootsyncHelmAuthType(configsync.AuthNone), rootsyncCACert(v1beta1.HelmSource, caCertSecret))
+	rs4 := rootSyncWithGit("rs-4", rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(configsync.AuthNone), rootsyncCACert(configsync.GitSource, caCertSecret))
+	rs5 := rootSyncWithOCI("rs-5", rootsyncOCIAuthType(configsync.AuthNone), rootsyncCACert(configsync.OciSource, caCertSecret))
+	rs6 := rootSyncWithHelm("rs-6", rootsyncHelmAuthType(configsync.AuthNone), rootsyncCACert(configsync.HelmSource, caCertSecret))
 
 	testCases := []struct {
 		name   string
@@ -2883,7 +2883,7 @@ func TestInjectFleetWorkloadIdentityCredentialsToRootSync(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(configsync.AuthGCPServiceAccount), rootsyncGCPSAEmail(gcpSAEmail))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 	// The membership doesn't have WorkloadIdentityPool and IdentityProvider specified, so FWI creds won't be injected.
 	testReconciler.membership = &hubv1.Membership{
 		Spec: hubv1.MembershipSpec{
@@ -3039,7 +3039,7 @@ func TestRootSyncWithHelm(t *testing.T) {
 	rs := rootSyncWithHelm(rootsyncName,
 		rootsyncHelmAuthType(configsync.AuthToken), rootsyncHelmSecretRef(secretName))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	helmSecret := secretObj(t, secretName, configsync.AuthToken, v1beta1.HelmSource, core.Namespace(rs.Namespace))
+	helmSecret := secretObj(t, secretName, configsync.AuthToken, configsync.HelmSource, core.Namespace(rs.Namespace))
 	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, helmSecret)
 
 	if _, err := testReconciler.Reconcile(ctx, reqNamespacedName); err != nil {
@@ -3561,7 +3561,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
@@ -3576,7 +3576,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
@@ -3591,7 +3591,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
 	}
@@ -3606,7 +3606,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -3622,7 +3622,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -3638,7 +3638,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{}
 	rs.Spec.Oci = nil
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
@@ -3655,7 +3655,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo}}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -3671,7 +3671,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart}}
 	if err := fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		t.Fatalf("failed to update the root sync request, got error: %v", err)
@@ -3687,7 +3687,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Git = nil
 	rs.Spec.Helm = nil
 	rs.Spec.Oci = &v1beta1.Oci{Image: ociImage, Auth: configsync.AuthNone}
@@ -3713,7 +3713,7 @@ func TestRootSyncSpecValidation(t *testing.T) {
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
 		t.Fatalf("failed to get the root sync: %v", err)
 	}
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Git = nil
 	rs.Spec.Oci = nil
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{Repo: helmRepo, Chart: helmChart, Auth: configsync.AuthNone}}
@@ -3791,7 +3791,7 @@ func TestRootSyncReconcileStaleClientCache(t *testing.T) {
 	rs = fake.RootSyncObjectV1Beta1(rootsyncName)
 	err = fakeClient.Get(ctx, core.ObjectNamespacedName(rs), rs)
 	require.NoError(t, err, "unexpected Get error")
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	err = fakeClient.Update(ctx, rs, client.FieldOwner(reconcilermanager.FieldManager))
 	require.NoError(t, err, "unexpected Update error")
 
@@ -3923,7 +3923,7 @@ func TestPopulateRootContainerEnvs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, testReconciler := setupRootReconciler(t, tc.rootSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(tc.rootSync.Namespace)))
+			_, _, testReconciler := setupRootReconciler(t, tc.rootSync, secretObj(t, reposyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(tc.rootSync.Namespace)))
 
 			env := testReconciler.populateContainerEnvs(ctx, tc.rootSync, rootReconcilerName)
 
@@ -3942,7 +3942,7 @@ func TestUpdateRootReconcilerLogLevelWithOverride(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -4041,7 +4041,7 @@ func TestCreateAndUpdateRootReconcilerWithOverrideOnAutopilot(t *testing.T) {
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH),
 		rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, util.FakeAutopilotWebhookObject(), rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	fakeClient, fakeDynamicClient, testReconciler := setupRootReconciler(t, util.FakeAutopilotWebhookObject(), rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test creating Deployment resources.
 	ctx := context.Background()
@@ -4184,7 +4184,7 @@ func TestRootReconcilerWithoutKnownHosts(t *testing.T) {
 
 	rs := rootSyncWithGit(rootsyncName, rootsyncRef(gitRevision), rootsyncBranch(branch), rootsyncSecretType(GitSecretConfigKeySSH), rootsyncSecretRef(rootsyncSSHKey))
 	reqNamespacedName := namespacedName(rs.Name, rs.Namespace)
-	_, _, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, v1beta1.GitSource, core.Namespace(rs.Namespace)))
+	_, _, testReconciler := setupRootReconciler(t, rs, secretObj(t, rootsyncSSHKey, configsync.AuthSSH, configsync.GitSource, core.Namespace(rs.Namespace)))
 
 	// Test performing reconcile
 	ctx := context.Background()

--- a/pkg/reconcilermanager/controllers/secret.go
+++ b/pkg/reconcilermanager/controllers/secret.go
@@ -45,18 +45,18 @@ func isUpsertedSecret(rs *v1beta1.RepoSync, secretName string) bool {
 }
 
 func getCACertName(rs *v1beta1.RepoSync) (string, bool) {
-	switch v1beta1.SourceType(rs.Spec.SourceType) {
-	case v1beta1.GitSource:
+	switch rs.Spec.SourceType {
+	case configsync.GitSource:
 		if rs.Spec.Git == nil || rs.Spec.Git.CACertSecretRef == nil {
 			return "", false
 		}
 		return v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef), true
-	case v1beta1.OciSource:
+	case configsync.OciSource:
 		if rs.Spec.Oci == nil || rs.Spec.Oci.CACertSecretRef == nil {
 			return "", false
 		}
 		return v1beta1.GetSecretName(rs.Spec.Oci.CACertSecretRef), true
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		if rs.Spec.Helm == nil || rs.Spec.Helm.CACertSecretRef == nil {
 			return "", false
 		}
@@ -67,11 +67,11 @@ func getCACertName(rs *v1beta1.RepoSync) (string, bool) {
 }
 
 func shouldUpsertGitSecret(rs *v1beta1.RepoSync) bool {
-	return v1beta1.SourceType(rs.Spec.SourceType) == v1beta1.GitSource && rs.Spec.Git != nil && rs.Spec.Git.SecretRef != nil && !SkipForAuth(rs.Spec.Auth)
+	return rs.Spec.SourceType == configsync.GitSource && rs.Spec.Git != nil && rs.Spec.Git.SecretRef != nil && !SkipForAuth(rs.Spec.Auth)
 }
 
 func shouldUpsertHelmSecret(rs *v1beta1.RepoSync) bool {
-	return v1beta1.SourceType(rs.Spec.SourceType) == v1beta1.HelmSource && rs.Spec.Helm != nil && rs.Spec.Helm.SecretRef != nil && !SkipForAuth(rs.Spec.Helm.Auth)
+	return rs.Spec.SourceType == configsync.HelmSource && rs.Spec.Helm != nil && rs.Spec.Helm.SecretRef != nil && !SkipForAuth(rs.Spec.Helm.Auth)
 }
 
 // upsertAuthSecret creates or updates the auth secret in the

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -38,8 +38,8 @@ import (
 const (
 	sshAuth        = configsync.AuthSSH
 	tokenAuth      = configsync.AuthToken
-	gitSource      = v1beta1.GitSource
-	helmSource     = v1beta1.HelmSource
+	gitSource      = configsync.GitSource
+	helmSource     = configsync.HelmSource
 	gitSecretName  = "ssh-key"
 	helmSecretName = "token"
 	keyData        = "test-key"
@@ -52,15 +52,15 @@ var nsReconcilerKey = types.NamespacedName{
 	Name:      nsReconcilerName,
 }
 
-func repoSyncWithAuth(ns, name string, auth configsync.AuthType, sourceType v1beta1.SourceType, opts ...core.MetaMutator) *v1beta1.RepoSync {
+func repoSyncWithAuth(ns, name string, auth configsync.AuthType, sourceType configsync.SourceType, opts ...core.MetaMutator) *v1beta1.RepoSync {
 	result := fake.RepoSyncObjectV1Beta1(ns, name, opts...)
-	result.Spec.SourceType = string(sourceType)
-	if sourceType == v1beta1.GitSource {
+	result.Spec.SourceType = sourceType
+	if sourceType == configsync.GitSource {
 		result.Spec.Git = &v1beta1.Git{
 			Auth:      auth,
 			SecretRef: &v1beta1.SecretReference{Name: gitSecretName},
 		}
-	} else if sourceType == v1beta1.HelmSource {
+	} else if sourceType == configsync.HelmSource {
 		result.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{
 			Auth:      auth,
 			SecretRef: &v1beta1.SecretReference{Name: helmSecretName},
@@ -69,7 +69,7 @@ func repoSyncWithAuth(ns, name string, auth configsync.AuthType, sourceType v1be
 	return result
 }
 
-func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceType v1beta1.SourceType, opts ...core.MetaMutator) *corev1.Secret {
+func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceType configsync.SourceType, opts ...core.MetaMutator) *corev1.Secret {
 	t.Helper()
 	result := fake.SecretObject(name, opts...)
 	result.Data = secretData(t, data, auth, sourceType)
@@ -82,13 +82,13 @@ func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceTyp
 	return result
 }
 
-func secretData(t *testing.T, data string, auth configsync.AuthType, sourceType v1beta1.SourceType) map[string][]byte {
+func secretData(t *testing.T, data string, auth configsync.AuthType, sourceType configsync.SourceType) map[string][]byte {
 	t.Helper()
 	key, err := json.Marshal(data)
 	if err != nil {
 		t.Fatalf("failed to marshal test key: %v", err)
 	}
-	if auth == configsync.AuthToken && sourceType == v1beta1.HelmSource {
+	if auth == configsync.AuthToken && sourceType == configsync.HelmSource {
 		return map[string][]byte{
 			"username": key,
 			"password": key,

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -42,7 +42,7 @@ func updateHydrationControllerImage(image string, overrides v1beta1.OverrideSpec
 }
 
 type hydrationOptions struct {
-	sourceType     string
+	sourceType     configsync.SourceType
 	gitConfig      *v1beta1.Git
 	ociConfig      *v1beta1.Oci
 	scope          declared.Scope
@@ -54,19 +54,19 @@ type hydrationOptions struct {
 func hydrationEnvs(opts hydrationOptions) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	var syncDir string
-	switch v1beta1.SourceType(opts.sourceType) {
-	case v1beta1.OciSource:
+	switch opts.sourceType {
+	case configsync.OciSource:
 		syncDir = opts.ociConfig.Dir
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		syncDir = opts.gitConfig.Dir
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		syncDir = "."
 	}
 
 	result = append(result,
 		corev1.EnvVar{
 			Name:  reconcilermanager.SourceTypeKey,
-			Value: opts.sourceType,
+			Value: string(opts.sourceType),
 		},
 		corev1.EnvVar{
 			Name:  reconcilermanager.ScopeKey,
@@ -98,7 +98,7 @@ type reconcilerOptions struct {
 	syncGeneration           int64
 	reconcilerName           string
 	reconcilerScope          declared.Scope
-	sourceType               string
+	sourceType               configsync.SourceType
 	gitConfig                *v1beta1.Git
 	ociConfig                *v1beta1.Oci
 	helmConfig               *v1beta1.HelmBase
@@ -122,11 +122,11 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 	var syncBranch string
 	var syncRevision string
 	var syncDir string
-	switch v1beta1.SourceType(opts.sourceType) {
-	case v1beta1.OciSource:
+	switch opts.sourceType {
+	case configsync.OciSource:
 		syncRepo = opts.ociConfig.Image
 		syncDir = opts.ociConfig.Dir
-	case v1beta1.HelmSource:
+	case configsync.HelmSource:
 		syncRepo = opts.helmConfig.Repo
 		syncDir = opts.helmConfig.Chart
 		if opts.helmConfig.Version != "" {
@@ -134,7 +134,7 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 		} else {
 			syncRevision = "latest"
 		}
-	case v1beta1.GitSource:
+	case configsync.GitSource:
 		syncRepo = opts.gitConfig.Repo
 		syncDir = opts.gitConfig.Dir
 		if opts.gitConfig.Branch != "" {
@@ -184,7 +184,7 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 		},
 		corev1.EnvVar{
 			Name:  reconcilermanager.SourceTypeKey,
-			Value: opts.sourceType,
+			Value: string(opts.sourceType),
 		},
 		corev1.EnvVar{
 			Name:  reconcilermanager.StatusMode,

--- a/pkg/reconcilermanager/controllers/validate_secret_test.go
+++ b/pkg/reconcilermanager/controllers/validate_secret_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 )
@@ -38,7 +37,7 @@ func TestValidateSecretExist(t *testing.T) {
 			name:            "Secret present",
 			secretNamespace: "bookinfo",
 			secretReference: "ssh-key",
-			wantSecret: secretObj(t, "ssh-key", configsync.AuthSSH, v1beta1.GitSource,
+			wantSecret: secretObj(t, "ssh-key", configsync.AuthSSH, configsync.GitSource,
 				core.Namespace("bookinfo"),
 				core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 			),
@@ -53,7 +52,7 @@ func TestValidateSecretExist(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	fakeClient := syncerFake.NewClient(t, core.Scheme, secretObj(t, "ssh-key", configsync.AuthSSH, v1beta1.GitSource, core.Namespace("bookinfo")))
+	fakeClient := syncerFake.NewClient(t, core.Scheme, secretObj(t, "ssh-key", configsync.AuthSSH, configsync.GitSource, core.Namespace("bookinfo")))
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -83,12 +82,12 @@ func TestValidateSecretData(t *testing.T) {
 		{
 			name:   "SSH auth data present",
 			auth:   configsync.AuthSSH,
-			secret: secretObj(t, "ssh-key", configsync.AuthSSH, v1beta1.GitSource, core.Namespace("bookinfo")),
+			secret: secretObj(t, "ssh-key", configsync.AuthSSH, configsync.GitSource, core.Namespace("bookinfo")),
 		},
 		{
 			name:   "Cookiefile auth data present",
 			auth:   configsync.AuthCookieFile,
-			secret: secretObj(t, "ssh-key", "cookie_file", v1beta1.GitSource, core.Namespace("bookinfo")),
+			secret: secretObj(t, "ssh-key", "cookie_file", configsync.GitSource, core.Namespace("bookinfo")),
 		},
 		{
 			name: "None auth",

--- a/pkg/testing/fake/reposync.go
+++ b/pkg/testing/fake/reposync.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -52,9 +53,9 @@ func RepoSyncObjectV1Beta1(ns, name string, opts ...core.MetaMutator) *v1beta1.R
 }
 
 // WithRepoSyncSourceType sets the sourceType of the RepoSync object.
-func WithRepoSyncSourceType(sourceType v1beta1.SourceType) core.MetaMutator {
+func WithRepoSyncSourceType(sourceType configsync.SourceType) core.MetaMutator {
 	return func(o client.Object) {
 		rs := o.(*v1beta1.RepoSync)
-		rs.Spec.SourceType = string(sourceType)
+		rs.Spec.SourceType = sourceType
 	}
 }

--- a/pkg/testing/fake/rootsync.go
+++ b/pkg/testing/fake/rootsync.go
@@ -53,9 +53,9 @@ func RootSyncObjectV1Beta1(name string, opts ...core.MetaMutator) *v1beta1.RootS
 }
 
 // WithRootSyncSourceType sets the sourceType of the RootSync object.
-func WithRootSyncSourceType(sourceType v1beta1.SourceType) core.MetaMutator {
+func WithRootSyncSourceType(sourceType configsync.SourceType) core.MetaMutator {
 	return func(o client.Object) {
 		rs := o.(*v1beta1.RootSync)
-		rs.Spec.SourceType = string(sourceType)
+		rs.Spec.SourceType = sourceType
 	}
 }

--- a/pkg/validate/raw/validate/repo_sync_validator.go
+++ b/pkg/validate/raw/validate/repo_sync_validator.go
@@ -15,6 +15,7 @@
 package validate
 
 import (
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -43,7 +44,7 @@ func RepoSync(obj ast.FileObject) status.Error {
 		rs = s.(*v1beta1.RepoSync)
 	}
 	if rs.Spec.SourceType == "" {
-		rs.Spec.SourceType = string(v1beta1.GitSource)
+		rs.Spec.SourceType = configsync.GitSource
 	}
 	return RepoSyncSpec(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, rs.Spec.Helm, rs)
 }

--- a/pkg/validate/raw/validate/root_sync_validator.go
+++ b/pkg/validate/raw/validate/root_sync_validator.go
@@ -15,6 +15,7 @@
 package validate
 
 import (
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -43,7 +44,7 @@ func RootSync(obj ast.FileObject) status.Error {
 		rs = s.(*v1beta1.RootSync)
 	}
 	if rs.Spec.SourceType == "" {
-		rs.Spec.SourceType = string(v1beta1.GitSource)
+		rs.Spec.SourceType = configsync.GitSource
 	}
 	return RootSyncSpec(rs.Spec.SourceType, rs.Spec.Git, rs.Spec.Oci, rs.Spec.Helm, rs)
 }

--- a/pkg/validate/raw/validate/source_spec_validator_test.go
+++ b/pkg/validate/raw/validate/source_spec_validator_test.go
@@ -86,7 +86,7 @@ func missingHelmChart(rs *v1beta1.RepoSync) {
 
 func repoSyncWithGit(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo: "fake repo",
 	}
@@ -98,7 +98,7 @@ func repoSyncWithGit(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 
 func repoSyncWithOci(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
-	rs.Spec.SourceType = string(v1beta1.OciSource)
+	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{
 		Image: "fake image",
 	}
@@ -110,7 +110,7 @@ func repoSyncWithOci(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 
 func repoSyncWithHelm(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{
 		Repo:  "fake repo",
 		Chart: "fake chart",
@@ -141,7 +141,7 @@ func withHelm() func(*v1beta1.RepoSync) {
 
 func rootSyncWithHelm(opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	rs.Spec.SourceType = string(v1beta1.HelmSource)
+	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{
 		Repo:  "fake repo",
 		Chart: "fake chart",

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -65,7 +65,7 @@ const dir = "acme"
 
 func validRootSync(name, path string, opts ...core.MetaMutator) ast.FileObject {
 	rs := fake.RootSyncObjectV1Beta1(name)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo: "https://github.com/test/abc",
 		Auth: "none",
@@ -78,7 +78,7 @@ func validRootSync(name, path string, opts ...core.MetaMutator) ast.FileObject {
 
 func validRepoSync(ns, name, path string, opts ...core.MetaMutator) ast.FileObject {
 	rs := fake.RepoSyncObjectV1Beta1(ns, name)
-	rs.Spec.SourceType = string(v1beta1.GitSource)
+	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo: "https://github.com/test/abc",
 		Auth: "none",


### PR DESCRIPTION
This changes the type of the sourceType field from string to the defined type in the RSync spec. This reduces the number of type conversions required and makes the code more self documenting.

The intent is to apply a similar refactor to `SourceFormat` with a subsequent PR.