### PR TITLE
Cherrypick 1.18.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ HELM_VERSION := v3.14.4-gke.2
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
-GIT_SYNC_VERSION := v4.2.1-gke.12__linux_amd64
+GIT_SYNC_VERSION := v4.2.3-gke.2__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.102.0-gke.5

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 GIT_SYNC_VERSION := v4.2.1-gke.12__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.102.0-gke.4
+OTELCONTRIBCOL_VERSION := v0.102.0-gke.5
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Keep KIND_VERSION in sync with the version defined in go.mod

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE := google-go.pkg.dev/golang:1.21.9
+GOLANG_IMAGE := google-go.pkg.dev/golang:1.21.11
 # Base image used for debian containers
 # When updating you can use this command: 
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ADDLICENSE := $(BIN_DIR)/addlicense
 GOLANGCI_LINT_VERSION := v1.56.2
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 
-KUSTOMIZE_VERSION := v5.3.0-gke.1
+KUSTOMIZE_VERSION := v5.4.2-gke.0
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ HELM_VERSION := v3.14.4-gke.1
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
-GIT_SYNC_VERSION := v4.2.1-gke.10__linux_amd64
+GIT_SYNC_VERSION := v4.2.1-gke.12__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.102.0-gke.4

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ HELM_VERSION := v3.14.4-gke.1
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
+GIT_SYNC_VERSION := v4.2.1-gke.10__linux_amd64
+GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
+
+OTELCONTRIBCOL_VERSION := v0.102.0-gke.4
+OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
+
 # Keep KIND_VERSION in sync with the version defined in go.mod
 # When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
 KIND_VERSION := v0.20.0

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ KUSTOMIZE_VERSION := v5.3.0-gke.1
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
-HELM_VERSION := v3.14.4-gke.1
+HELM_VERSION := v3.14.4-gke.2
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 

--- a/Makefile.build
+++ b/Makefile.build
@@ -142,6 +142,8 @@ build-manifests-oss: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|RECONCILER_MANAGER_IMAGE_NAME|$(call gen_image_tag,$(RECONCILER_MANAGER_IMAGE))|g" \
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
+			-e "s|GIT_SYNC_IMAGE_NAME|$(GIT_SYNC_IMAGE_NAME)|g" \
+			-e "s|OTELCONTRIBCOL_IMAGE_NAME|$(OTELCONTRIBCOL_IMAGE_NAME)|g" \
 		> $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(ADDLICENSE)" $(OSS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 
@@ -168,6 +170,8 @@ build-manifests-operator: "$(ADDLICENSE)" "$(KUSTOMIZE)" $(OUTPUT_DIR)
 			-e "s|WEBHOOK_IMAGE_NAME|$(call gen_image_tag,$(ADMISSION_WEBHOOK_IMAGE))|g" \
 			-e "s|ASKPASS_IMAGE_NAME|$(call gen_image_tag,$(ASKPASS_IMAGE))|g" \
 			-e "s|RESOURCE_GROUP_CONTROLLER_IMAGE_NAME|$(call gen_image_tag,$(RESOURCE_GROUP_IMAGE))|g" \
+			-e "s|GIT_SYNC_IMAGE_NAME|$(GIT_SYNC_IMAGE_NAME)|g" \
+			-e "s|OTELCONTRIBCOL_IMAGE_NAME|$(OTELCONTRIBCOL_IMAGE_NAME)|g" \
 		> $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 	@ "$(ADDLICENSE)" $(NOMOS_MANIFEST_STAGING_DIR)/config-sync-manifest.yaml
 

