### PR TITLE
feat: allow nomos migrate to continue on error

### DIFF
--- a/cmd/nomos/migrate/migrate.go
+++ b/cmd/nomos/migrate/migrate.go
@@ -112,7 +112,7 @@ var Cmd = &cobra.Command{
 			fmt.Println()
 			fmt.Println(util.Separator)
 			cs := &status.ClusterState{Ref: context}
-			if !c.IsInstalled(cmd.Context(), cs) || !c.IsConfigured(cmd.Context(), cs) {
+			if !c.IsInstalled(cmd.Context(), cs) {
 				printError(cs.Error)
 				migrationError = true
 				continue


### PR DESCRIPTION
ACM operator will soon report an error when monorepo mode is enabled. This change allows nomos migrate to still operate for new versions of ACM operator.

Alternatively we could filter by specific error message, however currently the only errors set by ACM operator are related to the git config issues. This solution is simpler and less brittle on account of hard coded string comparison.