### PR TITLE
ci: fix go lint deprecated field

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,10 +24,6 @@ linters:
   - unconvert
   - misspell
 
-linters-settings:
-  staticcheck:
-    go: "1.22"
-
 issues:
   exclude-rules:
     - linters:


### PR DESCRIPTION
The staticcheck go field is deprecated. It should be set in the run.go field, however this field defaults to the version in go.mod. So no need to define the go version in this file.