### PR TITLE
Add watch filtering by applyset label

### DIFF
--- a/pkg/applyset/applyset.go
+++ b/pkg/applyset/applyset.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applyset
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/resource"
+	kubectlapply "k8s.io/kubectl/pkg/cmd/apply"
+	"kpt.dev/configsync/pkg/declared"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+)
+
+// IDFromSync generates an ApplySet ID for the RootSync or RepoSync as
+// an ApplySet parent.
+func IDFromSync(syncName string, syncScope declared.Scope) string {
+	return FromSync(syncName, syncScope, nil, nil).ID()
+}
+
+// FromSync constructs a new ApplySet for the specified RootSync or RepoSync.
+// The RESTMapper & RESTClient are optional, depending on which methods you plan
+// to call.
+func FromSync(syncName string, syncScope declared.Scope, mapper meta.RESTMapper, client resource.RESTClient) *kubectlapply.ApplySet {
+	tooling := kubectlapply.ApplySetTooling{
+		Name:    metadata.ApplySetToolingName,
+		Version: metadata.ApplySetToolingVersion,
+	}
+	parent := &kubectlapply.ApplySetParentRef{
+		Name:      syncName,
+		Namespace: syncScope.SyncNamespace(),
+	}
+	switch syncScope {
+	case declared.RootScope:
+		parent.RESTMapping = kinds.RootSyncRESTMapping()
+	default:
+		parent.RESTMapping = kinds.RepoSyncRESTMapping()
+	}
+	return kubectlapply.NewApplySet(parent, tooling, mapper, client)
+}
+
+// ParseTooling parses the tooling value with format NAME/VERSION.
+// Returns an error if the input does not contain at least one slash (`/`).
+func ParseTooling(toolingValue string) (kubectlapply.ApplySetTooling, error) {
+	parts := strings.Split(toolingValue, "/")
+	if len(parts) >= 2 {
+		return kubectlapply.ApplySetTooling{
+			Name:    strings.Join(parts[:len(parts)-1], "/"),
+			Version: parts[len(parts)-1],
+		}, nil
+	}
+	// Invalid
+	return kubectlapply.ApplySetTooling{},
+		fmt.Errorf("invalid applyset tooling value: expected NAME/VERSION: %s", toolingValue)
+}
+
+// FormatTooling returns a formatted value for the ApplySet tooling annotation.
+func FormatTooling(name, version string) string {
+	tooling := kubectlapply.ApplySetTooling{
+		Name:    name,
+		Version: version,
+	}
+	return tooling.String()
+}

--- a/pkg/core/decorate.go
+++ b/pkg/core/decorate.go
@@ -66,6 +66,15 @@ func RemoveAnnotations(obj Annotated, annotations ...string) {
 	obj.SetAnnotations(as)
 }
 
