### PR TITLE
test: update kind to use in-memory etcd

### DIFF
--- a/e2e/nomostest/clusters/kind.go
+++ b/e2e/nomostest/clusters/kind.go
@@ -186,12 +186,13 @@ func createKindCluster(p *cluster.Provider, name, kcfgPath string, version KindV
 				},
 				// Enable ValidatingAdmissionWebhooks in the Kind cluster, as these
 				// are disabled by default.
+				// Also mount etcd to tmpfs for memory-backed storage.
 				KubeadmConfigPatches: []string{
 					`
-apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
-metadata:
-  name: config
+etcd:
+  local:
+    dataDir: /tmp/etcd
 apiServer:
   extraArgs:
     "enable-admission-plugins": "ValidatingAdmissionWebhook"`,


### PR DESCRIPTION
This updates the ClusterConfiguration used to provision kind clusters to mount etcd to a volume backed by tmpfs. This provides memory backed storage for faster i/o.

See: https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420