--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -77,13 +77,8 @@ var (
 )
 
 func errorBackoff() wait.Backoff {
-	return wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   2,
-		Steps:    math.MaxInt,
-		Jitter:   0.1,
-		Cap:      util.WaitTime(*flWait),
-	}
+	durationLimit := math.Max(*flWait, float64(util.MinimumSyncContainerBackoffCap))
+	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
 }
 
 func main() {

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -101,7 +101,7 @@ data:
                - ALL
            imagePullPolicy: IfNotPresent
          - name: git-sync
-           image: gcr.io/config-management-release/git-sync:v4.2.1-gke.10__linux_amd64
+           image: GIT_SYNC_IMAGE_NAME
            args: ["--root=/repo/source", "--link=rev", "--max-failures=30", "--error-file=error.json"]
            volumeMounts:
            - name: repo
@@ -161,7 +161,7 @@ data:
                - ALL
              runAsUser: 65533
          - name: otel-agent
-           image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+           image: OTELCONTRIBCOL_IMAGE_NAME
            command:
            - /otelcontribcol
            args:

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -63,7 +63,7 @@ spec:
               name: reconciler-manager
               optional: true  # Currently nothing mandatory in the ConfigMap
       - name: otel-agent
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         command:
         - /otelcontribcol
         args:

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -266,7 +266,7 @@ spec:
               fieldPath: metadata.labels['configsync.gke.io/deployment-name']
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
-        image: gcr.io/config-management-release/otelcontribcol:v0.102.0-gke.4
+        image: OTELCONTRIBCOL_IMAGE_NAME
         name: otel-agent
         ports:
         - containerPort: 55678

--- a/pkg/client/restconfig/config.go
+++ b/pkg/client/restconfig/config.go
@@ -48,11 +48,11 @@ func KubeConfigPath() (string, error) {
 	if envPath != "" {
 		return envPath, nil
 	}
-	curentUser, err := userCurrentTestHook()
+	currentUser, err := userCurrentTestHook()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
-	path := filepath.Join(curentUser.HomeDir, kubectlConfigPath)
+	path := filepath.Join(currentUser.HomeDir, kubectlConfigPath)
 	return path, nil
 }
 

--- a/pkg/client/restconfig/restconfig_test.go
+++ b/pkg/client/restconfig/restconfig_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restconfig
+
+import (
+	"fmt"
+	"os/user"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func Test_NewRestConfig_HomeDirWithoutKubeConfig(t *testing.T) {
+	t.Cleanup(func() {
+		userCurrentTestHook = defaultGetCurrentUser
+	})
+
+	userCurrentTestHook = func() (*user.User, error) {
+		return &user.User{
+			HomeDir: "/some/path/that/hopefully/does/not/exist",
+		}, nil
+	}
+	calledNewFromConfigFile := false
+	calledNewFromInClusterConfig := false
+	fakeBuilder := restConfigBuilder{
+		newFromConfigFileFn: func(_ string) (*rest.Config, error) {
+			calledNewFromConfigFile = true
+			return nil, fmt.Errorf("unexpected call to local config")
+		},
+		newFromInClusterConfigFn: func() (*rest.Config, error) {
+			calledNewFromInClusterConfig = true
+			return &rest.Config{}, nil
+		},
+	}
+
+	_, err := fakeBuilder.newRestConfig(time.Minute)
+	assert.NoError(t, err)
+	assert.False(t, calledNewFromConfigFile, "unexpected call to NewFromConfigFile")
+	assert.True(t, calledNewFromInClusterConfig, "expected call to NewFromInClusterConfig")
+}

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -52,7 +52,7 @@ const (
 	// HelmVersion is the recommended version of Helm for hydration.
 	HelmVersion = "v3.14.4-gke.2"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
-	KustomizeVersion = "v5.3.0-gke.1"
+	KustomizeVersion = "v5.4.2-gke.0"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.14.4-gke.1"
+	HelmVersion = "v3.14.4-gke.2"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.3.0-gke.1"
 	// Helm is the binary name of the installed Helm.

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util"
 )
 
 type sourceStatus struct {
@@ -98,12 +99,7 @@ const retryLimit = 12
 //	16.295984061s, 34.325711987s, 1m5.465642392s, 2m18.625713221s,
 //	4m24.712222056s, 9m18.97652295s, 17m15.344384599s, 35m15.603237976s.
 func defaultBackoff() wait.Backoff {
-	return wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   2,
-		Steps:    retryLimit,
-		Jitter:   0.1,
-	}
+	return util.BackoffWithDurationAndStepLimit(0, retryLimit)
 }
 
 func (s *reconcilerState) checkpoint() {

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -24,9 +24,11 @@ import (
 
 var (
 	// SourceRetryBackoff sets retry timeout for `SourceCommitAndDirWithRetry`.
-	SourceRetryBackoff = BackoffWithDurationLimit(5 * time.Minute)
+	SourceRetryBackoff = BackoffWithDurationAndStepLimit(5*time.Minute, 10)
 	// HydratedRetryBackoff sets retry timeout for `readHydratedDirWithRetry`.
-	HydratedRetryBackoff = BackoffWithDurationLimit(time.Minute)
+	HydratedRetryBackoff = BackoffWithDurationAndStepLimit(time.Minute, 10)
+	// MinimumSyncContainerBackoffCap is the minimum backoff cap for oci-sync/helm-sync.
+	MinimumSyncContainerBackoffCap = time.Hour
 )
 
 // RetriableError represents a transient error that is retriable.
@@ -52,16 +54,16 @@ func IsErrorRetriable(err error) bool {
 	return ok
 }
 
-// BackoffWithDurationLimit returns backoff with a duration limit in 10 steps.
+// BackoffWithDurationAndStepLimit returns backoff with a duration limit.
 // Here is an example of the duration between steps:
 //
 //	1.055843837s, 2.085359785s, 4.229560375s, 8.324724174s, 16.295984061s,
 //	34.325711987s, 1m5.465642392s, 2m18.625713221s, 4m24.712222056s, 9m18.97652295s.
-func BackoffWithDurationLimit(duration time.Duration) wait.Backoff {
+func BackoffWithDurationAndStepLimit(duration time.Duration, steps int) wait.Backoff {
 	return wait.Backoff{
 		Duration: 1 * time.Second,
 		Factor:   2,
-		Steps:    10,
+		Steps:    steps,
 		Cap:      duration,
 		Jitter:   0.1,
 	}


### PR DESCRIPTION
## PR list to be cherry-picked:
```
$ git log --oneline HEAD...upstream/main
71ac1c9f (upstream/main, origin/main, origin/HEAD, main) [WIP] Inject Parser.Clock for testing (#1299)
9bea5a9d feat: error backoff for oci-sync (#1298)
0e2cbffd Refactor reconciler status caching (#1296)
3c4415c8 chore: bump git-sync to v4.2.3-gke.2__linux_amd64 (#1295)
2f2abfb7 test: clean up root reconciler ClusterRoleBindings (#1294)
f1adb5e8 fix: multiple status update bugs (#1290)
c4764b8f chore: bump otelcontribcol to v0.102.0-gke.5 (#1293)
75391db3 test: increase helm-sync memory for TestPublicHelm (#1288)
0e553996 refactor: use SourceFormat in RSync spec (#1292)
2776151b test: wait for ACM operator to become ready (#1291)
6ca57cf3 refactor: use SourceType type in RSync spec (#1289)
adfc8f6d e2e: cleanup hydration tests (#1287)
9df16632 Revert "fix: multiple sync status update bugs (#1283)" (#1286)
f7f9486a chore: bump kustomize to v5.4.2-gke.0 (#1285)
43000044 chore: bump helm to v3.14.4-gke.2 (#1284)
3e091521 fix: multiple sync status update bugs (#1283)
49e26cbe cleanup: remove unused methods from remediator (#1282)
6d78bef3 chore: bump git-sync to v4.2.1-gke.12 (#1281)
faf3f035 e2e: update hydration tests to watch for errors (#1280)
fd2e3eda refactor: parametrize git-sync and otel version (#1279)
d74a4f01 chore: bump golang to 1.21.11 (#1278)
9b2c8b55 test: clean up ConfigManagement in e2e test (#1277)
08bfd3a2 fix: only use local config if file exists (#1275)
380feb92 Dedupe management conflict errors (#1274)

367f1f4a (HEAD -> cherrypick-1.18.3, tag: v1.18.2-rc.2, tag: v1.18.2, upstream/v1.18, origin/v1.18) [metric] Reset declared_resource to 0 when commit updates with test fix (#1232) (#1254)
```

## Selected cherrypick list:
- 9bea5a9d feat: error backoff for oci-sync (#1298)  ----> bug fix for b/349848478
- 3c4415c8 chore: bump git-sync to v4.2.3-gke.2__linux_amd64 (#1295)  ----> bug fix for b/349652543 
- c4764b8f chore: bump otelcontribcol to v0.102.0-gke.5 (#1293)  ----> CVE fix
- f7f9486a chore: bump kustomize to v5.4.2-gke.0 (#1285)  ----> CVE fix
- 43000044 chore: bump helm to v3.14.4-gke.2 (#1284)  ----> CVE fix
- 6d78bef3 chore: bump git-sync to v4.2.1-gke.12 (#1281)  ----> dependency of #1295
- fd2e3eda refactor: parametrize git-sync and otel version (#1279) ----> dependency of #1295
- d74a4f01 chore: bump golang to 1.21.11 (#1278)  ----> CVE fix
- 08bfd3a2 fix: only use local config if file exists (#1275)   ----> bug fix for [#1273](https://github.com/GoogleContainerTools/kpt-config-sync/issues/1273)

## Ignored cherrypick list:
- 71ac1c9f (upstream/main, origin/main, origin/HEAD, main) [WIP] Inject Parser.Clock for testing (#1299)
- 0e2cbffd Refactor reconciler status caching (#1296)
- 2f2abfb7 test: clean up root reconciler ClusterRoleBindings (#1294)
- f1adb5e8 fix: multiple status update bugs (#1290)
- 75391db3 test: increase helm-sync memory for TestPublicHelm (#1288)
- 0e553996 refactor: use SourceFormat in RSync spec (#1292)
- 2776151b test: wait for ACM operator to become ready (#1291)
- 6ca57cf3 refactor: use SourceType type in RSync spec (#1289)
- adfc8f6d e2e: cleanup hydration tests (#1287)
- 9df16632 Revert "fix: multiple sync status update bugs (#1283)" (#1286)
- 3e091521 fix: multiple sync status update bugs (#1283)
- 49e26cbe cleanup: remove unused methods from remediator (#1282)
- faf3f035 e2e: update hydration tests to watch for errors (#1280)
- 9b2c8b55 test: clean up ConfigManagement in e2e test (#1277)
- 380feb92 Dedupe management conflict errors (#1274)




