### PR TITLE
fix: remediator management conflict detection

### DIFF
--- a/pkg/remediator/conflict/handler.go
+++ b/pkg/remediator/conflict/handler.go
@@ -37,6 +37,8 @@ type Handler interface {
 	ConflictErrors() []status.ManagementConflictError
 	// HasConflictErrors returns true when there are conflict errors
 	HasConflictErrors() bool
+	// HasConflictError returns true when there is a conflict for the specified object ID.
+	HasConflictError(core.ID) bool
 }
 
 // handler implements Handler.
@@ -73,6 +75,15 @@ func (h *handler) AddConflictError(id core.ID, newErr status.ManagementConflictE
 	}
 
 	h.conflictErrs.Set(id, newErr)
+}
+
+// HasConflictError returns true when there is a conflict for the specified object ID.
+func (h *handler) HasConflictError(id core.ID) bool {
+	h.mux.RLock()
+	defer h.mux.RUnlock()
+
+	_, found := h.conflictErrs.Get(id)
+	return found
 }
 
 func (h *handler) RemoveConflictError(id core.ID) {

--- a/pkg/remediator/reconcile/worker.go
+++ b/pkg/remediator/reconcile/worker.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
+	"kpt.dev/configsync/pkg/remediator/conflict"
 	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/status"
 	syncerclient "kpt.dev/configsync/pkg/syncer/client"
@@ -42,10 +43,10 @@ type Worker struct {
 
 // NewWorker returns a new Worker for the given queue and declared resources.
 func NewWorker(scope declared.Scope, syncName string, a syncerreconcile.Applier,
-	q *queue.ObjectQueue, d *declared.Resources, fh fight.Handler) *Worker {
+	q *queue.ObjectQueue, d *declared.Resources, ch conflict.Handler, fh fight.Handler) *Worker {
 	return &Worker{
 		objectQueue: q,
-		reconciler:  newReconciler(scope, syncName, a, d, fh),
+		reconciler:  newReconciler(scope, syncName, a, d, ch, fh),
 	}
 }
 

--- a/pkg/remediator/reconcile/worker_test.go
+++ b/pkg/remediator/reconcile/worker_test.go
@@ -135,7 +135,8 @@ func TestWorker_Run_Remediates(t *testing.T) {
 			c := testingfake.NewClient(t, core.Scheme, tc.existingObjs...)
 
 			d := makeDeclared(t, randomCommitHash(), tc.declaredObjs...)
-			w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d, syncertestfake.NewFightHandler())
+			w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d,
+				syncertestfake.NewConflictHandler(), syncertestfake.NewFightHandler())
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -239,7 +240,8 @@ func TestWorker_Run_RemediatesExisting(t *testing.T) {
 	}
 
 	d := makeDeclared(t, randomCommitHash(), declaredObjs...)
-	w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d, syncertestfake.NewFightHandler())
+	w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d,
+		syncertestfake.NewConflictHandler(), syncertestfake.NewFightHandler())
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -347,7 +349,8 @@ func TestWorker_ProcessNextObject(t *testing.T) {
 			}
 
 			d := makeDeclared(t, randomCommitHash(), tc.declared...)
-			w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d, syncertestfake.NewFightHandler())
+			w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d,
+				syncertestfake.NewConflictHandler(), syncertestfake.NewFightHandler())
 
 			for _, obj := range tc.toProcess {
 				if err := w.processNextObject(context.Background()); err != nil {
@@ -367,7 +370,8 @@ func TestWorker_Run_CancelledWhenEmpty(t *testing.T) {
 	defer q.ShutDown()
 	c := testingfake.NewClient(t, core.Scheme)
 	d := makeDeclared(t, randomCommitHash()) // no resources declared
-	w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d, syncertestfake.NewFightHandler())
+	w := NewWorker(declared.RootScope, configsync.RootSyncName, c.Applier(configsync.FieldManager), q, d,
+		syncertestfake.NewConflictHandler(), syncertestfake.NewFightHandler())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -434,7 +438,8 @@ func TestWorker_Run_CancelledWhenNotEmpty(t *testing.T) {
 	c := testingfake.NewClient(t, core.Scheme, existingObjs...)
 	d := makeDeclared(t, randomCommitHash(), declaredObjs...)
 	a := &testingfake.Applier{Client: c, FieldManager: configsync.FieldManager}
-	w := NewWorker(declared.RootScope, configsync.RootSyncName, a, q, d, syncertestfake.NewFightHandler())
+	w := NewWorker(declared.RootScope, configsync.RootSyncName, a, q, d,
+		syncertestfake.NewConflictHandler(), syncertestfake.NewFightHandler())
 
 	// Run worker in the background
 	doneCh := make(chan struct{})

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -107,7 +107,7 @@ func New(
 	q := queue.New(scope.String())
 	workers := make([]*reconcile.Worker, numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		workers[i] = reconcile.NewWorker(scope, syncName, applier, q, decls, fightHandler)
+		workers[i] = reconcile.NewWorker(scope, syncName, applier, q, decls, conflictHandler, fightHandler)
 	}
 
 	remediator := &Remediator{

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -434,8 +434,6 @@ func (w *filteredWatcher) shouldProcess(object client.Object) bool {
 
 	// Process the resource if we are the manager regardless if it is declared or not.
 	if diff.IsManager(w.scope, w.syncName, object) {
-		// TODO: Remove conflict error AFTER it has been resolved, not before.
-		w.conflictHandler.RemoveConflictError(id)
 		return true
 	}
 
@@ -458,8 +456,6 @@ func (w *filteredWatcher) shouldProcess(object client.Object) bool {
 	}
 
 	if diff.CanManage(w.scope, w.syncName, object, diff.OperationManage) {
-		// TODO: Remove conflict error AFTER it has been resolved, not before.
-		w.conflictHandler.RemoveConflictError(id)
 		return true
 	}
 

--- a/pkg/syncer/syncertest/fake/conflict_handler.go
+++ b/pkg/syncer/syncertest/fake/conflict_handler.go
@@ -27,6 +27,11 @@ type ConflictHandler struct{}
 // AddConflictError is a fake implementation of AddConflictError of conflict.Handler.
 func (h *ConflictHandler) AddConflictError(core.ID, status.ManagementConflictError) {}
 
+// HasConflictError is a fake implementation of HasConflictError of conflict.Handler.
+func (h *ConflictHandler) HasConflictError(_ core.ID) bool {
+	return false
+}
+
 // RemoveConflictError is a fake implementation of the RemoveConflictError of conflict.Handler.
 func (h *ConflictHandler) RemoveConflictError(core.ID) {
 }


### PR DESCRIPTION
- Change the remediator worker to detect management conflicts.
  This fixes a bug when using watch filtering where conflicts
  may be ignored for objects that were "deleted" by having the
  required label removed after being successfully applied by
  the applier but before being remediated.
- Change the remediator worker to clear management conflicts.
  This fixes a bug where the conflict error might be prematurely
  removed from the status and then not actually resolved,
  causing the error to flap.

Depends on https://github.com/GoogleContainerTools/kpt-config-sync/pull/1354