### PR TITLE
fix: multiple status update bugs 

### DIFF
--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -96,8 +96,6 @@ type Parser interface {
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.
 	SyncErrors() status.MultiError
-	// Syncing returns true if the updater is running.
-	Syncing() bool
 	// K8sClient returns the Kubernetes client that talks to the API server.
 	K8sClient() client.Client
 	// setRequiresRendering sets the requires-rendering annotation on the RSync

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -51,7 +51,6 @@ type Updater struct {
 	SyncErrorCache *SyncErrorCache
 
 	updateMux sync.RWMutex
-	updating  bool
 }
 
 func (u *Updater) needToUpdateWatch() bool {
@@ -62,9 +61,9 @@ func (u *Updater) managementConflict() bool {
 	return u.Remediator.ManagementConflict()
 }
 
-// Updating returns true if the Update method is running.
-func (u *Updater) Updating() bool {
-	return u.updating
+// Remediating returns true if the Remediator is remediating.
+func (u *Updater) Remediating() bool {
+	return u.Remediator.Remediating()
 }
 
 // declaredCRDs returns the list of CRDs which are present in the updater's
@@ -98,11 +97,7 @@ func (u *Updater) declaredCRDs() ([]*v1beta1.CustomResourceDefinition, status.Mu
 // another reconciler.
 func (u *Updater) Update(ctx context.Context, cache *cacheForCommit) status.MultiError {
 	u.updateMux.Lock()
-	u.updating = true
-	defer func() {
-		u.updating = false
-		u.updateMux.Unlock()
-	}()
+	defer u.updateMux.Unlock()
 
 	return u.update(ctx, cache)
 }

--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -30,6 +30,7 @@ type Remediator struct {
 	ManagementConflictOutput bool
 	Watches                  map[schema.GroupVersionKind]struct{}
 	UpdateWatchesError       status.MultiError
+	Watching                 bool
 	Paused                   bool
 
 	needsUpdate bool
@@ -45,6 +46,11 @@ func (r *Remediator) NeedsUpdate() bool {
 	return r.needsUpdate
 }
 
+// Remediating returns true if not paused
+func (r *Remediator) Remediating() bool {
+	return r.Watching && !r.Paused
+}
+
 // Pause fakes remediator.Remediator.Pause
 func (r *Remediator) Pause() {
 	r.Paused = true
@@ -57,6 +63,7 @@ func (r *Remediator) Resume() {
 
 // UpdateWatches fakes remediator.Remediator.UpdateWatches
 func (r *Remediator) UpdateWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
+	r.Watching = true
 	r.Watches = watches
 	r.needsUpdate = false
 	return r.UpdateWatchesError

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -50,7 +50,9 @@ type Manager struct {
 	watcherFactory watcherFactory
 
 	// The following fields are guarded by the mutex.
-	mux sync.Mutex
+	mux sync.RWMutex
+	// watching is true if UpdateWatches has been called
+	watching bool
 	// watcherMap maps GVKs to their associated watchers
 	watcherMap map[schema.GroupVersionKind]Runnable
 	// needsUpdate indicates if the Manager's watches need to be updated.
@@ -99,10 +101,17 @@ func NewManager(scope declared.Scope, syncName string, cfg *rest.Config,
 	}, nil
 }
 
+// Watching returns true if UpdateWatches has been called, starting the watchers. This function is threadsafe.
+func (m *Manager) Watching() bool {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+	return m.watching
+}
+
 // NeedsUpdate returns true if the Manager's watches need to be updated. This function is threadsafe.
 func (m *Manager) NeedsUpdate() bool {
-	m.mux.Lock()
-	defer m.mux.Unlock()
+	m.mux.RLock()
+	defer m.mux.RUnlock()
 	return m.needsUpdate
 }
 
@@ -135,6 +144,7 @@ func (m *Manager) ManagementConflict() bool {
 func (m *Manager) UpdateWatches(ctx context.Context, gvkMap map[schema.GroupVersionKind]struct{}) status.MultiError {
 	m.mux.Lock()
 	defer m.mux.Unlock()
+	m.watching = true
 
 	klog.V(3).Infof("UpdateWatches(%v)", gvkMap)
 


### PR DESCRIPTION
- Update status.source after fetch before rendering if the commit
  changed. This allows using status.source.commit to see what
  commit has been fetched even if rendering fails.
  This also causes the Syncing condition to be updated at the same
  time, which tells the user the remediator is working on a new
  commit.
- Update status.sync periodically after a new commit has been
  published to status.source.commit or status.rendering.commit.
  This allows continuing to update remediator errors after a new
  commit has been fetched. Normally this isn't a long time, but it
  can be if there's a source or rendering error requiring change
  by the user.
- Update SetSyncStatus to only update the Syncing condition if
  the reconciler hasn't fetched a new commit. This prevents
  periodic updates from overwriting the Syncing condition for newer
  commits.
- Update SetSyncStatus to only record the last_sync_timestamp metric
  if the reconciler hasn't fetched a new commit. This prevents
  re-recording the metric, flapping between commits.
- Update SetSyncStatus, to only aggregate errors for a specific
  commit, avoiding the Syncing condition from referencing errors from
  old commits.

This replaces https://github.com/GoogleContainerTools/kpt-config-sync/pull/1283, which was reverted by https://github.com/GoogleContainerTools/kpt-config-sync/pull/1286. The test failures should be fixed by https://github.com/GoogleContainerTools/kpt-config-sync/pull/1287, which updated the expectations to check the rendering status and Syncing condition at the same time.