### PR TITLE
feat: add --version flag to nomos CLI

### DIFF
--- a/cmd/nomos/nomos.go
+++ b/cmd/nomos/nomos.go
@@ -34,15 +34,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
+const (
+	// versionTemplate is the template used when "nomos --version" is invoked.
+	// The default template outputs "nomos version <VERSION>". This just outputs
+	// "<VERSION>" for easier programmatic use.
+	versionTemplate = `{{.Version}}
+`
+)
+
 var (
 	rootCmd = &cobra.Command{
-		Use: configmanagement.CLIName,
+		Use:     configmanagement.CLIName,
+		Version: pkgversion.VERSION,
 		Short: fmt.Sprintf(
 			"Set up and manage a Anthos Configuration Management directory (version %v)", pkgversion.VERSION),
 	}
 )
 
 func init() {
+	rootCmd.SetVersionTemplate(versionTemplate)
 	rootCmd.AddCommand(initialize.Cmd)
 	rootCmd.AddCommand(hydrate.Cmd)
 	rootCmd.AddCommand(vet.Cmd)


### PR DESCRIPTION
There currently is not a clean way to programmatically capture the version of the nomos CLI. The nomos version command also fetches the config sync version installed on the cluster from the kube context.

This provides an easy way to simply print the version of the CLI.