### PR TITLE
Inject Parser.Clock for testing

### DIFF
--- a/pkg/parse/cache.go
+++ b/pkg/parse/cache.go
@@ -64,9 +64,6 @@ type cacheForCommit struct {
 
 	// needToRetry indicates whether a retry is needed.
 	needToRetry bool
-
-	// errs tracks all the errors encountered during the reconciliation.
-	errs status.MultiError
 }
 
 func (c *cacheForCommit) setParserResult(objs []ast.FileObject, parserErrs status.MultiError) {

--- a/pkg/parse/namespace.go
+++ b/pkg/parse/namespace.go
@@ -110,13 +110,13 @@ func (p *namespace) parseSource(ctx context.Context, state sourceState) ([]ast.F
 //
 // setSourceStatus sets the source status with a given source state and set of errors.  If errs is empty, all errors
 // will be removed from the status.
-func (p *namespace) setSourceStatus(ctx context.Context, newStatus SourceStatus) error {
+func (p *namespace) setSourceStatus(ctx context.Context, newStatus *SourceStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSourceStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus SourceStatus, denominator int) error {
+func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus *SourceStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
@@ -187,7 +187,7 @@ func (p *namespace) setRequiresRendering(ctx context.Context, renderingRequired 
 }
 
 // setRenderingStatus implements the Parser interface
-func (p *namespace) setRenderingStatus(ctx context.Context, oldStatus, newStatus RenderingStatus) error {
+func (p *namespace) setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error {
 	if oldStatus.Equals(newStatus) {
 		return nil
 	}
@@ -197,7 +197,7 @@ func (p *namespace) setRenderingStatus(ctx context.Context, oldStatus, newStatus
 	return p.setRenderingStatusWithRetires(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setRenderingStatusWithRetires(ctx context.Context, newStatus RenderingStatus, denominator int) error {
+func (p *namespace) setRenderingStatusWithRetires(ctx context.Context, newStatus *RenderingStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
@@ -251,13 +251,13 @@ func (p *namespace) setRenderingStatusWithRetires(ctx context.Context, newStatus
 // SetSyncStatus implements the Parser interface
 // SetSyncStatus sets the RepoSync sync status.
 // `errs` includes the errors encountered during the apply step;
-func (p *namespace) SetSyncStatus(ctx context.Context, newStatus SyncStatus) error {
+func (p *namespace) SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSyncStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setSyncStatusWithRetries(ctx context.Context, newStatus SyncStatus, denominator int) error {
+func (p *namespace) setSyncStatusWithRetries(ctx context.Context, newStatus *SyncStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}

--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem"
@@ -29,6 +30,10 @@ import (
 
 // Options holds configuration and core functionality required by all parsers.
 type Options struct {
+	// Clock is used for time tracking, namely to simplify testing by allowing
+	// a fake clock, instead of a RealClock.
+	Clock clock.Clock
+
 	// Parser defines the minimum interface required for Reconciler to use a
 	// Parser to read configs from a filesystem.
 	Parser filesystem.ConfigParser
@@ -89,9 +94,9 @@ type Options struct {
 // Parser represents a parser that can be pointed at and continuously parse a source.
 type Parser interface {
 	parseSource(ctx context.Context, state sourceState) ([]ast.FileObject, status.MultiError)
-	setSourceStatus(ctx context.Context, newStatus SourceStatus) error
-	setRenderingStatus(ctx context.Context, oldStatus, newStatus RenderingStatus) error
-	SetSyncStatus(ctx context.Context, newStatus SyncStatus) error
+	setSourceStatus(ctx context.Context, newStatus *SourceStatus) error
+	setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error
+	SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error
 	options() *Options
 	// SyncErrors returns all the sync errors, including remediator errors,
 	// validation errors, applier errors, and watch update errors.

--- a/pkg/parse/root.go
+++ b/pkg/parse/root.go
@@ -161,13 +161,13 @@ func (p *root) parseSource(ctx context.Context, state sourceState) ([]ast.FileOb
 }
 
 // setSourceStatus implements the Parser interface
-func (p *root) setSourceStatus(ctx context.Context, newStatus SourceStatus) error {
+func (p *root) setSourceStatus(ctx context.Context, newStatus *SourceStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSourceStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *root) setSourceStatusWithRetries(ctx context.Context, newStatus SourceStatus, denominator int) error {
+func (p *root) setSourceStatusWithRetries(ctx context.Context, newStatus *SourceStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
@@ -218,7 +218,7 @@ func (p *root) setSourceStatusWithRetries(ctx context.Context, newStatus SourceS
 	return nil
 }
 
-func setSourceStatusFields(source *v1beta1.SourceStatus, p Parser, newStatus SourceStatus, denominator int) {
+func setSourceStatusFields(source *v1beta1.SourceStatus, p Parser, newStatus *SourceStatus, denominator int) {
 	cse := status.ToCSE(newStatus.Errs)
 	source.Commit = newStatus.Commit
 	switch p.options().SourceType {
@@ -277,7 +277,7 @@ func (p *root) setRequiresRendering(ctx context.Context, renderingRequired bool)
 }
 
 // setRenderingStatus implements the Parser interface
-func (p *root) setRenderingStatus(ctx context.Context, oldStatus, newStatus RenderingStatus) error {
+func (p *root) setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error {
 	if oldStatus.Equals(newStatus) {
 		return nil
 	}
@@ -287,7 +287,7 @@ func (p *root) setRenderingStatus(ctx context.Context, oldStatus, newStatus Rend
 	return p.setRenderingStatusWithRetires(ctx, newStatus, defaultDenominator)
 }
 
-func (p *root) setRenderingStatusWithRetires(ctx context.Context, newStatus RenderingStatus, denominator int) error {
+func (p *root) setRenderingStatusWithRetires(ctx context.Context, newStatus *RenderingStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
@@ -338,7 +338,7 @@ func (p *root) setRenderingStatusWithRetires(ctx context.Context, newStatus Rend
 	return nil
 }
 
-func setRenderingStatusFields(rendering *v1beta1.RenderingStatus, p Parser, newStatus RenderingStatus, denominator int) {
+func setRenderingStatusFields(rendering *v1beta1.RenderingStatus, p Parser, newStatus *RenderingStatus, denominator int) {
 	cse := status.ToCSE(newStatus.Errs)
 	rendering.Commit = newStatus.Commit
 	switch p.options().SourceType {
@@ -384,13 +384,13 @@ func setRenderingStatusFields(rendering *v1beta1.RenderingStatus, p Parser, newS
 // SetSyncStatus implements the Parser interface
 // SetSyncStatus sets the RootSync sync status.
 // `errs` includes the errors encountered during the apply step;
-func (p *root) SetSyncStatus(ctx context.Context, newStatus SyncStatus) error {
+func (p *root) SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSyncStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *root) setSyncStatusWithRetries(ctx context.Context, newStatus SyncStatus, denominator int) error {
+func (p *root) setSyncStatusWithRetries(ctx context.Context, newStatus *SyncStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
@@ -456,7 +456,7 @@ func (p *root) setSyncStatusWithRetries(ctx context.Context, newStatus SyncStatu
 	return nil
 }
 
-func setSyncStatusFields(syncStatus *v1beta1.Status, newStatus SyncStatus, denominator int) {
+func setSyncStatusFields(syncStatus *v1beta1.Status, newStatus *SyncStatus, denominator int) {
 	cse := status.ToCSE(newStatus.Errs)
 	syncStatus.Sync.Commit = newStatus.Commit
 	syncStatus.Sync.Git = syncStatus.Source.Git

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
@@ -106,6 +107,7 @@ func TestReadConfigFiles(t *testing.T) {
 
 			parser := &root{
 				Options: &Options{
+					Clock:              clock.RealClock{}, // TODO: Test with fake clock
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
 					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
@@ -265,6 +267,7 @@ func TestReadHydratedDirWithRetry(t *testing.T) {
 
 			parser := &root{
 				Options: &Options{
+					Clock: clock.RealClock{}, // TODO: Test with fake clock
 					Files: Files{
 						FileSource: FileSource{
 							HydratedRoot: hydratedRoot,

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -19,6 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util"
 )
@@ -39,7 +40,7 @@ type reconcilerState struct {
 	// backoff should only be reset back to `defaultBackoff()` when a new commit is detected.
 	backoff wait.Backoff
 
-	retryTimer *time.Timer
+	retryTimer clock.Timer
 
 	retryPeriod time.Duration
 }
@@ -63,10 +64,8 @@ func (s *reconcilerState) checkpoint() {
 		return
 	}
 	klog.Infof("Reconciler checkpoint updated to %s", applied)
-	s.cache.errs = nil
 	s.lastApplied = applied
 	s.cache.needToRetry = false
-	s.cache.errs = nil
 }
 
 // reset sets the reconciler to retry in the next second because the rendering
@@ -82,7 +81,6 @@ func (s *reconcilerState) reset() {
 // invalidate does not clean up the `s.cache`.
 func (s *reconcilerState) invalidate(errs status.MultiError) {
 	klog.Errorf("Invalidating reconciler checkpoint: %v", status.FormatSingleLine(errs))
-	s.cache.errs = errs
 	// Invalidate state on error since this could be the result of switching
 	// branches or some other operation where inverting the operation would
 	// result in repeating a previous state that was checkpointed.

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
+	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/client/restconfig"
@@ -237,6 +238,7 @@ func Run(opts Options) {
 	}
 
 	parseOpts := &parse.Options{
+		Clock:              clock.RealClock{},
 		Parser:             filesystem.NewParser(&reader.File{}),
 		ClusterName:        opts.ClusterName,
 		Client:             cl,


### PR DESCRIPTION
- Update TestRun & TestRoot_Parse to validate the RootSync status
- Change SourceStatus, RenderingStatus, and SyncStatus to pointers and add DeepCopy methods, for easier generation of test permutations.
- Remove `cacheForCommit.errs`, which was only being used for testing errors in TestRun. Errors are now tested from the RSync status.