### PR TITLE
Refactor reconciler status caching

### DIFF
--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -89,9 +89,9 @@ type Options struct {
 // Parser represents a parser that can be pointed at and continuously parse a source.
 type Parser interface {
 	parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError)
-	setSourceStatus(ctx context.Context, newStatus sourceStatus) error
-	setRenderingStatus(ctx context.Context, oldStatus, newStatus renderingStatus) error
-	SetSyncStatus(ctx context.Context, newStatus syncStatus) error
+	setSourceStatus(ctx context.Context, newStatus SourceStatus) error
+	setRenderingStatus(ctx context.Context, oldStatus, newStatus RenderingStatus) error
+	SetSyncStatus(ctx context.Context, newStatus SyncStatus) error
 	options() *Options
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -496,6 +496,7 @@ func TestRoot_Parse(t *testing.T) {
 				"example.yaml",
 			}
 			state := &reconcilerState{
+				status: &ReconcilerStatus{},
 				cache: cacheForCommit{
 					source: sourceState{
 						commit:  testGitCommit,
@@ -707,7 +708,9 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					NamespaceStrategy: configsync.NamespaceStrategyExplicit,
 				},
 			}
-			state := &reconcilerState{}
+			state := &reconcilerState{
+				status: &ReconcilerStatus{},
+			}
 			if err := parseAndUpdate(context.Background(), parser, triggerReimport, state); err != nil {
 				t.Fatal(err)
 			}
@@ -960,7 +963,9 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					NamespaceStrategy: configsync.NamespaceStrategyImplicit,
 				},
 			}
-			state := &reconcilerState{}
+			state := &reconcilerState{
+				status: &ReconcilerStatus{},
+			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
@@ -1044,7 +1049,9 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					SourceFormat: configsync.SourceFormatUnstructured,
 				},
 			}
-			state := &reconcilerState{}
+			state := &reconcilerState{
+				status: &ReconcilerStatus{},
+			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
@@ -1130,7 +1137,9 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					SourceFormat: configsync.SourceFormatUnstructured,
 				},
 			}
