### PR TITLE
refactor: use SourceFormat in RSync spec

### DIFF
--- a/cmd/nomos/flags/flags.go
+++ b/cmd/nomos/flags/flags.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/client/restconfig"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 )
 
@@ -110,7 +110,7 @@ func AllClusters() bool {
 func AddSourceFormat(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&SourceFormat, reconcilermanager.SourceFormat, "",
 		fmt.Sprintf("Source format of the Git repository. Defaults to %s if not set. Use %s for unstructured repos.",
-			filesystem.SourceFormatHierarchy, filesystem.SourceFormatUnstructured))
+			configsync.SourceFormatHierarchy, configsync.SourceFormatUnstructured))
 }
 
 // AddOutputFormat adds the --format flag.

--- a/cmd/nomos/hydrate/hydrate.go
+++ b/cmd/nomos/hydrate/hydrate.go
@@ -22,6 +22,7 @@ import (
 	"kpt.dev/configsync/cmd/nomos/flags"
 	nomosparse "kpt.dev/configsync/cmd/nomos/parse"
 	"kpt.dev/configsync/cmd/nomos/util"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -72,9 +73,9 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true
 
-		sourceFormat := filesystem.SourceFormat(flags.SourceFormat)
+		sourceFormat := configsync.SourceFormat(flags.SourceFormat)
 		if sourceFormat == "" {
-			sourceFormat = filesystem.SourceFormatHierarchy
+			sourceFormat = configsync.SourceFormatHierarchy
 		}
 		rootDir, needsHydrate, err := hydrate.ValidateHydrateFlags(sourceFormat)
 		if err != nil {
@@ -105,7 +106,7 @@ which you could kubectl apply -fR to the cluster, or have Config Sync sync to th
 		}
 		validateOpts.FieldManager = util.FieldManager
 
-		if sourceFormat == filesystem.SourceFormatHierarchy {
+		if sourceFormat == configsync.SourceFormatHierarchy {
 			files = filesystem.FilterHierarchyFiles(rootDir, files)
 		} else {
 			// hydrate as a root repository to preview all the hydrated configs

--- a/cmd/nomos/migrate/migrate.go
+++ b/cmd/nomos/migrate/migrate.go
@@ -394,7 +394,7 @@ func createRootSync(ctx context.Context, cm *util.ConfigManagementClient) (*v1be
 			Namespace: configmanagement.ControllerNamespace,
 		},
 		Spec: v1beta1.RootSyncSpec{
-			SourceFormat: sourceFormat,
+			SourceFormat: configsync.SourceFormat(sourceFormat),
 			Git: &v1beta1.Git{
 				Repo:                   syncRepo,
 				Revision:               syncRev,

--- a/cmd/nomos/vet/vet.go
+++ b/cmd/nomos/vet/vet.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"kpt.dev/configsync/cmd/nomos/flags"
-	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 var (
@@ -38,7 +38,7 @@ func init() {
 	Cmd.Flags().StringVar(&namespaceValue, "namespace", "",
 		fmt.Sprintf(
 			"If set, validate the repository as a Namespace Repo with the provided name. Automatically sets --source-format=%s",
-			filesystem.SourceFormatUnstructured))
+			configsync.SourceFormatUnstructured))
 
 	Cmd.Flags().BoolVar(&keepOutput, "keep-output", false,
 		`If enabled, keep the hydrated output`)
@@ -64,6 +64,6 @@ returns a non-zero error code if any issues are found.
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true
 
-		return runVet(cmd.Context(), namespaceValue, filesystem.SourceFormat(flags.SourceFormat), flags.APIServerTimeout)
+		return runVet(cmd.Context(), namespaceValue, configsync.SourceFormat(flags.SourceFormat), flags.APIServerTimeout)
 	},
 }

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -25,6 +25,7 @@ import (
 	"kpt.dev/configsync/cmd/nomos/flags"
 	nomosparse "kpt.dev/configsync/cmd/nomos/parse"
 	"kpt.dev/configsync/cmd/nomos/util"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -51,14 +52,14 @@ import (
 // clusters is the set of clusters we are checking.
 //
 // Only used if allClusters is false.
-func runVet(ctx context.Context, namespace string, sourceFormat filesystem.SourceFormat, apiServerTimeout time.Duration) error {
+func runVet(ctx context.Context, namespace string, sourceFormat configsync.SourceFormat, apiServerTimeout time.Duration) error {
 	if sourceFormat == "" {
 		if namespace == "" {
 			// Default to hierarchical if --namespace is not provided.
-			sourceFormat = filesystem.SourceFormatHierarchy
+			sourceFormat = configsync.SourceFormatHierarchy
 		} else {
 			// Default to unstructured if --namespace is provided.
-			sourceFormat = filesystem.SourceFormatUnstructured
+			sourceFormat = configsync.SourceFormatUnstructured
 		}
 	}
 
@@ -92,16 +93,16 @@ func runVet(ctx context.Context, namespace string, sourceFormat filesystem.Sourc
 	validateOpts.FieldManager = util.FieldManager
 
 	switch sourceFormat {
-	case filesystem.SourceFormatHierarchy:
+	case configsync.SourceFormatHierarchy:
 		if namespace != "" {
 			// The user could technically provide --source-format=unstructured.
 			// This nuance isn't necessary to communicate nor confusing to omit.
 			return fmt.Errorf("if --namespace is provided, --%s must be omitted or set to %s",
-				reconcilermanager.SourceFormat, filesystem.SourceFormatUnstructured)
+				reconcilermanager.SourceFormat, configsync.SourceFormatUnstructured)
 		}
 
 		files = filesystem.FilterHierarchyFiles(rootDir, files)
-	case filesystem.SourceFormatUnstructured:
+	case configsync.SourceFormatUnstructured:
 		if namespace == "" {
 			validateOpts = parse.OptionsForScope(validateOpts, declared.RootScope)
 		} else {

--- a/cmd/nomos/vet/vet_test.go
+++ b/cmd/nomos/vet/vet_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/cmd/nomos/flags"
-	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	ft "kpt.dev/configsync/pkg/importer/filesystem/filesystemtest"
 )
@@ -33,7 +33,7 @@ func resetFlags() {
 	flags.Clusters = nil
 	flags.Path = flags.PathDefault
 	flags.SkipAPIServer = true
-	flags.SourceFormat = string(filesystem.SourceFormatHierarchy)
+	flags.SourceFormat = string(configsync.SourceFormatHierarchy)
 	namespaceValue = ""
 	keepOutput = false
 	outPath = flags.DefaultHydrationOutput

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -203,9 +203,9 @@ func main() {
 
 	if scope == declared.RootScope {
 		// Default to "hierarchy" if unset.
-		format := filesystem.SourceFormat(*sourceFormat)
+		format := configsync.SourceFormat(*sourceFormat)
 		if format == "" {
-			format = filesystem.SourceFormatHierarchy
+			format = configsync.SourceFormatHierarchy
 		}
 		// Default to "implicit" if unset.
 		nsStrat := configsync.NamespaceStrategy(*namespaceStrategy)

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -46,7 +46,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/importer/reader"
 	"kpt.dev/configsync/pkg/kinds"
@@ -648,9 +647,9 @@ func setupDelegatedControl(nt *NT) {
 }
 
 // RootSyncObjectV1Alpha1 returns the default RootSync object.
-func RootSyncObjectV1Alpha1(name, repoURL string, sourceFormat filesystem.SourceFormat) *v1alpha1.RootSync {
+func RootSyncObjectV1Alpha1(name, repoURL string, sourceFormat configsync.SourceFormat) *v1alpha1.RootSync {
 	rs := fake.RootSyncObjectV1Alpha1(name)
-	rs.Spec.SourceFormat = string(sourceFormat)
+	rs.Spec.SourceFormat = sourceFormat
 	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1alpha1.Git{
 		Repo:   repoURL,
@@ -697,9 +696,9 @@ func RootSyncObjectV1Alpha1FromRootRepo(nt *NT, name string) *v1alpha1.RootSync 
 }
 
 // RootSyncObjectV1Beta1 returns the default RootSync object with version v1beta1.
-func RootSyncObjectV1Beta1(name, repoURL string, sourceFormat filesystem.SourceFormat) *v1beta1.RootSync {
+func RootSyncObjectV1Beta1(name, repoURL string, sourceFormat configsync.SourceFormat) *v1beta1.RootSync {
 	rs := fake.RootSyncObjectV1Beta1(name)
-	rs.Spec.SourceFormat = string(sourceFormat)
+	rs.Spec.SourceFormat = sourceFormat
 	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo:   repoURL,
@@ -826,9 +825,9 @@ func RepoSyncObjectV1Alpha1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1a
 
 // RepoSyncObjectV1Beta1 returns the default RepoSync object
 // with version v1beta1 in the given namespace.
-func RepoSyncObjectV1Beta1(nn types.NamespacedName, repoURL string, sourceFormat filesystem.SourceFormat) *v1beta1.RepoSync {
+func RepoSyncObjectV1Beta1(nn types.NamespacedName, repoURL string, sourceFormat configsync.SourceFormat) *v1beta1.RepoSync {
 	rs := fake.RepoSyncObjectV1Beta1(nn.Namespace, nn.Name)
-	rs.Spec.SourceFormat = string(sourceFormat)
+	rs.Spec.SourceFormat = sourceFormat
 	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
 		Repo:   repoURL,

--- a/e2e/nomostest/gitproviders/repository.go
+++ b/e2e/nomostest/gitproviders/repository.go
@@ -31,8 +31,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -85,7 +85,7 @@ type Repository struct {
 	Root string
 	// Format is the source format for parsing the repository (hierarchy or
 	// unstructured).
-	Format filesystem.SourceFormat
+	Format configsync.SourceFormat
 	// PrivateKeyPath is the local path to the private key on disk to use to
 	// authenticate with the git server.
 	PrivateKeyPath string
@@ -121,7 +121,7 @@ type Repository struct {
 func NewRepository(
 	repoType RepoType,
 	syncNN types.NamespacedName,
-	sourceFormat filesystem.SourceFormat,
+	sourceFormat configsync.SourceFormat,
 	scheme *runtime.Scheme,
 	logger *testlogger.TestLogger,
 	provider GitProvider,
@@ -192,7 +192,7 @@ func (g *Repository) BulkGit(cmds ...[]string) error {
 }
 
 // InitialCommit initializes the Nomos repo with the Repo object.
-func (g *Repository) InitialCommit(sourceFormat filesystem.SourceFormat) error {
+func (g *Repository) InitialCommit(sourceFormat configsync.SourceFormat) error {
 	// Add .gitkeep to retain dir when empty, otherwise configsync will error.
 	if err := g.AddEmptyDir(DefaultSyncDir); err != nil {
 		return err
@@ -208,13 +208,13 @@ func (g *Repository) InitialCommit(sourceFormat filesystem.SourceFormat) error {
 		}
 	}
 	switch sourceFormat {
-	case filesystem.SourceFormatHierarchy:
+	case configsync.SourceFormatHierarchy:
 		// Hierarchy format requires a Repo object.
 		g.Logger.Infof("[repo %s] Setting repo format to %s", path.Base(g.Root), sourceFormat)
 		if err := g.AddRepoObject(DefaultSyncDir); err != nil {
 			return err
 		}
-	case filesystem.SourceFormatUnstructured:
+	case configsync.SourceFormatUnstructured:
 		// It is an error for unstructured repos to include the Repo object.
 		g.Logger.Infof("[repo %s] Setting repo format to %s", path.Base(g.Root), sourceFormat)
 	default:

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -37,7 +37,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testshell"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,7 +67,7 @@ func newOptStruct(testName, tmpDir string, ntOptions ...ntopts.Opt) *ntopts.New 
 			// Default to 1m to keep tests fast.
 			// To override, use WithReconcileTimeout.
 			ReconcileTimeout: ptr.To(1 * time.Minute),
-			SourceFormat:     filesystem.SourceFormatHierarchy,
+			SourceFormat:     configsync.SourceFormatHierarchy,
 		},
 	}
 	for _, opt := range ntOptions {
@@ -425,7 +424,7 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 		nt.RootRepos[name] = initRepository(nt, gitproviders.RootRepo, RootSyncNN(name), opts.SourceFormat)
 	}
 	for nsr := range opts.NamespaceRepos {
-		nt.NonRootRepos[nsr] = initRepository(nt, gitproviders.NamespaceRepo, nsr, filesystem.SourceFormatUnstructured)
+		nt.NonRootRepos[nsr] = initRepository(nt, gitproviders.NamespaceRepo, nsr, configsync.SourceFormatUnstructured)
 	}
 	// set up port forward if using in-cluster git server
 	if *e2e.GitProvider == e2e.Local {
@@ -443,7 +442,7 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 		initialCommit(nt, gitproviders.RootRepo, RootSyncNN(name), opts.SourceFormat)
 	}
 	for nsr := range opts.NamespaceRepos {
-		initialCommit(nt, gitproviders.NamespaceRepo, nsr, filesystem.SourceFormatUnstructured)
+		initialCommit(nt, gitproviders.NamespaceRepo, nsr, configsync.SourceFormatUnstructured)
 	}
 
 	if opts.InitialCommit != nil {

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -19,7 +19,7 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/api/configsync"
 )
 
 // RepoOpts defines options for a Repository.
@@ -30,7 +30,7 @@ type RepoOpts struct{}
 // If NonRootRepos is non-empty, the test is assumed to be running in
 // multi-repo mode.
 type MultiRepo struct {
-	filesystem.SourceFormat
+	configsync.SourceFormat
 	// NamespaceRepos is a set representing the Namespace repos to create.
 	//
 	// We don't support referencing the Root repository in this map; while we do
@@ -162,5 +162,5 @@ func RepoSyncPermissions(policy ...rbacv1.PolicyRule) Opt {
 
 // Unstructured will set the option for unstructured repo.
 func Unstructured(opts *New) {
-	opts.SourceFormat = filesystem.SourceFormatUnstructured
+	opts.SourceFormat = configsync.SourceFormatUnstructured
 }

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -32,7 +32,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -416,14 +415,14 @@ func stringSliceContains(list []string, value string) bool {
 }
 
 // ResetRepository creates or re-initializes a remote repository.
-func ResetRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *gitproviders.Repository {
+func ResetRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.Repository {
 	repo := initRepository(nt, repoType, nn, sourceFormat)
 	initialCommit(nt, repoType, nn, sourceFormat)
 	return repo
 }
 
 // initRepository inits a local repository and ensures its remote exists
-func initRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) *gitproviders.Repository {
+func initRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.Repository {
 	repo, found := nt.RemoteRepositories[nn]
 	if !found {
 		repo = gitproviders.NewRepository(repoType, nn, sourceFormat, nt.Scheme,
@@ -441,7 +440,7 @@ func initRepository(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedN
 }
 
 // initialCommit creates an initial commit and pushes it to the remote
-func initialCommit(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat filesystem.SourceFormat) {
+func initialCommit(nt *NT, repoType gitproviders.RepoType, nn types.NamespacedName, sourceFormat configsync.SourceFormat) {
 	repo, found := nt.RemoteRepositories[nn]
 	if !found {
 		nt.T.Fatal("repo %s not found", nn.String())

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -51,7 +51,6 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/hydrate"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -217,7 +216,7 @@ func TestNomosHydrateWithInvalidNamespaceSelectorsUnstructured(t *testing.T) {
 		"vet",
 		"--no-api-server-check",
 		"--path", configPath,
-		"--source-format", string(filesystem.SourceFormatUnstructured),
+		"--source-format", string(configsync.SourceFormatUnstructured),
 	}
 
 	out, err := nt.Shell.Command("nomos", args...).CombinedOutput()
@@ -230,7 +229,7 @@ func TestNomosHydrateWithInvalidNamespaceSelectorsUnstructured(t *testing.T) {
 		"hydrate",
 		"--no-api-server-check",
 		"--path", configPath,
-		"--source-format", string(filesystem.SourceFormatUnstructured),
+		"--source-format", string(configsync.SourceFormatUnstructured),
 		"--output", nt.TmpDir,
 	}
 	out, err = nt.Shell.Command("nomos", args...).CombinedOutput()
@@ -242,7 +241,7 @@ func TestNomosHydrateWithInvalidNamespaceSelectorsUnstructured(t *testing.T) {
 
 func TestNomosHydrateWithClusterSelectorsHierarchical(t *testing.T) {
 	configPath := "../../examples/hierarchy-repo-with-cluster-selectors"
-	testNomosHydrateWithClusterSelectors(t, configPath, filesystem.SourceFormatHierarchy)
+	testNomosHydrateWithClusterSelectors(t, configPath, configsync.SourceFormatHierarchy)
 }
 
 func TestNomosHydrateWithClusterSelectorsDefaultSourceFormat(t *testing.T) {
@@ -252,10 +251,10 @@ func TestNomosHydrateWithClusterSelectorsDefaultSourceFormat(t *testing.T) {
 
 func TestNomosHydrateWithClusterSelectorsUnstructured(t *testing.T) {
 	configPath := "../../examples/unstructured-repo-with-cluster-selectors"
-	testNomosHydrateWithClusterSelectors(t, configPath, filesystem.SourceFormatUnstructured)
+	testNomosHydrateWithClusterSelectors(t, configPath, configsync.SourceFormatUnstructured)
 }
 
-func testNomosHydrateWithClusterSelectors(t *testing.T, configPath string, sourceFormat filesystem.SourceFormat) {
+func testNomosHydrateWithClusterSelectors(t *testing.T, configPath string, sourceFormat configsync.SourceFormat) {
 	nt := nomostest.New(t, nomostesting.NomosCLI, ntopts.SkipConfigSyncInstall)
 
 	expectedCompiledDir := "../../examples/repo-with-cluster-selectors-compiled"
@@ -351,7 +350,7 @@ func testNomosHydrateWithClusterSelectors(t *testing.T, configPath string, sourc
 		"--output", compiledWithAPIServerCheckDir,
 	}
 
-	if sourceFormat == filesystem.SourceFormatUnstructured {
+	if sourceFormat == configsync.SourceFormatUnstructured {
 		args = append(args, "--source-format", string(sourceFormat))
 	}
 	out, err = nt.Shell.Command("nomos", args...).CombinedOutput()
@@ -555,7 +554,7 @@ func TestSyncFromNomosHydrateOutputJSONDir(t *testing.T) {
 	testSyncFromNomosHydrateOutput(nt, "../../examples/repo-with-cluster-selectors-compiled-json/cluster-dev/.")
 }
 
-func testSyncFromNomosHydrateOutputFlat(t *testing.T, sourceFormat filesystem.SourceFormat, outputFormat string) {
+func testSyncFromNomosHydrateOutputFlat(t *testing.T, sourceFormat configsync.SourceFormat, outputFormat string) {
 	nt := nomostest.New(t, nomostesting.NomosCLI, ntopts.Unstructured)
 
 	configPath := fmt.Sprintf("../../examples/%s-repo-with-cluster-selectors", sourceFormat)
@@ -571,7 +570,7 @@ func testSyncFromNomosHydrateOutputFlat(t *testing.T, sourceFormat filesystem.So
 		"--output", compiledConfigFile,
 	}
 
-	if sourceFormat == filesystem.SourceFormatUnstructured {
+	if sourceFormat == configsync.SourceFormatUnstructured {
 		args = append(args, "--source-format", string(sourceFormat))
 	}
 
@@ -585,19 +584,19 @@ func testSyncFromNomosHydrateOutputFlat(t *testing.T, sourceFormat filesystem.So
 }
 
 func TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorJSONFlat(t *testing.T) {
-	testSyncFromNomosHydrateOutputFlat(t, filesystem.SourceFormatHierarchy, "json")
+	testSyncFromNomosHydrateOutputFlat(t, configsync.SourceFormatHierarchy, "json")
 }
 
 func TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorJSONFlat(t *testing.T) {
-	testSyncFromNomosHydrateOutputFlat(t, filesystem.SourceFormatUnstructured, "json")
+	testSyncFromNomosHydrateOutputFlat(t, configsync.SourceFormatUnstructured, "json")
 }
 
 func TestSyncFromNomosHydrateHierarchicalOutputWithClusterSelectorYAMLFlat(t *testing.T) {
-	testSyncFromNomosHydrateOutputFlat(t, filesystem.SourceFormatHierarchy, "yaml")
+	testSyncFromNomosHydrateOutputFlat(t, configsync.SourceFormatHierarchy, "yaml")
 }
 
 func TestSyncFromNomosHydrateUnstructuredOutputWithClusterSelectorYAMLFlat(t *testing.T) {
-	testSyncFromNomosHydrateOutputFlat(t, filesystem.SourceFormatUnstructured, "yaml")
+	testSyncFromNomosHydrateOutputFlat(t, configsync.SourceFormatUnstructured, "yaml")
 }
 
 func TestNomosHydrateWithUnknownScopedObject(t *testing.T) {
@@ -696,67 +695,67 @@ func TestNomosHydrateAndVetDryRepos(t *testing.T) {
 		{
 			name:           "must use 'unstructured' format for DRY repos",
 			path:           "../testdata/hydration/helm-components",
-			sourceFormat:   string(filesystem.SourceFormatHierarchy),
-			expectedErrMsg: fmt.Sprintf("%s must be %s when Kustomization is needed", reconcilermanager.SourceFormat, filesystem.SourceFormatUnstructured),
+			sourceFormat:   string(configsync.SourceFormatHierarchy),
+			expectedErrMsg: fmt.Sprintf("%s must be %s when Kustomization is needed", reconcilermanager.SourceFormat, configsync.SourceFormatUnstructured),
 		},
 		{
 			name:           "hydrate error: a DRY repo without kustomization.yaml",
 			path:           "../testdata/hydration/dry-repo-without-kustomization",
-			sourceFormat:   string(filesystem.SourceFormatUnstructured),
+			sourceFormat:   string(configsync.SourceFormatUnstructured),
 			expectedErrMsg: `Object 'Kind' is missing in`,
 		},
 		{
 			name:           "hydrate error: deprecated Group and Kind",
 			path:           "../testdata/hydration/deprecated-GK",
-			sourceFormat:   string(filesystem.SourceFormatUnstructured),
+			sourceFormat:   string(configsync.SourceFormatUnstructured),
 			expectedErrMsg: "The config is using a deprecated Group and Kind. To fix, set the Group and Kind to \"Deployment.apps\"",
 		},
 		{
 			name:           "hydrate error: duplicate resources",
 			path:           "../testdata/hydration/resource-duplicate",
-			sourceFormat:   string(filesystem.SourceFormatUnstructured),
+			sourceFormat:   string(configsync.SourceFormatUnstructured),
 			expectedErrMsg: "may not add resource with an already registered id",
 		},
 		{
 			name:            "hydrate a DRY repo with helm components",
 			path:            "../testdata/hydration/helm-components",
 			outPath:         "helm-components/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/compiled/helm-components",
 		},
 		{
 			name:            "hydrate a DRY repo with kustomize components",
 			path:            "../testdata/hydration/kustomize-components",
 			outPath:         "kustomize-components/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/compiled/kustomize-components",
 		},
 		{
 			name:            "hydrate a DRY repo with helm overlay",
 			path:            "../testdata/hydration/helm-overlay",
 			outPath:         "helm-overlay/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/compiled/helm-overlay",
 		},
 		{
 			name:            "hydrate a DRY repo with remote base",
 			path:            "../testdata/hydration/remote-base",
 			outPath:         "remote-base/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/compiled/remote-base",
 		},
 		{
 			name:            "hydrate a DRY repo with relative path",
 			path:            "../testdata/hydration/relative-path/overlays/dev",
 			outPath:         "relative-path/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/compiled/relative-path",
 		},
 		{
 			name:            "hydrate a WET repo",
 			path:            "../testdata/hydration/wet-repo",
 			outPath:         "wet-repo/compiled",
-			sourceFormat:    string(filesystem.SourceFormatUnstructured),
+			sourceFormat:    string(configsync.SourceFormatUnstructured),
 			expectedOutPath: "../testdata/hydration/wet-repo",
 		},
 	}
@@ -868,7 +867,7 @@ func TestNomosVetNamespaceRepo(t *testing.T) {
 		{
 			name:           "nomos vet a namespace repo should fail when source-format is set to hierarchy",
 			namespace:      "tenant-a",
-			sourceFormat:   string(filesystem.SourceFormatHierarchy),
+			sourceFormat:   string(configsync.SourceFormatHierarchy),
 			expectedErrMsg: "Error: if --namespace is provided, --source-format must be omitted or set to unstructured",
 		},
 		{
@@ -880,7 +879,7 @@ func TestNomosVetNamespaceRepo(t *testing.T) {
 			name:         "nomos vet should automatically validate a namespace repo with the unstructured mode if source-format is set to unstructured",
 			namespace:    "tenant-a",
 			path:         "../testdata/hydration/compiled/remote-base/tenant-a",
-			sourceFormat: string(filesystem.SourceFormatUnstructured),
+			sourceFormat: string(configsync.SourceFormatUnstructured),
 		},
 		{
 			name:      "nomos vet should validate a DRY namespace repo",
@@ -1549,7 +1548,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 	}
 	expectedRootSyncSpec := v1beta1.RootSyncSpec{
 		SourceType:   configsync.GitSource,
-		SourceFormat: string(filesystem.SourceFormatUnstructured),
+		SourceFormat: configsync.SourceFormatUnstructured,
 		Override:     &v1beta1.RootSyncOverrideSpec{},
 		Git: &v1beta1.Git{
 			Repo:      "https://github.com/config-sync-examples/namespace-repo-bookinfo",

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -40,7 +40,6 @@ import (
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
@@ -119,12 +118,12 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	if nt.GitProvider.Type() == e2e.Local {
 		nomostest.InitGitRepos(nt, newRepos...)
 	}
-	nt.RootRepos[rr2] = nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr2), filesystem.SourceFormatUnstructured)
-	nt.RootRepos[rr3] = nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr3), filesystem.SourceFormatUnstructured)
-	nt.NonRootRepos[nn2] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn2, filesystem.SourceFormatUnstructured)
-	nt.NonRootRepos[nn3] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn3, filesystem.SourceFormatUnstructured)
-	nt.NonRootRepos[nn4] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn4, filesystem.SourceFormatUnstructured)
-	nt.NonRootRepos[nn5] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn5, filesystem.SourceFormatUnstructured)
+	nt.RootRepos[rr2] = nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr2), configsync.SourceFormatUnstructured)
+	nt.RootRepos[rr3] = nomostest.ResetRepository(nt, gitproviders.RootRepo, nomostest.RootSyncNN(rr3), configsync.SourceFormatUnstructured)
+	nt.NonRootRepos[nn2] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn2, configsync.SourceFormatUnstructured)
+	nt.NonRootRepos[nn3] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn3, configsync.SourceFormatUnstructured)
+	nt.NonRootRepos[nn4] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn4, configsync.SourceFormatUnstructured)
+	nt.NonRootRepos[nn5] = nomostest.ResetRepository(nt, gitproviders.NamespaceRepo, nn5, configsync.SourceFormatUnstructured)
 
 	nrb2 := nomostest.RepoSyncRoleBinding(nn2)
 	nrb3 := nomostest.RepoSyncRoleBinding(nn3)
@@ -809,7 +808,7 @@ func TestControllerValidationErrors(t *testing.T) {
 
 	nt.T.Logf("Validate RepoSync is not allowed in the config-management-system namespace")
 	nnControllerNamespace := nomostest.RepoSyncNN(configsync.ControllerNamespace, configsync.RepoSyncName)
-	rs := nomostest.RepoSyncObjectV1Beta1(nnControllerNamespace, "", filesystem.SourceFormatUnstructured)
+	rs := nomostest.RepoSyncObjectV1Beta1(nnControllerNamespace, "", configsync.SourceFormatUnstructured)
 	if err := nt.KubeClient.Create(rs); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -825,7 +824,7 @@ func TestControllerValidationErrors(t *testing.T) {
 	}
 	veryLongName := string(longBytes)
 	nnTooLong := nomostest.RepoSyncNN(testNs, veryLongName)
-	rs = nomostest.RepoSyncObjectV1Beta1(nnTooLong, "https://github.com/test/test", filesystem.SourceFormatUnstructured)
+	rs = nomostest.RepoSyncObjectV1Beta1(nnTooLong, "https://github.com/test/test", configsync.SourceFormatUnstructured)
 	if err := nt.KubeClient.Create(rs); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -840,7 +839,7 @@ func TestControllerValidationErrors(t *testing.T) {
 
 	nt.T.Logf("Validate an invalid config with a long RepoSync Secret name")
 	nnInvalidSecretRef := nomostest.RepoSyncNN(testNs, "repo-test")
-	rsInvalidSecretRef := nomostest.RepoSyncObjectV1Beta1(nnInvalidSecretRef, "https://github.com/test/test", filesystem.SourceFormatUnstructured)
+	rsInvalidSecretRef := nomostest.RepoSyncObjectV1Beta1(nnInvalidSecretRef, "https://github.com/test/test", configsync.SourceFormatUnstructured)
 	rsInvalidSecretRef.Spec.Auth = configsync.AuthSSH
 	rsInvalidSecretRef.Spec.SecretRef = &v1beta1.SecretReference{Name: veryLongName}
 	if err := nt.KubeClient.Create(rsInvalidSecretRef); err != nil {

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -48,7 +48,6 @@ import (
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -238,7 +237,7 @@ func TestStressLargeRequest(t *testing.T) {
 		reconcilerOverride.MemoryRequest = resource.MustParse("1500Mi")
 	}
 	rootSync.Spec = v1beta1.RootSyncSpec{
-		SourceFormat: string(filesystem.SourceFormatUnstructured),
+		SourceFormat: configsync.SourceFormatUnstructured,
 		Git: &v1beta1.Git{
 			Repo:      "https://github.com/config-sync-examples/crontab-crs",
 			Branch:    "main",

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -92,6 +92,20 @@ const (
 	DefaultHelmReleaseNamespace = "default"
 )
 
+// SourceFormat specifies how the Importer should parse the repository.
+type SourceFormat string
+
+const (
+	// SourceFormatUnstructured says to parse all YAMLs in the config directory and
+	// ignore directory structure.
+	SourceFormatUnstructured SourceFormat = "unstructured"
+
+	// SourceFormatHierarchy says to use hierarchical namespace inheritance based on
+	// directory structure and requires that manifests be declared in specific
+	// subdirectories.
+	SourceFormatHierarchy SourceFormat = "hierarchy"
+)
+
 // SourceType specifies the type of the source of truth.
 type SourceType string
 

--- a/pkg/api/configsync/v1alpha1/reposync_types.go
+++ b/pkg/api/configsync/v1alpha1/reposync_types.go
@@ -50,8 +50,9 @@ type RepoSyncSpec struct {
 	//
 	// The validation of this is case-sensitive.
 	// +kubebuilder:validation:Pattern=^(unstructured|)$
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceFormat string `json:"sourceFormat,omitempty"`
+	SourceFormat configsync.SourceFormat `json:"sourceFormat,omitempty"`
 
 	// sourceType specifies the type of the source of truth.
 	//

--- a/pkg/api/configsync/v1alpha1/rootsync_types.go
+++ b/pkg/api/configsync/v1alpha1/rootsync_types.go
@@ -50,8 +50,9 @@ type RootSyncSpec struct {
 	//
 	// The validation of this is case-sensitive.
 	// +kubebuilder:validation:Pattern=^(hierarchy|unstructured|)$
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceFormat string `json:"sourceFormat,omitempty"`
+	SourceFormat configsync.SourceFormat `json:"sourceFormat,omitempty"`
 
 	// sourceType specifies the type of the source of truth.
 	//

--- a/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/configsync/v1alpha1/zz_generated.conversion.go
@@ -883,7 +883,7 @@ func Convert_v1beta1_RepoSyncOverrideSpec_To_v1alpha1_RepoSyncOverrideSpec(in *v
 }
 
 func autoConvert_v1alpha1_RepoSyncSpec_To_v1beta1_RepoSyncSpec(in *RepoSyncSpec, out *v1beta1.RepoSyncSpec, s conversion.Scope) error {
-	out.SourceFormat = in.SourceFormat
+	out.SourceFormat = configsync.SourceFormat(in.SourceFormat)
 	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*v1beta1.Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*v1beta1.Oci)(unsafe.Pointer(in.Oci))
@@ -906,7 +906,7 @@ func Convert_v1alpha1_RepoSyncSpec_To_v1beta1_RepoSyncSpec(in *RepoSyncSpec, out
 }
 
 func autoConvert_v1beta1_RepoSyncSpec_To_v1alpha1_RepoSyncSpec(in *v1beta1.RepoSyncSpec, out *RepoSyncSpec, s conversion.Scope) error {
-	out.SourceFormat = in.SourceFormat
+	out.SourceFormat = configsync.SourceFormat(in.SourceFormat)
 	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*Oci)(unsafe.Pointer(in.Oci))
@@ -1145,7 +1145,7 @@ func Convert_v1beta1_RootSyncRoleRef_To_v1alpha1_RootSyncRoleRef(in *v1beta1.Roo
 }
 
 func autoConvert_v1alpha1_RootSyncSpec_To_v1beta1_RootSyncSpec(in *RootSyncSpec, out *v1beta1.RootSyncSpec, s conversion.Scope) error {
-	out.SourceFormat = in.SourceFormat
+	out.SourceFormat = configsync.SourceFormat(in.SourceFormat)
 	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*v1beta1.Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*v1beta1.Oci)(unsafe.Pointer(in.Oci))
@@ -1168,7 +1168,7 @@ func Convert_v1alpha1_RootSyncSpec_To_v1beta1_RootSyncSpec(in *RootSyncSpec, out
 }
 
 func autoConvert_v1beta1_RootSyncSpec_To_v1alpha1_RootSyncSpec(in *v1beta1.RootSyncSpec, out *RootSyncSpec, s conversion.Scope) error {
-	out.SourceFormat = in.SourceFormat
+	out.SourceFormat = configsync.SourceFormat(in.SourceFormat)
 	out.SourceType = configsync.SourceType(in.SourceType)
 	out.Git = (*Git)(unsafe.Pointer(in.Git))
 	out.Oci = (*Oci)(unsafe.Pointer(in.Oci))

--- a/pkg/api/configsync/v1beta1/reposync_types.go
+++ b/pkg/api/configsync/v1beta1/reposync_types.go
@@ -51,8 +51,9 @@ type RepoSyncSpec struct {
 	//
 	// The validation of this is case-sensitive.
 	// +kubebuilder:validation:Pattern=^(unstructured|)$
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceFormat string `json:"sourceFormat,omitempty"`
+	SourceFormat configsync.SourceFormat `json:"sourceFormat,omitempty"`
 
 	// sourceType specifies the type of the source of truth.
 	//

--- a/pkg/api/configsync/v1beta1/rootsync_types.go
+++ b/pkg/api/configsync/v1beta1/rootsync_types.go
@@ -51,8 +51,9 @@ type RootSyncSpec struct {
 	//
 	// The validation of this is case-sensitive.
 	// +kubebuilder:validation:Pattern=^(hierarchy|unstructured|)$
+	// +kubebuilder:validation:Type:=string
 	// +optional
-	SourceFormat string `json:"sourceFormat,omitempty"`
+	SourceFormat configsync.SourceFormat `json:"sourceFormat,omitempty"`
 
 	// sourceType specifies the type of the source of truth.
 	//

--- a/pkg/hydrate/for_each_cluster.go
+++ b/pkg/hydrate/for_each_cluster.go
@@ -17,6 +17,7 @@ package hydrate
 import (
 	"context"
 
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/importer/filesystem"
@@ -36,7 +37,7 @@ type ParseOptions struct {
 	// Parser is an interface to read configs from a filesystem.
 	Parser filesystem.ConfigParser
 	// SourceFormat specifies how the Parser should parse the source configs.
-	SourceFormat filesystem.SourceFormat
+	SourceFormat configsync.SourceFormat
 	// FilePaths encapsulates the list of absolute file paths to read and the
 	// absolute and relative path of the root directory.
 	FilePaths reader.FilePaths
@@ -77,7 +78,7 @@ func ForEachCluster(ctx context.Context, parseOpts ParseOptions, validateOpts va
 	defaultFileObjects, err := parseOpts.Parser.Parse(parseOpts.FilePaths)
 	errs = status.Append(errs, err)
 
-	if parseOpts.SourceFormat == filesystem.SourceFormatHierarchy {
+	if parseOpts.SourceFormat == configsync.SourceFormatHierarchy {
 		defaultFileObjects, err = validate.Hierarchical(defaultFileObjects, validateOpts)
 	} else {
 		defaultFileObjects, err = validate.Unstructured(ctx, nil, defaultFileObjects, validateOpts)
@@ -104,7 +105,7 @@ func ForEachCluster(ctx context.Context, parseOpts ParseOptions, validateOpts va
 		fileObjects, err := parseOpts.Parser.Parse(parseOpts.FilePaths)
 		errs = status.Append(errs, err)
 
-		if parseOpts.SourceFormat == filesystem.SourceFormatHierarchy {
+		if parseOpts.SourceFormat == configsync.SourceFormatHierarchy {
 			fileObjects, err = validate.Hierarchical(fileObjects, validateOpts)
 		} else {
 			fileObjects, err = validate.Unstructured(ctx, nil, fileObjects, validateOpts)

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -30,10 +30,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/cmd/nomos/flags"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kmetrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -257,7 +257,7 @@ func ValidateAndRunKustomize(sourcePath string) (cmpath.Absolute, error) {
 
 // ValidateHydrateFlags validates the hydrate and vet flags.
 // It returns the absolute path of the source directory, if hydration is needed, and errors.
-func ValidateHydrateFlags(sourceFormat filesystem.SourceFormat) (cmpath.Absolute, bool, error) {
+func ValidateHydrateFlags(sourceFormat configsync.SourceFormat) (cmpath.Absolute, bool, error) {
 	abs, err := filepath.Abs(flags.Path)
 	if err != nil {
 		return "", false, err
@@ -282,8 +282,8 @@ func ValidateHydrateFlags(sourceFormat filesystem.SourceFormat) (cmpath.Absolute
 		return "", false, fmt.Errorf("unable to check if Kustomize is needed for the source directory: %s: %w", abs, err)
 	}
 
-	if needsKustomize && sourceFormat == filesystem.SourceFormatHierarchy {
-		return "", false, fmt.Errorf("%s must be %s when Kustomization is needed", reconcilermanager.SourceFormat, filesystem.SourceFormatUnstructured)
+	if needsKustomize && sourceFormat == configsync.SourceFormatHierarchy {
+		return "", false, fmt.Errorf("%s must be %s when Kustomization is needed", reconcilermanager.SourceFormat, configsync.SourceFormatUnstructured)
 	}
 
 	return rootDir, needsKustomize, nil

--- a/pkg/importer/analyzer/transform/selectors/namespace_selectors.go
+++ b/pkg/importer/analyzer/transform/selectors/namespace_selectors.go
@@ -16,7 +16,7 @@ package selectors
 
 import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
-	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +59,7 @@ func ListNamespaceError(err error) status.Error {
 func UnsupportedNamespaceSelectorModeError(nsSelector client.Object) status.Error {
 	return invalidSelectorError.Sprintf("NamespaceSelector MUST NOT use the %s mode with the %s source format."+
 		" To fix, either switch to the %s source format, or remove `spec.mode` from the NamespaceSelector.",
-		v1.NSSelectorDynamicMode, filesystem.SourceFormatHierarchy, filesystem.SourceFormatUnstructured).
+		v1.NSSelectorDynamicMode, configsync.SourceFormatHierarchy, configsync.SourceFormatUnstructured).
 		BuildWithResources(nsSelector)
 }
 

--- a/pkg/importer/filesystem/config_parser.go
+++ b/pkg/importer/filesystem/config_parser.go
@@ -15,6 +15,7 @@
 package filesystem
 
 import (
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/reader"
 	"kpt.dev/configsync/pkg/status"
@@ -27,7 +28,7 @@ type ConfigParser interface {
 	Parse(filePaths reader.FilePaths) ([]ast.FileObject, status.MultiError)
 
 	// ReadClusterRegistryResources returns the list of Clusters contained in the repo.
-	ReadClusterRegistryResources(filePaths reader.FilePaths, sourceFormat SourceFormat) ([]ast.FileObject, status.MultiError)
+	ReadClusterRegistryResources(filePaths reader.FilePaths, sourceFormat configsync.SourceFormat) ([]ast.FileObject, status.MultiError)
 
 	// ReadClusterNamesFromSelector returns the list of cluster names specified in
 	// the `cluster-name-selector` annotation.

--- a/pkg/importer/filesystem/fake/config_parser.go
+++ b/pkg/importer/filesystem/fake/config_parser.go
@@ -17,6 +17,7 @@ package fake
 import (
 	"fmt"
 
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/reader"
@@ -58,7 +59,7 @@ func (p *ConfigParser) Parse(filePaths reader.FilePaths) ([]ast.FileObject, stat
 }
 
 // ReadClusterRegistryResources fakes filesystem.ConfigParser.ReadClusterRegistryResources
-func (p *ConfigParser) ReadClusterRegistryResources(_ reader.FilePaths, _ filesystem.SourceFormat) ([]ast.FileObject, status.MultiError) {
+func (p *ConfigParser) ReadClusterRegistryResources(_ reader.FilePaths, _ configsync.SourceFormat) ([]ast.FileObject, status.MultiError) {
 	return nil, nil
 }
 

--- a/pkg/importer/filesystem/parser.go
+++ b/pkg/importer/filesystem/parser.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"kpt.dev/configsync/pkg/api/configmanagement/v1/repo"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/importer/reader"
@@ -79,8 +80,8 @@ func filterTopDir(filePaths reader.FilePaths, topDir string) reader.FilePaths {
 
 // ReadClusterRegistryResources reads the manifests declared in clusterregistry/ for hierarchical format.
 // For unstructured format, it reads all files.
-func (p *Parser) ReadClusterRegistryResources(filePaths reader.FilePaths, format SourceFormat) ([]ast.FileObject, status.MultiError) {
-	if format == SourceFormatHierarchy {
+func (p *Parser) ReadClusterRegistryResources(filePaths reader.FilePaths, format configsync.SourceFormat) ([]ast.FileObject, status.MultiError) {
+	if format == configsync.SourceFormatHierarchy {
 		return p.reader.Read(filterTopDir(filePaths, repo.ClusterRegistryDir))
 	}
 	return p.reader.Read(filePaths)

--- a/pkg/importer/filesystem/source_format.go
+++ b/pkg/importer/filesystem/source_format.go
@@ -14,18 +14,6 @@
 
 package filesystem
 
-// SourceFormat specifies how the Importer should parse the repository.
-type SourceFormat string
-
-// SourceFormatUnstructured says to parse all YAMLs in the config directory and
-// ignore directory structure.
-const SourceFormatUnstructured SourceFormat = "unstructured"
-
-// SourceFormatHierarchy says to use hierarchical namespace inheritance based on
-// directory structure and requires that manifests be declared in specific
-// subdirectories.
-const SourceFormatHierarchy SourceFormat = "hierarchy"
-
 // SourceFormatKey is the OS env variable and ConfigMap key for the SOT
 // repository format.
 const SourceFormatKey = "SOURCE_FORMAT"

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -63,7 +63,7 @@ type RootOptions struct {
 	// SourceFormat defines the structure of the Root repository. Only the Root
 	// repository may be SourceFormatHierarchy; all others are implicitly
 	// SourceFormatUnstructured.
-	SourceFormat filesystem.SourceFormat
+	SourceFormat configsync.SourceFormat
 
 	// NamespaceStrategy indicates the NamespaceStrategy to be used by this
 	// reconciler.
@@ -98,7 +98,7 @@ func (p *root) options() *Options {
 // parseSource implements the Parser interface
 func (p *root) parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError) {
 	wantFiles := state.files
-	if p.SourceFormat == filesystem.SourceFormatHierarchy {
+	if p.SourceFormat == configsync.SourceFormatHierarchy {
 		// We're using hierarchical mode for the root repository, so ignore files
 		// outside of the allowed directories.
 		wantFiles = filesystem.FilterHierarchyFiles(state.syncDir, wantFiles)
@@ -138,7 +138,7 @@ func (p *root) parseSource(ctx context.Context, state sourceState) ([]ast.FileOb
 	}
 	options = OptionsForScope(options, p.Scope)
 
-	if p.SourceFormat == filesystem.SourceFormatUnstructured {
+	if p.SourceFormat == configsync.SourceFormatUnstructured {
 		if p.NamespaceStrategy == configsync.NamespaceStrategyImplicit {
 			options.Visitors = append(options.Visitors, p.addImplicitNamespaces)
 		}

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -81,7 +81,7 @@ func gitSpec(repo string, auth configsync.AuthType) core.MetaMutator {
 func TestRoot_Parse(t *testing.T) {
 	testCases := []struct {
 		name                string
-		format              filesystem.SourceFormat
+		format              configsync.SourceFormat
 		namespaceStrategy   configsync.NamespaceStrategy
 		existingObjects     []client.Object
 		parseOutputs        []fsfake.ParserOutputs
@@ -89,14 +89,14 @@ func TestRoot_Parse(t *testing.T) {
 	}{
 		{
 			name:   "no objects",
-			format: filesystem.SourceFormatUnstructured,
+			format: configsync.SourceFormatUnstructured,
 			parseOutputs: []fsfake.ParserOutputs{
 				{}, // One Parse call, no results or errors
 			},
 		},
 		{
 			name:              "implicit namespace if unstructured and not present",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			parseOutputs: []fsfake.ParserOutputs{
 				{
@@ -133,7 +133,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "no implicit namespace if namespaceStrategy is explicit",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyExplicit,
 			parseOutputs: []fsfake.ParserOutputs{
 				{
@@ -158,7 +158,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "implicit namespace if unstructured, present and self-managed",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{fake.NamespaceObject("foo",
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -204,7 +204,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "no implicit namespace if unstructured, present, but managed by others",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{fake.NamespaceObject("foo",
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -238,7 +238,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "no implicit namespace if unstructured, present, but unmanaged",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects:   []client.Object{fake.NamespaceObject("foo")},
 			parseOutputs: []fsfake.ParserOutputs{
@@ -264,7 +264,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "no implicit namespace if unstructured and namespace is config-management-system",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			parseOutputs: []fsfake.ParserOutputs{
 				{
@@ -290,7 +290,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "multiple objects share a single implicit namespace",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			parseOutputs: []fsfake.ParserOutputs{
 				{
@@ -339,7 +339,7 @@ func TestRoot_Parse(t *testing.T) {
 		},
 		{
 			name:              "multiple implicit namespaces",
-			format:            filesystem.SourceFormatUnstructured,
+			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{
 				fake.NamespaceObject("foo"), // foo exists but not managed, should NOT be added as an implicit namespace
@@ -703,7 +703,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					},
 				},
 				RootOptions: &RootOptions{
-					SourceFormat:      filesystem.SourceFormatUnstructured,
+					SourceFormat:      configsync.SourceFormatUnstructured,
 					NamespaceStrategy: configsync.NamespaceStrategyExplicit,
 				},
 			}
@@ -956,7 +956,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					},
 				},
 				RootOptions: &RootOptions{
-					SourceFormat:      filesystem.SourceFormatUnstructured,
+					SourceFormat:      configsync.SourceFormatUnstructured,
 					NamespaceStrategy: configsync.NamespaceStrategyImplicit,
 				},
 			}
@@ -1041,7 +1041,7 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					},
 				},
 				RootOptions: &RootOptions{
-					SourceFormat: filesystem.SourceFormatUnstructured,
+					SourceFormat: configsync.SourceFormatUnstructured,
 				},
 			}
 			state := &reconcilerState{}
@@ -1127,7 +1127,7 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 				},
 				RootOptions: &RootOptions{
-					SourceFormat: filesystem.SourceFormatUnstructured,
+					SourceFormat: configsync.SourceFormatUnstructured,
 				},
 			}
 			state := &reconcilerState{}

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -65,7 +65,7 @@ func newParser(t *testing.T, fs FileSource, renderingEnabled bool, retryPeriod t
 	}
 
 	parser.RootOptions = &RootOptions{
-		SourceFormat: filesystem.SourceFormatUnstructured,
+		SourceFormat: configsync.SourceFormatUnstructured,
 	}
 	parser.Options = &Options{
 		Parser:             filesystem.NewParser(&reader.File{}),

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
-	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	ft "kpt.dev/configsync/pkg/importer/filesystem/filesystemtest"
 	"kpt.dev/configsync/pkg/kinds"
@@ -116,7 +116,7 @@ func TestReadConfigFiles(t *testing.T) {
 					},
 				},
 				RootOptions: &RootOptions{
-					SourceFormat: filesystem.SourceFormatUnstructured,
+					SourceFormat: configsync.SourceFormatUnstructured,
 				},
 			}
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -129,7 +129,7 @@ type Options struct {
 // RootOptions are the options specific to parsing Root repositories.
 type RootOptions struct {
 	// SourceFormat is how the Root repository is structured.
-	SourceFormat filesystem.SourceFormat
+	SourceFormat configsync.SourceFormat
 	// NamespaceStrategy indicates the NamespaceStrategy used by this reconciler.
 	NamespaceStrategy configsync.NamespaceStrategy
 }

--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -243,10 +243,10 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 }
 
 // sourceFormatEnv returns the environment variable for SOURCE_FORMAT in the reconciler container.
-func sourceFormatEnv(format string) corev1.EnvVar {
+func sourceFormatEnv(format configsync.SourceFormat) corev1.EnvVar {
 	return corev1.EnvVar{
 		Name:  filesystem.SourceFormatKey,
-		Value: format,
+		Value: string(format),
 	}
 }
 


### PR DESCRIPTION
This changes the type of the sourceFormat field from string to the defined type in the RSync spec. This reduces the number of type conversions required and makes the code more self documenting.