+// RemoveLabels removes the passed set of labels from obj.
+func RemoveLabels(obj Labeled, labels ...string) {
+	actual := obj.GetLabels()
+	for _, label := range labels {
+		delete(actual, label)
+	}
+	obj.SetLabels(actual)
+}
+
 // AddAnnotations adds the specified annotations to the object.
 func AddAnnotations(obj Annotated, annotations map[string]string) {
 	existing := obj.GetAnnotations()

--- a/pkg/kinds/resources.go
+++ b/pkg/kinds/resources.go
@@ -16,6 +16,7 @@ package kinds
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 )
@@ -33,4 +34,22 @@ func RootSyncResource() schema.GroupVersionResource {
 // RepoSyncResource returns the canonical RepoSync GroupVersionResource.
 func RepoSyncResource() schema.GroupVersionResource {
 	return configsyncv1beta1.SchemeGroupVersion.WithResource("reposyncs")
+}
+
+// RootSyncRESTMapping returns the canonical RootSync RESTMapping.
+func RootSyncRESTMapping() *meta.RESTMapping {
+	return &meta.RESTMapping{
+		Resource:         RootSyncResource(),
+		GroupVersionKind: RootSyncV1Beta1(),
+		Scope:            meta.RESTScopeNamespace,
+	}
+}
+
+// RepoSyncRESTMapping returns the canonical RepoSync RESTMapping.
+func RepoSyncRESTMapping() *meta.RESTMapping {
+	return &meta.RESTMapping{
+		Resource:         RepoSyncResource(),
+		GroupVersionKind: RepoSyncV1Beta1(),
+		Scope:            meta.RESTScopeNamespace,
+	}
 }

--- a/pkg/metadata/applyset.go
+++ b/pkg/metadata/applyset.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	kubectlapply "k8s.io/kubectl/pkg/cmd/apply"
+	"kpt.dev/configsync/pkg/api/configsync"
+)
+
+// Labels with the `applyset.kubernetes.io/` prefix.
+const (
+	// ApplySetPartOfLabel is the key of the label which indicates that the
+	// object is a member of an ApplySet. The value of the label MUST match the
+	// value of ApplySetParentIDLabel on the parent object.
+	ApplySetPartOfLabel = kubectlapply.ApplysetPartOfLabel
+
+	// ApplySetParentIDLabel is the key of the label that makes object an
+	// ApplySet parent object. Its value MUST use the format specified in
+	// k8s.io/kubectl/pkg/cmd/apply.V1ApplySetIdFormat.
+	ApplySetParentIDLabel = kubectlapply.ApplySetParentIDLabel
+)
+
+// Annotations with the `applyset.kubernetes.io/` prefix.
+const (
+	// ApplySetToolingAnnotation is the key of the label that indicates which
+	// tool is used to manage this ApplySet. Tooling should refuse to mutate
+	// ApplySets belonging to other tools. The value must be in the format
+	// <toolname>/<semver>. Example value: "kubectl/v1.27" or "helm/v3" or
+	// "kpt/v1.0.0"
+	ApplySetToolingAnnotation = kubectlapply.ApplySetToolingAnnotation
+
+	// ApplySetToolingName is the name used to represent Config Sync in the
+	// ApplySet tooling annotation.
+	ApplySetToolingName = configsync.GroupName
+
+	// ApplySetToolingVersion is the version used to represent Config Sync in
+	// the ApplySet tooling annotation.
+	//
+	// The ApplySetKEP and kubectl require this to be a semantic version,
+	// implying that it should be the version of the tool. But we're using a
+	// static version instead, to allow listing all objects managed Config Sync,
+	// regardless of version.
+	ApplySetToolingVersion = "v1"
+)

--- a/pkg/parse/annotations.go
+++ b/pkg/parse/annotations.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/applyset"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -37,10 +38,12 @@ func addAnnotationsAndLabels(objs []ast.FileObject, scope declared.Scope, syncNa
 	if err != nil {
 		return fmt.Errorf("marshaling sourceContext: %w", err)
 	}
