### PR TITLE
feat: only sync once for oci image with digest

### DIFF
--- a/pkg/oci/fetcher.go
+++ b/pkg/oci/fetcher.go
@@ -34,6 +34,12 @@ import (
 	utillog "kpt.dev/configsync/pkg/util/log"
 )
 
+const (
+	// NoFurtherSyncsLog is the log message for when no further syncs will occur.
+	// exported as a const for use in testing.
+	NoFurtherSyncsLog = "Image has been synced, and no further syncs will occur"
+)
+
 // authenticator returns an authn.Authenticator that generates access tokens.
 func authenticator(authType string, logger *utillog.Logger) (authenticator authn.Authenticator, err error) {
 	switch configsync.AuthType(authType) {
@@ -45,6 +51,12 @@ func authenticator(authType string, logger *utillog.Logger) (authenticator authn
 		utillog.HandleError(logger, true, "ERROR: unsupported authentication type %q", authType)
 	}
 	return nil, nil
+}
+
+// HasDigest returns whether the provided image name contains a digest.
+func HasDigest(imageName string) bool {
+	_, err := name.NewDigest(imageName)
+	return err == nil
 }
 
 // FetchPackage fetches the package from the OCI repository and write it to the destination.

--- a/pkg/oci/fetcher_test.go
+++ b/pkg/oci/fetcher_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasDigest(t *testing.T) {
+	testCases := map[string]struct {
+		input  string
+		output bool
+	}{
+		"tag and digest": {
+			input:  "gcr.io/foo/bar:v1.0.0@sha256:c8c72263b8ca7c22578d1a56373c5dd7d9ac33ef12faf7bea4945c89ef607e75",
+			output: true,
+		},
+		"tag": {
+			input:  "gcr.io/foo/bar:v1.0.0",
+			output: false,
+		},
+		"digest": {
+			input:  "gcr.io/foo/bar@sha256:c8c72263b8ca7c22578d1a56373c5dd7d9ac33ef12faf7bea4945c89ef607e75",
+			output: true,
+		},
+		"invalid": {
+			input:  "some/other/thing",
+			output: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.output, HasDigest(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
If the image reference in the RSync spec contains a fully specified image with digest, it can be assumed that the image is immutable. Thus, after a single successful sync the oci-sync container does not need to continue polling.

This is implemented as a long sleep for now, since exiting the container would cause a crashloop. If oci-sync is integrated as a k8s sidecar container, then we can change this to exit.