### PR TITLE
feat: filter contexts before creating rest configs

### DIFF
--- a/cmd/nomos/status/client.go
+++ b/cmd/nomos/status/client.go
@@ -450,14 +450,13 @@ func (c *ClusterClient) IsConfigured(ctx context.Context, cs *ClusterState) bool
 // ClusterClients returns a map of of typed clients keyed by the name of the kubeconfig context they
 // are initialized from.
 func ClusterClients(ctx context.Context, contexts []string) (map[string]*ClusterClient, error) {
-	configs, err := restconfig.AllKubectlConfigs(flags.ClientTimeout)
+	configs, err := restconfig.AllKubectlConfigs(flags.ClientTimeout, contexts)
 	if configs == nil {
 		return nil, fmt.Errorf("failed to create client configs: %w", err)
 	}
 	if err != nil {
 		fmt.Println(err)
 	}
-	configs = filterConfigs(contexts, configs)
 
 	if klog.V(4).Enabled() {
 		// Sort contexts for consistent ordering in the log
@@ -544,22 +543,6 @@ func ClusterClients(ctx context.Context, contexts []string) (map[string]*Cluster
 		fmt.Println()
 	}
 	return clientMap, nil
-}
-
-// filterConfigs returns the intersection of the given slice and map. If contexts is nil then the
-// full map is returned unfiltered.
-// TODO: dedup this with the function in version/version.go
-func filterConfigs(contexts []string, all map[string]*rest.Config) map[string]*rest.Config {
-	if contexts == nil {
-		return all
-	}
-	cfgs := make(map[string]*rest.Config)
-	for _, name := range contexts {
-		if cfg, ok := all[name]; ok {
-			cfgs[name] = cfg
-		}
-	}
-	return cfgs
 }
 
 // isReachable returns true if the given ClientSet points to a reachable cluster.

--- a/cmd/nomos/version/version_test.go
+++ b/cmd/nomos/version/version_test.go
@@ -38,14 +38,12 @@ func TestVersion(t *testing.T) {
 		objects        []runtime.Object
 		expected       []string
 		currentContext string
-		contexts       []string
 		configs        map[string]*rest.Config
 	}{
 		{
-			name:     "specify zero clusters",
-			version:  "v1.2.3",
-			contexts: []string{},
-			configs:  nil,
+			name:    "specify zero clusters",
+			version: "v1.2.3",
+			configs: nil,
 			objects: []runtime.Object{
 				&unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -123,7 +121,7 @@ func TestVersion(t *testing.T) {
 			}
 			var b strings.Builder
 			ctx := context.Background()
-			versionInternal(ctx, test.configs, &b, test.contexts)
+			versionInternal(ctx, test.configs, &b)
 			actuals := strings.Split(b.String(), "\n")
 			if diff := cmp.Diff(test.expected, actuals); diff != "" {
 				t.Errorf(diff)

--- a/pkg/bugreport/bugreport.go
+++ b/pkg/bugreport/bugreport.go
@@ -488,7 +488,7 @@ func (b *BugReporter) copyToZip(inputFile *os.File, zipFileName string) error {
 
 // AddNomosVersionToZip writes `nomos version` to bugreport zip file
 func (b *BugReporter) AddNomosVersionToZip(ctx context.Context) {
-	if versionRc, err := version.GetVersionReadCloser(ctx, []string{b.k8sContext}); err != nil {
+	if versionRc, err := version.GetVersionReadCloser(ctx); err != nil {
 		b.ErrorList = append(b.ErrorList, err)
 	} else if err = b.writeReadableToZip(Readable{
 		Name:       path.Join(Processed, b.k8sContext, "version.txt"),

--- a/pkg/client/restconfig/config_test.go
+++ b/pkg/client/restconfig/config_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestFilterContexts(t *testing.T) {
+	testCases := map[string]struct {
+		wantContexts     []string
+		contexts         map[string]*clientcmdapi.Context
+		expectedContexts map[string]*clientcmdapi.Context
+	}{
+		"wantContexts is nil": {
+			contexts: map[string]*clientcmdapi.Context{
+				"context-1": nil,
+				"context-2": nil,
+			},
+			expectedContexts: map[string]*clientcmdapi.Context{
+				"context-1": nil,
+				"context-2": nil,
+			},
+		},
+		"wantContexts selects an element": {
+			wantContexts: []string{"context-1"},
+			contexts: map[string]*clientcmdapi.Context{
+				"context-1": nil,
+				"context-2": nil,
+			},
+			expectedContexts: map[string]*clientcmdapi.Context{
+				"context-1": nil,
+			},
+		},
+		"wantContexts is set but matches no elements": {
+			wantContexts: []string{},
+			contexts: map[string]*clientcmdapi.Context{
+				"context-1": nil,
+				"context-2": nil,
+			},
+			expectedContexts: map[string]*clientcmdapi.Context{},
+		},
+		"contexts is empty": {
+			wantContexts:     []string{"cluster-1"},
+			contexts:         map[string]*clientcmdapi.Context{},
+			expectedContexts: map[string]*clientcmdapi.Context{},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotContexts := filterContexts(tc.wantContexts, tc.contexts)
+			assert.Equal(t, tc.expectedContexts, gotContexts)
+		})
+	}
+}


### PR DESCRIPTION
The rest config creation can be expensive since it performs an API call with UpdateQPS. This can take an especially long time if you have a large kubeconfig that contains stale configs (e.g. cluster deleted) since it will wait for API timeout.