+	applySetID := applyset.IDFromSync(syncName, scope)
 	inventoryID := applier.InventoryID(syncName, scope.SyncNamespace())
 	manager := declared.ResourceManager(scope, syncName)
 	for _, obj := range objs {
 		core.SetLabel(obj, metadata.ManagedByKey, metadata.ManagedByValue)
+		core.SetLabel(obj, metadata.ApplySetPartOfLabel, applySetID)
 		core.SetAnnotation(obj, metadata.GitContextKey, string(gcVal))
 		core.SetAnnotation(obj, metadata.ResourceManagerKey, manager)
 		core.SetAnnotation(obj, metadata.SyncTokenAnnotationKey, commitHash)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/applyset"
 	"kpt.dev/configsync/pkg/client/restconfig"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
@@ -195,7 +196,8 @@ func Run(opts Options) {
 	if reconcileTimeout < 0 {
 		klog.Fatalf("Invalid reconcileTimeout: %v, timeout should not be negative", reconcileTimeout)
 	}
-	clientSet, err := applier.NewClientSet(cl, configFlags, opts.StatusMode)
+	applySetID := applyset.IDFromSync(opts.SyncName, opts.ReconcilerScope)
+	clientSet, err := applier.NewClientSet(cl, configFlags, opts.StatusMode, applySetID)
 	if err != nil {
 		klog.Fatalf("Error creating clients: %v", err)
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -320,11 +320,15 @@ func (r *RepoSyncReconciler) upsertManagedObjects(ctx context.Context, reconcile
 }
 
 // setup performs the following steps:
+// - Patch RepoSync to upsert ApplySet metadata
 // - Create or update managed objects
 // - Convert any error into RepoSync status conditions
 // - Update the RepoSync status
 func (r *RepoSyncReconciler) setup(ctx context.Context, reconcilerRef types.NamespacedName, rs *v1beta1.RepoSync) error {
-	err := r.upsertManagedObjects(ctx, reconcilerRef, rs)
+	_, err := r.patchSyncMetadata(ctx, rs)
+	if err == nil {
+		err = r.upsertManagedObjects(ctx, reconcilerRef, rs)
+	}
 	updated, updateErr := r.updateSyncStatus(ctx, rs, reconcilerRef, func(syncObj *v1beta1.RepoSync) error {
 		// Modify the sync status,
 		// but keep the upsert error separate from the status update error.

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -269,11 +269,15 @@ func (r *RootSyncReconciler) upsertManagedObjects(ctx context.Context, reconcile
 }
 
 // setup performs the following steps:
+// - Patch RootSync to upsert ApplySet metadata
 // - Create or update managed objects
 // - Convert any error into RootSync status conditions
 // - Update the RootSync status
 func (r *RootSyncReconciler) setup(ctx context.Context, reconcilerRef types.NamespacedName, rs *v1beta1.RootSync) error {
-	err := r.upsertManagedObjects(ctx, reconcilerRef, rs)
+	_, err := r.patchSyncMetadata(ctx, rs)
+	if err == nil {
+		err = r.upsertManagedObjects(ctx, reconcilerRef, rs)
+	}
 	updated, updateErr := r.updateSyncStatus(ctx, rs, reconcilerRef, func(syncObj *v1beta1.RootSync) error {
 		// Modify the sync status,
 		// but keep the upsert error separate from the status update error.

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/ptr"
@@ -346,6 +347,7 @@ func TestFilteredWatcher(t *testing.T) {
 					return <-watches, nil
 				},
 				conflictHandler: testfake.NewConflictHandler(),
+				labelSelector:   labels.Everything(),
 			}
 			w := NewFiltered(cfg)
 

--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"kpt.dev/configsync/pkg/declared"
@@ -40,6 +41,7 @@ func fakeRunnable() Runnable {
 			return watch.NewFake(), nil
 		},
 		conflictHandler: fake.NewConflictHandler(),
+		labelSelector:   labels.Everything(),
 	}
 	return NewFiltered(cfg)
 }

--- a/pkg/remediator/watch/watcher.go
+++ b/pkg/remediator/watch/watcher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
@@ -38,6 +39,7 @@ type watcherConfig struct {
 	syncName        string
 	startWatch      WatchFunc
 	conflictHandler conflict.Handler
+	labelSelector   labels.Selector
 }
 
 // watcherFactory knows how to build watch.Runnables.
@@ -56,6 +58,9 @@ func watcherFactoryFromListerWatcherFactory(factory ListerWatcherFactory) watche
 					namespace = string(cfg.scope)
 				}
 				lw := factoryPtr(cfg.gvk, namespace)
+				if cfg.labelSelector != nil {
+					options.LabelSelector = cfg.labelSelector.String()
+				}
 				return ListAndWatch(ctx, lw, options)
 			}
 		}


### PR DESCRIPTION
- Add "applyset.kubernetes.io/part-of" label to managed objects
- Add "applyset.kubernetes.io/id" label to RootSyncs/RepoSyncs
- Add "applyset.kubernetes.io/tooling" annotation to RootSyncs/RepoSyncs
- Error if the RSync already has a tooling annotation for a different tool (unlikely, but required by KEP).
- Generate ApplySet IDs using kubectl code for compatibility.
- Update TestKubectlCreatesManagedNamespaceResourceMultiRepo & TestAddUpdateDeleteLabels with new labels & annotations

### Design

go/config-sync-watch-filter

### Drift from KEP

#### Metadata Prefixes

In the KEP, the labels and annotations begin with `applyset.k8s.io`. However, when implemented in kubectl, this was changed to `applyset.kubernetes.io`. The reason for this is unclear. But we decided compatibility with kubectl was more important, since it's the only other known ApplySet implementation at this time.

#### ApplySet ID Format

In the KEP, the ID format is specified as `base64(sha256(<NAME>.<NAMESPACE>.<KIND>.<RESOURCE_GROUP>))`. However, when implemented in kubectl, this format was wrapped with the prefix `applyset-` and suffix `-v1`, because "Label values must start and end with alphanumeric values" (https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/applyset.go#L175).

If I were designing this again, I would recommend using `hex(fnv32a(<NAME>.<NAMESPACE>.<KIND>.<RESOURCE_GROUP>))`, because it's faster and only includes alphanumeric values. But we decided compatibility with the KEP & kubectl was more important.

### Tooling Format

For consistency with other Config Sync labels and annotations, we decided on `configsync.gke.io` as the name of the tool.

In the KEP, the tooling format is recommended to be `<toolname>/<semver>`, with examples that show a loose definition of semver with a leading `v` prefix and without requiring all three version segments.

In order to facilitate listing ALL the objects of a resource that are managed by Config Sync, and avoid the complexity of needing to inject the latest version into the code before the tag has been created, we opted here to just use `v1` as the version. Specifying a version also conveniently allows us to share more code with kubectl and stick to the guidelines in the KEP for compatibility with other tools that may try to parse the tooling value and not be as lenient as kubectl.

So the tooling value is `configsync.gke.io/v1`, and should continue using this version for the foreseeable future.

### Dependencies

- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1274
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1328
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1335
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1342
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1343
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1344
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1354
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1356

### Follow Ups

- Race condition: Remediate deletion of objects between remediator pasue and unpause, while the applier is running (b/353334354 & b/355532135)
- Distinguish between resource version conflict & management conflict (b/355533809)
- Remove "applyset.kubernetes.io/part-of" label when an object is abandoned. (b/355534413)

### Unplanned

- Add "applyset.k8s.io/additional-namespaces" annotation to RootSyncs/RepoSyncs.
  - This annotation would need to be applied by the reconciler, not the reconciler-manager.
  - The list of namespaces may change frequently for RootSync, whenever a new source commit is seen.
- Add "applyset.k8s.io/contains-group-kinds" annotation to RootSyncs/RepoSyncs.
  - This annotation would need to be applied by the reconciler, not the reconciler-manager.
  - The list of namespaces may change frequently for RootSync, whenever a new source commit is seen.
  - For large apply sets, especially when using may resource types (ex: KCC or Crossplane), the inventory annotation length may dramatically increase the object size, increasing the risk of reaching the max object size in etcd.
- Add "applyset.k8s.io/inventory" annotation to RootSyncs/RepoSyncs.
  - This annotation would need to be applied by the reconciler, not the reconciler-manager.
  - The list of namespaces may change frequently for RootSync, whenever a new source commit is seen.
  - For large apply sets, the inventory annotation length may overflow the max annotation length.
  - For large apply sets, the inventory annotation length may dramatically increase the object size, increasing the risk of reaching the max object size in etcd.
- Error when attempting to apply an object with a non-matching "applyset.kubernetes.io/part-of" label.
  - Look ups before applying were removed from Config Sync (a few years ago) to reduce the number of API calls made and speed up applying large apply sets. Adding them back would be required to perform this kind of validation/protection.

### Notes

This PR replaces https://github.com/GoogleContainerTools/kpt-config-sync/pull/1239 with less refactoring. The refactoring can be done separately.