### PR TITLE
feat: error backoff for oci-sync

### DIFF
--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -77,13 +77,8 @@ var (
 )
 
 func errorBackoff() wait.Backoff {
-	return wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   2,
-		Steps:    math.MaxInt,
-		Jitter:   0.1,
-		Cap:      util.WaitTime(*flWait),
-	}
+	durationLimit := math.Max(*flWait, float64(util.MinimumSyncContainerBackoffCap))
+	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
 }
 
 func main() {

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util"
 )
 
 type sourceStatus struct {
@@ -98,12 +99,7 @@ const retryLimit = 12
 //	16.295984061s, 34.325711987s, 1m5.465642392s, 2m18.625713221s,
 //	4m24.712222056s, 9m18.97652295s, 17m15.344384599s, 35m15.603237976s.
 func defaultBackoff() wait.Backoff {
-	return wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   2,
-		Steps:    retryLimit,
-		Jitter:   0.1,
-	}
+	return util.BackoffWithDurationAndStepLimit(0, retryLimit)
 }
 
 func (s *reconcilerState) checkpoint() {

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -25,9 +25,11 @@ import (
 
 var (
 	// SourceRetryBackoff sets retry timeout for `SourceCommitAndDirWithRetry`.
-	SourceRetryBackoff = BackoffWithDurationLimit(5 * time.Minute)
+	SourceRetryBackoff = BackoffWithDurationAndStepLimit(5*time.Minute, 10)
 	// HydratedRetryBackoff sets retry timeout for `readHydratedDirWithRetry`.
-	HydratedRetryBackoff = BackoffWithDurationLimit(time.Minute)
+	HydratedRetryBackoff = BackoffWithDurationAndStepLimit(time.Minute, 10)
+	// MinimumSyncContainerBackoffCap is the minimum backoff cap for oci-sync/helm-sync.
+	MinimumSyncContainerBackoffCap = time.Hour
 )
 
 // RetriableError represents a transient error that is retriable.
@@ -65,16 +67,16 @@ func IsErrorRetriable(err error) bool {
 	return ok
 }
 
-// BackoffWithDurationLimit returns backoff with a duration limit in 10 steps.
+// BackoffWithDurationAndStepLimit returns backoff with a duration limit.
 // Here is an example of the duration between steps:
 //
 //	1.055843837s, 2.085359785s, 4.229560375s, 8.324724174s, 16.295984061s,
 //	34.325711987s, 1m5.465642392s, 2m18.625713221s, 4m24.712222056s, 9m18.97652295s.
-func BackoffWithDurationLimit(duration time.Duration) wait.Backoff {
+func BackoffWithDurationAndStepLimit(duration time.Duration, steps int) wait.Backoff {
 	return wait.Backoff{
 		Duration: 1 * time.Second,
 		Factor:   2,
-		Steps:    10,
+		Steps:    steps,
 		Cap:      duration,
 		Jitter:   0.1,
 	}


### PR DESCRIPTION
This adds exponential backoff to the oci-sync when it encounters repeated errors. This makes the behavior comparable to the behavior for helm-sync. The code is refactored to use a common backoff creation function and a minimum cap is defined for the sync containers.