### PR TITLE
ci: bump go environment to 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE_VERSION := 1.21.11
+GOLANG_IMAGE_VERSION := 1.22.5
 GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command: 


### PR DESCRIPTION
Builds on https://github.com/GoogleContainerTools/kpt-config-sync/pull/1309 to simplify the process of bumping Go build environments