-			state := &reconcilerState{}
+			state := &reconcilerState{
+				status: &ReconcilerStatus{},
+			}
 			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -404,15 +404,15 @@ func TestRun(t *testing.T) {
 
 			assert.Equal(t, tc.needRetry, state.cache.needToRetry)
 			testerrors.AssertEqual(t, tc.expectedErrors, state.cache.errs, "[%s] unexpected state.cache.errs return", tc.name)
-			testerrors.AssertEqual(t, tc.expectedStateSourceErrs, state.sourceStatus.errs, "[%s] unexpected state.sourceStatus.errs return", tc.name)
-			testerrors.AssertEqual(t, tc.expectedStateRenderingErrs, state.renderingStatus.errs, "[%s] unexpected state.renderingStatus.errs return", tc.name)
+			testerrors.AssertEqual(t, tc.expectedStateSourceErrs, state.status.SourceStatus.Errs, "[%s] unexpected state.status.sourceStatus.errs return", tc.name)
+			testerrors.AssertEqual(t, tc.expectedStateRenderingErrs, state.status.RenderingStatus.Errs, "[%s] unexpected state.status.renderingStatus.errs return", tc.name)
 
 			rs := &v1beta1.RootSync{}
 			if err = parser.options().Client.Get(context.Background(), rootsync.ObjectKey(parser.options().SyncName), rs); err != nil {
 				t.Fatal(err)
 			}
-			expectedRSSourceErrs := status.ToCSE(state.sourceStatus.errs)
-			expectedRSRenderingErrs := status.ToCSE(state.renderingStatus.errs)
+			expectedRSSourceErrs := status.ToCSE(state.status.SourceStatus.Errs)
+			expectedRSRenderingErrs := status.ToCSE(state.status.RenderingStatus.Errs)
 			testutil.AssertEqual(t, expectedRSSourceErrs, rs.Status.Source.Errors, "[%s] unexpected source errors in RootSync return", tc.name)
 			testutil.AssertEqual(t, expectedRSRenderingErrs, rs.Status.Rendering.Errors, "[%s] unexpected rendering errors in RootSync return", tc.name)
 

--- a/pkg/parse/status.go
+++ b/pkg/parse/status.go
@@ -1,0 +1,116 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/status"
+)
+
+// ReconcilerStatus represents the status of the reconciler.
+type ReconcilerStatus struct {
+	// SourceStatus tracks info from the `Status.Source` field of a RepoSync/RootSync.
+	SourceStatus SourceStatus
+
+	// RenderingStatus tracks info from the `Status.Rendering` field of a RepoSync/RootSync.
+	RenderingStatus RenderingStatus
+
+	// SyncStatus tracks info from the `Status.Sync` field of a RepoSync/RootSync.
+	SyncStatus SyncStatus
+
+	// SyncingConditionLastUpdate tracks when the `Syncing` condition was updated most recently.
+	SyncingConditionLastUpdate metav1.Time
+}
+
+// needToSetSourceStatus returns true if `p.setSourceStatus` should be called.
+func (s *ReconcilerStatus) needToSetSourceStatus(newStatus SourceStatus) bool {
+	// Update if not initialized
+	if s.SourceStatus.LastUpdate.IsZero() {
+		return true
+	}
+	// Update if source status was last updated before the rendering status
+	if s.SourceStatus.LastUpdate.Before(&s.RenderingStatus.LastUpdate) {
+		return true
+	}
+	// Update if there's a diff
+	return !newStatus.Equals(s.SourceStatus)
+}
+
+// needToSetSyncStatus returns true if `p.SetSyncStatus` should be called.
+func (s *ReconcilerStatus) needToSetSyncStatus(newStatus SyncStatus) bool {
+	// Update if not initialized
+	if s.SyncStatus.LastUpdate.IsZero() {
+		return true
+	}
+	// Update if sync status was last updated before the rendering status
+	if s.SyncStatus.LastUpdate.Before(&s.RenderingStatus.LastUpdate) {
+		return true
+	}
+	// Update if sync status was last updated before the source status
+	if s.SyncStatus.LastUpdate.Before(&s.SourceStatus.LastUpdate) {
+		return true
+	}
+	// Update if there's a diff
+	return !newStatus.Equals(s.SyncStatus)
+}
+
+// SourceStatus represents the status of the source stage of the pipeline.
+type SourceStatus struct {
+	Commit     string
+	Errs       status.MultiError
+	LastUpdate metav1.Time
+}
+
+// Equals returns true if the specified SourceStatus equals this
+// SourceStatus, excluding the LastUpdate timestamp.
+func (gs SourceStatus) Equals(other SourceStatus) bool {
+	return gs.Commit == other.Commit &&
+		status.DeepEqual(gs.Errs, other.Errs)
+}
+
+// RenderingStatus represents the status of the rendering stage of the pipeline.
+type RenderingStatus struct {
+	Commit     string
+	Message    string
+	Errs       status.MultiError
+	LastUpdate metav1.Time
+	// RequiresRendering indicates whether the sync source has dry configs
+	// only used internally (not surfaced on RSync status)
+	RequiresRendering bool
+}
+
+// Equals returns true if the specified RenderingStatus equals this
+// RenderingStatus, excluding the LastUpdate timestamp.
+func (rs RenderingStatus) Equals(other RenderingStatus) bool {
+	return rs.Commit == other.Commit &&
+		rs.Message == other.Message &&
+		status.DeepEqual(rs.Errs, other.Errs)
+}
+
+// SyncStatus represents the status of the sync stage of the pipeline.
+type SyncStatus struct {
+	Syncing    bool
+	Commit     string
+	Errs       status.MultiError
+	LastUpdate metav1.Time
+}
+
+// Equals returns true if the specified SyncStatus equals this
+// SyncStatus, excluding the LastUpdate timestamp.
+func (ss SyncStatus) Equals(other SyncStatus) bool {
+	return ss.Syncing == other.Syncing &&
+		ss.Commit == other.Commit &&
+		status.DeepEqual(ss.Errs, other.Errs)
+}


### PR DESCRIPTION
Prior to this change, the reconcilerState in the parser package contained both status reported to the RSync and internal state used to keep track of progress.

With this change, the status persisted to the RSync is now under the ReconcilerStatus struct, under reconcilerState. This seperates the two different domains in preperation for adding more stage-specific caching for RSync spec, which is used to populate the RSync status.

ReconcilerStatus uses primarily public fields, because it helps distinguish between fields intended for external manipulation and fields that should only be manipulated by methods on the struct, even if the manipulator is in the same package. Hopefully, we can expand this convention in the future, but for now it's limited in scope to keep the size of this PR reviewable.

Blocks: https://github.com/GoogleContainerTools/kpt-config-sync/pull/1276