### PR TITLE
ci: publish all infra images in postsubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE := google-go.pkg.dev/golang:1.21.11
+GOLANG_IMAGE_VERSION := 1.21.11
+GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command: 
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 
@@ -46,9 +47,11 @@ DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.3-gke.1
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options
-GCLOUD_IMAGE := gcr.io/google.com/cloudsdktool/google-cloud-cli:449.0.0-slim
+GCLOUD_IMAGE_VERSION := 449.0.0
+GCLOUD_IMAGE := gcr.io/google.com/cloudsdktool/google-cloud-cli:$(GCLOUD_IMAGE_VERSION)-slim
 # Base image used for docker cli install, primarily used for test images.
-DOCKER_CLI_IMAGE := gcr.io/cloud-builders/docker:20.10.14
+DOCKER_CLI_IMAGE_VERSION := 20.10.14
+DOCKER_CLI_IMAGE := gcr.io/cloud-builders/docker:$(DOCKER_CLI_IMAGE_VERSION)
 
 # Directory containing installed go binaries.
 BIN_DIR := $(GO_DIR)/bin
@@ -137,12 +140,20 @@ OLD_REGISTRY ?= $(REGISTRY)
 TEST_INFRA_PROJECT ?= kpt-config-sync-ci-artifacts
 TEST_INFRA_REGISTRY ?= $(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/test-infra
 INFRA_IMAGE_PREFIX := infrastructure-public-image
+# Arbitrary semver to indicate infra versioning. Can be bumped in the future
+# if there are notable changes. Bumping this will force all infra images to
+# be re-published.
+INFRA_VERSION := v2.0.0
+INFRA_IMAGE_VERSION := $(INFRA_IMAGE_PREFIX)-$(INFRA_VERSION)-$(shell git rev-parse --short HEAD)
 
 # Docker image used for build and test. This image does not support CGO.
 # When upgrading this tag, the image will be rebuilt locally during presubmits.
 # After the change is submitted, a postsubmit job will publish the new tag.
 # There is no need to manually publish this image.
-BUILDENV_IMAGE := $(TEST_INFRA_REGISTRY)/buildenv:$(INFRA_IMAGE_PREFIX)-v0.3.3
+BUILDENV_IMAGE := $(TEST_INFRA_REGISTRY)/buildenv:$(INFRA_VERSION)-go$(GOLANG_IMAGE_VERSION)-gcloud$(GCLOUD_IMAGE_VERSION)
+# The buildenv image is also tagged with a git sha so that it can be traced
+# back to commit it was built from.
+BUILDENV_SHA_IMAGE := $(TEST_INFRA_REGISTRY)/buildenv:$(INFRA_IMAGE_VERSION)
 
 # Nomos docker images containing all binaries.
 RECONCILER_IMAGE := reconciler

--- a/Makefile.build
+++ b/Makefile.build
@@ -22,6 +22,8 @@ build-buildenv: build/buildenv/Dockerfile
 push-buildenv: build-buildenv
 	@gcloud $(GCLOUD_QUIET) auth configure-docker $(firstword $(subst /, ,$(BUILDENV_IMAGE)))
 	@docker push $(BUILDENV_IMAGE)
+	@docker tag $(BUILDENV_IMAGE) $(BUILDENV_SHA_IMAGE)
+	@docker push $(BUILDENV_SHA_IMAGE)
 
 ###################################
 # Docker images
@@ -244,22 +246,28 @@ push-http-git-server:
 	@docker push $(E2E_TEST_IMAGE_HTTP_GIT_SERVER)
 
 # Used by the vulnerability scanning periodic prow job.
-VULNERABILITY_SCANNER_VERSION := $(INFRA_IMAGE_PREFIX)-v1.0.0-$(shell git rev-parse --short HEAD)
-VULNERABILITY_SCANNER_IMAGE_TAG := $(TEST_INFRA_REGISTRY)/vulnerability-scanner:$(VULNERABILITY_SCANNER_VERSION)
+VULNERABILITY_SCANNER_VERSION := $(INFRA_VERSION)-go$(GOLANG_IMAGE_VERSION)-gcloud$(GCLOUD_IMAGE_VERSION)
+VULNERABILITY_SCANNER_IMAGE := $(TEST_INFRA_REGISTRY)/vulnerability-scanner:$(VULNERABILITY_SCANNER_VERSION)
+# The vuln-scanner image is also tagged with a git sha so that it can be traced
+# back to commit it was built from.
+VULNERABILITY_SCANNER_SHA_IMAGE := $(TEST_INFRA_REGISTRY)/vulnerability-scanner:$(INFRA_IMAGE_VERSION)
 .PHONY: build-vulnerability-scanner
 build-vulnerability-scanner:
-	@echo "+++ Building $(VULNERABILITY_SCANNER_IMAGE_TAG)"
+	@echo "+++ Building $(VULNERABILITY_SCANNER_IMAGE)"
 	docker buildx build \
-		-t $(VULNERABILITY_SCANNER_IMAGE_TAG) \
+		-t $(VULNERABILITY_SCANNER_IMAGE) \
 		$(DOCKER_BUILD_ARGS) \
 		build/prow/vulnerability-scanner/
 
-# Push vulnerability-scanner image to registry. For now this is done manually.
+# Push vulnerability-scanner image to registry. This is done automatically by
+# the postsubmit whenever one of the input images changes.
 .PHONY: push-vulnerability-scanner
 push-vulnerability-scanner:
-	@echo "+++ Pushing $(VULNERABILITY_SCANNER_IMAGE_TAG)"
-	@gcloud $(GCLOUD_QUIET) auth configure-docker $(firstword $(subst /, ,$(VULNERABILITY_SCANNER_IMAGE_TAG)))
-	docker push $(VULNERABILITY_SCANNER_IMAGE_TAG)
+	@echo "+++ Pushing $(VULNERABILITY_SCANNER_IMAGE)"
+	@gcloud $(GCLOUD_QUIET) auth configure-docker $(firstword $(subst /, ,$(VULNERABILITY_SCANNER_IMAGE)))
+	docker push $(VULNERABILITY_SCANNER_IMAGE)
+	docker tag $(VULNERABILITY_SCANNER_IMAGE) $(VULNERABILITY_SCANNER_SHA_IMAGE)
+	docker push $(VULNERABILITY_SCANNER_SHA_IMAGE)
 
 .PHONY: deploy
 deploy:

--- a/Makefile.e2e.ci
+++ b/Makefile.e2e.ci
@@ -22,12 +22,27 @@ postsubmit: build-cli
 		IMAGE_TAG=$(INFRA_IMAGE_PREFIX)-$(IMAGE_TAG)
 	$(MAKE) publish-gcs GCS_PREFIX=$(POSTSUBMIT_GCS_PREFIX)
 	$(MAKE) publish-buildenv
+	$(MAKE) publish-gke-e2e
+	$(MAKE) publish-vulnerability-scanner
 
 # publish-buildenv checks if the buildenv image tag exists in the remote registry.
 # if it does not exist, the image will be built and published.
 .PHONY: publish-buildenv
 publish-buildenv:
 	docker manifest inspect $(BUILDENV_IMAGE) &> /dev/null || $(MAKE) build-buildenv push-buildenv
+
+# publish-gke-e2e checks if the gke-e2e image tag exists in the remote registry.
+# if it does not exist, the image will be built and published.
+.PHONY: publish-gke-e2e
+publish-gke-e2e:
+	docker manifest inspect $(GKE_E2E_IMAGE) &> /dev/null || $(MAKE) build-gke-e2e push-gke-e2e
+
+# publish-vulnerability-scanner checks if the vulnerability-scanner image tag
+# exists in the remote registry.
+# if it does not exist, the image will be built and published.
+.PHONY: publish-vulnerability-scanner
+publish-vulnerability-scanner:
+	docker manifest inspect $(VULNERABILITY_SCANNER_IMAGE) &> /dev/null || $(MAKE) build-vulnerability-scanner push-vulnerability-scanner
 
 .PHONY: publish-gcs
 publish-gcs:

--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -19,10 +19,12 @@
 
 # This is the image used by the new GKE e2e jobs. This job type runs against GKE
 # clusters rather than kind, so we don't need docker in docker.
-# Note: nothing builds this, if you update the version, you will need to rebuild manually.
-# TODO: setup postsubmit job to build this image
-GKE_E2E_TAG := $(INFRA_IMAGE_PREFIX)-v1.0.0-$(shell git rev-parse --short HEAD)
+# This is published automatically by postsubmit whenever an input changes.
+GKE_E2E_TAG := $(INFRA_VERSION)-go$(GOLANG_IMAGE_VERSION)-gcloud$(GCLOUD_IMAGE_VERSION)-docker$(DOCKER_CLI_IMAGE_VERSION)
 GKE_E2E_IMAGE := $(TEST_INFRA_REGISTRY)/gke-e2e:$(GKE_E2E_TAG)
+# The gke-e2e image is also tagged with a git sha so that it can be traced
+# back to commit it was built from.
+GKE_E2E_SHA_IMAGE := $(TEST_INFRA_REGISTRY)/gke-e2e:$(INFRA_IMAGE_VERSION)
 .PHONY: build-gke-e2e
 build-gke-e2e:
 	@echo "+++ Building $(GKE_E2E_IMAGE)"
@@ -36,6 +38,8 @@ build-gke-e2e:
 .PHONY: push-gke-e2e
 push-gke-e2e:
 	@docker push $(GKE_E2E_IMAGE)
+	@docker tag $(GKE_E2E_IMAGE) $(GKE_E2E_SHA_IMAGE)
+	@docker push $(GKE_E2E_SHA_IMAGE)
 
 ###################################
 # Prow environment provisioning


### PR DESCRIPTION
Prior to this change, only the buildenv image was published on
postsubmit and required manually bumping the buildenv image tag. This
makes two key changes:
- Forms the image tag using the image inputs (dependencies), such that a
  new image will be published whenever one of the inputs changes. For
  example when the Go base image is updated, the postsubmit will publish
  a new image.
- Adds steps to publish both the gke-e2e and vulnerability-scanner
  images during postsubmit, using the same logic as buildenv.
