### PR TITLE
Fix remediator to catch conflicts during apply

### DIFF
--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -120,6 +120,13 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 		if err != nil {
 			return err
 		}
+		// Add new resources to the watch list, without removing old ones.
+		// This ensures controller conflicts are caught while the applier is running.
+		declaredGVKs, _ := u.Resources.DeclaredGVKs()
+		err = u.addWatches(ctx, declaredGVKs)
+		if err != nil {
+			return err
+		}
 		// Only mark the declared resources as updated if there were no (non-blocking) parse errors.
 		// This ensures the update will be retried until parsing fully succeeds.
 		if cache.parserErrs == nil {
@@ -143,7 +150,7 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 	// Update the resource watches (triggers for the Remediator).
 	if !cache.watchesUpdated {
 		declaredGVKs, _ := u.Resources.DeclaredGVKs()
-		err := u.watch(ctx, declaredGVKs)
+		err := u.updateWatches(ctx, declaredGVKs)
 		if err != nil {
 			return err
 		}
@@ -213,9 +220,23 @@ func (u *Updater) apply(ctx context.Context, objs []client.Object, commit string
 	return nil
 }
 
-// watch updates the Remediator's watches to start new ones and stop old
-// ones.
-func (u *Updater) watch(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
+// addWatches tells the Remediator to watch additional resources without
+// stopping any.
+func (u *Updater) addWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
+	klog.V(1).Info("Remediator watches adding...")
+	watchErrs := u.Remediator.AddWatches(ctx, gvks)
+	u.SyncErrorCache.SetWatchErrs(watchErrs)
+	if watchErrs != nil {
+		klog.Warningf("Failed to add resource watches: %v", watchErrs)
+		return watchErrs
+	}
+	klog.V(3).Info("Remediator watches added")
+	return nil
+}
+
+// updateWatches tells the Remediator to watch additional resources and stop
+// watching any old resources that were removed from the apply set.
+func (u *Updater) updateWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
 	klog.V(1).Info("Remediator watches updating...")
 	watchErrs := u.Remediator.UpdateWatches(ctx, gvks)
 	u.SyncErrorCache.SetWatchErrs(watchErrs)

--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -29,6 +29,7 @@ import (
 type Remediator struct {
 	ManagementConflictOutput bool
 	Watches                  map[schema.GroupVersionKind]struct{}
+	AddWatchesError          status.MultiError
 	UpdateWatchesError       status.MultiError
 	Watching                 bool
 	Paused                   bool
@@ -59,6 +60,19 @@ func (r *Remediator) Pause() {
 // Resume fakes remediator.Remediator.Resume
 func (r *Remediator) Resume() {
 	r.Paused = false
+}
+
+// AddWatches fakes remediator.Remediator.AddWatches
+func (r *Remediator) AddWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
+	r.Watching = true
+	if r.Watches == nil {
+		r.Watches = watches
+	} else {
+		for gvk := range watches {
+			r.Watches[gvk] = struct{}{}
+		}
+	}
+	return r.AddWatchesError
 }
 
 // UpdateWatches fakes remediator.Remediator.UpdateWatches

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -79,6 +79,9 @@ type Interface interface {
 	// NeedsUpdate returns true if the Remediator needs its watches to be updated
 	// (typically due to some asynchronous error that occurred).
 	NeedsUpdate() bool
+	// AddWatches starts server-side watches based upon the given map of GVKs
+	// which should be watched.
+	AddWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
 	// UpdateWatches starts and stops server-side watches based upon the given map
 	// of GVKs which should be watched.
 	UpdateWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
@@ -224,6 +227,11 @@ func (r *Remediator) Resume() {
 // NeedsUpdate implements Interface.
 func (r *Remediator) NeedsUpdate() bool {
 	return r.watchMgr.NeedsUpdate()
+}
+
+// AddWatches implements Interface.
+func (r *Remediator) AddWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
+	return r.watchMgr.AddWatches(ctx, gvks)
 }
 
 // UpdateWatches implements Interface.


### PR DESCRIPTION
This fix starts new watches before applying, to ensure that conflicts on existing objects are caught by the remediator immediately after the applier mutates an object and before the whole apply set has succeeded and reconciled.

This is only a partial fix. It doesn't work for custom resources which are applid with their CRD in the same ApplySet. To resolve that case, we will need to asynchronously start watches when the resource is available, which we can add later.