### PR TITLE
refactor: rename fake package

### DIFF
--- a/cmd/nomos/status/cluster_state_test.go
+++ b/cmd/nomos/status/cluster_state_test.go
@@ -27,7 +27,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1494,7 +1494,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:          "[accurate status before syncing condition is supported] repo is synced",
 			gitSpec:       git,
-			resourceGroup: fake.ResourceGroupObject(core.Namespace("bookstore"), core.Name("repo-sync"), withResources()),
+			resourceGroup: k8sobjects.ResourceGroupObject(core.Namespace("bookstore"), core.Name("repo-sync"), withResources()),
 			conditions:    []v1beta1.RepoSyncCondition{reconciledCondition},
 			renderingStatus: v1beta1.RenderingStatus{
 				Git:     toGitStatus(git),
@@ -1524,7 +1524,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 		{
 			name:                      "[accurate status with syncing condition supported] repo is synced",
 			gitSpec:                   git,
-			resourceGroup:             fake.ResourceGroupObject(core.Namespace("bookstore"), core.Name("repo-sync"), withResourcesAndCommit("abc123")),
+			resourceGroup:             k8sobjects.ResourceGroupObject(core.Namespace("bookstore"), core.Name("repo-sync"), withResourcesAndCommit("abc123")),
 			syncingConditionSupported: true,
 			conditions: []v1beta1.RepoSyncCondition{
 				reconciledCondition,
@@ -1771,7 +1771,7 @@ func TestRepoState_NamespaceRepoStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			repoSync := fake.RepoSyncObjectV1Beta1("bookstore", configsync.RepoSyncName)
+			repoSync := k8sobjects.RepoSyncObjectV1Beta1("bookstore", configsync.RepoSyncName)
 			repoSync.Spec.Git = tc.gitSpec
 			repoSync.Spec.Oci = tc.ociSpec
 			if tc.helmSpec != nil {
@@ -2842,7 +2842,7 @@ func TestRepoState_RootRepoStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+			rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 			rootSync.Spec.Git = tc.gitSpec
 			rootSync.Status.Conditions = tc.conditions
 			rootSync.Status.Source = tc.sourceStatus

--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -24,6 +24,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/hnc"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
@@ -42,7 +43,6 @@ import (
 	"kpt.dev/configsync/pkg/parse"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/client"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/clusterconfig"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	"kpt.dev/configsync/pkg/vet"
@@ -82,44 +82,44 @@ func Generate() AllExamples {
 	result.add(validation.IllegalNamespaceSubdirectoryError(node("namespaces/foo/bar"), node("namespaces/foo")))
 
 	// 1004
-	result.add(nonhierarchical.IllegalNamespaceSelectorAnnotationError(fake.Namespace("namespaces/foo")))
-	result.add(nonhierarchical.IllegalClusterSelectorAnnotationError(fake.Cluster(), csmetadata.ClusterNameSelectorAnnotationKey))
+	result.add(nonhierarchical.IllegalNamespaceSelectorAnnotationError(k8sobjects.Namespace("namespaces/foo")))
+	result.add(nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.Cluster(), csmetadata.ClusterNameSelectorAnnotationKey))
 
 	// 1005
-	result.add(nonhierarchical.IllegalManagementAnnotationError(fake.Role(), "invalid"))
+	result.add(nonhierarchical.IllegalManagementAnnotationError(k8sobjects.Role(), "invalid"))
 
 	// 1006
-	result.add(status.ObjectParseError(fake.Role(), errors.New("wrong type")))
+	result.add(status.ObjectParseError(k8sobjects.Role(), errors.New("wrong type")))
 
 	// 1007
-	result.add(validation.IllegalAbstractNamespaceObjectKindError(fake.RoleAtPath("namespaces/foo/bar/role.yaml")))
+	result.add(validation.IllegalAbstractNamespaceObjectKindError(k8sobjects.RoleAtPath("namespaces/foo/bar/role.yaml")))
 
 	// 1008 is Deprecated.
 	result.markDeprecated("1008")
 
 	// 1009
 	result.add(metadata.IllegalMetadataNamespaceDeclarationError(
-		fake.RoleAtPath("namespaces/foo/r.yaml", core.Namespace("bar")), "foo"))
+		k8sobjects.RoleAtPath("namespaces/foo/r.yaml", core.Namespace("bar")), "foo"))
 
 	// 1010
-	result.add(metadata.IllegalAnnotationDefinitionError(fake.Role(), []string{csmetadata.ConfigManagementPrefix + "illegal-annotation"}))
+	result.add(metadata.IllegalAnnotationDefinitionError(k8sobjects.Role(), []string{csmetadata.ConfigManagementPrefix + "illegal-annotation"}))
 
 	// 1011
-	result.add(metadata.IllegalLabelDefinitionError(fake.Role(), []string{csmetadata.ConfigManagementPrefix + "label"}))
+	result.add(metadata.IllegalLabelDefinitionError(k8sobjects.Role(), []string{csmetadata.ConfigManagementPrefix + "label"}))
 
 	// 1012 is Deprecated.
 	result.markDeprecated("1012")
 
 	// 1013
-	result.add(selectors.ObjectHasUnknownClusterSelector(fake.Role(), "undeclared-selector"))
-	result.add(selectors.ObjectHasUnknownNamespaceSelector(fake.Role(), "undeclared-selector"))
+	result.add(selectors.ObjectHasUnknownClusterSelector(k8sobjects.Role(), "undeclared-selector"))
+	result.add(selectors.ObjectHasUnknownNamespaceSelector(k8sobjects.Role(), "undeclared-selector"))
 	result.add(selectors.ObjectNotInNamespaceSelectorSubdirectory(
-		fake.RoleAtPath("namespaces/foo/role.yaml"),
-		fake.NamespaceSelectorAtPathWithName("namespaces/bar/selector.yaml", "default-ns-selector")))
+		k8sobjects.RoleAtPath("namespaces/foo/role.yaml"),
+		k8sobjects.NamespaceSelectorAtPathWithName("namespaces/bar/selector.yaml", "default-ns-selector")))
 
 	// 1014
-	result.add(selectors.InvalidSelectorError(fake.NamespaceSelector(), errors.New("some parse error")))
-	result.add(selectors.EmptySelectorError(fake.NamespaceSelector()))
+	result.add(selectors.InvalidSelectorError(k8sobjects.NamespaceSelector(), errors.New("some parse error")))
+	result.add(selectors.EmptySelectorError(k8sobjects.NamespaceSelector()))
 
 	// 1015 is Deprecated.
 	result.markDeprecated("1015")
@@ -134,13 +134,13 @@ func Generate() AllExamples {
 	result.markDeprecated("1018")
 
 	// 1019
-	result.add(metadata.IllegalTopLevelNamespaceError(fake.Namespace("namespaces")))
+	result.add(metadata.IllegalTopLevelNamespaceError(k8sobjects.Namespace("namespaces")))
 
 	// 1020
-	result.add(metadata.InvalidNamespaceNameError(fake.Namespace("namespaces/foo", core.Name("bar")), "foo"))
+	result.add(metadata.InvalidNamespaceNameError(k8sobjects.Namespace("namespaces/foo", core.Name("bar")), "foo"))
 
 	// 1021
-	result.add(status.UnknownObjectKindError(fake.UnstructuredAtPath(schema.GroupVersionKind{
+	result.add(status.UnknownObjectKindError(k8sobjects.UnstructuredAtPath(schema.GroupVersionKind{
 		Group:   "com.me",
 		Version: "v1",
 		Kind:    "Engineer",
@@ -162,7 +162,7 @@ func Generate() AllExamples {
 	result.markDeprecated("1026")
 
 	// 1027
-	result.add(system.UnsupportedRepoSpecVersion(fake.Repo(fake.RepoVersion("")), "0.0.0"))
+	result.add(system.UnsupportedRepoSpecVersion(k8sobjects.Repo(k8sobjects.RepoVersion("")), "0.0.0"))
 
 	// 1028
 	result.add(syntax.ReservedDirectoryNameError(cmpath.RelativeSlash("namespaces/" + configmanagement.ControllerNamespace)))
@@ -170,89 +170,89 @@ func Generate() AllExamples {
 
 	// 1029
 	result.add(nonhierarchical.NamespaceCollisionError("qux",
-		fake.Namespace("namespaces/foo/qux"),
-		fake.Namespace("namespaces/bar/qux")))
+		k8sobjects.Namespace("namespaces/foo/qux"),
+		k8sobjects.Namespace("namespaces/bar/qux")))
 	result.add(nonhierarchical.NamespaceMetadataNameCollisionError(kinds.Role().GroupKind(),
 		"backend", "admin",
-		fake.RoleAtPath("namespaces/backend/admin-1.yaml", core.Namespace("backend"), core.Name("admin")),
-		fake.RoleAtPath("namespaces/backend/admin-2.yaml", core.Namespace("backend"), core.Name("admin")),
-		fake.RoleAtPath("namespaces/backend/admin-3.yaml", core.Namespace("backend"), core.Name("admin")),
+		k8sobjects.RoleAtPath("namespaces/backend/admin-1.yaml", core.Namespace("backend"), core.Name("admin")),
+		k8sobjects.RoleAtPath("namespaces/backend/admin-2.yaml", core.Namespace("backend"), core.Name("admin")),
+		k8sobjects.RoleAtPath("namespaces/backend/admin-3.yaml", core.Namespace("backend"), core.Name("admin")),
 	))
 	result.add(nonhierarchical.ClusterMetadataNameCollisionError(kinds.ClusterRole().GroupKind(),
 		"cluster-admin",
-		fake.ClusterRoleAtPath("cluster/admin-1.yaml", core.Name("cluster-admin")),
-		fake.ClusterRoleAtPath("cluster/admin-2.yaml", core.Name("cluster-admin")),
+		k8sobjects.ClusterRoleAtPath("cluster/admin-1.yaml", core.Name("cluster-admin")),
+		k8sobjects.ClusterRoleAtPath("cluster/admin-2.yaml", core.Name("cluster-admin")),
 	))
 
 	// 1030
-	result.add(semantic.MultipleSingletonsError(fake.Namespace("namespaces/foo"), fake.Namespace("namespaces/foo")))
+	result.add(semantic.MultipleSingletonsError(k8sobjects.Namespace("namespaces/foo"), k8sobjects.Namespace("namespaces/foo")))
 
 	// 1031
-	result.add(nonhierarchical.MissingObjectNameError(fake.Role(core.Name(""))))
+	result.add(nonhierarchical.MissingObjectNameError(k8sobjects.Role(core.Name(""))))
 
 	// 1032
-	result.add(nonhierarchical.IllegalHierarchicalKind(fake.Repo()))
+	result.add(nonhierarchical.IllegalHierarchicalKind(k8sobjects.Repo()))
 
 	// 1033
-	result.add(syntax.IllegalSystemResourcePlacementError(fake.RepoAtPath("namespaces/repo.yaml")))
-	result.add(syntax.IllegalSystemResourcePlacementError(fake.HierarchyConfigAtPath("system/hierarchy-config.yaml")))
+	result.add(syntax.IllegalSystemResourcePlacementError(k8sobjects.RepoAtPath("namespaces/repo.yaml")))
+	result.add(syntax.IllegalSystemResourcePlacementError(k8sobjects.HierarchyConfigAtPath("system/hierarchy-config.yaml")))
 
 	// 1034
-	result.add(nonhierarchical.IllegalNamespace(fake.Namespace("namespaces/" + configmanagement.ControllerNamespace)))
+	result.add(nonhierarchical.IllegalNamespace(k8sobjects.Namespace("namespaces/" + configmanagement.ControllerNamespace)))
 
 	// 1035 is Deprecated.
 	result.markDeprecated("1035")
 
 	// 1036
-	result.add(nonhierarchical.InvalidMetadataNameError(fake.Role(core.Name("ABC"))))
+	result.add(nonhierarchical.InvalidMetadataNameError(k8sobjects.Role(core.Name("ABC"))))
 
 	// 1037 is Deprecated.
 	result.markDeprecated("1037")
 
 	// 1038
-	result.add(syntax.IllegalKindInNamespacesError(fake.NamespaceSelectorAtPath("namespaces/foo/ns-selector.yaml")))
+	result.add(syntax.IllegalKindInNamespacesError(k8sobjects.NamespaceSelectorAtPath("namespaces/foo/ns-selector.yaml")))
 
 	// 1039
-	result.add(validation.ShouldBeInSystemError(fake.RepoAtPath("namespaces/repo.yaml")))
-	result.add(validation.ShouldBeInClusterRegistryError(fake.ClusterAtPath("namespaces/cluster.yaml")))
-	result.add(validation.ShouldBeInClusterError(fake.ClusterRoleAtPath("namespaces/clusterrole.yaml")))
-	result.add(validation.ShouldBeInNamespacesError(fake.RoleAtPath("cluster/role.yaml")))
+	result.add(validation.ShouldBeInSystemError(k8sobjects.RepoAtPath("namespaces/repo.yaml")))
+	result.add(validation.ShouldBeInClusterRegistryError(k8sobjects.ClusterAtPath("namespaces/cluster.yaml")))
+	result.add(validation.ShouldBeInClusterError(k8sobjects.ClusterRoleAtPath("namespaces/clusterrole.yaml")))
+	result.add(validation.ShouldBeInNamespacesError(k8sobjects.RoleAtPath("cluster/role.yaml")))
 
 	// 1040 is Deprecated.
 	result.markDeprecated("1040")
 
 	// 1041
-	result.add(hierarchyconfig.UnsupportedResourceInHierarchyConfigError(fake.HierarchyConfig(), kinds.Namespace().GroupKind()))
+	result.add(hierarchyconfig.UnsupportedResourceInHierarchyConfigError(k8sobjects.HierarchyConfig(), kinds.Namespace().GroupKind()))
 
 	// 1042
-	result.add(hierarchyconfig.IllegalHierarchyModeError(fake.HierarchyConfig(), kinds.Role().GroupKind(), "invalid"))
+	result.add(hierarchyconfig.IllegalHierarchyModeError(k8sobjects.HierarchyConfig(), kinds.Role().GroupKind(), "invalid"))
 
 	// 1043
-	result.add(nonhierarchical.UnsupportedObjectError(fake.CustomResourceDefinitionV1Beta1()))
-	result.add(nonhierarchical.UnsupportedObjectError(fake.CustomResourceDefinitionV1()))
+	result.add(nonhierarchical.UnsupportedObjectError(k8sobjects.CustomResourceDefinitionV1Beta1()))
+	result.add(nonhierarchical.UnsupportedObjectError(k8sobjects.CustomResourceDefinitionV1()))
 
 	// 1044
 	result.add(semantic.UnsyncableResourcesInLeaf(node("namespaces/foo")))
 	result.add(semantic.UnsyncableResourcesInNonLeaf(node("namespaces/foo")))
 
 	// 1045
-	result.add(syntax.IllegalFieldsInConfigError(fake.Role(), id.Status))
+	result.add(syntax.IllegalFieldsInConfigError(k8sobjects.Role(), id.Status))
 
 	// 1046
-	result.add(hierarchyconfig.ClusterScopedResourceInHierarchyConfigError(fake.HierarchyConfig(), kinds.ClusterRole().GroupKind()))
+	result.add(hierarchyconfig.ClusterScopedResourceInHierarchyConfigError(k8sobjects.HierarchyConfig(), kinds.ClusterRole().GroupKind()))
 
 	// 1047
-	result.add(nonhierarchical.UnsupportedCRDRemovalError(fake.CustomResourceDefinitionV1Beta1()))
+	result.add(nonhierarchical.UnsupportedCRDRemovalError(k8sobjects.CustomResourceDefinitionV1Beta1()))
 
 	// 1048
-	result.add(nonhierarchical.InvalidCRDNameError(fake.CustomResourceDefinitionV1Beta1(), "default-names.apiextensions.k8s.io"))
+	result.add(nonhierarchical.InvalidCRDNameError(k8sobjects.CustomResourceDefinitionV1Beta1(), "default-names.apiextensions.k8s.io"))
 
 	// 1049 is Deprecated.
 	result.markDeprecated("1049")
 
 	// 1050
 	result.add(nonhierarchical.DeprecatedGroupKindError(
-		fake.UnstructuredAtPath(schema.GroupVersionKind{
+		k8sobjects.UnstructuredAtPath(schema.GroupVersionKind{
 			Group:   "extensions",
 			Version: "v1beta1",
 			Kind:    kinds.Deployment().Kind,
@@ -262,34 +262,34 @@ func Generate() AllExamples {
 	result.markDeprecated("1051")
 
 	// 1052
-	result.add(nonhierarchical.IllegalNamespaceOnClusterScopedResourceError(fake.ClusterRole(core.Namespace("foo"))))
+	result.add(nonhierarchical.IllegalNamespaceOnClusterScopedResourceError(k8sobjects.ClusterRole(core.Namespace("foo"))))
 
 	// 1053
-	result.add(nonhierarchical.MissingNamespaceOnNamespacedResourceError(fake.Role(core.Namespace(""))))
+	result.add(nonhierarchical.MissingNamespaceOnNamespacedResourceError(k8sobjects.Role(core.Namespace(""))))
 
 	// 1054
-	result.add(reader.InvalidAnnotationValueError(fake.Role(), []string{"foo", "bar"}))
+	result.add(reader.InvalidAnnotationValueError(k8sobjects.Role(), []string{"foo", "bar"}))
 
 	// 1055
-	result.add(nonhierarchical.InvalidNamespaceError(fake.Repo(core.Namespace("FOO"))))
+	result.add(nonhierarchical.InvalidNamespaceError(k8sobjects.Repo(core.Namespace("FOO"))))
 
 	// 1056
-	result.add(nonhierarchical.ManagedResourceInUnmanagedNamespace("foo", fake.Role()))
+	result.add(nonhierarchical.ManagedResourceInUnmanagedNamespace("foo", k8sobjects.Role()))
 
 	// 1057
-	result.add(hnc.IllegalDepthLabelError(fake.Role(), []string{"label" + csmetadata.DepthSuffix}))
+	result.add(hnc.IllegalDepthLabelError(k8sobjects.Role(), []string{"label" + csmetadata.DepthSuffix}))
 
 	// 1058
-	result.add(parse.BadScopeErr(fake.Role(core.Namespace("shipping")), "dev"))
+	result.add(parse.BadScopeErr(k8sobjects.Role(core.Namespace("shipping")), "dev"))
 
 	// 1059 is Deprecated.
 	result.markDeprecated("1059")
 
 	// 1060
-	result.add(status.ManagementConflictErrorWrap(fake.Role(), declared.ResourceManager(declared.RootScope, configsync.RootSyncName)))
+	result.add(status.ManagementConflictErrorWrap(k8sobjects.Role(), declared.ResourceManager(declared.RootScope, configsync.RootSyncName)))
 
 	// 1061
-	result.add(validate.MissingGitRepo(fake.RepoSyncObjectV1Beta1("bookstore", configsync.RepoSyncName)))
+	result.add(validate.MissingGitRepo(k8sobjects.RepoSyncObjectV1Beta1("bookstore", configsync.RepoSyncName)))
 
 	// 1062 is Deprecated.
 	result.markDeprecated("1062")
@@ -306,20 +306,20 @@ func Generate() AllExamples {
 	// 1065
 	result.add(clusterconfig.MalformedCRDError(
 		fmt.Errorf("spec.names.shortNames accessor error: foo is of the type string, expected []interface{}"),
-		fake.CustomResourceDefinitionV1Object()))
+		k8sobjects.CustomResourceDefinitionV1Object()))
 
 	// 1066
-	result.add(selectors.ClusterSelectorAnnotationConflictError(fake.NamespaceObject("my-namespace")))
+	result.add(selectors.ClusterSelectorAnnotationConflictError(k8sobjects.NamespaceObject("my-namespace")))
 
 	// 1067
-	result.add(status.EncodeDeclaredFieldError(fake.NamespaceObject("my-namespace"),
+	result.add(status.EncodeDeclaredFieldError(k8sobjects.NamespaceObject("my-namespace"),
 		fmt.Errorf(".spec.version not defined")))
 
 	// 1068
 	result.add(status.HydrationError(status.ActionableHydrationErrorCode, errors.New("user actionable rendering error")))
 
 	// 1069
-	result.add(validate.SelfReconcileError(fake.RootSyncV1Beta1(configsync.RootSyncName)))
+	result.add(validate.SelfReconcileError(k8sobjects.RootSyncV1Beta1(configsync.RootSyncName)))
 
 	// 2001
 	result.add(status.PathWrapError(errors.New("error creating directory"), "namespaces/foo"))
@@ -334,7 +334,7 @@ func Generate() AllExamples {
 	result.add(status.SourceError.Sprint("unable to connect to Git repository").Build())
 
 	// 2005
-	result.add(status.FightError(9.5, fake.NamespaceObject("gatekeeper-system")))
+	result.add(status.FightError(9.5, k8sobjects.NamespaceObject("gatekeeper-system")))
 
 	// 2006
 	result.add(status.EmptySourceError(10, "namespaces"))
@@ -344,22 +344,22 @@ func Generate() AllExamples {
 	result.markDeprecated("2007")
 
 	// 2008
-	result.add(client.ConflictCreateAlreadyExists(errors.New("already exists"), fake.RoleObject()))
-	result.add(client.ConflictUpdateOldVersion(errors.New("old version"), fake.RoleObject()))
-	result.add(client.ConflictUpdateDoesNotExist(errors.New("does not exist"), fake.RoleObject()))
+	result.add(client.ConflictCreateAlreadyExists(errors.New("already exists"), k8sobjects.RoleObject()))
+	result.add(client.ConflictUpdateOldVersion(errors.New("old version"), k8sobjects.RoleObject()))
+	result.add(client.ConflictUpdateDoesNotExist(errors.New("does not exist"), k8sobjects.RoleObject()))
 
 	// 2009
 	result.add(applier.Error(errors.New("failed to initialize an error")))
 
 	// 2010
-	result.add(status.ResourceWrap(errors.New("specific problem with resource"), "general message", fake.Role()))
+	result.add(status.ResourceWrap(errors.New("specific problem with resource"), "general message", k8sobjects.Role()))
 
 	// 2011
 	result.add(status.MissingResourceWrap(errors.New("the Role 'foo' in Namespace 'bar' was not found"),
-		"unable to update resource", fake.Role(core.Name("foo"), core.Namespace("bar"))))
+		"unable to update resource", k8sobjects.Role(core.Name("foo"), core.Namespace("bar"))))
 
 	// 2012
-	result.add(status.MultipleSingletonsError(fake.Repo(), fake.Repo()))
+	result.add(status.MultipleSingletonsError(k8sobjects.Repo(), k8sobjects.Repo()))
 
 	// 2013
 	result.add(status.InsufficientPermissionErrorBuilder.Sprint("could not create resources").Wrap(

--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -26,8 +26,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/gitproviders"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -111,11 +111,11 @@ func gitServer() []client.Object {
 }
 
 func gitNamespace() *corev1.Namespace {
-	return fake.NamespaceObject(testGitNamespace)
+	return k8sobjects.NamespaceObject(testGitNamespace)
 }
 
 func gitService() *corev1.Service {
-	service := fake.ServiceObject(
+	service := k8sobjects.ServiceObject(
 		core.Name(testGitServer),
 		core.Namespace(testGitNamespace),
 	)
@@ -126,7 +126,7 @@ func gitService() *corev1.Service {
 }
 
 func gitDeployment() *appsv1.Deployment {
-	deployment := fake.DeploymentObject(core.Name(testGitServer),
+	deployment := k8sobjects.DeploymentObject(core.Name(testGitServer),
 		core.Namespace(testGitNamespace),
 		core.Labels(testGitServerSelector()),
 	)

--- a/e2e/nomostest/gitproviders/repository.go
+++ b/e2e/nomostest/gitproviders/repository.go
@@ -33,7 +33,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -630,7 +630,7 @@ func (g *Repository) MustHash(t testing.NTB) string {
 // AddSafetyNamespace adds a Namespace to prevent the mono-repo safety check
 // (KNV2006) from preventing deletion of other objects.
 func (g *Repository) AddSafetyNamespace() error {
-	return g.Add(g.SafetyNSPath, fake.NamespaceObject(g.SafetyNSName))
+	return g.Add(g.SafetyNSPath, k8sobjects.NamespaceObject(g.SafetyNSName))
 }
 
 // RemoveSafetyNamespace removes the safety Namespace.
@@ -641,7 +641,7 @@ func (g *Repository) RemoveSafetyNamespace() error {
 // AddSafetyClusterRole adds a ClusterRole to prevent the mono-repo safety check
 // (KNV2006) from preventing deletion of other objects.
 func (g *Repository) AddSafetyClusterRole() error {
-	return g.Add(g.SafetyClusterRolePath, fake.ClusterRoleObject(core.Name(g.SafetyClusterRoleName)))
+	return g.Add(g.SafetyClusterRolePath, k8sobjects.ClusterRoleObject(core.Name(g.SafetyClusterRoleName)))
 }
 
 // RemoveSafetyClusterRole removes the safety ClusterRole.
@@ -652,5 +652,5 @@ func (g *Repository) RemoveSafetyClusterRole() error {
 // AddRepoObject adds a system.repo.yaml under the specified directory path.
 // Use this for structured repositories.
 func (g *Repository) AddRepoObject(syncDir string) error {
-	return g.Add(filepath.Join(syncDir, "system", "repo.yaml"), fake.RepoObject())
+	return g.Add(filepath.Join(syncDir, "system", "repo.yaml"), k8sobjects.RepoObject())
 }

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -37,8 +37,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testshell"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -357,10 +357,10 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	})
 
 	// You can't add Secrets to Namespaces that don't exist, so create them now.
-	if err := nt.KubeClient.Create(fake.NamespaceObject(configmanagement.ControllerNamespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(configmanagement.ControllerNamespace)); err != nil {
 		nt.T.Fatal(err)
 	}
-	if err := nt.KubeClient.Create(fake.NamespaceObject(configmanagement.MonitoringNamespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(configmanagement.MonitoringNamespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -42,8 +42,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testshell"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util"
 	"kpt.dev/configsync/pkg/util/log"
 
@@ -908,7 +908,7 @@ func (nt *NT) detectClusterVersion() {
 
 // RepoSyncClusterRole returns the NS reconciler ClusterRole
 func (nt *NT) RepoSyncClusterRole() *rbacv1.ClusterRole {
-	cr := fake.ClusterRoleObject(core.Name(clusterRoleName))
+	cr := k8sobjects.ClusterRoleObject(core.Name(clusterRoleName))
 	cr.Rules = append(cr.Rules, nt.repoSyncPermissions...)
 	return cr
 }

--- a/e2e/nomostest/prometheus.go
+++ b/e2e/nomostest/prometheus.go
@@ -26,8 +26,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,7 +83,7 @@ func uninstallPrometheus(nt *NT) error {
 
 func prometheusObjects() []client.Object {
 	return []client.Object{
-		fake.NamespaceObject(prometheusNamespace),
+		k8sobjects.NamespaceObject(prometheusNamespace),
 		prometheusClusterRole(),
 		prometheusClusterRoleBinding(),
 		prometheusConfigMap(),
@@ -92,7 +92,7 @@ func prometheusObjects() []client.Object {
 }
 
 func prometheusClusterRole() client.Object {
-	clusterRole := fake.ClusterRoleObject(core.Name(prometheusClusterRoleName))
+	clusterRole := k8sobjects.ClusterRoleObject(core.Name(prometheusClusterRoleName))
 	clusterRole.Rules = []rbacv1.PolicyRule{
 		{
 			Verbs:     []string{"get", "list", "watch"},
@@ -119,7 +119,7 @@ func prometheusClusterRole() client.Object {
 }
 
 func prometheusClusterRoleBinding() client.Object {
-	clusterRole := fake.ClusterRoleBindingObject(core.Name(prometheusClusterRoleName))
+	clusterRole := k8sobjects.ClusterRoleBindingObject(core.Name(prometheusClusterRoleName))
 	clusterRole.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
@@ -136,7 +136,7 @@ func prometheusClusterRoleBinding() client.Object {
 }
 
 func prometheusConfigMap() client.Object {
-	configMap := fake.ConfigMapObject(core.Name(prometheusConfigMapName),
+	configMap := k8sobjects.ConfigMapObject(core.Name(prometheusConfigMapName),
 		core.Namespace(prometheusNamespace),
 		core.Labels(map[string]string{"name": prometheusConfigMapName}))
 	configMap.Data = map[string]string{
@@ -236,7 +236,7 @@ func prometheusServerSelector() map[string]string {
 }
 
 func prometheusDeployment() client.Object {
-	deployment := fake.DeploymentObject(core.Name(prometheusServerDeploymentName),
+	deployment := k8sobjects.DeploymentObject(core.Name(prometheusServerDeploymentName),
 		core.Namespace(prometheusNamespace),
 		core.Labels(prometheusServerSelector()),
 	)

--- a/e2e/nomostest/registry_server.go
+++ b/e2e/nomostest/registry_server.go
@@ -30,8 +30,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/registryproviders"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -76,7 +76,7 @@ func setupRegistry(nt *NT) error {
 		return err
 	}
 	if *e2e.OCIProvider == e2e.Local || *e2e.HelmProvider == e2e.Local {
-		if err := nt.KubeClient.Create(fake.NamespaceObject(TestRegistryNamespace)); err != nil {
+		if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(TestRegistryNamespace)); err != nil {
 			return err
 		}
 
@@ -219,7 +219,7 @@ func registryServer() []client.Object {
 // This service exposes a port which maps to the nginx endpoint which uses HTTPS
 // but does not require authentication
 func registryService() *v1.Service {
-	service := fake.ServiceObject(
+	service := k8sobjects.ServiceObject(
 		core.Name(TestRegistryServer),
 		core.Namespace(TestRegistryNamespace),
 	)
@@ -233,7 +233,7 @@ func registryService() *v1.Service {
 // This service exposes a port which maps to the nginx endpoint which requires
 // authentication (using contrived username/password)
 func registryServiceAuthenticated() *v1.Service {
-	service := fake.ServiceObject(
+	service := k8sobjects.ServiceObject(
 		core.Name(TestRegistryServerAuthenticated),
 		core.Namespace(TestRegistryNamespace),
 	)
@@ -245,7 +245,7 @@ func registryServiceAuthenticated() *v1.Service {
 }
 
 func nginxConfigMap() *v1.ConfigMap {
-	configMap := fake.ConfigMapObject(core.Name(nginxConfigMapName),
+	configMap := k8sobjects.ConfigMapObject(core.Name(nginxConfigMapName),
 		core.Namespace(TestRegistryNamespace),
 		core.Labels(testRegistryServerSelector()),
 	)
@@ -256,7 +256,7 @@ func nginxConfigMap() *v1.ConfigMap {
 }
 
 func registryDeployment() *appsv1.Deployment {
-	deployment := fake.DeploymentObject(core.Name(TestRegistryServer),
+	deployment := k8sobjects.DeploymentObject(core.Name(TestRegistryServer),
 		core.Namespace(TestRegistryNamespace),
 		core.Labels(testRegistryServerSelector()),
 	)

--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -29,10 +29,10 @@ import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/rootsync"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/repo"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
@@ -261,7 +261,7 @@ func (nt *NT) WaitForRootSyncSourceError(rsName, code string, message string, op
 	Wait(nt.T, fmt.Sprintf("RootSync %s source error code %s", rsName, code), nt.DefaultWaitTimeout,
 		func() error {
 			nt.T.Helper()
-			rs := fake.RootSyncObjectV1Beta1(rsName)
+			rs := k8sobjects.RootSyncObjectV1Beta1(rsName)
 			if err := nt.KubeClient.Get(rs.GetName(), rs.GetNamespace(), rs); err != nil {
 				return err
 			}
@@ -280,7 +280,7 @@ func (nt *NT) WaitForRootSyncSyncError(rsName, code string, message string, reso
 	Wait(nt.T, fmt.Sprintf("RootSync %s rendering error code %s", rsName, code), nt.DefaultWaitTimeout,
 		func() error {
 			nt.T.Helper()
-			rs := fake.RootSyncObjectV1Beta1(rsName)
+			rs := k8sobjects.RootSyncObjectV1Beta1(rsName)
 			err := nt.KubeClient.Get(rs.GetName(), rs.GetNamespace(), rs)
 			if err != nil {
 				return err
@@ -300,7 +300,7 @@ func (nt *NT) WaitForRepoSyncSyncError(ns, rsName, code string, message string, 
 	Wait(nt.T, fmt.Sprintf("RepoSync %s/%s rendering error code %s", ns, rsName, code), nt.DefaultWaitTimeout,
 		func() error {
 			nt.T.Helper()
-			rs := fake.RepoSyncObjectV1Beta1(ns, rsName)
+			rs := k8sobjects.RepoSyncObjectV1Beta1(ns, rsName)
 			err := nt.KubeClient.Get(rs.GetName(), rs.GetNamespace(), rs)
 			if err != nil {
 				return err
@@ -320,7 +320,7 @@ func (nt *NT) WaitForRepoSyncSourceError(ns, rsName, code, message string, opts 
 	Wait(nt.T, fmt.Sprintf("RepoSync %s/%s source error code %s", ns, rsName, code), nt.DefaultWaitTimeout,
 		func() error {
 			nt.T.Helper()
-			rs := fake.RepoSyncObjectV1Beta1(ns, rsName)
+			rs := k8sobjects.RepoSyncObjectV1Beta1(ns, rsName)
 			err := nt.KubeClient.Get(rs.GetName(), rs.GetNamespace(), rs)
 			if err != nil {
 				return err
@@ -419,7 +419,7 @@ func (nt *NT) WaitForRootSyncStalledError(rsNamespace, rsName, reason, message s
 					Name:      rsName,
 					Namespace: rsNamespace,
 				},
-				TypeMeta: fake.ToTypeMeta(kinds.RootSyncV1Beta1()),
+				TypeMeta: k8sobjects.ToTypeMeta(kinds.RootSyncV1Beta1()),
 			}
 			if err := nt.KubeClient.Get(rsName, rsNamespace, rs); err != nil {
 				return err
@@ -450,7 +450,7 @@ func (nt *NT) WaitForRepoSyncStalledError(rsNamespace, rsName, reason, message s
 					Name:      rsName,
 					Namespace: rsNamespace,
 				},
-				TypeMeta: fake.ToTypeMeta(kinds.RepoSyncV1Beta1()),
+				TypeMeta: k8sobjects.ToTypeMeta(kinds.RepoSyncV1Beta1()),
 			}
 			if err := nt.KubeClient.Get(rsName, rsNamespace, rs); err != nil {
 				return err

--- a/e2e/nomostest/webhook.go
+++ b/e2e/nomostest/webhook.go
@@ -21,8 +21,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/webhook/configuration"
 )
 
@@ -43,7 +43,7 @@ func StopWebhook(nt *NT) {
 		return
 	}
 	webhookName := configuration.Name
-	err := nt.KubeClient.Delete(fake.AdmissionWebhookObject(webhookName))
+	err := nt.KubeClient.Delete(k8sobjects.AdmissionWebhookObject(webhookName))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -28,10 +28,10 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	"kpt.dev/configsync/pkg/testing/fake"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
@@ -46,7 +46,7 @@ func TestAdmission(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
 
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml",
-		fake.NamespaceObject("hello", core.Annotation("goodbye", "moon"))))
+		k8sobjects.NamespaceObject("hello", core.Annotation("goodbye", "moon"))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -155,7 +155,7 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 	// Test starts with Admission Webhook already installed
 	nomostest.WaitForWebhookReadiness(nt)
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", fake.NamespaceObject("hello")))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", k8sobjects.NamespaceObject("hello")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add test namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -189,7 +189,7 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 
 	// The object should be deleted and restored by Remediator
 	nt.T.Log("Verify that the webhook is disabled")
-	if err := nt.KubeClient.Delete(fake.Namespace("hello")); err != nil {
+	if err := nt.KubeClient.Delete(k8sobjects.Namespace("hello")); err != nil {
 		nt.T.Fatalf("failed to run `kubectl delete ns hello` %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.NamespaceRepo(namespaceRepo, configsync.RepoSyncName), ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	repoSyncNN := nomostest.RepoSyncNN(namespaceRepo, configsync.RepoSyncName)
-	sa := fake.ServiceAccountObject("store", core.Namespace(namespaceRepo))
+	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(namespaceRepo))
 	nt.Must(nt.NonRootRepos[repoSyncNN].Add("acme/sa.yaml", sa))
 	nt.Must(nt.NonRootRepos[repoSyncNN].CommitAndPush("Adding test service account"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/adopt_client_side_applied_test.go
+++ b/e2e/testcases/adopt_client_side_applied_test.go
@@ -24,7 +24,7 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestAdoptClientSideAppliedResource(t *testing.T) {
@@ -32,7 +32,7 @@ func TestAdoptClientSideAppliedResource(t *testing.T) {
 
 	// Declare a ClusterRole and `kubectl apply -f` it to the cluster.
 	nsViewerName := "ns-viewer"
-	nsViewer := fake.ClusterRoleObject(core.Name(nsViewerName),
+	nsViewer := k8sobjects.ClusterRoleObject(core.Name(nsViewerName),
 		core.Label("permissions", "viewer"))
 	nsViewer.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},

--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -27,7 +27,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 const (
@@ -178,7 +178,7 @@ func manageNamespace(nt *nomostest.NT, namespace string) {
 	}
 
 	nt.T.Cleanup(func() {
-		svcObj := fake.ServiceObject(core.Name("some-other-service"), core.Namespace(namespace))
+		svcObj := k8sobjects.ServiceObject(core.Name("some-other-service"), core.Namespace(namespace))
 		if err := nomostest.DeleteObjectsAndWait(nt, svcObj); err != nil {
 			nt.T.Fatal(err)
 		}

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -50,12 +50,12 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -121,8 +121,8 @@ func TestNomosInitHydrate(t *testing.T) {
 	err = hydrate.PrintFile(fmt.Sprintf("%s/namespaces/foo/ns.yaml", tmpDir),
 		flags.OutputYAML,
 		[]*unstructured.Unstructured{
-			fake.UnstructuredObject(kinds.Namespace(), core.Name("foo"), core.Annotation(metadata.HNCManagedBy, "controller1")),
-			fake.UnstructuredObject(kinds.ConfigMap(), core.Name("cm1"), core.Namespace("foo")),
+			k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("foo"), core.Annotation(metadata.HNCManagedBy, "controller1")),
+			k8sobjects.UnstructuredObject(kinds.ConfigMap(), core.Name("cm1"), core.Namespace("foo")),
 		})
 	if err != nil {
 		tw.Fatal(err)
@@ -1329,7 +1329,7 @@ func TestNomosMigrate(t *testing.T) {
 		}
 		// Delete the ConfigManagement operator in case the test failed early.
 		// If this lingers around it could cause issues for subsequent tests.
-		cmDeployment := fake.DeploymentObject(
+		cmDeployment := k8sobjects.DeploymentObject(
 			core.Namespace(configsync.ControllerNamespace),
 			core.Name(util.ACMOperatorDeployment),
 		)
@@ -1475,7 +1475,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 		}
 		// Delete the ConfigManagement operator in case the test failed early.
 		// If this lingers around it could cause issues for subsequent tests.
-		cmDeployment := fake.DeploymentObject(
+		cmDeployment := k8sobjects.DeploymentObject(
 			core.Namespace(configsync.ControllerNamespace),
 			core.Name(util.ACMOperatorDeployment),
 		)
@@ -1486,7 +1486,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 			nt.T.Error(err)
 		}
 		// Ensure the RootSync is deleted since it's not registered with nt
-		rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+		rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 		if err := nt.KubeClient.Delete(rs, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
 			nt.T.Error(err)
 		}

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -28,8 +28,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,7 +78,7 @@ func TestRevertClusterRole(t *testing.T) {
 
 	crName := "e2e-test-clusterrole"
 
-	err := nt.ValidateNotFound(crName, "", fake.ClusterRoleObject())
+	err := nt.ValidateNotFound(crName, "", k8sobjects.ClusterRoleObject())
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestRevertClusterRole(t *testing.T) {
 			Verbs:     []string{"get", "list", "create"},
 		},
 	}
-	declaredCr := fake.ClusterRoleObject(core.Name(crName))
+	declaredCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	declaredCr.Rules = declaredRules
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole"))
@@ -113,7 +113,7 @@ func TestRevertClusterRole(t *testing.T) {
 			Verbs:     []string{"get", "list"}, // missing "create"
 		},
 	}
-	appliedCr := fake.ClusterRoleObject(core.Name(crName))
+	appliedCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	appliedCr.Rules = appliedRules
 	err = nt.KubeClient.Update(appliedCr)
 	// The admission webhook should deny the conflicting change.
@@ -146,7 +146,7 @@ func TestClusterRoleLifecycle(t *testing.T) {
 
 	crName := "e2e-test-clusterrole"
 
-	err := nt.ValidateNotFound(crName, "", fake.ClusterRoleObject())
+	err := nt.ValidateNotFound(crName, "", k8sobjects.ClusterRoleObject())
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestClusterRoleLifecycle(t *testing.T) {
 			Verbs:     []string{"get", "list", "create"},
 		},
 	}
-	declaredCr := fake.ClusterRoleObject(core.Name(crName))
+	declaredCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	declaredCr.Rules = declaredRules
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole"))
@@ -192,7 +192,7 @@ func TestClusterRoleLifecycle(t *testing.T) {
 			Verbs:     []string{"get", "list"}, // missing "create"
 		},
 	}
-	updatedCr := fake.ClusterRoleObject(core.Name(crName))
+	updatedCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	updatedCr.Rules = updatedRules
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", updatedCr))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("update ClusterRole to get/list"))

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -34,11 +34,11 @@ import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,17 +62,17 @@ var (
 )
 
 func clusterObject(name, label, value string) *clusterregistry.Cluster {
-	return fake.ClusterObject(core.Name(name), core.Label(label, value))
+	return k8sobjects.ClusterObject(core.Name(name), core.Label(label, value))
 }
 
 func clusterSelector(name, label, value string) *v1.ClusterSelector {
-	cs := fake.ClusterSelectorObject(core.Name(name))
+	cs := k8sobjects.ClusterSelectorObject(core.Name(name))
 	cs.Spec.Selector.MatchLabels = map[string]string{label: value}
 	return cs
 }
 
 func resourceQuota(name, namespace, pods string, annotations map[string]string) *corev1.ResourceQuota {
-	rq := fake.ResourceQuotaObject(
+	rq := k8sobjects.ResourceQuotaObject(
 		core.Name(name),
 		core.Namespace(namespace),
 		core.Annotations(annotations))
@@ -81,7 +81,7 @@ func resourceQuota(name, namespace, pods string, annotations map[string]string) 
 }
 
 func roleBinding(name, namespace string, annotations map[string]string) *rbacv1.RoleBinding {
-	rb := fake.RoleBindingObject(
+	rb := k8sobjects.RoleBindingObject(
 		core.Name(name),
 		core.Namespace(namespace),
 		core.Annotations(annotations))
@@ -97,7 +97,7 @@ func roleBinding(name, namespace string, annotations map[string]string) *rbacv1.
 }
 
 func namespaceObject(name string, annotations map[string]string) *corev1.Namespace {
-	return fake.NamespaceObject(name, core.Annotations(annotations))
+	return k8sobjects.NamespaceObject(name, core.Annotations(annotations))
 }
 
 func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -40,10 +40,10 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object/mutation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -151,7 +151,7 @@ func TestComposition(t *testing.T) {
 	})
 
 	nt.T.Logf("Adding Namespace & RoleBindings for RepoSyncs")
-	nt.Must(lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("ns-%s.yaml", testNs)), fake.NamespaceObject(testNs)))
+	nt.Must(lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("ns-%s.yaml", testNs)), k8sobjects.NamespaceObject(testNs)))
 	nt.Must(lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("rb-%s-%s.yaml", testNs, lvl2NN.Name)), lvl2RB))
 	nt.Must(lvl0Repo.Add(filepath.Join(lvl0SubDir, fmt.Sprintf("rb-%s-%s.yaml", testNs, lvl3NN.Name)), lvl3RB))
 	nt.Must(lvl0Repo.CommitAndPush("Adding Namespace & RoleBindings for RepoSyncs"))

--- a/e2e/testcases/custom_resource_definitions_schema_test.go
+++ b/e2e/testcases/custom_resource_definitions_schema_test.go
@@ -24,7 +24,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
@@ -45,7 +45,7 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/crd.yaml", crdContent))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo")))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", k8sobjects.NamespaceObject("foo")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/cr.yaml", crContent))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a CRD and CR"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -31,16 +31,16 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/webhook/configuration"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nsObj := fake.NamespaceObject("foo")
+	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
 	anvilObj := anvilCR("v1", "heavy", 10)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilObj))
@@ -130,7 +130,7 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	}
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/anvil-crd.yaml", crdContent))
 	crdObj := nt.RootRepos[configsync.RootSyncName].MustGet(nt.T, "acme/cluster/anvil-crd.yaml")
-	nsObj := fake.NamespaceObject("prod")
+	nsObj := k8sobjects.NamespaceObject("prod")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", nsObj))
 	anvilObj := anvilCR("v1", "e2e-test-anvil", 10)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil.yaml", anvilObj))
@@ -183,7 +183,7 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
+	err = nt.ValidateNotFound("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 	}
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/anvil-crd.yaml", crdContent))
 	crdObj := nt.RootRepos[configsync.RootSyncName].MustGet(nt.T, "acme/cluster/anvil-crd.yaml")
-	nsObj := fake.NamespaceObject("prod")
+	nsObj := k8sobjects.NamespaceObject("prod")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -230,7 +230,7 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
+	err = nt.Validate("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 		nt.T.Fatal(err)
 	}
 
-	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
+	err = nt.ValidateNotFound("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("clusteranvils.acme.com", "", fake.CustomResourceDefinitionV1Object(), hasTwoVersions)
+	err = nt.Validate("clusteranvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object(), hasTwoVersions)
 	if err != nil {
 		nt.T.Error(err)
 	}
@@ -337,7 +337,7 @@ func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	if err != nil {
 		nt.T.Error(err)
 	}
-	err = nt.ValidateNotFound("clusteranvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
+	err = nt.ValidateNotFound("clusteranvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Error(err)
 	}
@@ -360,7 +360,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	crdObj := nt.RootRepos[configsync.RootSyncName].MustGet(nt.T, "acme/cluster/anvil-crd.yaml")
 	anvilObj := anvilCR("v1", "e2e-test-anvil", 10)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/anvil.yaml", anvilObj))
-	nsObj := fake.NamespaceObject("prod")
+	nsObj := k8sobjects.NamespaceObject("prod")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/prod/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding namespacescoped Anvil CRD and CR"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -401,7 +401,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object(), hasTwoVersions)
+	err = nt.Validate("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object(), hasTwoVersions)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -419,7 +419,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object(), nomostest.IsEstablished, hasTwoVersions)
+	err = nt.Validate("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object(), nomostest.IsEstablished, hasTwoVersions)
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -438,7 +438,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	}
 
 	// Validate the CustomResource is also deleted from cluster.
-	err = nt.ValidateNotFound("anvils.acme.com", "", fake.CustomResourceDefinitionV1Object())
+	err = nt.ValidateNotFound("anvils.acme.com", "", k8sobjects.CustomResourceDefinitionV1Object())
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -29,9 +29,9 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/webhook/configuration"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,7 +56,7 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	nsObj := fake.NamespaceObject("foo")
+	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
 	anvilObj := anvilCR("v1", "heavy", 10)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilObj))
@@ -197,7 +197,7 @@ func TestSyncUpdateCustomResource(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", fake.NamespaceObject("foo")))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", k8sobjects.NamespaceObject("foo")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 10)))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CR"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/declared_fields_test.go
+++ b/e2e/testcases/declared_fields_test.go
@@ -18,19 +18,18 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
-	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/kinds"
-
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
-	"kpt.dev/configsync/pkg/testing/fake"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+	"kpt.dev/configsync/pkg/kinds"
 )
 
 func TestDeclaredFieldsPod(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore")
+	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	// We use literal YAML here instead of an object as:
 	// 1) If we used a literal struct the protocol field would implicitly be added.

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -30,8 +30,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testutils"
 	"kpt.dev/configsync/e2e/nomostest/workloadidentity"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 const (
@@ -64,7 +64,7 @@ func TestGCENodeCSR(t *testing.T) {
 	nt.T.Log("Add the kustomize-components root directory to RootSync's repo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/kustomize-components", "."))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rootSync, `{
 		"spec": {
 			"git": {
@@ -74,7 +74,7 @@ func TestGCENodeCSR(t *testing.T) {
 	}`)
 
 	nt.T.Log("Add the namespace-repo directory to RepoSync's repo")
-	repoSync := fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName)
+	repoSync := k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName)
 	repoSyncRef := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
 	nt.Must(nt.NonRootRepos[repoSyncRef].Copy("../testdata/hydration/namespace-repo", "."))
 	nt.Must(nt.NonRootRepos[repoSyncRef].CommitAndPush("add DRY configs to the repository"))
@@ -119,7 +119,7 @@ func TestGCENodeOCI(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	rootSyncRef := nomostest.RootSyncNN(rootSync.Name)
 	rootImage, err := nt.BuildAndPushOCIImage(
 		rootSyncRef,

--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -22,13 +22,13 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController)
 
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	if err := nt.KubeClient.Get(configsync.RootSyncName, configmanagement.ControllerNamespace, rs); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Push("HEAD:upstream/main"))
 
 	nt.T.Logf("Update the remote main branch by adding a test namespace")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", fake.NamespaceObject("hello")))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/hello/ns.yaml", k8sobjects.NamespaceObject("hello")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add Namespace"))
 
 	nt.T.Logf("Verify git-sync can pull the latest commit with the default branch and revision")

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -30,13 +30,13 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 var expectedBuiltinOrigin = "configuredIn: kustomization.yaml\nconfiguredBy:\n  apiVersion: builtin\n  kind: HelmChartInflationGenerator\n"
@@ -77,7 +77,7 @@ func TestHydrateKustomizeComponents(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 
 	nt.T.Log("Update RootSync to sync from the kustomize-components directory")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "kustomize-components"}}}`)
 	nt.Must(nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(syncDirMap)))
 
@@ -181,7 +181,7 @@ func TestHydrateHelmComponents(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 
 	nt.T.Log("Update RootSync to sync from the helm-components directory")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	if nt.IsGKEAutopilot {
 		// b/209458334: set a higher memory of the hydration-controller on Autopilot clusters to avoid the kustomize build failure
 		nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "helm-components"}, "override": {"resources": [{"containerName": "hydration-controller", "memoryRequest": "200Mi"}]}}}`)
@@ -241,7 +241,7 @@ func TestHydrateHelmOverlay(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 
 	nt.T.Log("Update RootSync to sync from the helm-overlay directory")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	if nt.IsGKEAutopilot {
 		// b/209458334: set a higher memory of the hydration-controller on Autopilot clusters to avoid the kustomize build failure
 		nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "helm-overlay"}, "override": {"resources": [{"containerName": "hydration-controller", "memoryRequest": "200Mi"}]}}}`)
@@ -296,7 +296,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy("../testdata/hydration/remote-base", "."))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 	nt.T.Log("Update RootSync to sync from the remote-base directory without enable shell in hydration controller")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "remote-base"}}}`)
 	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
 		[]testpredicates.Predicate{
@@ -369,7 +369,7 @@ func TestHydrateResourcesInRelativePath(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 
 	nt.T.Log("Update RootSync to sync from the relative-path directory")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "relative-path/overlays/dev"}}}`)
 
 	nt.Must(nt.WatchForAllSyncs(nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{nomostest.DefaultRootRepoNamespacedName: "relative-path/overlays/dev"})))

--- a/e2e/testcases/invalid_auth_test.go
+++ b/e2e/testcases/invalid_auth_test.go
@@ -22,9 +22,9 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/metrics"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestInvalidAuth(t *testing.T) {
@@ -32,7 +32,7 @@ func TestInvalidAuth(t *testing.T) {
 
 	// Update RootSync to sync from a GitHub repo with an ssh key.
 	// The ssh key only works for test-git-server, not GitHub, so it will get a permission error.
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, fmt.Sprintf(`{
 		"spec": {
 			"git": {

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -24,8 +24,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestInvalidRootSyncBranchStatus(t *testing.T) {
@@ -144,7 +144,7 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CheckoutBranch(devBranch))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		fmt.Sprintf("acme/namespaces/%s/ns.yaml", auditNS),
-		fake.NamespaceObject(auditNS)))
+		k8sobjects.NamespaceObject(auditNS)))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPushBranch("add namespace to acme directory", devBranch))
 
 	// Update RootSync to sync from the dev branch
@@ -154,7 +154,7 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 	}
 
 	// Validate namespace 'acme' created.
-	err := nt.Validate(auditNS, "", fake.NamespaceObject(auditNS))
+	err := nt.Validate(auditNS, "", k8sobjects.NamespaceObject(auditNS))
 	if err != nil {
 		nt.T.Error(err)
 	}

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -31,8 +31,8 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 // This file includes tests for KCC resources from a cloud source repository.
@@ -43,7 +43,7 @@ import (
 func TestKCCResourcesOnCSR(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.KCCTest, ntopts.RequireGKE(t))
 
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("sync to the kcc resources from a CSR repo")
 	nt.MustMergePatch(rs, fmt.Sprintf(`{"spec": {"git": {"dir": "kcc", "branch": "main", "repo": "%s/p/%s/r/configsync-kcc", "auth": "gcpserviceaccount","gcpServiceAccountEmail": "e2e-test-csr-reader@%s.iam.gserviceaccount.com", "secretRef": {"name": ""}}, "sourceFormat": "unstructured"}}`,
 		nomostesting.CSRHost, *e2e.GCPProject, *e2e.GCPProject))
@@ -142,11 +142,11 @@ func TestKCCResourceGroup(t *testing.T) {
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
 		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
 			nt.T.Error(err)
 		}
 	})
-	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 	rgNN := types.NamespacedName{

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -21,7 +21,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/metrics"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestIgnoreKptfiles(t *testing.T) {
@@ -31,7 +31,7 @@ func TestIgnoreKptfiles(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/Kptfile", []byte("random content")))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/Kptfile", nil))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/subdir/Kptfile", []byte("# some comment")))
-	nsObj := fake.NamespaceObject("foo")
+	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding multiple Kptfiles"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -39,7 +39,7 @@ func TestIgnoreKptfiles(t *testing.T) {
 	}
 	nt.RenewClient()
 
-	err := nt.Validate("foo", "", fake.NamespaceObject("foo"))
+	err := nt.Validate("foo", "", k8sobjects.NamespaceObject("foo"))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -27,9 +27,9 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/syncer/differ"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util"
 	"sigs.k8s.io/cli-utils/pkg/common"
 )
@@ -46,7 +46,7 @@ func TestPreventDeletionNamespace(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	role := fake.RoleObject(core.Name("shipping-admin"))
+	role := k8sobjects.RoleObject(core.Name("shipping-admin"))
 	role.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},
 		Resources: []string{"configmaps"},
@@ -54,7 +54,7 @@ func TestPreventDeletionNamespace(t *testing.T) {
 	}}
 
 	// Declare the Namespace with the lifecycle annotation, and ensure it is created.
-	nsObj := fake.NamespaceObject("shipping", preventDeletion)
+	nsObj := k8sobjects.NamespaceObject("shipping", preventDeletion)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Namespace with prevent deletion lifecycle annotation"))
@@ -113,7 +113,7 @@ func TestPreventDeletionNamespace(t *testing.T) {
 	}
 
 	// Remove the lifecycle annotation from the namespace so that the namespace can be deleted after the test case.
-	nsObj = fake.NamespaceObject("shipping")
+	nsObj = k8sobjects.NamespaceObject("shipping")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from Namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -142,13 +142,13 @@ func TestPreventDeletionRole(t *testing.T) {
 	}
 
 	// Declare the Role with the lifecycle annotation, and ensure it is created.
-	role := fake.RoleObject(core.Name("shipping-admin"), preventDeletion)
+	role := k8sobjects.RoleObject(core.Name("shipping-admin"), preventDeletion)
 	role.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},
 		Resources: []string{"configmaps"},
 		Verbs:     []string{"get"},
 	}}
-	nsObj := fake.NamespaceObject("shipping")
+	nsObj := k8sobjects.NamespaceObject("shipping")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Role with prevent deletion lifecycle annotation"))
@@ -244,7 +244,7 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 	}
 
 	// Declare the ClusterRole with the lifecycle annotation, and ensure it is created.
-	clusterRole := fake.ClusterRoleObject(core.Name("test-admin"), preventDeletion)
+	clusterRole := k8sobjects.ClusterRoleObject(core.Name("test-admin"), preventDeletion)
 	clusterRole.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},
 		Resources: []string{"configmaps"},
@@ -325,9 +325,9 @@ func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 
 	for ns := range specialNamespaces {
 		checkpointProtectedNamespace(nt, ns)
-		nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/ns-%s.yaml", ns), fake.NamespaceObject(ns)))
+		nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/ns-%s.yaml", ns), k8sobjects.NamespaceObject(ns)))
 	}
-	bookstoreNS := fake.NamespaceObject("bookstore")
+	bookstoreNS := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns-bookstore.yaml", bookstoreNS))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add special namespaces and one non-special namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/local_config_test.go
+++ b/e2e/testcases/local_config_test.go
@@ -22,9 +22,9 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 var LocalConfigValue = "true"
@@ -35,11 +35,11 @@ func TestLocalConfig(t *testing.T) {
 	ns := "local-config"
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		"acme/namespaces/local-config/ns.yaml",
-		fake.NamespaceObject(ns)))
+		k8sobjects.NamespaceObject(ns)))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/local-config/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap as local config"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -53,7 +53,7 @@ func TestLocalConfig(t *testing.T) {
 	}
 
 	// Remove the local-config annotation
-	cm = fake.ConfigMapObject(core.Name(cmName))
+	cm = k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap without local-config annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -68,7 +68,7 @@ func TestLocalConfig(t *testing.T) {
 
 	// Add the local-config annotation again.
 	// This will make the object pruned.
-	cm = fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
+	cm = k8sobjects.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Changing ConfigMap to local config"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -88,11 +88,11 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	ns := "local-config"
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		"acme/namespaces/local-config/ns.yaml",
-		fake.NamespaceObject(ns)))
+		k8sobjects.NamespaceObject(ns)))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/local-config/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -106,7 +106,7 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	}
 
 	// Add the management disabled annotation.
-	cm = fake.ConfigMapObject(core.Name(cmName), syncertest.ManagementDisabled)
+	cm = k8sobjects.ConfigMapObject(core.Name(cmName), syncertest.ManagementDisabled)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Disable the management of ConfigMap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -120,7 +120,7 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	}
 
 	// Add the local-config annotation to the unmanaged configmap
-	cm = fake.ConfigMapObject(core.Name(cmName), syncertest.ManagementDisabled,
+	cm = k8sobjects.ConfigMapObject(core.Name(cmName), syncertest.ManagementDisabled,
 		core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change the ConfigMap to local config"))
@@ -135,7 +135,7 @@ func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	}
 
 	// Remove the management disabled annotation
-	cm = fake.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
+	cm = k8sobjects.ConfigMapObject(core.Name(cmName), core.Annotation(metadata.LocalConfigAnnotationKey, LocalConfigValue))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove the managed disabled annotation and keep the local-config annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -22,17 +22,16 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
-
-	"kpt.dev/configsync/e2e/nomostest"
-	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 // This file includes tests for drift correction and drift prevention.
@@ -62,7 +61,7 @@ import (
 func TestKubectlCreatesManagedNamespaceResourceMultiRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore")
+	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -209,14 +208,14 @@ metadata:
 func TestKubectlCreatesManagedConfigMapResource(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore")
+	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -410,14 +409,14 @@ metadata:
 func TestDeleteManagedResources(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore")
+	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -470,14 +469,14 @@ func TestDeleteManagedResources(t *testing.T) {
 func TestDeleteManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", fake.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -529,7 +528,7 @@ func TestDeleteManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 func TestAddFieldsIntoManagedResources(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore")
+	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -588,7 +587,7 @@ func TestAddFieldsIntoManagedResources(t *testing.T) {
 func TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -616,7 +615,7 @@ func TestAddFieldsIntoManagedResourcesWithIgnoreMutationAnnotation(t *testing.T)
 func TestModifyManagedFields(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore", core.Annotation("season", "summer"))
+	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -676,7 +675,7 @@ func TestModifyManagedFields(t *testing.T) {
 func TestModifyManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore",
+	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
@@ -722,7 +721,7 @@ func TestModifyManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 func TestDeleteManagedFields(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore", core.Annotation("season", "summer"))
+	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -780,7 +779,7 @@ func TestDeleteManagedFields(t *testing.T) {
 func TestDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
 
-	namespace := fake.NamespaceObject("bookstore",
+	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -39,11 +39,11 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -131,7 +131,7 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	nrb5 := nomostest.RepoSyncRoleBinding(nn5)
 
 	nt.T.Logf("Adding Namespace & RoleBindings for RepoSyncs")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/cluster/ns-%s.yaml", testNs), fake.NamespaceObject(testNs)))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/cluster/ns-%s.yaml", testNs), k8sobjects.NamespaceObject(testNs)))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/rb-%s.yaml", testNs, nn2.Name), nrb2))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/rb-%s.yaml", testNs, nn4.Name), nrb4))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Namespace & RoleBindings for RepoSyncs"))
@@ -775,7 +775,7 @@ func TestConflictingDefinitions_NamespaceToNamespace(t *testing.T) {
 func TestControllerValidationErrors(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.MultiRepos)
 
-	testNamespace := fake.NamespaceObject(testNs)
+	testNamespace := k8sobjects.NamespaceObject(testNs)
 	if err := nt.KubeClient.Create(testNamespace); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -857,7 +857,7 @@ func TestControllerValidationErrors(t *testing.T) {
 }
 
 func rootPodRole() *rbacv1.Role {
-	result := fake.RoleObject(
+	result := k8sobjects.RoleObject(
 		core.Name("pods"),
 		core.Namespace(testNs),
 	)
@@ -872,7 +872,7 @@ func rootPodRole() *rbacv1.Role {
 }
 
 func namespacePodRole() *rbacv1.Role {
-	result := fake.RoleObject(
+	result := k8sobjects.RoleObject(
 		core.Name("pods"),
 		core.Namespace(testNs),
 	)

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -29,7 +29,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,7 +47,7 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	nt.RenewClient()
 
 	// Add the v1 Anvils and verify they are created.
-	nsObj := fake.NamespaceObject("foo")
+	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
 	anvilv1Obj := anvilCR("v1", "first", 10)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
@@ -101,7 +101,7 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 }
 
 func anvilV1CRD() *apiextensionsv1.CustomResourceDefinition {
-	crd := fake.CustomResourceDefinitionV1Object(core.Name("anvils.acme.com"))
+	crd := k8sobjects.CustomResourceDefinitionV1Object(core.Name("anvils.acme.com"))
 	crd.Spec.Group = "acme.com"
 	crd.Spec.Names = apiextensionsv1.CustomResourceDefinitionNames{
 		Plural:   "anvils",
@@ -186,7 +186,7 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
 
-	rbV1 := fake.RoleBindingObject(core.Name("v1user"))
+	rbV1 := k8sobjects.RoleBindingObject(core.Name("v1user"))
 	rbV1.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "Role",
@@ -199,7 +199,7 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 	})
 
 	// Add the v1 RoleBinding and verify it is created.
-	nsObj := fake.NamespaceObject("foo")
+	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/rbv1.yaml", rbV1))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 RoleBinding"))

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -40,9 +40,9 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -85,7 +85,7 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 		nt.T.Errorf("store service account already present: %v", err)
 	}
 
-	sa := fake.ServiceAccountObject("store", core.Namespace(bsNamespace))
+	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(bsNamespace))
 	nt.Must(repo.Add("acme/sa.yaml", sa))
 	nt.Must(repo.CommitAndPush("Adding service account"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -206,7 +206,7 @@ func configureRBACInCentralizedMode(nt *nomostest.NT, ns string, verbs []string)
 			Verbs:     verbs,
 		},
 	}
-	rsRole := fake.RoleObject(
+	rsRole := k8sobjects.RoleObject(
 		core.Name("deployment-admin"),
 		core.Namespace(ns),
 	)
@@ -217,7 +217,7 @@ func configureRBACInCentralizedMode(nt *nomostest.NT, ns string, verbs []string)
 		Kind:     rsRole.Kind,
 		Name:     rsRole.Name,
 	}
-	rb := fake.RoleBindingObject(core.Name("syncs-repo"), core.Namespace(ns))
+	rb := k8sobjects.RoleBindingObject(core.Name("syncs-repo"), core.Namespace(ns))
 	sb := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -239,7 +239,7 @@ func configureRBACInDelegatedMode(nt *nomostest.NT, ns string, verbs []string) {
 			Verbs:     verbs,
 		},
 	}
-	rsRole := fake.RoleObject(
+	rsRole := k8sobjects.RoleObject(
 		core.Name("deployment-admin"),
 		core.Namespace(ns),
 	)
@@ -263,7 +263,7 @@ func configureRBACInDelegatedMode(nt *nomostest.NT, ns string, verbs []string) {
 		Kind:     rsRole.Kind,
 		Name:     rsRole.Name,
 	}
-	rb := fake.RoleBindingObject(core.Name("syncs-repo"), core.Namespace(ns))
+	rb := k8sobjects.RoleBindingObject(core.Name("syncs-repo"), core.Namespace(ns))
 	sb := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -338,7 +338,7 @@ func TestNamespaceRepo_Delegated(t *testing.T) {
 		nt.T.Errorf("store service account already present: %v", err)
 	}
 
-	sa := fake.ServiceAccountObject("store", core.Namespace(bsNamespaceRepo))
+	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(bsNamespaceRepo))
 	nt.Must(nt.NonRootRepos[repoSyncNN].Add("acme/sa.yaml", sa))
 	nt.Must(nt.NonRootRepos[repoSyncNN].CommitAndPush("Adding service account"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -473,7 +473,7 @@ func TestManageSelfRepoSync(t *testing.T) {
 	if err := nt.KubeClient.Get(configsync.RepoSyncName, bsNamespace, rs); err != nil {
 		nt.T.Fatal(err)
 	}
-	sanitizedRs := fake.RepoSyncObjectV1Beta1(rs.Namespace, rs.Name)
+	sanitizedRs := k8sobjects.RepoSyncObjectV1Beta1(rs.Namespace, rs.Name)
 	sanitizedRs.Spec = rs.Spec
 	rsNN := nomostest.RepoSyncNN(rs.Namespace, rs.Name)
 	nt.Must(nt.NonRootRepos[rsNN].Add("acme/repo-sync.yaml", sanitizedRs))

--- a/e2e/testcases/namespace_selectors_test.go
+++ b/e2e/testcases/namespace_selectors_test.go
@@ -31,11 +31,11 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	k8sobjects2 "kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	fake "kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,41 +51,41 @@ const (
 
 var (
 	selectedResourcesWithBookstoreNSSAndShoestoreNSS = []client.Object{
-		fake.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(bookstoreCMName)),
-		fake.ResourceQuotaObject(core.Namespace(bookstoreNS), core.Name(bookstoreRQName)),
-		fake.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(shoestoreCMName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(bookstoreCMName)),
+		k8sobjects2.ResourceQuotaObject(core.Namespace(bookstoreNS), core.Name(bookstoreRQName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(shoestoreCMName)),
 	}
 
 	unselectedResourcesWithBookstoreNSSAndShoestoreNSS = []client.Object{
-		fake.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(shoestoreCMName)),
-		fake.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(bookstoreCMName)),
-		fake.ResourceQuotaObject(core.Namespace(shoestoreNS), core.Name(bookstoreRQName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(shoestoreCMName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(bookstoreCMName)),
+		k8sobjects2.ResourceQuotaObject(core.Namespace(shoestoreNS), core.Name(bookstoreRQName)),
 	}
 
 	selectedResourcesWithShoestoreNSSOnly = []client.Object{
-		fake.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(shoestoreCMName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(shoestoreCMName)),
 	}
 
 	unselectedResourcesWithShoestoreNSSOnly = []client.Object{
-		fake.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(bookstoreCMName)),
-		fake.ResourceQuotaObject(core.Namespace(bookstoreNS), core.Name(bookstoreRQName)),
-		fake.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(shoestoreCMName)),
-		fake.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(bookstoreCMName)),
-		fake.ResourceQuotaObject(core.Namespace(shoestoreNS), core.Name(bookstoreRQName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(bookstoreCMName)),
+		k8sobjects2.ResourceQuotaObject(core.Namespace(bookstoreNS), core.Name(bookstoreRQName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(bookstoreNS), core.Name(shoestoreCMName)),
+		k8sobjects2.ConfigMapObject(core.Namespace(shoestoreNS), core.Name(bookstoreCMName)),
+		k8sobjects2.ResourceQuotaObject(core.Namespace(shoestoreNS), core.Name(bookstoreRQName)),
 	}
 )
 
 func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
 
-	bookstoreNSS := fake.NamespaceSelectorObject(core.Name(bookstoreNSSName))
-	bookstoreCM := fake.ConfigMapObject(core.Name(bookstoreCMName),
+	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
+	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, bookstoreNSSName))
-	bookstoreRQ := fake.ResourceQuotaObject(core.Name(bookstoreRQName),
+	bookstoreRQ := k8sobjects2.ResourceQuotaObject(core.Name(bookstoreRQName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, bookstoreNSSName))
 
-	shoestoreNSS := fake.NamespaceSelectorObject(core.Name(shoestoreNSSName))
-	shoestoreCM := fake.ConfigMapObject(core.Name(shoestoreCMName),
+	shoestoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(shoestoreNSSName))
+	shoestoreCM := k8sobjects2.ConfigMapObject(core.Name(shoestoreCMName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, shoestoreNSSName))
 
 	nt.T.Log("Add Namespaces, NamespaceSelectors and Namespace-scoped resources")
@@ -97,8 +97,8 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/namespace-selector-bookstore.yaml", bookstoreNSS))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/namespace-selector-shoestore.yaml", shoestoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/bookstore/ns.yaml", fake.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shoestore/ns.yaml", fake.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/bookstore/ns.yaml", k8sobjects2.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shoestore/ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/cm-bookstore.yaml", bookstoreCM))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/rq-bookstore.yaml", bookstoreRQ))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/cm-shoestore.yaml", shoestoreCM))
@@ -124,14 +124,14 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector, ntopts.Unstructured)
 
-	bookstoreNSS := fake.NamespaceSelectorObject(core.Name(bookstoreNSSName))
-	bookstoreCM := fake.ConfigMapObject(core.Name(bookstoreCMName),
+	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
+	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, bookstoreNSSName))
-	bookstoreRQ := fake.ResourceQuotaObject(core.Name(bookstoreRQName),
+	bookstoreRQ := k8sobjects2.ResourceQuotaObject(core.Name(bookstoreRQName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, bookstoreNSSName))
 
-	shoestoreNSS := fake.NamespaceSelectorObject(core.Name(shoestoreNSSName))
-	shoestoreCM := fake.ConfigMapObject(core.Name(shoestoreCMName),
+	shoestoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(shoestoreNSSName))
+	shoestoreCM := k8sobjects2.ConfigMapObject(core.Name(shoestoreCMName),
 		core.Annotation(metadata.NamespaceSelectorAnnotationKey, shoestoreNSSName))
 
 	nt.T.Log("Add Namespaces, NamespaceSelectors and Namespace-scoped resources")
@@ -142,7 +142,7 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-shoestore.yaml", shoestoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/shoestore-ns.yaml", fake.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/shoestore-ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm-bookstore.yaml", bookstoreCM))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/rq-bookstore.yaml", bookstoreRQ))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm-shoestore.yaml", shoestoreCM))
@@ -207,7 +207,7 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	)
 
 	nt.Logger.Info("Creating a Namespace with labels, matching resources should be selected")
-	bookstoreNamespace := fake.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))
+	bookstoreNamespace := k8sobjects2.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))
 	if err := nt.KubeClient.Create(bookstoreNamespace); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -26,10 +26,10 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestNoSSLVerifyV1Alpha1(t *testing.T) {
@@ -61,7 +61,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
@@ -140,7 +140,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -39,11 +39,11 @@ import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metrics"
 	csmetrics "kpt.dev/configsync/pkg/metrics"
 	rgmetrics "kpt.dev/configsync/pkg/resourcegroup/controllers/metrics"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 const (
@@ -130,7 +130,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 	startTime := time.Now().UTC()
 
 	nt.T.Log("Adding test commit after otel-collector is started up so multiple commit hashes are processed in pipelines")
-	namespace := fake.NamespaceObject("foo")
+	namespace := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding foo namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -187,7 +187,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add DRY configs to the repository"))
 
 	nt.T.Log("Update RootSync to sync from the kustomize-components directory")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.MustMergePatch(rs, `{"spec": {"git": {"dir": "kustomize-components"}}}`)
 	syncDirMap := map[types.NamespacedName]string{
 		nomostest.DefaultRootRepoNamespacedName: "kustomize-components",
@@ -272,7 +272,7 @@ func TestGCMMetrics(t *testing.T) {
 	}
 
 	nt.T.Log("Adding test namespace")
-	namespace := fake.NamespaceObject("foo")
+	namespace := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding foo namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -325,7 +325,7 @@ func TestOtelCollectorGCMLabelAggregation(t *testing.T) {
 	startTime := time.Now().UTC()
 
 	nt.T.Log("Adding test commit")
-	namespace := fake.NamespaceObject("foo")
+	namespace := k8sobjects.NamespaceObject("foo")
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding foo namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -28,10 +28,10 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
@@ -63,7 +63,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
@@ -161,7 +161,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -26,10 +26,10 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestOverrideRootSyncLogLevel(t *testing.T) {
@@ -37,7 +37,7 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 
 	rootSyncName := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerName := core.RootReconcilerObjectKey(rootSyncName.Name)
-	rootSyncV1 := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSyncV1 := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	// add kustomize to enable hydration controller container in root-sync
 	nt.T.Log("Add the kustomize components root directory")

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -28,8 +28,8 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	resourcegroupv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,7 +37,7 @@ import (
 // TestOverrideReconcileTimeout tests that a misconfigured pod will never reconcile (timeout).
 func TestOverrideReconcileTimeout(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	// Override reconcileTimeout to a short time 30s, only actuation should succeed, reconcile should time out.
 	if err := nt.KubeClient.MergePatch(rootSync,
@@ -90,11 +90,11 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 			PeriodSeconds:       10,
 		},
 	}
-	pod1 := fake.PodObject(pod1Name, []corev1.Container{container}, core.Namespace(namespaceName))
+	pod1 := k8sobjects.PodObject(pod1Name, []corev1.Container{container}, core.Namespace(namespaceName))
 	idToVerify := core.IDOf(pod1)
 
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/pod-1.yaml", pod1))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns-1.yaml", fake.NamespaceObject(namespaceName)))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns-1.yaml", k8sobjects.NamespaceObject(namespaceName)))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush(fmt.Sprintf("Add namespace/%s & pod/%s (never ready)", namespaceName, pod1Name)))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -30,10 +30,10 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
@@ -95,7 +95,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	nsReconcilerBackendDeploymentGeneration := nsReconcilerBackendDeployment.Generation
 	nsReconcilerFrontendDeploymentGeneration := nsReconcilerFrontendDeployment.Generation
 
-	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 
 	backendNN := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, backendNN)
@@ -463,7 +463,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nsReconcilerBackendDeploymentGeneration := nsReconcilerBackendDeployment.Generation
 	nsReconcilerFrontendDeploymentGeneration := nsReconcilerFrontendDeployment.Generation
 
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	backendNN := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, backendNN)

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -28,9 +28,9 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestRootSyncRoleRefs(t *testing.T) {
@@ -68,8 +68,8 @@ func TestRootSyncRoleRefs(t *testing.T) {
 			Namespace: "foo",
 		},
 	}
-	roleObject := fake.RoleObject(core.Name("foo-role"), core.Namespace("foo"))
-	clusterRoleObject := fake.ClusterRoleObject(core.Name("foo-role"))
+	roleObject := k8sobjects.RoleObject(core.Name("foo-role"), core.Namespace("foo"))
+	clusterRoleObject := k8sobjects.ClusterRoleObject(core.Name("foo-role"))
 	clusterRoleObject.Rules = []rbacv1.PolicyRule{
 		{ // permission to manage the "safety clusterrole"
 			Verbs:     []string{"*"},
@@ -82,7 +82,7 @@ func TestRootSyncRoleRefs(t *testing.T) {
 			Resources: []string{"namespaces"},
 		},
 	}
-	clusterRoleObject2 := fake.ClusterRoleObject(core.Name("bar-role"))
+	clusterRoleObject2 := k8sobjects.ClusterRoleObject(core.Name("bar-role"))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		nomostest.StructuredNSPath(rootSyncA.Namespace, rootSyncA.Name),
 		rootSyncA,

--- a/e2e/testcases/preserve_fields_test.go
+++ b/e2e/testcases/preserve_fields_test.go
@@ -32,9 +32,9 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,12 +44,12 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 
 	// Declare the Service's Namespace
 	ns := "autogen-fields"
-	nsObj := fake.NamespaceObject(ns)
+	nsObj := k8sobjects.NamespaceObject(ns)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/namespaces/%s/ns.yaml", ns), nsObj))
 
 	// Declare the Service.
 	serviceName := "e2e-test-service"
-	serviceObj := fake.ServiceObject(core.Name(serviceName))
+	serviceObj := k8sobjects.ServiceObject(core.Name(serviceName))
 	// The port numbers are arbitrary - just any unused port.
 	// Don't reuse these port in other tests just in case.
 	targetPort1 := 9376
@@ -159,7 +159,7 @@ func TestPreserveGeneratedClusterRoleFields(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
 
 	nsViewerName := "namespace-viewer"
-	nsViewer := fake.ClusterRoleObject(core.Name(nsViewerName),
+	nsViewer := k8sobjects.ClusterRoleObject(core.Name(nsViewerName),
 		core.Label("permissions", "viewer"))
 	nsViewer.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},
@@ -169,7 +169,7 @@ func TestPreserveGeneratedClusterRoleFields(t *testing.T) {
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/ns-viewer-cr.yaml", nsViewer))
 
 	rbacViewerName := "rbac-viewer"
-	rbacViewer := fake.ClusterRoleObject(core.Name(rbacViewerName),
+	rbacViewer := k8sobjects.ClusterRoleObject(core.Name(rbacViewerName),
 		core.Label("permissions", "viewer"))
 	rbacViewer.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{rbacv1.SchemeGroupVersion.Group},
@@ -268,7 +268,7 @@ func TestPreserveLastApplied(t *testing.T) {
 
 	// Declare a ClusterRole and wait for it to sync.
 	nsViewerName := "namespace-viewer"
-	nsViewer := fake.ClusterRoleObject(core.Name(nsViewerName),
+	nsViewer := k8sobjects.ClusterRoleObject(core.Name(nsViewerName),
 		core.Label("permissions", "viewer"))
 	nsViewer.Rules = []rbacv1.PolicyRule{{
 		APIGroups: []string{""},
@@ -321,12 +321,12 @@ func TestAddUpdateDeleteLabels(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
 
 	ns := "crud-labels"
-	nsObj := fake.NamespaceObject(ns)
+	nsObj := k8sobjects.NamespaceObject(ns)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/crud-labels/ns.yaml", nsObj))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/crud-labels/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap with no labels to repo"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -388,12 +388,12 @@ func TestAddUpdateDeleteAnnotations(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
 
 	ns := "crud-annotations"
-	nsObj := fake.NamespaceObject(ns)
+	nsObj := k8sobjects.NamespaceObject(ns)
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/crud-annotations/ns.yaml", nsObj))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/crud-annotations/configmap.yaml"
-	cmObj := fake.ConfigMapObject(core.Name(cmName))
+	cmObj := k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cmObj))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding ConfigMap with no annotations to repo"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -35,11 +35,11 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func caCertSecretPatch(sourceType configsync.SourceType, name string) string {
@@ -85,7 +85,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
 	reconcilerName := core.NsReconcilerName(backendNamespace, configsync.RepoSyncName)
@@ -203,7 +203,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
 	reconcilerName := core.NsReconcilerName(backendNamespace, configsync.RepoSyncName)
@@ -397,8 +397,8 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 
 	caCertSecret := nomostest.PublicCertSecretName(nomostest.RegistrySyncSource)
 
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	image, err := nt.BuildAndPushOCIImage(nomostest.RootSyncNN(configsync.RootSyncName), registryproviders.ImageInputObjects(nt.Scheme, fake.NamespaceObject("foo-ns")))
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	image, err := nt.BuildAndPushOCIImage(nomostest.RootSyncNN(configsync.RootSyncName), registryproviders.ImageInputObjects(nt.Scheme, k8sobjects.NamespaceObject("foo-ns")))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -439,7 +439,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	upsertedSecret := controllers.ReconcilerResourceName(
 		core.NsReconcilerName(nn.Namespace, nn.Name), caCertSecret)
 
-	cm := fake.ConfigMapObject(core.Name("foo-cm"), core.Namespace(nn.Namespace))
+	cm := k8sobjects.ConfigMapObject(core.Name("foo-cm"), core.Namespace(nn.Namespace))
 	image, err := nt.BuildAndPushOCIImage(nn, registryproviders.ImageInputObjects(nt.Scheme, cm))
 	if err != nil {
 		nt.T.Fatal(err)
@@ -510,9 +510,9 @@ func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 
 	caCertSecret := nomostest.PublicCertSecretName(nomostest.RegistrySyncSource)
 
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	chart, err := nt.BuildAndPushHelmPackage(nomostest.RootSyncNN(configsync.RootSyncName),
-		registryproviders.HelmChartObjects(nt.Scheme, fake.NamespaceObject("foo-ns")))
+		registryproviders.HelmChartObjects(nt.Scheme, k8sobjects.NamespaceObject("foo-ns")))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -557,7 +557,7 @@ func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	upsertedSecret := controllers.ReconcilerResourceName(
 		core.NsReconcilerName(nn.Namespace, nn.Name), caCertSecret)
 
-	cm := fake.ConfigMapObject(core.Name("foo-cm"), core.Namespace(nn.Namespace))
+	cm := k8sobjects.ConfigMapObject(core.Name("foo-cm"), core.Namespace(nn.Namespace))
 	chart, err := nt.BuildAndPushHelmPackage(nn, registryproviders.HelmChartObjects(nt.Scheme, cm))
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -26,9 +26,9 @@ import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,7 +50,7 @@ func TestSyncingThroughAProxy(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 	nt.T.Log("Verify the NoOpProxyError")
-	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", `KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`)
 
 	nt.T.Log("Set auth type to cookiefile")

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -41,9 +41,9 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +69,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	})
 
 	// Add namespace to RootSync
-	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+	namespace1 := k8sobjects.NamespaceObject(namespace1NN.Name)
 	nt.Must(rootRepo.Add(nomostest.StructuredNSPath(namespace1NN.Name, namespace1NN.Name), namespace1))
 
 	// Add deployment-helloworld-1 to RootSync
@@ -95,7 +95,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Disabling RootSync deletion propagation")
-	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
 	err := nt.KubeClient.Get(rootSync.GetName(), rootSync.GetNamespace(), rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -158,7 +158,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	})
 
 	// Add namespace to RootSync
-	namespace1 := fake.NamespaceObject(namespace1NN.Name)
+	namespace1 := k8sobjects.NamespaceObject(namespace1NN.Name)
 	nt.Must(rootRepo.Add(nomostest.StructuredNSPath(namespace1NN.Name, namespace1NN.Name), namespace1))
 
 	// Add deployment-helloworld-1 to RootSync
@@ -184,7 +184,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.RootReconcilerObjectKey(rootSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
-	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
 	err := nt.KubeClient.Get(rootSync.Name, rootSync.Namespace, rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -293,7 +293,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
-	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
 	err := nt.KubeClient.Get(rootSync.Name, rootSync.Namespace, rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -418,7 +418,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	go nomostest.TailReconcilerLogs(ctx, nt, nomostest.NsReconcilerObjectKey(repoSyncNN.Namespace, repoSyncNN.Name))
 
 	nt.T.Log("Enabling RootSync deletion propagation")
-	rootSync := fake.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
 	err := nt.KubeClient.Get(rootSync.Name, rootSync.Namespace, rootSync)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -516,7 +516,7 @@ func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 		ntopts.WithReconcileTimeout(10*time.Second), // Reconcile expected to fail, so use a short timeout
 	)
 	// add a Namespace to the nested RootSync
-	namespace := fake.NamespaceObject(namespaceNN.Name)
+	namespace := k8sobjects.NamespaceObject(namespaceNN.Name)
 	nsPath := nomostest.StructuredNSPath(namespace.GetNamespace(), namespaceNN.Name)
 	nt.Must(nt.RootRepos[nestedRootSyncNN.Name].Add(nsPath, namespace))
 	nt.Must(nt.RootRepos[nestedRootSyncNN.Name].CommitAndPush(fmt.Sprintf("add Namespace %s", namespaceNN.Name)))
@@ -554,7 +554,7 @@ func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 
 	// Remove the fake finalizer
 	t.Cleanup(func() {
-		namespace = fake.NamespaceObject(namespaceNN.Name)
+		namespace = k8sobjects.NamespaceObject(namespaceNN.Name)
 		nt.T.Logf("Remove the fake finalizer named %s from Namespace %s", contrivedFinalizer, namespaceNN.Name)
 		if err := nt.KubeClient.Apply(namespace); err != nil {
 			nt.T.Fatal(err)
@@ -613,12 +613,12 @@ func cleanupSingleLevel(nt *nomostest.NT,
 ) {
 	cleanupSyncsAndObjects(nt,
 		[]client.Object{
-			fake.RootSyncObjectV1Beta1(rootSyncNN.Name),
+			k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name),
 		},
 		[]client.Object{
-			fake.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace)),
-			fake.NamespaceObject(namespace1NN.Name),
-			fake.NamespaceObject(safetyNamespace1NN.Name),
+			k8sobjects.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace)),
+			k8sobjects.NamespaceObject(namespace1NN.Name),
+			k8sobjects.NamespaceObject(safetyNamespace1NN.Name),
 		})
 }
 
@@ -629,15 +629,15 @@ func cleanupMultiLevel(nt *nomostest.NT,
 ) {
 	cleanupSyncsAndObjects(nt,
 		[]client.Object{
-			fake.RootSyncObjectV1Beta1(rootSyncNN.Name),
-			fake.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name),
+			k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name),
+			k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name),
 		},
 		[]client.Object{
-			fake.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace)),
-			fake.DeploymentObject(core.Name(deployment2NN.Name), core.Namespace(deployment2NN.Namespace)),
-			fake.NamespaceObject(namespace1NN.Name),
-			fake.NamespaceObject(safetyNamespace1NN.Name),
-			fake.NamespaceObject(safetyNamespace2NN.Name),
+			k8sobjects.DeploymentObject(core.Name(deployment1NN.Name), core.Namespace(deployment1NN.Namespace)),
+			k8sobjects.DeploymentObject(core.Name(deployment2NN.Name), core.Namespace(deployment2NN.Namespace)),
+			k8sobjects.NamespaceObject(namespace1NN.Name),
+			k8sobjects.NamespaceObject(safetyNamespace1NN.Name),
+			k8sobjects.NamespaceObject(safetyNamespace2NN.Name),
 		})
 }
 

--- a/e2e/testcases/remediator_test.go
+++ b/e2e/testcases/remediator_test.go
@@ -24,8 +24,8 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestSurfaceFightError(t *testing.T) {
@@ -34,7 +34,7 @@ func TestSurfaceFightError(t *testing.T) {
 	nt.T.Logf("Stop the admission webhook to generate the fights")
 	nomostest.StopWebhook(nt)
 
-	ns := fake.NamespaceObject("test-ns", core.Annotation("foo", "bar"))
+	ns := k8sobjects.NamespaceObject("test-ns", core.Annotation("foo", "bar"))
 	rb := roleBinding("test-rb", ns.Name, map[string]string{"foo": "bar"})
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		fmt.Sprintf("acme/namespaces/%s/ns.yaml", ns.Name), ns))

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -32,9 +32,9 @@ import (
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/resourcegroup"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestResourceGroupController(t *testing.T) {
@@ -43,11 +43,11 @@ func TestResourceGroupController(t *testing.T) {
 	ns := "rg-test"
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
 		"acme/namespaces/rg-test/ns.yaml",
-		fake.NamespaceObject(ns)))
+		k8sobjects.NamespaceObject(ns)))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/rg-test/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName), core.Namespace(ns))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName), core.Namespace(ns))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a ConfigMap to repo"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -77,11 +77,11 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
 		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
 			nt.T.Error(err)
 		}
 	})
-	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 	rgNN := types.NamespacedName{
@@ -237,11 +237,11 @@ func TestResourceGroupCustomResource(t *testing.T) {
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
 		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
 			nt.T.Error(err)
 		}
 	})
-	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 	rgNN := types.NamespacedName{
@@ -362,11 +362,11 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
 		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(fake.NamespaceObject(namespace)); err != nil {
+		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
 			nt.T.Error(err)
 		}
 	})
-	if err := nt.KubeClient.Create(fake.NamespaceObject(namespace)); err != nil {
+	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
 		nt.T.Fatal(err)
 	}
 	rgNN := types.NamespacedName{

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -25,11 +25,11 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestRootSyncSSHKnownHost(t *testing.T) {
@@ -85,7 +85,7 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 	// try syncing resource and validate
 	cmName := "configmap-test"
 	cmPath := "acme/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding test ConfigMap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -181,7 +181,7 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 	// try syncing resource and validate
 	cmName := "configmap-test"
 	cmPath := "acme/configmap.yaml"
-	cm := fake.ConfigMapObject(core.Name(cmName))
+	cm := k8sobjects.ConfigMapObject(core.Name(cmName))
 	nt.Must(nt.NonRootRepos[repoSyncNN].Add(cmPath, cm))
 	nt.Must(nt.NonRootRepos[repoSyncNN].CommitAndPush("Adding test ConfigMap"))
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -28,8 +28,8 @@ import (
 	resourcegroupv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,7 +41,7 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
 	id := applier.InventoryID(configsync.RootSyncName, configsync.ControllerNamespace)
 
-	rootSync := fake.RootSyncObjectV1Alpha1(configsync.RootSyncName)
+	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 	// Override the statusMode for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"statusMode": "disabled"}}}`)
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -50,7 +50,7 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 
 	namespaceName := "status-test"
 	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespaceObject(namespaceName, nil)))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm1.yaml", fake.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName))))
+	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm1.yaml", k8sobjects.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName))))
 	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a namespace and a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -38,11 +38,11 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -307,8 +307,8 @@ func TestWorkloadIdentity(t *testing.T) {
 			testutils.ClearMembershipInfo(nt, fleetMembership, *e2e.GCPProject, gkeURI)
 			testutils.ClearMembershipInfo(nt, fleetMembership, testutils.TestCrossProjectFleetProjectID, gkeURI)
 
-			rootSync := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
-			repoSync := fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName)
+			rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
+			repoSync := k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName)
 			rsRef := nomostest.RootSyncNN(rootSync.Name)
 			nsRef := nomostest.RepoSyncNN(repoSync.Namespace, repoSync.Name)
 			nt.T.Cleanup(func() {

--- a/pkg/applier/applier_err_test.go
+++ b/pkg/applier/applier_err_test.go
@@ -21,24 +21,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestErrorForResourceWithResource(t *testing.T) {
 	namespace := "test-namespace"
-	namespaceObj := fake.UnstructuredObject(kinds.Namespace(),
+	namespaceObj := k8sobjects.UnstructuredObject(kinds.Namespace(),
 		core.Name(namespace))
 	namespaceObjID := core.IDOf(namespaceObj)
 
-	cmObj := fake.UnstructuredObject(kinds.ConfigMap(),
+	cmObj := k8sobjects.UnstructuredObject(kinds.ConfigMap(),
 		core.Name("test-configmap"), core.Namespace(namespace))
 	cmObjID := core.IDOf(cmObj)
 
-	anvilObj := fake.UnstructuredObject(kinds.Anvil(),
+	anvilObj := k8sobjects.UnstructuredObject(kinds.Anvil(),
 		core.Namespace(namespace), core.Name("test-anvil"),
 		core.Annotation(metadata.SourcePathAnnotationKey, "foo/anvil.yaml"))
 	anvilObjID := core.IDOf(anvilObj)

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -30,12 +30,12 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier/stats"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	testingfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/apply"
@@ -112,7 +112,7 @@ func TestApply(t *testing.T) {
 
 	objs := []client.Object{deploymentObj, testObj1}
 
-	namespaceObj := fake.UnstructuredObject(kinds.Namespace(),
+	namespaceObj := k8sobjects.UnstructuredObject(kinds.Namespace(),
 		core.Name(syncScope.SyncNamespace()))
 	namespaceObjMeta := object.UnstructuredToObjMetadata(namespaceObj)
 	namespaceObjID := core.IDOf(namespaceObj)
@@ -721,12 +721,12 @@ func TestProcessWaitEvent(t *testing.T) {
 }
 
 func newDeploymentObj() *unstructured.Unstructured {
-	return fake.UnstructuredObject(kinds.Deployment(),
+	return k8sobjects.UnstructuredObject(kinds.Deployment(),
 		core.Namespace("test-namespace"), core.Name("random-name"), core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"))
 }
 
 func newTestObj(name string) *unstructured.Unstructured {
-	return fake.UnstructuredObject(schema.GroupVersionKind{
+	return k8sobjects.UnstructuredObject(schema.GroupVersionKind{
 		Group:   "configsync.test",
 		Version: "v1",
 		Kind:    "Test",

--- a/pkg/applier/destroyer_test.go
+++ b/pkg/applier/destroyer_test.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/applier/stats"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	testingfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/apply"
@@ -79,7 +79,7 @@ func TestDestroy(t *testing.T) {
 	testObj2 := newTestObj("test-2")
 	testObj2ID := core.IDOf(testObj2)
 
-	namespaceObj := fake.UnstructuredObject(kinds.Namespace(),
+	namespaceObj := k8sobjects.UnstructuredObject(kinds.Namespace(),
 		core.Name("test-namespace"))
 	namespaceMeta := object.UnstructuredToObjMetadata(namespaceObj)
 	namespaceObjID := core.IDOf(namespaceObj)

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,8 +38,8 @@ func TestPartitionObjs(t *testing.T) {
 		{
 			name: "all managed objs",
 			objs: []client.Object{
-				fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementEnabled),
-				fake.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementEnabled),
+				k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementEnabled),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementEnabled),
 			},
 			enabledCount:  2,
 			disabledCount: 0,
@@ -47,8 +47,8 @@ func TestPartitionObjs(t *testing.T) {
 		{
 			name: "all disabled objs",
 			objs: []client.Object{
-				fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementDisabled),
-				fake.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementDisabled),
+				k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementDisabled),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementDisabled),
 			},
 			enabledCount:  0,
 			disabledCount: 2,
@@ -56,8 +56,8 @@ func TestPartitionObjs(t *testing.T) {
 		{
 			name: "mixed objs",
 			objs: []client.Object{
-				fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementEnabled),
-				fake.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementDisabled),
+				k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"), syncertest.ManagementEnabled),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"), syncertest.ManagementDisabled),
 			},
 			enabledCount:  1,
 			disabledCount: 1,
@@ -77,7 +77,7 @@ func TestPartitionObjs(t *testing.T) {
 }
 
 func TestObjMetaFrom(t *testing.T) {
-	d := fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
+	d := k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
 	expected := object.ObjMetadata{
 		Namespace: "default",
 		Name:      "deploy",
@@ -93,7 +93,7 @@ func TestObjMetaFrom(t *testing.T) {
 }
 
 func TestIDFrom(t *testing.T) {
-	d := fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
+	d := k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
 	meta := ObjMetaFromObject(d)
 	id := idFrom(meta)
 	if id != core.IDOf(d) {
@@ -111,51 +111,51 @@ func TestRemoveFrom(t *testing.T) {
 		{
 			name: "toRemove is empty",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: nil,
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "all toRemove are in the original list",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
-				fake.ServiceObject(core.Name("service"), core.Namespace("default")),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "some toRemove are not in the original list",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
-				fake.ServiceObject(core.Name("service"), core.Namespace("default")),
-				fake.ConfigMapObject(core.Name("cm"), core.Namespace("default")),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default")),
+				k8sobjects.ConfigMapObject(core.Name("cm"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "toRemove are the same as original objects",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(fake.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(fake.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
-				fake.DeploymentObject(core.Name("deploy"), core.Namespace("default")),
-				fake.ServiceObject(core.Name("service"), core.Namespace("default")),
+				k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default")),
+				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default")),
 			},
 			expected: nil,
 		},

--- a/pkg/bugreport/bugreport_test.go
+++ b/pkg/bugreport/bugreport_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestAssembleLogSources(t *testing.T) {
@@ -35,45 +35,45 @@ func TestAssembleLogSources(t *testing.T) {
 	}{
 		{
 			name:           "No pods",
-			ns:             *fake.NamespaceObject("foo"),
+			ns:             *k8sobjects.NamespaceObject("foo"),
 			pods:           v1.PodList{Items: make([]v1.Pod, 0)},
 			expectedValues: make(logSources, 0),
 		},
 		{
 			name: "Multiple pods with various container configurations",
-			ns:   *fake.NamespaceObject("foo"),
+			ns:   *k8sobjects.NamespaceObject("foo"),
 			pods: v1.PodList{Items: []v1.Pod{
-				*fake.PodObject("foo_a", []v1.Container{
-					*fake.ContainerObject("1"),
-					*fake.ContainerObject("2"),
+				*k8sobjects.PodObject("foo_a", []v1.Container{
+					*k8sobjects.ContainerObject("1"),
+					*k8sobjects.ContainerObject("2"),
 				}),
-				*fake.PodObject("foo_b", []v1.Container{
-					*fake.ContainerObject("3"),
+				*k8sobjects.PodObject("foo_b", []v1.Container{
+					*k8sobjects.ContainerObject("3"),
 				}),
 			}},
 			expectedValues: logSources{
 				&logSource{
-					ns: *fake.NamespaceObject("foo"),
-					pod: *fake.PodObject("foo_a", []v1.Container{
-						*fake.ContainerObject("1"),
-						*fake.ContainerObject("2"),
+					ns: *k8sobjects.NamespaceObject("foo"),
+					pod: *k8sobjects.PodObject("foo_a", []v1.Container{
+						*k8sobjects.ContainerObject("1"),
+						*k8sobjects.ContainerObject("2"),
 					}),
-					cont: *fake.ContainerObject("1"),
+					cont: *k8sobjects.ContainerObject("1"),
 				},
 				&logSource{
-					ns: *fake.NamespaceObject("foo"),
-					pod: *fake.PodObject("foo_a", []v1.Container{
-						*fake.ContainerObject("1"),
-						*fake.ContainerObject("2"),
+					ns: *k8sobjects.NamespaceObject("foo"),
+					pod: *k8sobjects.PodObject("foo_a", []v1.Container{
+						*k8sobjects.ContainerObject("1"),
+						*k8sobjects.ContainerObject("2"),
 					}),
-					cont: *fake.ContainerObject("2"),
+					cont: *k8sobjects.ContainerObject("2"),
 				},
 				&logSource{
-					ns: *fake.NamespaceObject("foo"),
-					pod: *fake.PodObject("foo_b", []v1.Container{
-						*fake.ContainerObject("3"),
+					ns: *k8sobjects.NamespaceObject("foo"),
+					pod: *k8sobjects.PodObject("foo_b", []v1.Container{
+						*k8sobjects.ContainerObject("3"),
 					}),
-					cont: *fake.ContainerObject("3"),
+					cont: *k8sobjects.ContainerObject("3"),
 				},
 			},
 		},

--- a/pkg/bugreport/logsource_test.go
+++ b/pkg/bugreport/logsource_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestLogSourceGetPathName(t *testing.T) {
@@ -30,9 +30,9 @@ func TestLogSourceGetPathName(t *testing.T) {
 		{
 			name: "valid loggable produces hyphenated name",
 			source: logSource{
-				ns:   *fake.NamespaceObject("myNamespace"),
-				pod:  *fake.PodObject("myPod", make([]v1.Container, 0)),
-				cont: *fake.ContainerObject("myContainer"),
+				ns:   *k8sobjects.NamespaceObject("myNamespace"),
+				pod:  *k8sobjects.PodObject("myPod", make([]v1.Container, 0)),
+				cont: *k8sobjects.ContainerObject("myContainer"),
 			},
 			expectedName: "namespaces/myNamespace/myPod/myContainer",
 		},

--- a/pkg/core/id_test.go
+++ b/pkg/core/id_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,12 +30,12 @@ func TestGKNN(t *testing.T) {
 	}{
 		{
 			name: "a namespaced object",
-			obj:  fake.RoleObject(core.Namespace("test")),
+			obj:  k8sobjects.RoleObject(core.Namespace("test")),
 			want: "rbac.authorization.k8s.io_role_test_default-name",
 		},
 		{
 			name: "a cluster-scoped object",
-			obj:  fake.ClusterRoleObject(),
+			obj:  k8sobjects.ClusterRoleObject(),
 			want: "rbac.authorization.k8s.io_clusterrole_default-name",
 		},
 		{

--- a/pkg/core/k8sobjects/admission_webhook.go
+++ b/pkg/core/k8sobjects/admission_webhook.go
@@ -12,27 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kinds"
 )
 
-// DeploymentObject initializes a Deployment.
-func DeploymentObject(opts ...core.MetaMutator) *appsv1.Deployment {
-	result := &appsv1.Deployment{TypeMeta: ToTypeMeta(kinds.Deployment())}
+// AdmissionWebhookObject initializes a AdmissionWebhook object.
+func AdmissionWebhookObject(name string, opts ...core.MetaMutator) *v1.ValidatingWebhookConfiguration {
+	result := &v1.ValidatingWebhookConfiguration{TypeMeta: ToTypeMeta(kinds.ValidatingWebhookConfiguration())}
 	defaultMutate(result)
+	mutate(result, core.Name(name))
 	mutate(result, opts...)
 
 	return result
 }
 
-// Deployment returns a Deployment in a FileObject.
-func Deployment(dir string, opts ...core.MetaMutator) ast.FileObject {
-	relative := cmpath.RelativeSlash(dir).Join(cmpath.RelativeSlash("deployment.yaml"))
-	return FileObject(DeploymentObject(opts...), relative.SlashPath())
+// AdmissionWebhook returns a AdmissionWebhook in a FileObject.
+func AdmissionWebhook(name, dir string, opts ...core.MetaMutator) ast.FileObject {
+	relative := cmpath.RelativeSlash(dir).Join(cmpath.RelativeSlash("admission_webhook.yaml"))
+	return FileObject(AdmissionWebhookObject(name, opts...), relative.SlashPath())
 }

--- a/pkg/core/k8sobjects/build.go
+++ b/pkg/core/k8sobjects/build.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	"encoding/json"

--- a/pkg/core/k8sobjects/cluster_config.go
+++ b/pkg/core/k8sobjects/cluster_config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"

--- a/pkg/core/k8sobjects/container.go
+++ b/pkg/core/k8sobjects/container.go
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/kinds"
+	v1 "k8s.io/api/core/v1"
 )
 
-// SecretObject returns an initialized Secret.
-func SecretObject(name string, opts ...core.MetaMutator) *corev1.Secret {
-	result := &corev1.Secret{TypeMeta: ToTypeMeta(kinds.Secret())}
-	mutate(result, core.Name(name))
-	mutate(result, opts...)
-
-	return result
+// ContainerObject returns an initialized Container.
+func ContainerObject(name string) *v1.Container {
+	return &v1.Container{Name: name}
 }

--- a/pkg/core/k8sobjects/deployment.go
+++ b/pkg/core/k8sobjects/deployment.go
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
-	v1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kinds"
 )
 
-// AdmissionWebhookObject initializes a AdmissionWebhook object.
-func AdmissionWebhookObject(name string, opts ...core.MetaMutator) *v1.ValidatingWebhookConfiguration {
-	result := &v1.ValidatingWebhookConfiguration{TypeMeta: ToTypeMeta(kinds.ValidatingWebhookConfiguration())}
+// DeploymentObject initializes a Deployment.
+func DeploymentObject(opts ...core.MetaMutator) *appsv1.Deployment {
+	result := &appsv1.Deployment{TypeMeta: ToTypeMeta(kinds.Deployment())}
 	defaultMutate(result)
-	mutate(result, core.Name(name))
 	mutate(result, opts...)
 
 	return result
 }
 
-// AdmissionWebhook returns a AdmissionWebhook in a FileObject.
-func AdmissionWebhook(name, dir string, opts ...core.MetaMutator) ast.FileObject {
-	relative := cmpath.RelativeSlash(dir).Join(cmpath.RelativeSlash("admission_webhook.yaml"))
-	return FileObject(AdmissionWebhookObject(name, opts...), relative.SlashPath())
+// Deployment returns a Deployment in a FileObject.
+func Deployment(dir string, opts ...core.MetaMutator) ast.FileObject {
+	relative := cmpath.RelativeSlash(dir).Join(cmpath.RelativeSlash("deployment.yaml"))
+	return FileObject(DeploymentObject(opts...), relative.SlashPath())
 }

--- a/pkg/core/k8sobjects/hierarchy_config.go
+++ b/pkg/core/k8sobjects/hierarchy_config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/core/k8sobjects/metadata.go
+++ b/pkg/core/k8sobjects/metadata.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/core/k8sobjects/namespace.go
+++ b/pkg/core/k8sobjects/namespace.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	v1 "k8s.io/api/core/v1"

--- a/pkg/core/k8sobjects/namespace_config.go
+++ b/pkg/core/k8sobjects/namespace_config.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package objects
+package k8sobjects
 
 import (
-	"os"
-	"testing"
-
-	"k8s.io/klog/v2"
+	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/kinds"
 )
 
-// TestMain executes the tests for this package, with optional logging.
-// To see all logs, use:
-// go test kpt.dev/configsync/pkg/validate/objects -v -args -v=5
-func TestMain(m *testing.M) {
-	klog.InitFlags(nil)
-	os.Exit(m.Run())
+// NamespaceConfigObject initializes a NamespaceConfig.
+func NamespaceConfigObject(opts ...core.MetaMutator) *v1.NamespaceConfig {
+	result := &v1.NamespaceConfig{TypeMeta: ToTypeMeta(kinds.NamespaceConfig())}
+	defaultMutate(result)
+	for _, opt := range opts {
+		opt(result)
+	}
+
+	return result
 }

--- a/pkg/core/k8sobjects/objects.go
+++ b/pkg/core/k8sobjects/objects.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	"encoding/json"

--- a/pkg/core/k8sobjects/pod.go
+++ b/pkg/core/k8sobjects/pod.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	v1 "k8s.io/api/core/v1"

--- a/pkg/core/k8sobjects/repo.go
+++ b/pkg/core/k8sobjects/repo.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"

--- a/pkg/core/k8sobjects/reposync.go
+++ b/pkg/core/k8sobjects/reposync.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/core/k8sobjects/resourcegroup.go
+++ b/pkg/core/k8sobjects/resourcegroup.go
@@ -12,21 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
-	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/resourcegroup"
 )
 
-// NamespaceConfigObject initializes a NamespaceConfig.
-func NamespaceConfigObject(opts ...core.MetaMutator) *v1.NamespaceConfig {
-	result := &v1.NamespaceConfig{TypeMeta: ToTypeMeta(kinds.NamespaceConfig())}
+// ResourceGroupObject initializes a ResourceGroup.
+func ResourceGroupObject(opts ...core.MetaMutator) *unstructured.Unstructured {
+	result := resourcegroup.Unstructured("", "", "")
 	defaultMutate(result)
-	for _, opt := range opts {
-		opt(result)
-	}
+	mutate(result, opts...)
 
 	return result
 }

--- a/pkg/core/k8sobjects/rootsync.go
+++ b/pkg/core/k8sobjects/rootsync.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/core/k8sobjects/secret.go
+++ b/pkg/core/k8sobjects/secret.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package k8sobjects
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/resourcegroup"
+	"kpt.dev/configsync/pkg/kinds"
 )
 
-// ResourceGroupObject initializes a ResourceGroup.
-func ResourceGroupObject(opts ...core.MetaMutator) *unstructured.Unstructured {
-	result := resourcegroup.Unstructured("", "", "")
-	defaultMutate(result)
+// SecretObject returns an initialized Secret.
+func SecretObject(name string, opts ...core.MetaMutator) *corev1.Secret {
+	result := &corev1.Secret{TypeMeta: ToTypeMeta(kinds.Secret())}
+	mutate(result, core.Name(name))
 	mutate(result, opts...)
 
 	return result

--- a/pkg/declared/namespace_safeguard_test.go
+++ b/pkg/declared/namespace_safeguard_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/elliotchance/orderedmap/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestDontDeleteAllNamespaces(t *testing.T) {
@@ -85,12 +85,12 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			previous := orderedmap.NewOrderedMap[core.ID, *unstructured.Unstructured]()
 			for _, p := range tc.previous {
-				u := fake.UnstructuredObject(kinds.Namespace(), core.Name(p))
+				u := k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name(p))
 				previous.Set(core.IDOf(u), u)
 			}
 			current := orderedmap.NewOrderedMap[core.ID, *unstructured.Unstructured]()
 			for _, c := range tc.current {
-				u := fake.UnstructuredObject(kinds.Namespace(), core.Name(c))
+				u := k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name(c))
 				current.Set(core.IDOf(u), u)
 			}
 

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -26,16 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/syncer/reconcile"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testmetrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	obj1 = fake.CustomResourceDefinitionV1Beta1Object()
-	obj2 = fake.ResourceQuotaObject()
+	obj1 = k8sobjects.CustomResourceDefinitionV1Beta1Object()
+	obj2 = k8sobjects.ResourceQuotaObject()
 
 	testSet = []client.Object{obj1, obj2}
 	nilSet  = []client.Object{nil}
@@ -70,9 +70,9 @@ func TestMutateImpossible(t *testing.T) {
 	wantResourceVersion := "version 1"
 
 	dr := Resources{}
-	o1 := fake.RoleObject(core.Name("foo"), core.Namespace("bar"))
+	o1 := k8sobjects.RoleObject(core.Name("foo"), core.Namespace("bar"))
 	o1.SetResourceVersion(wantResourceVersion)
-	o2 := asUnstructured(t, fake.RoleObject(core.Name("baz"), core.Namespace("bar")))
+	o2 := asUnstructured(t, k8sobjects.RoleObject(core.Name("baz"), core.Namespace("bar")))
 	o2.SetResourceVersion(wantResourceVersion)
 
 	expectedCommit := "example"

--- a/pkg/diff/precedence_test.go
+++ b/pkg/diff/precedence_test.go
@@ -22,10 +22,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/diff/difftest"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -43,77 +43,77 @@ func TestCanManage(t *testing.T) {
 		{
 			"Root can manage unmanaged object",
 			declared.RootScope,
-			fake.DeploymentObject(),
+			k8sobjects.DeploymentObject(),
 			OperationManage,
 			true,
 		},
 		{
 			"Root can manage any non-root-managed object",
 			declared.RootScope,
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", "any-rs")),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", "any-rs")),
 			OperationManage,
 			true,
 		},
 		{
 			"Root can manage self-managed object",
 			declared.RootScope,
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, rsName)),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, rsName)),
 			OperationManage,
 			true,
 		},
 		{
 			"Root can NOT manage other root-managed object",
 			declared.RootScope,
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, "other-rs")),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, "other-rs")),
 			OperationManage,
 			false,
 		},
 		{
 			"Root can manage seemingly other root-managed object",
 			declared.RootScope,
-			fake.DeploymentObject(difftest.ManagedBy(declared.RootScope, "other-rs")),
+			k8sobjects.DeploymentObject(difftest.ManagedBy(declared.RootScope, "other-rs")),
 			OperationManage,
 			true,
 		},
 		{
 			"Non-root can manage unmanaged object",
 			"foo",
-			fake.DeploymentObject(),
+			k8sobjects.DeploymentObject(),
 			OperationManage,
 			true,
 		},
 		{
 			"Non-root can manage self-managed object",
 			"foo",
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", rsName)),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", rsName)),
 			OperationManage,
 			true,
 		},
 		{
 			"Non-root can NOT manage other non-root-managed object",
 			"foo",
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", "other-rs")),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy("foo", "other-rs")),
 			OperationManage,
 			false,
 		},
 		{
 			"Non-root can NOT manage root-managed object",
 			"foo",
-			fake.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, "any-rs")),
+			k8sobjects.DeploymentObject(syncertest.ManagementEnabled, difftest.ManagedBy(declared.RootScope, "any-rs")),
 			OperationManage,
 			false,
 		},
 		{
 			"Non-root can manage seemingly other non-root-managed object",
 			"foo",
-			fake.DeploymentObject(difftest.ManagedBy("foo", "other-rs")),
+			k8sobjects.DeploymentObject(difftest.ManagedBy("foo", "other-rs")),
 			OperationManage,
 			true,
 		},
 		{
 			"Non-root can manage seemingly root-managed object",
 			"foo",
-			fake.DeploymentObject(difftest.ManagedBy(declared.RootScope, "any-rs")),
+			k8sobjects.DeploymentObject(difftest.ManagedBy(declared.RootScope, "any-rs")),
 			OperationManage,
 			true,
 		},

--- a/pkg/diff/unknown_test.go
+++ b/pkg/diff/unknown_test.go
@@ -17,7 +17,7 @@ package diff
 import (
 	"testing"
 
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,7 +34,7 @@ func TestIsUnknown(t *testing.T) {
 		},
 		{
 			"known object",
-			fake.ConfigMapObject(),
+			k8sobjects.ConfigMapObject(),
 			false,
 		},
 	}

--- a/pkg/hydrate/file_name_test.go
+++ b/pkg/hydrate/file_name_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func cluster(name string) core.MetaMutator {
@@ -42,39 +42,39 @@ func TestToFileObjects(t *testing.T) {
 		{
 			name: "namespaced role works",
 			objects: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("prod"), cluster("na-1")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("prod"), cluster("na-1")),
 			},
 			expected: []ast.FileObject{
-				fake.FileObject(fake.RoleObject(core.Name("alice"), core.Namespace("prod"), cluster("na-1")), "na-1/prod/role_alice.yaml"),
+				k8sobjects.FileObject(k8sobjects.RoleObject(core.Name("alice"), core.Namespace("prod"), cluster("na-1")), "na-1/prod/role_alice.yaml"),
 			},
 		},
 		{
 			name: "non-namespaced clusterrolebinding works",
 			objects: []ast.FileObject{
-				fake.ClusterRoleBinding(core.Name("alice"), cluster("eu-2")),
+				k8sobjects.ClusterRoleBinding(core.Name("alice"), cluster("eu-2")),
 			},
 			expected: []ast.FileObject{
-				fake.FileObject(fake.ClusterRoleBindingObject(core.Name("alice"), cluster("eu-2")), "eu-2/clusterrolebinding_alice.yaml"),
+				k8sobjects.FileObject(k8sobjects.ClusterRoleBindingObject(core.Name("alice"), cluster("eu-2")), "eu-2/clusterrolebinding_alice.yaml"),
 			},
 		},
 		{
 			name: "conflict resolved",
 			objects: []ast.FileObject{
-				fake.Unstructured(schema.GroupVersionKind{
+				k8sobjects.Unstructured(schema.GroupVersionKind{
 					Group: "rbac",
 					Kind:  "ClusterRole",
 				}, core.Name("alice")),
-				fake.Unstructured(schema.GroupVersionKind{
+				k8sobjects.Unstructured(schema.GroupVersionKind{
 					Group: "oauth",
 					Kind:  "ClusterRole",
 				}, core.Name("alice")),
 			},
 			expected: []ast.FileObject{
-				fake.UnstructuredAtPath(schema.GroupVersionKind{
+				k8sobjects.UnstructuredAtPath(schema.GroupVersionKind{
 					Group: "rbac",
 					Kind:  "ClusterRole",
 				}, "defaultcluster/clusterrole.rbac_alice.yaml", core.Name("alice")),
-				fake.UnstructuredAtPath(schema.GroupVersionKind{
+				k8sobjects.UnstructuredAtPath(schema.GroupVersionKind{
 					Group: "oauth",
 					Kind:  "ClusterRole",
 				}, "defaultcluster/clusterrole.oauth_alice.yaml", core.Name("alice")),

--- a/pkg/importer/customresources/customresources_test.go
+++ b/pkg/importer/customresources/customresources_test.go
@@ -23,9 +23,9 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -91,42 +91,42 @@ func TestGetCRDs(t *testing.T) {
 		},
 		{
 			name: "ignore non-CRD",
-			objs: []ast.FileObject{fake.Role()},
+			objs: []ast.FileObject{k8sobjects.Role()},
 		},
 		{
 			name: "one v1beta1 CRD",
 			objs: []ast.FileObject{
-				fake.CustomResourceDefinitionV1Beta1(),
+				k8sobjects.CustomResourceDefinitionV1Beta1(),
 			},
 			want: []*apiextensionsv1beta1.CustomResourceDefinition{
-				fake.CustomResourceDefinitionV1Beta1Object(),
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(),
 			},
 		},
 		{
 			name: "one v1 CRD",
 			objs: []ast.FileObject{
-				fake.CustomResourceDefinitionV1(servedStorage(t, true, true)),
+				k8sobjects.CustomResourceDefinitionV1(servedStorage(t, true, true)),
 			},
 			want: []*apiextensionsv1beta1.CustomResourceDefinition{
 				// The default if unspecified is true/true for served/storage.
-				fake.CustomResourceDefinitionV1Beta1Object(servedStorage(t, true, true), preserveUnknownFields(t, false)),
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(servedStorage(t, true, true), preserveUnknownFields(t, false)),
 			},
 		},
 		{
 			name: "both CRD versions",
 			objs: []ast.FileObject{
-				fake.CustomResourceDefinitionV1Beta1(core.Name("a"),
+				k8sobjects.CustomResourceDefinitionV1Beta1(core.Name("a"),
 					groupKind(t, kinds.Role().GroupKind())),
-				fake.CustomResourceDefinitionV1(
+				k8sobjects.CustomResourceDefinitionV1(
 					servedStorage(t, true, true),
 					core.Name("b"),
 					groupKind(t, kinds.ClusterRole().GroupKind())),
 			},
 			want: []*apiextensionsv1beta1.CustomResourceDefinition{
 				// The default if unspecified is true/true for served/storage.
-				fake.CustomResourceDefinitionV1Beta1Object(core.Name("a"),
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(core.Name("a"),
 					groupKind(t, kinds.Role().GroupKind())),
-				fake.CustomResourceDefinitionV1Beta1Object(
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(
 					servedStorage(t, true, true),
 					core.Name("b"),
 					groupKind(t, kinds.ClusterRole().GroupKind()),

--- a/pkg/importer/filesystem/parser_read_files_test.go
+++ b/pkg/importer/filesystem/parser_read_files_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/syntax"
 	"kpt.dev/configsync/pkg/importer/analyzer/vet/vettesting"
@@ -33,7 +34,6 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/resourcequota"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -90,7 +90,7 @@ func TestFilesystemReader(t *testing.T) {
 			testFiles: ft.FileContentMap{
 				"namespaces/bar/namespace.yaml": aNamespace("bar"),
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"))),
 		},
 		{
 			testName: "Namespace dir with JSON Namespace",
@@ -105,7 +105,7 @@ func TestFilesystemReader(t *testing.T) {
 }
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.json", core.Name("bar"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.json", core.Name("bar"))),
 		},
 		{
 			testName: "Namespaces dir with ignored file",
@@ -120,7 +120,7 @@ func TestFilesystemReader(t *testing.T) {
 				"namespaces/bar/ignore":         "",
 				"namespaces/bar/ignore2":        "blah blah blah",
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"))),
 		},
 		{
 			testName: "Namespace with labels/annotations",
@@ -136,7 +136,7 @@ metadata:
     audit: "true"
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"), core.Label("env", "prod"), core.Annotation("audit", "true"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/bar/namespace.yaml", core.Name("bar"), core.Label("env", "prod"), core.Annotation("audit", "true"))),
 		},
 		{
 			testName: "Abstract Namespace dir with ignored file",
@@ -157,7 +157,7 @@ spec:
     pods: "10"
 `,
 			},
-			expectObject: pointer(ast.NewFileObject(fake.UnstructuredObject(kinds.ResourceQuota(), specHardPods, core.Name("pod-quota")), cmpath.RelativeSlash("namespaces/bar/rq.yaml"))),
+			expectObject: pointer(ast.NewFileObject(k8sobjects.UnstructuredObject(kinds.ResourceQuota(), specHardPods, core.Name("pod-quota")), cmpath.RelativeSlash("namespaces/bar/rq.yaml"))),
 		},
 		{
 			testName: "Namespace dir with Custom Resource",
@@ -248,7 +248,7 @@ metadata:
     number: "0000"
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Annotation("number", "0000"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Annotation("number", "0000"))),
 		},
 		{
 			testName: "metadata.annotations with boolean value",
@@ -276,7 +276,7 @@ metadata:
     boolean: "true"
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Annotation("boolean", "true"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Annotation("boolean", "true"))),
 		},
 		{
 			testName: "metadata.labels with boolean value",
@@ -304,7 +304,7 @@ metadata:
     boolean: "true"
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Label("boolean", "true"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Label("boolean", "true"))),
 		},
 		{
 			testName: "metadata.labels with numerical value",
@@ -332,7 +332,7 @@ metadata:
     number: "123456789"
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Label("number", "123456789"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/backend/namespace.yaml", core.Name("backend"), core.Label("number", "123456789"))),
 		},
 		{
 			testName: "parses nested List",
@@ -350,7 +350,7 @@ items:
       name: foo
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Namespace(), "namespaces/foo/list.yaml", core.Name("foo"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Namespace(), "namespaces/foo/list.yaml", core.Name("foo"))),
 		},
 		{
 			testName: "parses specialized List",
@@ -365,7 +365,7 @@ items:
     name: my-role
 `,
 			},
-			expectObject: pointer(fake.UnstructuredAtPath(kinds.Role(), "namespaces/foo/list.yaml", core.Name("my-role"))),
+			expectObject: pointer(k8sobjects.UnstructuredAtPath(kinds.Role(), "namespaces/foo/list.yaml", core.Name("my-role"))),
 		},
 		{
 			testName: "illegal field in list-embedded resource",

--- a/pkg/importer/reader/parse_file_test.go
+++ b/pkg/importer/reader/parse_file_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestParseYAMLFile(t *testing.T) {
@@ -78,7 +78,7 @@ metadata:
   name: shipping
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("shipping")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("shipping")),
 			},
 		}, {
 			name: "one document with triple-dash in a string",
@@ -90,7 +90,7 @@ metadata:
     "a": "---"
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("shipping"), core.Label("a", "---")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("shipping"), core.Label("a", "---")),
 			},
 		},
 		{
@@ -110,7 +110,7 @@ rules:
   verbs: [all]
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("shipping")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("shipping")),
 				{
 					Object: map[string]interface{}{
 						"apiVersion": "rbac/v1",
@@ -139,7 +139,7 @@ kind: Namespace
 metadata:
   name: foo`,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("foo")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("foo")),
 			},
 		},
 		{
@@ -156,7 +156,7 @@ metadata:
       is not a separator
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("foo"),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("foo"),
 					core.Label("a", "this --- is not a separator\n")),
 			},
 		},
@@ -176,8 +176,8 @@ metadata:
   name: bar
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("foo")),
-				fake.UnstructuredObject(kinds.Namespace(), core.Name("bar")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("foo")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("bar")),
 			},
 		},
 		{
@@ -400,7 +400,7 @@ metadata:
 # comment
 `,
 			expected: []*unstructured.Unstructured{
-				fake.UnstructuredObject(kinds.KptFile(), core.Name("package-name")),
+				k8sobjects.UnstructuredObject(kinds.KptFile(), core.Name("package-name")),
 			},
 		}, {
 			name: "one document with another type",

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,72 +36,72 @@ func TestHasConfigSyncMetadata(t *testing.T) {
 	}{
 		{
 			name: "An object without Config Sync metadata",
-			obj:  fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy")),
+			obj:  k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy")),
 			want: false,
 		},
 		{
 			name: "An object with the `OwningInventoryKey` annotation",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.OwningInventoryKey, "random-value")),
 			want: true,
 		},
 		{
 			name: "An object with the `LifecycleMutationAnnotation` annotation",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.LifecycleMutationAnnotation, "random-value")),
 			want: true,
 		},
 		{
 			name: "An object with the `client.lifecycle.config.k8s.io/others` annotation",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.LifecyclePrefix+"/others", "random-value")),
 			want: false,
 		},
 		{
 			name: "An object with the `ResourceManagementKey` annotation",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled)),
 			want: true,
 		},
 		{
 			name: "An object with the `ResourceIDKey` annotation",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.ResourceIDKey, "random-value")),
 			want: true,
 		},
 		{
 			name: "An object with the `HNCManagedBy` annotation (random value)",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.HNCManagedBy, "random-value")),
 			want: false,
 		},
 		{
 			name: "An object with the `HNCManagedBy` annotation (correct value)",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Annotation(metadata.HNCManagedBy, configmanagement.GroupName)),
 			want: true,
 		},
 		{
 			name: "An object with the `DeclaredVersionLabel` label",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Label(metadata.DeclaredVersionLabel, "v1")),
 			want: true,
 		},
 		{
 			name: "An object with the `SystemLabel` label",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Label(metadata.SystemLabel, "random-value")),
 			want: true,
 		},
 		{
 			name: "An object with the `ManagedByKey` label (correct value)",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue)),
 			want: true,
 		},
 		{
 			name: "An object with the `ManagedByKey` label (random value)",
-			obj: fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+			obj: k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 				core.Label(metadata.ManagedByKey, "random-value")),
 			want: false,
 		},
@@ -118,7 +118,7 @@ func TestHasConfigSyncMetadata(t *testing.T) {
 }
 
 func TestRemoveConfigSyncMetadata(t *testing.T) {
-	obj := fake.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
+	obj := k8sobjects.UnstructuredObject(kinds.Deployment(), core.Name("deploy"),
 		syncertest.ManagementEnabled,
 		core.Annotation(metadata.OwningInventoryKey, "random-value"),
 		core.Annotation(metadata.LifecycleMutationAnnotation, "random-value"),

--- a/pkg/parse/annotations_test.go
+++ b/pkg/parse/annotations_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestAddAnnotationsAndLabels(t *testing.T) {
@@ -46,8 +46,8 @@ func TestAddAnnotationsAndLabels(t *testing.T) {
 				Rev:    "HEAD",
 			},
 			commitHash: "1234567",
-			actual:     []ast.FileObject{fake.Role(core.Namespace("foo"))},
-			expected: []ast.FileObject{fake.Role(
+			actual:     []ast.FileObject{k8sobjects.Role(core.Namespace("foo"))},
+			expected: []ast.FileObject{k8sobjects.Role(
 				core.Namespace("foo"),
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 				core.Annotation(metadata.ResourceManagementKey, "enabled"),

--- a/pkg/parse/repository_scope_test.go
+++ b/pkg/parse/repository_scope_test.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
@@ -37,19 +37,19 @@ func TestNamespaceScopeVisitor(t *testing.T) {
 		{
 			name:  "correct Namespace pass",
 			scope: "foo",
-			obj:   fake.Role(core.Namespace("foo")),
+			obj:   k8sobjects.Role(core.Namespace("foo")),
 		},
 		{
 			name:  "blank Namespace pass and update Namespace",
 			scope: "foo",
-			obj:   fake.Role(core.Namespace("")),
-			want:  fake.Role(core.Namespace("foo")),
+			obj:   k8sobjects.Role(core.Namespace("")),
+			want:  k8sobjects.Role(core.Namespace("foo")),
 		},
 		{
 			name:    "wrong Namespace error",
 			scope:   "foo",
-			obj:     fake.Role(core.Namespace("bar")),
-			wantErr: BadScopeErr(fake.Role(core.Namespace("bar")), "foo"),
+			obj:     k8sobjects.Role(core.Namespace("bar")),
+			wantErr: BadScopeErr(k8sobjects.Role(core.Namespace("bar")), "foo"),
 		},
 	}
 

--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -37,6 +37,7 @@ import (
 	"kpt.dev/configsync/pkg/applier"
 	applierfake "kpt.dev/configsync/pkg/applier/fake"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/diff/difftest"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -53,7 +54,6 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
 	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"kpt.dev/configsync/pkg/testing/testmetrics"
@@ -254,12 +254,12 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("foo")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -270,7 +270,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_foo_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -295,12 +295,12 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("foo")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -319,7 +319,7 @@ func TestRoot_Parse(t *testing.T) {
 			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{
-				fake.NamespaceObject("foo",
+				k8sobjects.NamespaceObject("foo",
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion),
 					core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
@@ -333,12 +333,12 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("foo")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -349,7 +349,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_foo_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -368,7 +368,7 @@ func TestRoot_Parse(t *testing.T) {
 			name:              "no implicit namespace if unstructured, present, but managed by others",
 			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
-			existingObjects: []client.Object{fake.NamespaceObject("foo",
+			existingObjects: []client.Object{k8sobjects.NamespaceObject("foo",
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 				core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion),
 				core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
@@ -382,12 +382,12 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("foo")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -406,18 +406,18 @@ func TestRoot_Parse(t *testing.T) {
 			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{
-				fake.NamespaceObject("foo"),
+				k8sobjects.NamespaceObject("foo"),
 				rootSyncInput.DeepCopy(),
 			},
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("foo")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -441,13 +441,13 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.RootSyncV1Beta1("test", fake.WithRootSyncSourceType(configsync.GitSource), gitSpec("https://github.com/test/test.git", configsync.AuthNone)),
+						k8sobjects.RootSyncV1Beta1("test", k8sobjects.WithRootSyncSourceType(configsync.GitSource), gitSpec("https://github.com/test/test.git", configsync.AuthNone)),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.RootSyncV1Beta1("test", gitSpec("https://github.com/test/test.git", configsync.AuthNone),
-					fake.WithRootSyncSourceType(configsync.GitSource),
+				k8sobjects.RootSyncV1Beta1("test", gitSpec("https://github.com/test/test.git", configsync.AuthNone),
+					k8sobjects.WithRootSyncSourceType(configsync.GitSource),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1beta1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, fmt.Sprintf("namespaces/%s/test.yaml", configsync.ControllerNamespace)),
@@ -471,13 +471,13 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("bar")),
-						fake.ConfigMap(core.Namespace("bar")),
+						k8sobjects.Role(core.Namespace("bar")),
+						k8sobjects.ConfigMap(core.Namespace("bar")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("bar"),
+				k8sobjects.Role(core.Namespace("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -488,7 +488,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_bar_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.ConfigMap(core.Namespace("bar"),
+				k8sobjects.ConfigMap(core.Namespace("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/configmap.yaml"),
@@ -499,7 +499,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "_configmap_bar_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -519,9 +519,9 @@ func TestRoot_Parse(t *testing.T) {
 			format:            configsync.SourceFormatUnstructured,
 			namespaceStrategy: configsync.NamespaceStrategyImplicit,
 			existingObjects: []client.Object{
-				fake.NamespaceObject("foo"), // foo exists but not managed, should NOT be added as an implicit namespace
+				k8sobjects.NamespaceObject("foo"), // foo exists but not managed, should NOT be added as an implicit namespace
 				// bar not exists, should be added as an implicit namespace
-				fake.NamespaceObject("baz", // baz exists and self-managed, should be added as an implicit namespace
+				k8sobjects.NamespaceObject("baz", // baz exists and self-managed, should be added as an implicit namespace
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion),
 					core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
@@ -535,16 +535,16 @@ func TestRoot_Parse(t *testing.T) {
 			parseOutputs: []fsfake.ParserOutputs{
 				{
 					FileObjects: []ast.FileObject{
-						fake.Role(core.Namespace("foo")),
-						fake.Role(core.Namespace("bar")),
-						fake.ConfigMap(core.Namespace("bar")),
-						fake.Role(core.Namespace("baz")),
-						fake.ConfigMap(core.Namespace("baz")),
+						k8sobjects.Role(core.Namespace("foo")),
+						k8sobjects.Role(core.Namespace("bar")),
+						k8sobjects.ConfigMap(core.Namespace("bar")),
+						k8sobjects.Role(core.Namespace("baz")),
+						k8sobjects.ConfigMap(core.Namespace("baz")),
 					},
 				},
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -555,7 +555,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_foo_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.Role(core.Namespace("bar"),
+				k8sobjects.Role(core.Namespace("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -566,7 +566,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_bar_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.ConfigMap(core.Namespace("bar"),
+				k8sobjects.ConfigMap(core.Namespace("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/configmap.yaml"),
@@ -577,7 +577,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "_configmap_bar_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.Role(core.Namespace("baz"),
+				k8sobjects.Role(core.Namespace("baz"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -588,7 +588,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_baz_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.ConfigMap(core.Namespace("baz"),
+				k8sobjects.ConfigMap(core.Namespace("baz"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/configmap.yaml"),
@@ -599,7 +599,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "_configmap_baz_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("bar"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -611,7 +611,7 @@ func TestRoot_Parse(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "_namespace_bar"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("baz"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -650,7 +650,7 @@ func TestRoot_Parse(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
-			tc.existingObjects = append(tc.existingObjects, fake.RootSyncObjectV1Beta1(rootSyncName))
+			tc.existingObjects = append(tc.existingObjects, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			parser := &root{
 				Options: &Options{
 					Clock:              fakeClock,
@@ -739,7 +739,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 		{
 			name:           "has declared-fields annotation, admission webhook is disabled",
 			webhookEnabled: false,
-			existingObjects: []client.Object{fake.NamespaceObject("foo",
+			existingObjects: []client.Object{k8sobjects.NamespaceObject("foo",
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 				core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 				core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:rules":{}}`),
@@ -749,10 +749,10 @@ func TestRoot_DeclaredFields(t *testing.T) {
 				core.Annotation(metadata.ResourceIDKey, "_namespace_foo"),
 				difftest.ManagedBy(declared.RootScope, "other-root-sync"))},
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -768,7 +768,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 		{
 			name:           "has declared-fields annotation, admission webhook enabled",
 			webhookEnabled: true,
-			existingObjects: []client.Object{fake.NamespaceObject("foo",
+			existingObjects: []client.Object{k8sobjects.NamespaceObject("foo",
 				core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 				core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 				core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{},"f:labels":{}},"f:rules":{}}`),
@@ -779,10 +779,10 @@ func TestRoot_DeclaredFields(t *testing.T) {
 				difftest.ManagedBy(declared.RootScope, "other-root-sync")),
 			},
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{"f:configmanagement.gke.io/source-path":{}},"f:labels":{"f:configsync.gke.io/declared-version":{}}},"f:rules":{}}`),
@@ -800,7 +800,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 			name:           "has no declared-fields annotation, admission webhook is enabled",
 			webhookEnabled: true,
 			existingObjects: []client.Object{
-				fake.NamespaceObject("foo",
+				k8sobjects.NamespaceObject("foo",
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 					core.Annotation(metadata.GitContextKey, nilGitContext),
@@ -808,13 +808,13 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					core.Annotation(metadata.OwningInventoryKey, applier.InventoryID(rootSyncName, configmanagement.ControllerNamespace)),
 					core.Annotation(metadata.ResourceIDKey, "_namespace_foo"),
 					difftest.ManagedBy(declared.RootScope, "other-root-sync")),
-				fake.AdmissionWebhookObject(webhookconfiguration.Name),
+				k8sobjects.AdmissionWebhookObject(webhookconfiguration.Name),
 			},
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.DeclaredFieldsKey, `{"f:metadata":{"f:annotations":{"f:configmanagement.gke.io/source-path":{}},"f:labels":{"f:configsync.gke.io/declared-version":{}}},"f:rules":{}}`),
@@ -832,7 +832,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 			name:           "has no declared-fields annotation, admission webhook disabled",
 			webhookEnabled: false,
 			existingObjects: []client.Object{
-				fake.NamespaceObject("foo",
+				k8sobjects.NamespaceObject("foo",
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Annotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 					core.Annotation(metadata.GitContextKey, nilGitContext),
@@ -842,10 +842,10 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					difftest.ManagedBy(declared.RootScope, "other-root-sync")),
 			},
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -878,7 +878,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
-			tc.existingObjects = append(tc.existingObjects, fake.RootSyncObjectV1Beta1(rootSyncName))
+			tc.existingObjects = append(tc.existingObjects, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			parser := &root{
 				Options: &Options{
 					Clock:              clock.RealClock{}, // TODO: Test with fake clock
@@ -920,7 +920,7 @@ func TestRoot_DeclaredFields(t *testing.T) {
 }
 
 func fakeCRD(opts ...core.MetaMutator) ast.FileObject {
-	crd := fake.CustomResourceDefinitionV1Object(opts...)
+	crd := k8sobjects.CustomResourceDefinitionV1Object(opts...)
 	crd.Spec.Group = "acme.com"
 	crd.Spec.Names = apiextensionsv1.CustomResourceDefinitionNames{
 		Plural:   "anvils",
@@ -953,13 +953,13 @@ func fakeCRD(opts ...core.MetaMutator) ast.FileObject {
 			},
 		},
 	}
-	return fake.FileObject(crd, "cluster/crd.yaml")
+	return k8sobjects.FileObject(crd, "cluster/crd.yaml")
 }
 
 func fakeFileObjects() []ast.FileObject {
 	var fileObjects []ast.FileObject
 	for i := 0; i < 500; i++ {
-		fileObjects = append(fileObjects, fake.RoleAtPath(fmt.Sprintf("namespaces/foo/role%v.yaml", i), core.Namespace("foo")))
+		fileObjects = append(fileObjects, k8sobjects.RoleAtPath(fmt.Sprintf("namespaces/foo/role%v.yaml", i), core.Namespace("foo")))
 	}
 	return fileObjects
 }
@@ -995,9 +995,9 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 			discoveryClient: syncertest.NewDiscoveryClientWithError(context.DeadlineExceeded, kinds.Namespace(), kinds.Role()),
 			expectedError:   fakeParseError(context.DeadlineExceeded, kinds.Namespace(), kinds.Role()),
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 				// add a faked obect in parser.parsed without CRD so it's scope will be unknown when validating
-				fake.Unstructured(kinds.Anvil(), core.Name("deploy")),
+				k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy")),
 			},
 			expectedObjsToApply: nil,
 		},
@@ -1007,9 +1007,9 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 			discoveryClient: syncertest.NewDiscoveryClientWithError(errors.New("net/http: request canceled (Client.Timeout exceeded while awaiting headers)"), kinds.Namespace(), kinds.Role()),
 			expectedError:   fakeParseError(errors.New("net/http: request canceled (Client.Timeout exceeded while awaiting headers)"), kinds.Namespace(), kinds.Role()),
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 				// add a faked obect in parser.parsed without CRD so it's scope will be unknown when validating
-				fake.Unstructured(kinds.Anvil(), core.Name("deploy")),
+				k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy")),
 			},
 			expectedObjsToApply: nil,
 		},
@@ -1018,7 +1018,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 			name:                "unknown scoped object with discovery failure of 500 deadline exceeded failure",
 			discoveryClient:     syncertest.NewDiscoveryClientWithError(context.DeadlineExceeded, fakeGVKs()...),
 			expectedError:       fakeParseError(context.DeadlineExceeded, fakeGVKs()...),
-			parsed:              append(fakeFileObjects(), fake.Unstructured(kinds.Anvil(), core.Name("deploy"))),
+			parsed:              append(fakeFileObjects(), k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy"))),
 			expectedObjsToApply: nil,
 		},
 		{
@@ -1026,16 +1026,16 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 			name:            "unknown scoped object without discovery failure",
 			discoveryClient: syncertest.NewDiscoveryClientWithError(nil, kinds.Namespace(), kinds.Role()),
 			expectedError: status.UnknownObjectKindError(
-				fake.Unstructured(kinds.Anvil(), core.Name("deploy"),
+				k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/obj.yaml"),
 				)),
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 				// add a faked obect in parser.parsed without CRD so it's scope will be unknown when validating
-				fake.Unstructured(kinds.Anvil(), core.Name("deploy")),
+				k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy")),
 			},
 			expectedObjsToApply: []ast.FileObject{
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -1046,7 +1046,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_foo_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -1066,9 +1066,9 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 			discoveryClient: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 			expectedError:   nil,
 			parsed: []ast.FileObject{
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo")),
 				fakeCRD(core.Name("anvils.acme.com")),
-				fake.Unstructured(kinds.Anvil(), core.Name("deploy"), core.Namespace("foo")),
+				k8sobjects.Unstructured(kinds.Anvil(), core.Name("deploy"), core.Namespace("foo")),
 			},
 			expectedObjsToApply: []ast.FileObject{
 				fakeCRD(core.Name("anvils.acme.com"),
@@ -1081,7 +1081,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					core.Annotation(metadata.OwningInventoryKey, applier.InventoryID(rootSyncName, configmanagement.ControllerNamespace)),
 					core.Annotation(metadata.ResourceIDKey, "apiextensions.k8s.io_customresourcedefinition_anvils.acme.com"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName)),
-				fake.Role(core.Namespace("foo"),
+				k8sobjects.Role(core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.DeclaredVersionLabel, "v1"),
 					core.Annotation(metadata.SourcePathAnnotationKey, "namespaces/foo/role.yaml"),
@@ -1092,7 +1092,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "rbac.authorization.k8s.io_role_foo_default-name"),
 					difftest.ManagedBy(declared.RootScope, rootSyncName),
 				),
-				fake.Unstructured(kinds.Anvil(),
+				k8sobjects.Unstructured(kinds.Anvil(),
 					core.Name("deploy"),
 					core.Namespace("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -1105,7 +1105,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					core.Annotation(metadata.OwningInventoryKey, applier.InventoryID(rootSyncName, configmanagement.ControllerNamespace)),
 					core.Annotation(metadata.ResourceIDKey, "acme.com_anvil_foo_deploy"),
 				),
-				fake.UnstructuredAtPath(kinds.Namespace(),
+				k8sobjects.UnstructuredAtPath(kinds.Namespace(),
 					"",
 					core.Name("foo"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
@@ -1145,7 +1145,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					Parser:             fakeConfigParser,
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: tc.discoveryClient,
 					Converter:          converter,
 					Updater: Updater{
@@ -1237,7 +1237,7 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					Parser:             fakeConfigParser,
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Updater: Updater{
 						Scope:          declared.RootScope,
@@ -1336,7 +1336,7 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					},
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 				},
 				RootOptions: &RootOptions{
@@ -1793,9 +1793,9 @@ func TestPrependRootSyncRemediatorStatus(t *testing.T) {
 	const rootSyncName = "my-root-sync"
 	const thisManager = "this-manager"
 	const otherManager = "other-manager"
-	conflictingObject := fake.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, otherManager))
+	conflictingObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, otherManager))
 	conflictAB := status.ManagementConflictErrorWrap(conflictingObject, thisManager)
-	invertedObject := fake.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, thisManager))
+	invertedObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, thisManager))
 	conflictBA := status.ManagementConflictErrorWrap(invertedObject, otherManager)
 	conflictABInverted := conflictAB.Invert()
 	// KptManagementConflictError is created with the desired object, not the current live object.
@@ -1889,7 +1889,7 @@ For more information, see https://g.co/cloud/acm-errors#knv1060`
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			rootSync := fake.RootSyncObjectV1Beta1(rootSyncName)
+			rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncName)
 			rootSync.Status.Sync.Errors = tc.thisSyncErrors
 			fakeClient := syncertest.NewClient(t, core.Scheme, rootSync)
 			ctx := context.Background()

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -36,6 +36,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	applierfake "kpt.dev/configsync/pkg/applier/fake"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
@@ -51,7 +52,6 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/util"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
@@ -129,29 +129,29 @@ func TestSplitObjects(t *testing.T) {
 		{
 			name: "no unknown scope objects",
 			objs: []ast.FileObject{
-				fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-				fake.Role(core.Namespace("prod")),
+				k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+				k8sobjects.Role(core.Namespace("prod")),
 			},
 			knownScopeObjs: []ast.FileObject{
-				fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-				fake.Role(core.Namespace("prod")),
+				k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+				k8sobjects.Role(core.Namespace("prod")),
 			},
 		},
 		{
 			name: "has unknown scope objects",
 			objs: []ast.FileObject{
-				fake.ClusterRole(
+				k8sobjects.ClusterRole(
 					core.Annotation(metadata.UnknownScopeAnnotationKey, metadata.UnknownScopeAnnotationValue),
 				),
-				fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-				fake.Role(core.Namespace("prod")),
+				k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+				k8sobjects.Role(core.Namespace("prod")),
 			},
 			knownScopeObjs: []ast.FileObject{
-				fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-				fake.Role(core.Namespace("prod")),
+				k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+				k8sobjects.Role(core.Namespace("prod")),
 			},
 			unknownScopeObjs: []ast.FileObject{
-				fake.ClusterRole(
+				k8sobjects.ClusterRole(
 					core.Annotation(metadata.UnknownScopeAnnotationKey, metadata.UnknownScopeAnnotationValue),
 				),
 			},
@@ -745,7 +745,7 @@ func TestRun(t *testing.T) {
 				SourceRepo:   fileSource.SourceRepo,
 				SourceBranch: fileSource.SourceBranch,
 			}
-			fakeClient := syncerFake.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName))
+			fakeClient := syncerFake.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			parser := newParser(t, fakeClock, fakeClient, fs, tc.renderingEnabled, configsync.DefaultReconcilerRetryPeriod, configsync.DefaultReconcilerPollingPeriod)
 			state := &reconcilerState{
 				backoff:     defaultBackoff(),
@@ -770,7 +770,7 @@ func TestRun(t *testing.T) {
 
 func TestBackoffRetryCount(t *testing.T) {
 	realClock := clock.RealClock{}
-	fakeClient := syncerFake.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName))
+	fakeClient := syncerFake.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 	parser := newParser(t, realClock, fakeClient, FileSource{}, false, 10*time.Microsecond, 150*time.Microsecond)
 	testState := &namespacecontroller.State{}
 	reimportCount := 0

--- a/pkg/parse/source_test.go
+++ b/pkg/parse/source_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/hydrate"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
@@ -34,7 +35,6 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 var originCommit = "1234567890abcde"
@@ -111,7 +111,7 @@ func TestReadConfigFiles(t *testing.T) {
 					Clock:              clock.RealClock{}, // TODO: Test with fake clock
 					SyncName:           rootSyncName,
 					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, fake.RootSyncObjectV1Beta1(rootSyncName)),
+					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
 					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
 					Updater: Updater{
 						Scope:     declared.RootScope,

--- a/pkg/reconciler/namespacecontroller/state_test.go
+++ b/pkg/reconciler/namespacecontroller/state_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 var (
@@ -41,35 +41,35 @@ func TestMatchChanged(t *testing.T) {
 			name:               "a Namespace was previously selected by two selectors, but not selected at all",
 			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
 			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
-			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "prod")),
+			ns:                 k8sobjects.NamespaceObject("test-ns", core.Label("environment", "prod")),
 			wantChanged:        true,
 		},
 		{
 			name:               "a Namespace was previously selected by two selectors, but only partially selected",
 			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
 			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
-			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "dev")),
+			ns:                 k8sobjects.NamespaceObject("test-ns", core.Label("environment", "dev")),
 			wantChanged:        true,
 		},
 		{
 			name:               "a Namespace was previously selected, and is also selected now",
 			nsSelectors:        map[string]labels.Selector{"dev-nss": devLabelSelector, "feature-nss": featureLabelSelector},
 			selectedNamespaces: map[string][]labels.Selector{"test-ns": {devLabelSelector, featureLabelSelector}},
-			ns:                 fake.NamespaceObject("test-ns", core.Labels(map[string]string{"environment": "dev", "feature": "abc"})),
+			ns:                 k8sobjects.NamespaceObject("test-ns", core.Labels(map[string]string{"environment": "dev", "feature": "abc"})),
 			wantChanged:        false,
 		},
 		{
 			name:               "a Namespace was not selected before, but is selected now",
 			nsSelectors:        map[string]labels.Selector{"test-nss": devLabelSelector},
 			selectedNamespaces: map[string][]labels.Selector{"other-ns": {devLabelSelector}},
-			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "dev")),
+			ns:                 k8sobjects.NamespaceObject("test-ns", core.Label("environment", "dev")),
 			wantChanged:        true,
 		},
 		{
 			name:               "a Namespace is neither selected before nor selected now",
 			nsSelectors:        map[string]labels.Selector{"test-nss": devLabelSelector},
 			selectedNamespaces: map[string][]labels.Selector{"test-other": {devLabelSelector}},
-			ns:                 fake.NamespaceObject("test-ns", core.Label("environment", "prod")),
+			ns:                 k8sobjects.NamespaceObject("test-ns", core.Label("environment", "prod")),
 			wantChanged:        false,
 		},
 	}

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -26,11 +26,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	syncerFake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,7 +79,7 @@ func TestOtelReconciler(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	reqNamespacedName := namespacedName(metrics.OtelCollectorName, configmanagement.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, k8sobjects.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(_ context.Context) (*google.Credentials, error) {
 		return nil, errors.New("could not find default credentials")
@@ -91,7 +91,7 @@ func TestOtelReconciler(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantDeployment := fake.DeploymentObject(
+	wantDeployment := k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
@@ -123,7 +123,7 @@ func TestOtelReconcilerGooglecloud(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	reqNamespacedName := namespacedName(metrics.OtelCollectorName, configmanagement.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, k8sobjects.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(_ context.Context) (*google.Credentials, error) {
 		return &google.Credentials{
@@ -152,7 +152,7 @@ func TestOtelReconcilerGooglecloud(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 
-	wantDeployment := fake.DeploymentObject(
+	wantDeployment := k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
@@ -191,7 +191,7 @@ func TestOtelReconcilerCustom(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, configmanagement.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, k8sobjects.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(_ context.Context) (*google.Credentials, error) {
 		return nil, nil
@@ -203,7 +203,7 @@ func TestOtelReconcilerCustom(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantDeployment := fake.DeploymentObject(
+	wantDeployment := k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -243,7 +243,7 @@ func TestOtelReconcilerDeleteCustom(t *testing.T) {
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
 	)
 	reqNamespacedName := namespacedName(metrics.OtelCollectorCustomCM, configmanagement.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
+	fakeClient, testReconciler := setupOtelReconciler(t, cm, cmCustom, k8sobjects.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	getDefaultCredentials = func(_ context.Context) (*google.Credentials, error) {
 		return nil, nil
@@ -264,7 +264,7 @@ func TestOtelReconcilerDeleteCustom(t *testing.T) {
 		t.Fatalf("unexpected reconciliation error, got error: %q, want error: nil", err)
 	}
 
-	wantDeployment := fake.DeploymentObject(
+	wantDeployment := k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 		core.UID("1"), core.ResourceVersion("1"), core.Generation(1),
@@ -306,16 +306,16 @@ const test1GSAEmail = "metric-writer@test1.iam.gserviceaccount.com"
 const test2GSAEmail = "metric-writer@test2.iam.gserviceaccount.com"
 
 func TestOtelSAReconciler(t *testing.T) {
-	sa := fake.ServiceAccountObject(
+	sa := k8sobjects.ServiceAccountObject(
 		defaultSAName,
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Annotation(GCPSAAnnotationKey, test1GSAEmail),
 	)
 	reqNamespacedName := namespacedName(defaultSAName, configmanagement.MonitoringNamespace)
-	fakeClient, testReconciler := setupOtelSAReconciler(t, sa, fake.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
+	fakeClient, testReconciler := setupOtelSAReconciler(t, sa, k8sobjects.DeploymentObject(core.Name(metrics.OtelCollectorName), core.Namespace(configmanagement.MonitoringNamespace)))
 
 	// Verify that the otel-collector Deployment does not have the GCPSAAnnotationKey annotation.
-	wantDeployment := fake.DeploymentObject(
+	wantDeployment := k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)
@@ -333,7 +333,7 @@ func TestOtelSAReconciler(t *testing.T) {
 	}
 
 	// Verify that the otel-collector Deployment has the GCPSAAnnotationKey annotation.
-	wantDeployment = fake.DeploymentObject(
+	wantDeployment = k8sobjects.DeploymentObject(
 		core.Namespace(configmanagement.MonitoringNamespace),
 		core.Name(metrics.OtelCollectorName),
 	)

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,7 +53,7 @@ var nsReconcilerKey = types.NamespacedName{
 }
 
 func repoSyncWithAuth(ns, name string, auth configsync.AuthType, sourceType configsync.SourceType, opts ...core.MetaMutator) *v1beta1.RepoSync {
-	result := fake.RepoSyncObjectV1Beta1(ns, name, opts...)
+	result := k8sobjects.RepoSyncObjectV1Beta1(ns, name, opts...)
 	result.Spec.SourceType = sourceType
 	if sourceType == configsync.GitSource {
 		result.Spec.Git = &v1beta1.Git{
@@ -71,7 +71,7 @@ func repoSyncWithAuth(ns, name string, auth configsync.AuthType, sourceType conf
 
 func secret(t *testing.T, name, data string, auth configsync.AuthType, sourceType configsync.SourceType, opts ...core.MetaMutator) *corev1.Secret {
 	t.Helper()
-	result := fake.SecretObject(name, opts...)
+	result := k8sobjects.SecretObject(name, opts...)
 	result.Data = secretData(t, data, auth, sourceType)
 	result.SetLabels(map[string]string{
 		metadata.SyncNamespaceLabel:       reposyncNs,

--- a/pkg/remediator/queue/deleted_test.go
+++ b/pkg/remediator/queue/deleted_test.go
@@ -21,8 +21,8 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metrics"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testmetrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,15 +34,15 @@ func TestWasDeleted(t *testing.T) {
 	}{
 		{
 			"object with no annotations",
-			fake.ConfigMapObject(),
+			k8sobjects.ConfigMapObject(),
 		},
 		{
 			"object with an annotation",
-			fake.ConfigMapObject(core.Annotation("hello", "world")),
+			k8sobjects.ConfigMapObject(core.Annotation("hello", "world")),
 		},
 		{
 			"object with explicitly empty annotations",
-			fake.ConfigMapObject(core.Annotations(map[string]string{})),
+			k8sobjects.ConfigMapObject(core.Annotations(map[string]string{})),
 		},
 	}
 

--- a/pkg/remediator/queue/queue_test.go
+++ b/pkg/remediator/queue/queue_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -63,10 +63,10 @@ func done(toDone client.Object, wantLen int) action {
 }
 
 func TestObjectQueue(t *testing.T) {
-	cmHelloGen0 := fake.ConfigMapObject(core.Namespace("foo-ns"), core.Name("hello"))
-	cmHelloGen1 := fake.ConfigMapObject(core.Namespace("foo-ns"), core.Name("hello"), core.Generation(1))
-	cmGoodbyeGen0 := fake.ConfigMapObject(core.Namespace("foo-ns"), core.Name("goodbye"))
-	cmGoodbyeGen1 := fake.ConfigMapObject(core.Namespace("foo-ns"), core.Name("goodbye"), core.Generation(1))
+	cmHelloGen0 := k8sobjects.ConfigMapObject(core.Namespace("foo-ns"), core.Name("hello"))
+	cmHelloGen1 := k8sobjects.ConfigMapObject(core.Namespace("foo-ns"), core.Name("hello"), core.Generation(1))
+	cmGoodbyeGen0 := k8sobjects.ConfigMapObject(core.Namespace("foo-ns"), core.Name("goodbye"))
+	cmGoodbyeGen1 := k8sobjects.ConfigMapObject(core.Namespace("foo-ns"), core.Name("goodbye"), core.Generation(1))
 
 	testCases := []struct {
 		name    string

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/ptr"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/diff/difftest"
 	"kpt.dev/configsync/pkg/kinds"
@@ -36,7 +37,6 @@ import (
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	testfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,18 +52,18 @@ func TestFilteredWatcher(t *testing.T) {
 	scope := declared.Scope("test")
 	syncName := "rs"
 
-	deployment1 := fake.DeploymentObject(core.Name("hello"))
-	deployment1Beta := fake.DeploymentObject(core.Name("hello"))
+	deployment1 := k8sobjects.DeploymentObject(core.Name("hello"))
+	deployment1Beta := k8sobjects.DeploymentObject(core.Name("hello"))
 	deployment1Beta.GetObjectKind().SetGroupVersionKind(deployment1Beta.GroupVersionKind().GroupKind().WithVersion("beta1"))
 
-	deployment2 := fake.DeploymentObject(core.Name("world"))
-	deployment3 := fake.DeploymentObject(core.Name("nomes"))
+	deployment2 := k8sobjects.DeploymentObject(core.Name("world"))
+	deployment3 := k8sobjects.DeploymentObject(core.Name("nomes"))
 
-	managedBySelfDeployment := fake.DeploymentObject(core.Name("not-declared"),
+	managedBySelfDeployment := k8sobjects.DeploymentObject(core.Name("not-declared"),
 		syncertest.ManagementEnabled, difftest.ManagedBy(scope, syncName))
-	managedByOtherDeployment := fake.DeploymentObject(core.Name("not-declared"),
+	managedByOtherDeployment := k8sobjects.DeploymentObject(core.Name("not-declared"),
 		syncertest.ManagementEnabled, difftest.ManagedBy("other", "other-rs"))
-	deploymentForRoot := fake.DeploymentObject(core.Name("managed-by-root"), difftest.ManagedBy(declared.RootScope, "any-rs"))
+	deploymentForRoot := k8sobjects.DeploymentObject(core.Name("managed-by-root"), difftest.ManagedBy(declared.RootScope, "any-rs"))
 
 	testCases := []struct {
 		name     string

--- a/pkg/reposync/conditions_test.go
+++ b/pkg/reposync/conditions_test.go
@@ -26,8 +26,8 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,19 +73,19 @@ func TestIsReconciling(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is false",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			want: false,
 		},
 		{
 			name: "False condition is false",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
 			want: false,
 		},
 		{
 			name: "True condition is true",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -110,19 +110,19 @@ func TestIsStalled(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is false",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			want: false,
 		},
 		{
 			name: "False condition is false",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
 			want: false,
 		},
 		{
 			name: "True condition is true",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -147,19 +147,19 @@ func TestReconcilingMessage(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is empty",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			want: "",
 		},
 		{
 			name: "False condition is empty",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
 			want: "",
 		},
 		{
 			name: "True condition is its message",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -184,19 +184,19 @@ func TestStalledMessage(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is empty",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			want: "",
 		},
 		{
 			name: "False condition is empty",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
 			want: "",
 		},
 		{
 			name: "True condition is its message",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -225,7 +225,7 @@ func TestClearCondition(t *testing.T) {
 	}{
 		{
 			name: "Clear existing true condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -239,7 +239,7 @@ func TestClearCondition(t *testing.T) {
 		},
 		{
 			name: "Ignore existing false condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -253,7 +253,7 @@ func TestClearCondition(t *testing.T) {
 		},
 		{
 			name:    "Handle empty conditions",
-			rs:      fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:      k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			toClear: v1beta1.RepoSyncStalled,
 			want:    nil,
 		},
@@ -286,7 +286,7 @@ func TestSetReconciling(t *testing.T) {
 	}{
 		{
 			name: "Set new reconciling condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow))),
 			reason:  "Test1",
@@ -300,7 +300,7 @@ func TestSetReconciling(t *testing.T) {
 		},
 		{
 			name: "Update existing reconciling condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -346,7 +346,7 @@ func TestSetStalled(t *testing.T) {
 	}{
 		{
 			name:   "Set new stalled condition",
-			rs:     fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:     k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			reason: "Error1",
 			err:    errors.New("this is error 1"),
 			want: []v1beta1.RepoSyncCondition{
@@ -358,7 +358,7 @@ func TestSetStalled(t *testing.T) {
 		},
 		{
 			name: "Update existing stalled condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RepoSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RepoSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -406,7 +406,7 @@ func TestSetSyncing(t *testing.T) {
 	}{
 		{
 			name:         "Set new syncing condition without error",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			status:       true,
 			reason:       "Syncing",
 			message:      "",
@@ -433,7 +433,7 @@ func TestSetSyncing(t *testing.T) {
 		},
 		{
 			name: "Update to add syncing error",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:               v1beta1.RepoSyncSyncing,
@@ -480,7 +480,7 @@ func TestSetSyncing(t *testing.T) {
 		},
 		{
 			name: "Transition to completed",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:    v1beta1.RepoSyncSyncing,
@@ -548,7 +548,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 	}{
 		{
 			name:    "Set new finalizing condition without error",
-			rs:      fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:      k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			reason:  "Finalizing",
 			message: "",
 			want: []v1beta1.RepoSyncCondition{
@@ -566,7 +566,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 		},
 		{
 			name: "Update to add change message",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:               v1beta1.RepoSyncReconcilerFinalizing,
@@ -607,7 +607,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 }
 
 func TestSetReconcilerFinalizerFailure(t *testing.T) {
-	deployment1 := fake.DeploymentObject()
+	deployment1 := k8sobjects.DeploymentObject()
 	deployment1ID := core.IDOf(deployment1)
 
 	now = func() metav1.Time {
@@ -622,7 +622,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 	}{
 		{
 			name: "Set new finalizer failure condition without error",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			errs: nil,
 			want: []v1beta1.RepoSyncCondition{
 				// Update and transition
@@ -639,7 +639,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Set new finalizer failure condition with error",
-			rs:   fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:   k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			errs: applier.DeleteErrorForResource(errors.New("fake error"), deployment1ID),
 			want: []v1beta1.RepoSyncCondition{
 				// Update and transition
@@ -662,7 +662,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Update to change status",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
@@ -694,7 +694,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Update to change error message",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:    v1beta1.RepoSyncReconcilerFinalizerFailure,
@@ -756,7 +756,7 @@ func TestRemoveCondition(t *testing.T) {
 	}{
 		{
 			name: "Remove Reconciling condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:               v1beta1.RepoSyncReconciling,
@@ -773,7 +773,7 @@ func TestRemoveCondition(t *testing.T) {
 		},
 		{
 			name: "Remove Syncing condition when Reconciling",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:               v1beta1.RepoSyncSyncing,
@@ -809,7 +809,7 @@ func TestRemoveCondition(t *testing.T) {
 		},
 		{
 			name: "Remove missing condition",
-			rs: fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
+			rs: k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName,
 				withConditions(
 					v1beta1.RepoSyncCondition{
 						Type:               v1beta1.RepoSyncReconcilerFinalizing,

--- a/pkg/reposync/errors_test.go
+++ b/pkg/reposync/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -69,7 +69,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources is nil, rs is not nil",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName),
 			errorSources: nil,
 			want:         nil,
 		},
@@ -81,13 +81,13 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{},
 			want:         nil,
 		},
 		{
 			name:         "errorSources = {RenderingError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -95,7 +95,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SourceError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1021", ErrorMessage: "1021-error-message"},
@@ -104,7 +104,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SyncError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "2009", ErrorMessage: "apiserver error"},
@@ -113,7 +113,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SourceError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SourceError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -123,7 +123,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SyncError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -133,7 +133,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SourceError, SyncError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1021", ErrorMessage: "1021-error-message"},
@@ -144,7 +144,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SourceError, SyncError}",
-			rs:           fake.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RepoSyncObjectV1Beta1(testNs, configsync.RepoSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SourceError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},

--- a/pkg/rootsync/conditions_test.go
+++ b/pkg/rootsync/conditions_test.go
@@ -26,8 +26,8 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -72,19 +72,19 @@ func TestIsReconciling(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is false",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			want: false,
 		},
 		{
 			name: "False condition is false",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
 			want: false,
 		},
 		{
 			name: "True condition is true",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -109,19 +109,19 @@ func TestIsStalled(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is false",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			want: false,
 		},
 		{
 			name: "False condition is false",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
 			want: false,
 		},
 		{
 			name: "True condition is true",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -146,19 +146,19 @@ func TestReconcilingMessage(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is empty",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			want: "",
 		},
 		{
 			name: "False condition is empty",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionFalse, initialNow, initialNow))),
 			want: "",
 		},
 		{
 			name: "True condition is its message",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -183,19 +183,19 @@ func TestStalledMessage(t *testing.T) {
 	}{
 		{
 			name: "Missing condition is empty",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			want: "",
 		},
 		{
 			name: "False condition is empty",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
 			want: "",
 		},
 		{
 			name: "True condition is its message",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionFalse, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -224,7 +224,7 @@ func TestClearCondition(t *testing.T) {
 	}{
 		{
 			name: "Clear existing true condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionTrue, initialNow, initialNow))),
@@ -238,7 +238,7 @@ func TestClearCondition(t *testing.T) {
 		},
 		{
 			name: "Ignore existing false condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -252,7 +252,7 @@ func TestClearCondition(t *testing.T) {
 		},
 		{
 			name:    "Handle empty conditions",
-			rs:      fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:      k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			toClear: v1beta1.RootSyncStalled,
 			want:    nil,
 		},
@@ -285,7 +285,7 @@ func TestSetReconciling(t *testing.T) {
 	}{
 		{
 			name: "Set new reconciling condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow))),
 			reason:  "Test1",
@@ -299,7 +299,7 @@ func TestSetReconciling(t *testing.T) {
 		},
 		{
 			name: "Update existing reconciling condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -345,7 +345,7 @@ func TestSetStalled(t *testing.T) {
 	}{
 		{
 			name:   "Set new stalled condition",
-			rs:     fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:     k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			reason: "Error1",
 			err:    errors.New("this is error 1"),
 			want: []v1beta1.RootSyncCondition{
@@ -357,7 +357,7 @@ func TestSetStalled(t *testing.T) {
 		},
 		{
 			name: "Update existing stalled condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					fakeCondition(v1beta1.RootSyncReconciling, metav1.ConditionTrue, initialNow, initialNow),
 					fakeCondition(v1beta1.RootSyncStalled, metav1.ConditionFalse, initialNow, initialNow))),
@@ -405,7 +405,7 @@ func TestSetSyncing(t *testing.T) {
 	}{
 		{
 			name:         "Set new syncing condition without error",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			status:       true,
 			reason:       "Syncing",
 			message:      "",
@@ -432,7 +432,7 @@ func TestSetSyncing(t *testing.T) {
 		},
 		{
 			name: "Update to add syncing error",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:               v1beta1.RootSyncSyncing,
@@ -479,7 +479,7 @@ func TestSetSyncing(t *testing.T) {
 		},
 		{
 			name: "Transition to completed",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:    v1beta1.RootSyncSyncing,
@@ -547,7 +547,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 	}{
 		{
 			name:    "Set new finalizing condition without error",
-			rs:      fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:      k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			reason:  "Finalizing",
 			message: "",
 			want: []v1beta1.RootSyncCondition{
@@ -565,7 +565,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 		},
 		{
 			name: "Update to add change message",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:               v1beta1.RootSyncReconcilerFinalizing,
@@ -606,7 +606,7 @@ func TestSetReconcilerFinalizing(t *testing.T) {
 }
 
 func TestSetReconcilerFinalizerFailure(t *testing.T) {
-	deployment1 := fake.DeploymentObject()
+	deployment1 := k8sobjects.DeploymentObject()
 	deployment1ID := core.IDOf(deployment1)
 
 	now = func() metav1.Time {
@@ -621,7 +621,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 	}{
 		{
 			name: "Set new finalizer failure condition without error",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			errs: nil,
 			want: []v1beta1.RootSyncCondition{
 				// Update and transition
@@ -638,7 +638,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Set new finalizer failure condition with error",
-			rs:   fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:   k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			errs: applier.DeleteErrorForResource(errors.New("fake error"), deployment1ID),
 			want: []v1beta1.RootSyncCondition{
 				// Update and transition
@@ -661,7 +661,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Update to change status",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
@@ -693,7 +693,7 @@ func TestSetReconcilerFinalizerFailure(t *testing.T) {
 		},
 		{
 			name: "Update to change error message",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:    v1beta1.RootSyncReconcilerFinalizerFailure,
@@ -755,7 +755,7 @@ func TestRemoveCondition(t *testing.T) {
 	}{
 		{
 			name: "Remove Reconciling condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:               v1beta1.RootSyncReconciling,
@@ -772,7 +772,7 @@ func TestRemoveCondition(t *testing.T) {
 		},
 		{
 			name: "Remove Syncing condition when Reconciling",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:               v1beta1.RootSyncSyncing,
@@ -808,7 +808,7 @@ func TestRemoveCondition(t *testing.T) {
 		},
 		{
 			name: "Remove missing condition",
-			rs: fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+			rs: k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 				withConditions(
 					v1beta1.RootSyncCondition{
 						Type:               v1beta1.RootSyncReconcilerFinalizing,

--- a/pkg/rootsync/errors_test.go
+++ b/pkg/rootsync/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -69,7 +69,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources is nil, rs is not nil",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName),
 			errorSources: nil,
 			want:         nil,
 		},
@@ -81,13 +81,13 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{},
 			want:         nil,
 		},
 		{
 			name:         "errorSources = {RenderingError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -95,7 +95,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SourceError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1021", ErrorMessage: "1021-error-message"},
@@ -104,7 +104,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SyncError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "2009", ErrorMessage: "apiserver error"},
@@ -113,7 +113,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SourceError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SourceError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -123,7 +123,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SyncError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},
@@ -133,7 +133,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {SourceError, SyncError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1021", ErrorMessage: "1021-error-message"},
@@ -144,7 +144,7 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			name:         "errorSources = {RenderingError, SourceError, SyncError}",
-			rs:           fake.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
+			rs:           k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName, withSyncStatus(fakeSyncStatus())),
 			errorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SourceError, v1beta1.SyncError},
 			want: []v1beta1.ConfigSyncError{
 				{Code: "1061", ErrorMessage: "rendering-error-message"},

--- a/pkg/status/fake_errors.go
+++ b/pkg/status/fake_errors.go
@@ -12,33 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package status
 
 import (
 	"fmt"
 
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
-	"kpt.dev/configsync/pkg/status"
 )
 
-// Errors returns a MultiError consisting of fake errors. For use in unit tests
+// FakeMultiError returns a MultiError consisting of fake errors. For use in unit tests
 // where multiple errors are expected to be returned.
 //
-// In all cases where a single error is expected, it is safe to use fake.Error
+// In all cases where a single error is expected, it is safe to use fake.FakeError
 // instead.
-func Errors(codes ...string) status.MultiError {
-	var result status.MultiError
+func FakeMultiError(codes ...string) MultiError {
+	var result MultiError
 	for i, code := range codes {
-		result = status.Append(result, fakeError{id: i + 1, code: code})
+		result = Append(result, fakeError{id: i + 1, code: code})
 	}
 	return result
 }
 
-// Error returns a fake error for use in tests which matches errors with the
+// FakeError returns a fake error for use in tests which matches errors with the
 // specified KNV code. This is preferable to requiring test authors to specify
 // fields they don't really care about.
-func Error(code string) status.Error {
+func FakeError(code string) Error {
 	return fakeError{id: 1, code: code}
 }
 
@@ -47,22 +46,22 @@ type fakeError struct {
 	code string
 }
 
-// Cause implements status.Error.
+// Cause implements Error.
 func (f fakeError) Cause() error {
 	return nil
 }
 
-// Cause implements status.Error.
+// Cause implements Error.
 func (f fakeError) Error() string {
 	return fmt.Sprintf("KNV%s fake error %d", f.code, f.id)
 }
 
-// Errors implements status.Error.
-func (f fakeError) Errors() []status.Error {
-	return []status.Error{f}
+// Errors implements Error.
+func (f fakeError) Errors() []Error {
+	return []Error{f}
 }
 
-// ToCME implements status.Error.
+// ToCME implements Error.
 func (f fakeError) ToCME() v1.ConfigManagementError {
 	return v1.ConfigManagementError{
 		Code:         f.code,
@@ -70,7 +69,7 @@ func (f fakeError) ToCME() v1.ConfigManagementError {
 	}
 }
 
-// ToCSE implements status.Error.
+// ToCSE implements Error.
 func (f fakeError) ToCSE() v1beta1.ConfigSyncError {
 	return v1beta1.ConfigSyncError{
 		Code:         f.code,
@@ -78,22 +77,22 @@ func (f fakeError) ToCSE() v1beta1.ConfigSyncError {
 	}
 }
 
-// Code implements status.Error.
+// Code implements Error.
 func (f fakeError) Code() string {
 	return f.code
 }
 
-// Body implements status.Error.
+// Body implements Error.
 func (f fakeError) Body() string {
 	return f.Error()
 }
 
-// Is implements status.Error.
+// Is implements Error.
 func (f fakeError) Is(target error) bool {
 	switch err := target.(type) {
-	case status.Error:
+	case Error:
 		return err.Code() == f.code
-	case status.MultiError:
+	case MultiError:
 		return len(err.Errors()) == 1 && err.Errors()[0].Code() == f.code
 	default:
 		return false

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -22,10 +22,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
 	syncerclient "kpt.dev/configsync/pkg/syncer/client"
 	syncertestfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,26 +39,26 @@ func TestClient_Create(t *testing.T) {
 	}{
 		{
 			name:     "Creates if does not exist",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewClient(t, core.Scheme),
 			wantErr:  nil,
 		},
 		{
 			name:     "Retriable if receives AlreadyExists",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewClient(t, core.Scheme,
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			),
 			wantErr: syncerclient.ConflictCreateAlreadyExists(
 				apierrors.NewAlreadyExists(rbacv1.Resource("Role"), "billing/admin"),
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic APIServerError if other error",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some API server error")),
 			wantErr: status.APIServerError(errors.New("some API server error"), "failed to create object",
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 	}
 
@@ -81,24 +81,24 @@ func TestClient_Apply(t *testing.T) {
 	}{
 		{
 			name:     "Conflict error if not found",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewErrorClient(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin")),
 			wantErr: syncerclient.ConflictUpdateDoesNotExist(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin"),
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic error if other error",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some error")),
 			wantErr: status.ResourceWrap(errors.New("some error"),
 				"failed to get object to update",
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "No error if client does not return error",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(nil),
 			wantErr:  nil,
 		},
@@ -125,23 +125,23 @@ func TestClient_Update(t *testing.T) {
 	}{
 		{
 			name:     "Conflict error if not found",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewErrorClient(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin")),
 			wantErr: syncerclient.ConflictUpdateDoesNotExist(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin"),
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "Generic error if other error",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(errors.New("some error")),
 			wantErr: status.ResourceWrap(errors.New("some error"), "failed to update",
-				fake.RoleObject(core.Name("admin"), core.Namespace("billing"))),
+				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
 		{
 			name:     "No error if client does not return error",
-			declared: fake.RoleObject(core.Name("admin"), core.Namespace("billing")),
+			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client:   syncertestfake.NewErrorClient(nil),
 			wantErr:  nil,
 		},

--- a/pkg/syncer/differ/namespace_test.go
+++ b/pkg/syncer/differ/namespace_test.go
@@ -22,14 +22,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 func namespaceConfig(opts ...core.MetaMutator) *v1.NamespaceConfig {
-	result := fake.NamespaceConfigObject(opts...)
+	result := k8sobjects.NamespaceConfigObject(opts...)
 	return result
 }
 
@@ -70,63 +70,63 @@ func TestNamespaceDiffType(t *testing.T) {
 		{
 			name:       "in both, update",
 			declared:   namespaceConfig(),
-			actual:     fake.NamespaceObject("foo"),
+			actual:     k8sobjects.NamespaceObject("foo"),
 			expectType: Update,
 		},
 		{
 			name:       "in both, update even though cluster has invalid annotation",
 			declared:   namespaceConfig(),
-			actual:     fake.NamespaceObject("foo", managementInvalid),
+			actual:     k8sobjects.NamespaceObject("foo", managementInvalid),
 			expectType: Update,
 		},
 		{
 			name:     "in both, management disabled unmanage",
 			declared: namespaceConfig(disableManaged),
-			actual:   fake.NamespaceObject("foo", syncertest.ManagementEnabled),
+			actual:   k8sobjects.NamespaceObject("foo", syncertest.ManagementEnabled),
 
 			expectType: Unmanage,
 		},
 		{
 			name:       "in both, management disabled noop",
 			declared:   namespaceConfig(disableManaged),
-			actual:     fake.NamespaceObject("foo"),
+			actual:     k8sobjects.NamespaceObject("foo"),
 			expectType: NoOp,
 		},
 		{
 			name:       "if not in repo but managed in cluster, noop",
-			actual:     fake.NamespaceObject("foo", syncertest.ManagementEnabled),
+			actual:     k8sobjects.NamespaceObject("foo", syncertest.ManagementEnabled),
 			expectType: NoOp,
 		},
 		{
 			name:       "delete",
 			declared:   markForDeletion(namespaceConfig()),
-			actual:     fake.NamespaceObject("foo", syncertest.ManagementEnabled),
+			actual:     k8sobjects.NamespaceObject("foo", syncertest.ManagementEnabled),
 			expectType: Delete,
 		},
 		{
 			name:       "marked for deletion, unmanage if deletion: prevent",
 			declared:   markForDeletion(namespaceConfig()),
-			actual:     fake.NamespaceObject("foo", syncertest.ManagementEnabled, preventDeletion),
+			actual:     k8sobjects.NamespaceObject("foo", syncertest.ManagementEnabled, preventDeletion),
 			expectType: UnmanageNamespace,
 		},
 		{
 			name:       "in cluster only, unset noop",
-			actual:     fake.NamespaceObject("foo"),
+			actual:     k8sobjects.NamespaceObject("foo"),
 			expectType: NoOp,
 		},
 		{
 			name:       "in cluster only, the `configmanagement.gke.io/managed` annotation is set to empty",
-			actual:     fake.NamespaceObject("foo", managementEmpty),
+			actual:     k8sobjects.NamespaceObject("foo", managementEmpty),
 			expectType: NoOp,
 		},
 		{
 			name:       "in cluster only, has an invalid `configmanagement.gke.io/managed` annotation",
-			actual:     fake.NamespaceObject("foo", managementInvalid),
+			actual:     k8sobjects.NamespaceObject("foo", managementInvalid),
 			expectType: NoOp,
 		},
 		{
 			name:       "in cluster only, has an invalid `configmanagement.gke.io/managed` and other nomos metatdatas",
-			actual:     fake.NamespaceObject("foo", managementInvalid, syncertest.TokenAnnotation),
+			actual:     k8sobjects.NamespaceObject("foo", managementInvalid, syncertest.TokenAnnotation),
 			expectType: NoOp,
 		},
 	}

--- a/pkg/syncer/differ/special_namespaces_test.go
+++ b/pkg/syncer/differ/special_namespaces_test.go
@@ -19,8 +19,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/api/configmanagement"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/policycontroller"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestIsManageableSystem(t *testing.T) {
@@ -39,7 +39,7 @@ func TestIsManageableSystem(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
-			reserved := IsManageableSystemNamespace(fake.NamespaceObject(testcase.name))
+			reserved := IsManageableSystemNamespace(k8sobjects.NamespaceObject(testcase.name))
 			if reserved != testcase.reserved {
 				t.Errorf("Expected %v got %v", testcase.reserved, reserved)
 			}

--- a/pkg/syncer/reconcile/apply_test.go
+++ b/pkg/syncer/reconcile/apply_test.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,20 +34,20 @@ func TestEqual(t *testing.T) {
 	}{
 		{
 			name:          "exactly the same object",
-			dryrunStatus:  fake.UnstructuredObject(kinds.Namespace(), core.Name("test")),
-			currentStatus: fake.UnstructuredObject(kinds.Namespace(), core.Name("test")),
+			dryrunStatus:  k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test")),
+			currentStatus: k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test")),
 			equal:         true,
 		},
 		{
 			name:          "same object with different generations, different timestamp",
-			dryrunStatus:  fake.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Generation(1), core.CreationTimeStamp(metav1.Time{})),
-			currentStatus: fake.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Generation(2), core.CreationTimeStamp(metav1.Now())),
+			dryrunStatus:  k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Generation(1), core.CreationTimeStamp(metav1.Time{})),
+			currentStatus: k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Generation(2), core.CreationTimeStamp(metav1.Now())),
 			equal:         true,
 		},
 		{
 			name:         "same object with status",
-			dryrunStatus: fake.UnstructuredObject(kinds.Namespace(), core.Name("test")),
-			currentStatus: fake.UnstructuredObject(kinds.Namespace(), core.Name("test"),
+			dryrunStatus: k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test")),
+			currentStatus: k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test"),
 				func(o client.Object) {
 					u := o.(*unstructured.Unstructured)
 					err := unstructured.SetNestedField(u.Object, "Active", "status", "phase")
@@ -59,8 +59,8 @@ func TestEqual(t *testing.T) {
 		},
 		{
 			name:          "same object with different labels",
-			dryrunStatus:  fake.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Label("key", "val1")),
-			currentStatus: fake.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Label("key", "val2")),
+			dryrunStatus:  k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Label("key", "val1")),
+			currentStatus: k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test"), core.Label("key", "val2")),
 			equal:         false,
 		},
 	}

--- a/pkg/syncer/reconcile/as_unstructured_test.go
+++ b/pkg/syncer/reconcile/as_unstructured_test.go
@@ -20,8 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,11 +33,11 @@ func TestAsUnstructured_AddsStatus(t *testing.T) {
 	}{
 		{
 			name: "Namespace",
-			obj:  &corev1.Namespace{TypeMeta: fake.ToTypeMeta(kinds.Namespace())},
+			obj:  &corev1.Namespace{TypeMeta: k8sobjects.ToTypeMeta(kinds.Namespace())},
 		},
 		{
 			name: "Service",
-			obj:  &corev1.Service{TypeMeta: fake.ToTypeMeta(kinds.Service())},
+			obj:  &corev1.Service{TypeMeta: k8sobjects.ToTypeMeta(kinds.Service())},
 		},
 	}
 
@@ -109,11 +109,11 @@ func TestAsUnstructuredSanitized_DoesNotAddStatus(t *testing.T) {
 	}{
 		{
 			name: "Namespace",
-			obj:  &corev1.Namespace{TypeMeta: fake.ToTypeMeta(kinds.Namespace())},
+			obj:  &corev1.Namespace{TypeMeta: k8sobjects.ToTypeMeta(kinds.Namespace())},
 		},
 		{
 			name: "Service",
-			obj:  &corev1.Service{TypeMeta: fake.ToTypeMeta(kinds.Service())},
+			obj:  &corev1.Service{TypeMeta: k8sobjects.ToTypeMeta(kinds.Service())},
 		},
 	}
 
@@ -145,7 +145,7 @@ func TestAsUnstructuredSanitized_DeepCopy(t *testing.T) {
 	}{
 		{
 			name: "Namespace as object",
-			obj:  &corev1.Namespace{TypeMeta: fake.ToTypeMeta(kinds.Namespace())},
+			obj:  &corev1.Namespace{TypeMeta: k8sobjects.ToTypeMeta(kinds.Namespace())},
 		},
 		{
 			name: "Namespace as unstructured",

--- a/pkg/syncer/reconcile/fight/detector_test.go
+++ b/pkg/syncer/reconcile/fight/detector_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/testing/fake"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 // durations creates a sequence of evenly-spaced time.Durations.
@@ -131,11 +131,11 @@ func TestFight(t *testing.T) {
 }
 
 func roleID(name, ns string) core.ID {
-	return core.IDOf(fake.RoleObject(core.Name(name), core.Namespace(ns)))
+	return core.IDOf(k8sobjects.RoleObject(core.Name(name), core.Namespace(ns)))
 }
 
 func roleBindingID(name, ns string) core.ID {
-	return core.IDOf(fake.RoleBinding(core.Name(name), core.Namespace(ns)))
+	return core.IDOf(k8sobjects.RoleBinding(core.Name(name), core.Namespace(ns)))
 }
 
 func TestFightDetector(t *testing.T) {
@@ -189,7 +189,7 @@ func TestFightDetector(t *testing.T) {
 
 			now := time.Now()
 			for id, updates := range tc.updates {
-				u := fake.Unstructured(id.WithVersion(""), core.Namespace(id.Namespace), core.Name(id.Name))
+				u := k8sobjects.Unstructured(id.WithVersion(""), core.Namespace(id.Namespace), core.Name(id.Name))
 
 				aboveThreshold := false
 				logged := false

--- a/pkg/util/clusterconfig/crd_test.go
+++ b/pkg/util/clusterconfig/crd_test.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/decode"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -59,19 +59,19 @@ func TestGetCRDs(t *testing.T) {
 		{
 			name: "v1Beta1 CRD",
 			objs: []client.Object{
-				fake.CustomResourceDefinitionV1Beta1Unstructured(),
+				k8sobjects.CustomResourceDefinitionV1Beta1Unstructured(),
 			},
 			want: []*apiextensionsv1beta1.CustomResourceDefinition{
-				fake.CustomResourceDefinitionV1Beta1Object(),
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(),
 			},
 		},
 		{
 			name: "v1 CRD",
 			objs: []client.Object{
-				fake.CustomResourceDefinitionV1Object(),
+				k8sobjects.CustomResourceDefinitionV1Object(),
 			},
 			want: []*apiextensionsv1beta1.CustomResourceDefinition{
-				fake.CustomResourceDefinitionV1Beta1Object(preserveUnknownFields(t, false)),
+				k8sobjects.CustomResourceDefinitionV1Beta1Object(preserveUnknownFields(t, false)),
 			},
 		},
 	}
@@ -99,7 +99,7 @@ const importToken = "abcde"
 // clusterConfig generates a valid ClusterConfig to be put in AllConfigs given the set of hydrated
 // cluster-scoped client.Objects.
 func clusterConfig(objects ...client.Object) *v1.ClusterConfig {
-	config := fake.ClusterConfigObject()
+	config := k8sobjects.ClusterConfigObject()
 	config.Spec.Token = importToken
 	for _, o := range objects {
 		config.AddResource(o)
@@ -108,7 +108,7 @@ func clusterConfig(objects ...client.Object) *v1.ClusterConfig {
 }
 
 func generateMalformedCRD(t *testing.T) *unstructured.Unstructured {
-	u := fake.CustomResourceDefinitionV1Beta1Unstructured()
+	u := k8sobjects.CustomResourceDefinitionV1Beta1Unstructured()
 
 	// the `spec.group` field should be a string
 	// set it to a bool to construct a malformed CRD
@@ -126,12 +126,12 @@ func TestAsCRD(t *testing.T) {
 	}{
 		{
 			name:    "well-formed v1beta1 CRD",
-			obj:     fake.CustomResourceDefinitionV1Beta1Unstructured(),
+			obj:     k8sobjects.CustomResourceDefinitionV1Beta1Unstructured(),
 			wantErr: nil,
 		},
 		{
 			name:    "well-formed v1 CRD",
-			obj:     fake.CustomResourceDefinitionV1Unstructured(),
+			obj:     k8sobjects.CustomResourceDefinitionV1Unstructured(),
 			wantErr: nil,
 		},
 		{

--- a/pkg/validate/fileobjects/main_test.go
+++ b/pkg/validate/fileobjects/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fake
+package fileobjects
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
 )
 
-// ContainerObject returns an initialized Container.
-func ContainerObject(name string) *v1.Container {
-	return &v1.Container{Name: name}
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test kpt.dev/configsync/pkg/validate/objects -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
 }

--- a/pkg/validate/fileobjects/raw.go
+++ b/pkg/validate/fileobjects/raw.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package objects
+package fileobjects
 
 import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/pkg/validate/fileobjects/scoped.go
+++ b/pkg/validate/fileobjects/scoped.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package objects
+package fileobjects
 
 import (
 	"kpt.dev/configsync/pkg/declared"

--- a/pkg/validate/fileobjects/tree.go
+++ b/pkg/validate/fileobjects/tree.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package objects
+package fileobjects
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/validate/final/validate/duplicate_name_validator_test.go
+++ b/pkg/validate/final/validate/duplicate_name_validator_test.go
@@ -20,11 +20,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func customResource(group, kind, name, namespace string) ast.FileObject {
@@ -33,7 +33,7 @@ func customResource(group, kind, name, namespace string) ast.FileObject {
 		Version: "v1",
 		Kind:    kind,
 	}
-	return fake.Unstructured(gvk, core.Name(name), core.Namespace(namespace))
+	return k8sobjects.Unstructured(gvk, core.Name(name), core.Namespace(namespace))
 }
 
 func TestDuplicateNames(t *testing.T) {
@@ -45,57 +45,57 @@ func TestDuplicateNames(t *testing.T) {
 		{
 			name: "Two objects with different names pass",
 			objs: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
-				fake.Role(core.Name("bob"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("bob"), core.Namespace("shipping")),
 			},
 		},
 		{
 			name: "Two objects with different namespaces pass",
 			objs: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
-				fake.Role(core.Name("alice"), core.Namespace("production")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("production")),
 			},
 		},
 		{
 			name: "Two objects with different kinds pass",
 			objs: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
-				fake.RoleBinding(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.RoleBinding(core.Name("alice"), core.Namespace("shipping")),
 			},
 		},
 		{
 			name: "Two objects with different groups pass",
 			objs: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
 				customResource("acme", "Role", "alice", "shipping"),
 			},
 		},
 		{
 			name: "Two duplicate namespaced objects fail",
 			objs: []ast.FileObject{
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
-				fake.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
+				k8sobjects.Role(core.Name("alice"), core.Namespace("shipping")),
 			},
 			wantErrs: nonhierarchical.NamespaceMetadataNameCollisionError(
-				kinds.Role().GroupKind(), "shipping", "alice", fake.Role()),
+				kinds.Role().GroupKind(), "shipping", "alice", k8sobjects.Role()),
 		},
 		{
 			name: "Two duplicate cluster-scoped objects fail",
 			objs: []ast.FileObject{
-				fake.ClusterRole(core.Name("alice")),
-				fake.ClusterRole(core.Name("alice")),
+				k8sobjects.ClusterRole(core.Name("alice")),
+				k8sobjects.ClusterRole(core.Name("alice")),
 			},
 			wantErrs: nonhierarchical.ClusterMetadataNameCollisionError(
-				kinds.ClusterRole().GroupKind(), "alice", fake.ClusterRole()),
+				kinds.ClusterRole().GroupKind(), "alice", k8sobjects.ClusterRole()),
 		},
 		{
 			name: "Two duplicate namespaces fail",
 			objs: []ast.FileObject{
-				fake.Namespace("namespaces/hello"),
-				fake.Namespace("namespaces/hello"),
+				k8sobjects.Namespace("namespaces/hello"),
+				k8sobjects.Namespace("namespaces/hello"),
 			},
 			wantErrs: nonhierarchical.NamespaceCollisionError(
-				"hello", fake.Namespace("hamespaces/hello")),
+				"hello", k8sobjects.Namespace("hamespaces/hello")),
 		},
 	}
 

--- a/pkg/validate/final/validate/unmanaged_namespace_validator_test.go
+++ b/pkg/validate/final/validate/unmanaged_namespace_validator_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestUnmanagedNamespaces(t *testing.T) {
@@ -35,32 +35,32 @@ func TestUnmanagedNamespaces(t *testing.T) {
 		{
 			name: "Cluster-scoped objects pass",
 			objs: []ast.FileObject{
-				fake.ClusterRole(),
-				fake.ClusterRole(syncertest.ManagementDisabled),
+				k8sobjects.ClusterRole(),
+				k8sobjects.ClusterRole(syncertest.ManagementDisabled),
 			},
 		},
 		{
 			name: "Namespace-scoped objects in managed namespace pass",
 			objs: []ast.FileObject{
-				fake.Namespace("namespaces/foo"),
-				fake.Role(core.Namespace("foo")),
-				fake.Role(core.Namespace("foo"), syncertest.ManagementDisabled),
+				k8sobjects.Namespace("namespaces/foo"),
+				k8sobjects.Role(core.Namespace("foo")),
+				k8sobjects.Role(core.Namespace("foo"), syncertest.ManagementDisabled),
 			},
 		},
 		{
 			name: "Unmanaged namespace-scoped object in unmanaged namespace passes",
 			objs: []ast.FileObject{
-				fake.Namespace("namespaces/foo", syncertest.ManagementDisabled),
-				fake.Role(core.Namespace("foo"), syncertest.ManagementDisabled),
+				k8sobjects.Namespace("namespaces/foo", syncertest.ManagementDisabled),
+				k8sobjects.Role(core.Namespace("foo"), syncertest.ManagementDisabled),
 			},
 		},
 		{
 			name: "Unmanaged namespace-scoped object in managed namespace fails",
 			objs: []ast.FileObject{
-				fake.Namespace("namespaces/foo", syncertest.ManagementDisabled),
-				fake.Role(core.Namespace("foo")),
+				k8sobjects.Namespace("namespaces/foo", syncertest.ManagementDisabled),
+				k8sobjects.Role(core.Namespace("foo")),
 			},
-			wantErrs: fake.Errors(nonhierarchical.ManagedResourceInUnmanagedNamespaceErrorCode),
+			wantErrs: status.FakeMultiError(nonhierarchical.ManagedResourceInUnmanagedNamespaceErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/hydrate/cluster_name_hydrator.go
+++ b/pkg/validate/raw/hydrate/cluster_name_hydrator.go
@@ -18,12 +18,12 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // ClusterName annotates the given Raw objects with the name of the current
 // cluster.
-func ClusterName(objs *objects.Raw) status.MultiError {
+func ClusterName(objs *fileobjects.Raw) status.MultiError {
 	if objs.ClusterName == "" {
 		return nil
 	}

--- a/pkg/validate/raw/hydrate/cluster_name_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/cluster_name_hydrator_test.go
@@ -19,49 +19,49 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestClusterName(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "Hydrate with cluster name",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				ClusterName: "hello-world",
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml"),
-					fake.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml"),
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				ClusterName: "hello-world",
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml",
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml",
 						core.Annotation(metadata.ClusterNameAnnotationKey, "hello-world")),
-					fake.RoleBindingAtPath("namespaces/foo/rolebinding.yaml",
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rolebinding.yaml",
 						core.Annotation(metadata.ClusterNameAnnotationKey, "hello-world")),
 				},
 			},
 		},
 		{
 			name: "Hydrate with empty cluster name",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml"),
-					fake.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml"),
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml"),
-					fake.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml"),
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rolebinding.yaml"),
 				},
 			},
 		},

--- a/pkg/validate/raw/hydrate/cluster_selector_hydrator.go
+++ b/pkg/validate/raw/hydrate/cluster_selector_hydrator.go
@@ -26,13 +26,13 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // ClusterSelectors hydrates the given Raw objects by performing cluster
 // selection to filter out objects which are not specified for the current
 // cluster.
-func ClusterSelectors(objs *objects.Raw) status.MultiError {
+func ClusterSelectors(objs *fileobjects.Raw) status.MultiError {
 	set, errs := buildHydratorSet(objs)
 	if errs != nil {
 		return errs
@@ -96,7 +96,7 @@ func ClusterSelectors(objs *objects.Raw) status.MultiError {
 
 // buildHydratorSet splits the given Raw objects into important types (Cluster,
 // ClusterSelector, Namespace) and populates a hydratorSet with them.
-func buildHydratorSet(objs *objects.Raw) (*hydratorSet, status.MultiError) {
+func buildHydratorSet(objs *fileobjects.Raw) (*hydratorSet, status.MultiError) {
 	set := &hydratorSet{}
 	var errs status.MultiError
 	for _, object := range objs.Objects {

--- a/pkg/validate/raw/hydrate/declared_field_hydrator.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator.go
@@ -28,7 +28,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -36,7 +36,7 @@ import (
 // its fields that are declared in Git. This annotation is what enables the
 // Config Sync admission controller webhook to protect these declared fields
 // from being changed by another controller or user.
-func DeclaredFields(objs *objects.Raw) status.MultiError {
+func DeclaredFields(objs *fileobjects.Raw) status.MultiError {
 	if objs.Converter == nil {
 		klog.Warning("Skipping declared field hydration. This should only happen for offline executions of nomos vet/hydrate/init.")
 		return nil

--- a/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator_raw_test.go
@@ -21,7 +21,7 @@ import (
 	"kpt.dev/configsync/clientgen/apis/scheme"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/testing/openapitest"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestRawYAML(t *testing.T) {
@@ -384,7 +384,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			objs := &objects.Raw{
+			objs := &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{{
 					Unstructured: u,

--- a/pkg/validate/raw/hydrate/declared_field_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/declared_field_hydrator_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestDeclaredFields(t *testing.T) {
@@ -36,15 +36,15 @@ func TestDeclaredFields(t *testing.T) {
 
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "encode fields for Role with rules",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": rbacv1.SchemeGroupVersion.String(),
 							"kind":       "Role",
@@ -63,10 +63,10 @@ func TestDeclaredFields(t *testing.T) {
 					}, "role.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": rbacv1.SchemeGroupVersion.String(),
 							"kind":       "Role",
@@ -91,10 +91,10 @@ func TestDeclaredFields(t *testing.T) {
 		},
 		{
 			name: "encode fields for Role with a label",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": rbacv1.SchemeGroupVersion.String(),
 							"kind":       "Role",
@@ -109,10 +109,10 @@ func TestDeclaredFields(t *testing.T) {
 					}, "role.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": rbacv1.SchemeGroupVersion.String(),
 							"kind":       "Role",
@@ -133,10 +133,10 @@ func TestDeclaredFields(t *testing.T) {
 		},
 		{
 			name: "encode fields for Custom Resource",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": "acme.com/v1",
 							"kind":       "Anvil",
@@ -153,10 +153,10 @@ func TestDeclaredFields(t *testing.T) {
 					}, "anvil.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Converter: converter,
 				Objects: []ast.FileObject{
-					fake.FileObject(&unstructured.Unstructured{
+					k8sobjects.FileObject(&unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": "acme.com/v1",
 							"kind":       "Anvil",
@@ -177,7 +177,7 @@ func TestDeclaredFields(t *testing.T) {
 		},
 	}
 
-	ignoreConverter := cmpopts.IgnoreFields(objects.Raw{}, "Converter")
+	ignoreConverter := cmpopts.IgnoreFields(fileobjects.Raw{}, "Converter")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/validate/raw/hydrate/declared_version_hydrator.go
+++ b/pkg/validate/raw/hydrate/declared_version_hydrator.go
@@ -18,12 +18,12 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // DeclaredVersion annotates the given Raw objects with the API Version the
 // object was declared in the repository.
-func DeclaredVersion(objs *objects.Raw) status.MultiError {
+func DeclaredVersion(objs *fileobjects.Raw) status.MultiError {
 	for _, obj := range objs.Objects {
 		core.Label(metadata.DeclaredVersionLabel, obj.GetObjectKind().GroupVersionKind().Version)(obj)
 	}

--- a/pkg/validate/raw/hydrate/declared_version_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/declared_version_hydrator_test.go
@@ -19,41 +19,41 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestDeclaredVersion(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "v1 RoleBinding",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.RoleBinding(),
+					k8sobjects.RoleBinding(),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.RoleBinding(core.Label(metadata.DeclaredVersionLabel, "v1")),
+					k8sobjects.RoleBinding(core.Label(metadata.DeclaredVersionLabel, "v1")),
 				},
 			},
 		},
 		{
 			name: "v1beta1 RoleBinding",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.RoleBindingV1Beta1(),
+					k8sobjects.RoleBindingV1Beta1(),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.RoleBindingV1Beta1(core.Label(metadata.DeclaredVersionLabel, "v1beta1")),
+					k8sobjects.RoleBindingV1Beta1(core.Label(metadata.DeclaredVersionLabel, "v1beta1")),
 				},
 			},
 		},

--- a/pkg/validate/raw/hydrate/filepath_hydrator.go
+++ b/pkg/validate/raw/hydrate/filepath_hydrator.go
@@ -18,12 +18,12 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // Filepath annotates the given Raw objects with the path from the Git repo
 // policy directory to the files which declare them.
-func Filepath(objs *objects.Raw) status.MultiError {
+func Filepath(objs *fileobjects.Raw) status.MultiError {
 	for _, obj := range objs.Objects {
 		path := objs.PolicyDir.Join(obj.Relative).SlashPath()
 		core.SetAnnotation(obj, metadata.SourcePathAnnotationKey, path)

--- a/pkg/validate/raw/hydrate/filepath_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/filepath_hydrator_test.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 const dir = "acme/"
@@ -31,32 +31,32 @@ const dir = "acme/"
 func TestFilepath(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "Hydrate with filepaths",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				PolicyDir: cmpath.RelativeSlash(dir),
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml", core.Name("reader")),
-					fake.RoleAtPath("namespaces/role.yaml", core.Name("writer")),
-					fake.Namespace("namespaces/hello"),
-					fake.RoleBindingAtPath("namespaces/hello/binding.yaml", core.Name("bind-writer")),
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml", core.Name("reader")),
+					k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("writer")),
+					k8sobjects.Namespace("namespaces/hello"),
+					k8sobjects.RoleBindingAtPath("namespaces/hello/binding.yaml", core.Name("bind-writer")),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				PolicyDir: cmpath.RelativeSlash(dir),
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml",
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml",
 						core.Name("reader"),
 						core.Annotation(metadata.SourcePathAnnotationKey, dir+"cluster/clusterrole.yaml")),
-					fake.RoleAtPath("namespaces/role.yaml",
+					k8sobjects.RoleAtPath("namespaces/role.yaml",
 						core.Name("writer"),
 						core.Annotation(metadata.SourcePathAnnotationKey, dir+"namespaces/role.yaml")),
-					fake.Namespace("namespaces/hello",
+					k8sobjects.Namespace("namespaces/hello",
 						core.Annotation(metadata.SourcePathAnnotationKey, dir+"namespaces/hello/namespace.yaml")),
-					fake.RoleBindingAtPath("namespaces/hello/binding.yaml",
+					k8sobjects.RoleBindingAtPath("namespaces/hello/binding.yaml",
 						core.Name("bind-writer"),
 						core.Annotation(metadata.SourcePathAnnotationKey, dir+"namespaces/hello/binding.yaml")),
 				},
@@ -64,18 +64,18 @@ func TestFilepath(t *testing.T) {
 		},
 		{
 			name: "Preserve existing annotations",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				PolicyDir: cmpath.RelativeSlash(dir),
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml",
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml",
 						core.Name("reader"),
 						core.Annotation("color", "blue")),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				PolicyDir: cmpath.RelativeSlash(dir),
 				Objects: []ast.FileObject{
-					fake.ClusterRoleAtPath("cluster/clusterrole.yaml",
+					k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml",
 						core.Name("reader"),
 						core.Annotation("color", "blue"),
 						core.Annotation(metadata.SourcePathAnnotationKey, dir+"cluster/clusterrole.yaml")),

--- a/pkg/validate/raw/hydrate/hnc_depth_hydrator.go
+++ b/pkg/validate/raw/hydrate/hnc_depth_hydrator.go
@@ -22,12 +22,12 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // HNCDepth hydrates the given Raw objects by annotating each Namespace with its
 // depth to be compatible with the Hierarchy Namespace Controller.
-func HNCDepth(objs *objects.Raw) status.MultiError {
+func HNCDepth(objs *fileobjects.Raw) status.MultiError {
 	for _, obj := range objs.Objects {
 		if obj.GetObjectKind().GroupVersionKind() == kinds.Namespace() {
 			addDepthLabels(obj)

--- a/pkg/validate/raw/hydrate/hnc_depth_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/hnc_depth_hydrator_test.go
@@ -19,37 +19,37 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestBuilderVisitor(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "label and annotate namespace",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Namespace("namespaces/foo/bar"),
-					fake.Namespace("namespaces/qux"),
-					fake.Role(),
+					k8sobjects.Namespace("namespaces/foo/bar"),
+					k8sobjects.Namespace("namespaces/qux"),
+					k8sobjects.Role(),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Namespace("namespaces/foo/bar",
+					k8sobjects.Namespace("namespaces/foo/bar",
 						core.Annotation(metadata.HNCManagedBy, metadata.ManagedByValue),
 						core.Label("foo.tree.hnc.x-k8s.io/depth", "1"),
 						core.Label("bar.tree.hnc.x-k8s.io/depth", "0")),
-					fake.Namespace("namespaces/qux",
+					k8sobjects.Namespace("namespaces/qux",
 						core.Annotation(metadata.HNCManagedBy, metadata.ManagedByValue),
 						core.Label("qux.tree.hnc.x-k8s.io/depth", "0")),
-					fake.Role(),
+					k8sobjects.Role(),
 				},
 			},
 		},

--- a/pkg/validate/raw/hydrate/object_namespace_hydrator.go
+++ b/pkg/validate/raw/hydrate/object_namespace_hydrator.go
@@ -20,13 +20,13 @@ import (
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // ObjectNamespaces hydrates the given raw Objects by setting the metadata
 // namespace field for objects that are located in a namespace directory but do
 // not have their namespace specified yet.
-func ObjectNamespaces(objs *objects.Raw) status.MultiError {
+func ObjectNamespaces(objs *fileobjects.Raw) status.MultiError {
 	namespaces := make(map[string]bool)
 	for _, obj := range objs.Objects {
 		if isValidHierarchicalNamespace(obj) {

--- a/pkg/validate/raw/hydrate/object_namespace_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/object_namespace_hydrator_test.go
@@ -19,38 +19,38 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestObjectNamespaces(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Raw
-		want *objects.Raw
+		objs *fileobjects.Raw
+		want *fileobjects.Raw
 	}{
 		{
 			name: "Set namespace on object in namespace directory",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("foo")),
-					fake.RoleBindingAtPath("namespaces/foo/rb.yaml",
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rb.yaml",
 						core.Name("reader-binding")),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("foo")),
-					fake.RoleBindingAtPath("namespaces/foo/rb.yaml",
+					k8sobjects.RoleBindingAtPath("namespaces/foo/rb.yaml",
 						core.Name("reader-binding"),
 						core.Namespace("foo")),
 				},
@@ -61,20 +61,20 @@ func TestObjectNamespaces(t *testing.T) {
 			// it later. So the main thing here is to make sure that we don't
 			// accidentally change an incorrect namespace to the correct namespace.
 			name: "Ignore object with incorrect namespace already set",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("bar")),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("bar")),
 				},
@@ -82,37 +82,37 @@ func TestObjectNamespaces(t *testing.T) {
 		},
 		{
 			name: "Ignore object in abstract namespace directory",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo/bar"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo/bar"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader")),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo/bar"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo/bar"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader")),
 				},
 			},
 		},
 		{
 			name: "Ignore objects in non-namespaced directories",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.ClusterAtPath("clusterregistry/cluster.yaml"),
-					fake.ClusterRoleAtPath("cluster/cr.yaml"),
+					k8sobjects.Repo(),
+					k8sobjects.ClusterAtPath("clusterregistry/cluster.yaml"),
+					k8sobjects.ClusterRoleAtPath("cluster/cr.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.ClusterAtPath("clusterregistry/cluster.yaml"),
-					fake.ClusterRoleAtPath("cluster/cr.yaml"),
+					k8sobjects.Repo(),
+					k8sobjects.ClusterAtPath("clusterregistry/cluster.yaml"),
+					k8sobjects.ClusterRoleAtPath("cluster/cr.yaml"),
 				},
 			},
 		},
@@ -121,24 +121,24 @@ func TestObjectNamespaces(t *testing.T) {
 			// expected under the namespace/ directory, so we want to make sure we
 			// don't accidentally assign them a namespace.
 			name: "Ignore NamespaceSelector in namespace directory",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("foo")),
-					fake.NamespaceSelectorAtPath("namespaces/foo/nss.yaml"),
+					k8sobjects.NamespaceSelectorAtPath("namespaces/foo/nss.yaml"),
 				},
 			},
-			want: &objects.Raw{
+			want: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(),
-					fake.Namespace("namespaces/foo"),
-					fake.RoleAtPath("namespaces/foo/role.yaml",
+					k8sobjects.Repo(),
+					k8sobjects.Namespace("namespaces/foo"),
+					k8sobjects.RoleAtPath("namespaces/foo/role.yaml",
 						core.Name("reader"),
 						core.Namespace("foo")),
-					fake.NamespaceSelectorAtPath("namespaces/foo/nss.yaml"),
+					k8sobjects.NamespaceSelectorAtPath("namespaces/foo/nss.yaml"),
 				},
 			},
 		},

--- a/pkg/validate/raw/hydrate/prevent_deletion_hydrator.go
+++ b/pkg/validate/raw/hydrate/prevent_deletion_hydrator.go
@@ -19,13 +19,13 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/differ"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 // PreventDeletion adds the `client.lifecycle.config.k8s.io/deletion: detach` annotation to special namespaces,
 // which include `default`, `kube-system`, `kube-public`, `kube-node-lease`, and `gatekeeper-system`.
-func PreventDeletion(objs *objects.Raw) status.MultiError {
+func PreventDeletion(objs *fileobjects.Raw) status.MultiError {
 	for _, obj := range objs.Objects {
 		if obj.GetObjectKind().GroupVersionKind().GroupKind() == kinds.Namespace().GroupKind() && differ.SpecialNamespaces[obj.GetName()] {
 			core.SetAnnotation(obj, common.LifecycleDeleteAnnotation, common.PreventDeletion)

--- a/pkg/validate/raw/hydrate/prevent_deletion_hydrator_test.go
+++ b/pkg/validate/raw/hydrate/prevent_deletion_hydrator_test.go
@@ -19,34 +19,34 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 func TestPreventDeletion(t *testing.T) {
-	objs := &objects.Raw{
+	objs := &fileobjects.Raw{
 		Objects: []ast.FileObject{
-			fake.ClusterRoleAtPath("cluster/clusterrole.yaml", core.Name("reader")),
-			fake.Namespace("namespaces/default"),
-			fake.Namespace("namespaces/kube-system"),
-			fake.Namespace("namespaces/kube-public"),
-			fake.Namespace("namespaces/kube-node-lease"),
-			fake.Namespace("namespaces/gatekeeper-system"),
-			fake.Namespace("namespaces/bookstore"),
+			k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml", core.Name("reader")),
+			k8sobjects.Namespace("namespaces/default"),
+			k8sobjects.Namespace("namespaces/kube-system"),
+			k8sobjects.Namespace("namespaces/kube-public"),
+			k8sobjects.Namespace("namespaces/kube-node-lease"),
+			k8sobjects.Namespace("namespaces/gatekeeper-system"),
+			k8sobjects.Namespace("namespaces/bookstore"),
 		},
 	}
-	want := &objects.Raw{
+	want := &fileobjects.Raw{
 		Objects: []ast.FileObject{
-			fake.ClusterRoleAtPath("cluster/clusterrole.yaml",
+			k8sobjects.ClusterRoleAtPath("cluster/clusterrole.yaml",
 				core.Name("reader")),
-			fake.Namespace("namespaces/default", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
-			fake.Namespace("namespaces/kube-system", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
-			fake.Namespace("namespaces/kube-public", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
-			fake.Namespace("namespaces/kube-node-lease", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
-			fake.Namespace("namespaces/gatekeeper-system", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
-			fake.Namespace("namespaces/bookstore"),
+			k8sobjects.Namespace("namespaces/default", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
+			k8sobjects.Namespace("namespaces/kube-system", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
+			k8sobjects.Namespace("namespaces/kube-public", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
+			k8sobjects.Namespace("namespaces/kube-node-lease", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
+			k8sobjects.Namespace("namespaces/gatekeeper-system", core.Annotation(common.LifecycleDeleteAnnotation, common.PreventDeletion)),
+			k8sobjects.Namespace("namespaces/bookstore"),
 		},
 	}
 

--- a/pkg/validate/raw/raw.go
+++ b/pkg/validate/raw/raw.go
@@ -17,7 +17,7 @@ package raw
 import (
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"kpt.dev/configsync/pkg/validate/raw/hydrate"
 	"kpt.dev/configsync/pkg/validate/raw/validate"
 )
@@ -25,7 +25,7 @@ import (
 // Hierarchical performs initial validation and hydration for a structured
 // hierarchical repo against the given Raw objects. Note that this will modify
 // the Raw objects in-place.
-func Hierarchical(objs *objects.Raw) status.MultiError {
+func Hierarchical(objs *fileobjects.Raw) status.MultiError {
 	var errs status.MultiError
 	// Note that the ordering here and in all other collections of validators is
 	// somewhat arbitrary. We always run all validators in a collection before
@@ -35,21 +35,21 @@ func Hierarchical(objs *objects.Raw) status.MultiError {
 	// object. That way the first error in the list is more likely the real
 	// problem (eg they need to remove the object rather than fixing its
 	// namespace).
-	validators := []objects.RawVisitor{
-		objects.VisitAllRaw(validate.Annotations),
-		objects.VisitAllRaw(validate.Labels),
-		objects.VisitAllRaw(validate.IllegalKindsForHierarchical),
-		objects.VisitAllRaw(validate.DeprecatedKinds),
-		objects.VisitAllRaw(validate.Name),
-		objects.VisitAllRaw(validate.Namespace),
-		objects.VisitAllRaw(validate.Directory),
-		objects.VisitAllRaw(validate.HNCLabels),
-		objects.VisitAllRaw(validate.ManagementAnnotation),
-		objects.VisitAllRaw(validate.IllegalCRD),
-		objects.VisitAllRaw(validate.CRDName),
-		objects.VisitAllRaw(validate.RootSync),
-		objects.VisitAllRaw(validate.RepoSync),
-		objects.VisitAllRaw(validate.SelfReconcile(declared.ReconcilerNameFromScope(objs.Scope, objs.SyncName))),
+	validators := []fileobjects.RawVisitor{
+		fileobjects.VisitAllRaw(validate.Annotations),
+		fileobjects.VisitAllRaw(validate.Labels),
+		fileobjects.VisitAllRaw(validate.IllegalKindsForHierarchical),
+		fileobjects.VisitAllRaw(validate.DeprecatedKinds),
+		fileobjects.VisitAllRaw(validate.Name),
+		fileobjects.VisitAllRaw(validate.Namespace),
+		fileobjects.VisitAllRaw(validate.Directory),
+		fileobjects.VisitAllRaw(validate.HNCLabels),
+		fileobjects.VisitAllRaw(validate.ManagementAnnotation),
+		fileobjects.VisitAllRaw(validate.IllegalCRD),
+		fileobjects.VisitAllRaw(validate.CRDName),
+		fileobjects.VisitAllRaw(validate.RootSync),
+		fileobjects.VisitAllRaw(validate.RepoSync),
+		fileobjects.VisitAllRaw(validate.SelfReconcile(declared.ReconcilerNameFromScope(objs.Scope, objs.SyncName))),
 		validate.DisallowedFields,
 		validate.RemovedCRDs,
 		validate.ClusterSelectorsForHierarchical,
@@ -69,7 +69,7 @@ func Hierarchical(objs *objects.Raw) status.MultiError {
 	// namespace if a namespace gets filtered out. Then we perform cluster
 	// selection so that we can filter out irrelevant objects before trying to
 	// modify them.
-	hydrators := []objects.RawVisitor{
+	hydrators := []fileobjects.RawVisitor{
 		hydrate.DeclaredVersion,
 		hydrate.ObjectNamespaces,
 		hydrate.ClusterSelectors,
@@ -90,22 +90,22 @@ func Hierarchical(objs *objects.Raw) status.MultiError {
 // Unstructured performs initial validation and hydration for an unstructured
 // repo against the given Raw objects. Note that this will modify the Raw
 // objects in-place.
-func Unstructured(objs *objects.Raw) status.MultiError {
+func Unstructured(objs *fileobjects.Raw) status.MultiError {
 	var errs status.MultiError
 	// See the note about ordering above in Hierarchical().
-	validators := []objects.RawVisitor{
-		objects.VisitAllRaw(validate.Annotations),
-		objects.VisitAllRaw(validate.Labels),
-		objects.VisitAllRaw(validate.IllegalKindsForUnstructured),
-		objects.VisitAllRaw(validate.DeprecatedKinds),
-		objects.VisitAllRaw(validate.Name),
-		objects.VisitAllRaw(validate.Namespace),
-		objects.VisitAllRaw(validate.ManagementAnnotation),
-		objects.VisitAllRaw(validate.IllegalCRD),
-		objects.VisitAllRaw(validate.CRDName),
-		objects.VisitAllRaw(validate.RootSync),
-		objects.VisitAllRaw(validate.RepoSync),
-		objects.VisitAllRaw(validate.SelfReconcile(declared.ReconcilerNameFromScope(objs.Scope, objs.SyncName))),
+	validators := []fileobjects.RawVisitor{
+		fileobjects.VisitAllRaw(validate.Annotations),
+		fileobjects.VisitAllRaw(validate.Labels),
+		fileobjects.VisitAllRaw(validate.IllegalKindsForUnstructured),
+		fileobjects.VisitAllRaw(validate.DeprecatedKinds),
+		fileobjects.VisitAllRaw(validate.Name),
+		fileobjects.VisitAllRaw(validate.Namespace),
+		fileobjects.VisitAllRaw(validate.ManagementAnnotation),
+		fileobjects.VisitAllRaw(validate.IllegalCRD),
+		fileobjects.VisitAllRaw(validate.CRDName),
+		fileobjects.VisitAllRaw(validate.RootSync),
+		fileobjects.VisitAllRaw(validate.RepoSync),
+		fileobjects.VisitAllRaw(validate.SelfReconcile(declared.ReconcilerNameFromScope(objs.Scope, objs.SyncName))),
 		validate.DisallowedFields,
 		validate.RemovedCRDs,
 		validate.ClusterSelectorsForUnstructured,
@@ -121,7 +121,7 @@ func Unstructured(objs *objects.Raw) status.MultiError {
 	// that we do this step before any other hydration so that we capture the
 	// object exactly as it is declared in Git. Then we perform cluster selection
 	// so that we can filter out irrelevant objects before trying to modify them.
-	hydrators := []objects.RawVisitor{
+	hydrators := []fileobjects.RawVisitor{
 		hydrate.DeclaredVersion,
 		hydrate.ClusterSelectors,
 		hydrate.ClusterName,

--- a/pkg/validate/raw/validate/annotation_validator_test.go
+++ b/pkg/validate/raw/validate/annotation_validator_test.go
@@ -20,11 +20,11 @@ import (
 
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/metadata"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 const (
@@ -41,37 +41,37 @@ func TestAnnotations(t *testing.T) {
 	}{
 		{
 			name: "no annotations",
-			obj:  fake.Role(),
+			obj:  k8sobjects.Role(),
 		},
 		{
 			name: "legal annotation",
-			obj:  fake.Role(core.Annotation(legalAnnotation, "a")),
+			obj:  k8sobjects.Role(core.Annotation(legalAnnotation, "a")),
 		},
 		{
 			name: "legal namespace selector annotation",
-			obj:  fake.Role(core.Annotation(csmetadata.NamespaceSelectorAnnotationKey, "a")),
+			obj:  k8sobjects.Role(core.Annotation(csmetadata.NamespaceSelectorAnnotationKey, "a")),
 		},
 		{
 			name: "legal legacy cluster selector annotation",
-			obj:  fake.Role(core.Annotation(csmetadata.LegacyClusterSelectorAnnotationKey, "a")),
+			obj:  k8sobjects.Role(core.Annotation(csmetadata.LegacyClusterSelectorAnnotationKey, "a")),
 		},
 		{
 			name: "legal inline cluster selector annotation",
-			obj:  fake.Role(core.Annotation(csmetadata.ClusterNameSelectorAnnotationKey, "a")),
+			obj:  k8sobjects.Role(core.Annotation(csmetadata.ClusterNameSelectorAnnotationKey, "a")),
 		},
 		{
 			name: "legal management annotation",
-			obj:  fake.RoleBinding(core.Annotation(csmetadata.ResourceManagementKey, "a")),
+			obj:  k8sobjects.RoleBinding(core.Annotation(csmetadata.ResourceManagementKey, "a")),
 		},
 		{
 			name:    "illegal ConfigManagement annotation",
-			obj:     fake.Role(core.Annotation(cmAnnotation, "a")),
-			wantErr: metadata.IllegalAnnotationDefinitionError(fake.Role(), []string{cmAnnotation}),
+			obj:     k8sobjects.Role(core.Annotation(cmAnnotation, "a")),
+			wantErr: metadata.IllegalAnnotationDefinitionError(k8sobjects.Role(), []string{cmAnnotation}),
 		},
 		{
 			name:    "illegal ConfigSync annotation",
-			obj:     fake.RoleBinding(core.Annotation(csAnnotation, "a")),
-			wantErr: metadata.IllegalAnnotationDefinitionError(fake.RoleBinding(), []string{csAnnotation}),
+			obj:     k8sobjects.RoleBinding(core.Annotation(csAnnotation, "a")),
+			wantErr: metadata.IllegalAnnotationDefinitionError(k8sobjects.RoleBinding(), []string{csAnnotation}),
 		},
 	}
 

--- a/pkg/validate/raw/validate/cluster_selector_validator.go
+++ b/pkg/validate/raw/validate/cluster_selector_validator.go
@@ -23,24 +23,24 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ClusterSelectorsForHierarchical verifies that all ClusterSelectors have a
 // unique name and are under the correct top-level directory. It also verifies
 // that no invalid FileObjects are cluster-selected.
-func ClusterSelectorsForHierarchical(objs *objects.Raw) status.MultiError {
+func ClusterSelectorsForHierarchical(objs *fileobjects.Raw) status.MultiError {
 	return clusterSelectors(objs, true)
 }
 
 // ClusterSelectorsForUnstructured verifies that all ClusterSelectors have a
 // unique name. It also verifies that no invalid FileObjects are cluster-selected.
-func ClusterSelectorsForUnstructured(objs *objects.Raw) status.MultiError {
+func ClusterSelectorsForUnstructured(objs *fileobjects.Raw) status.MultiError {
 	return clusterSelectors(objs, false)
 }
 
-func clusterSelectors(objs *objects.Raw, checkDir bool) status.MultiError {
+func clusterSelectors(objs *fileobjects.Raw, checkDir bool) status.MultiError {
 	var errs status.MultiError
 	clusterGK := kinds.Cluster().GroupKind()
 	selectorGK := kinds.ClusterSelector().GroupKind()

--- a/pkg/validate/raw/validate/cluster_selector_validator_test.go
+++ b/pkg/validate/raw/validate/cluster_selector_validator_test.go
@@ -19,14 +19,14 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 var (
@@ -37,121 +37,121 @@ var (
 func TestClusterSelectorsForHierarchical(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Raw
+		objs     *fileobjects.Raw
 		wantErrs status.MultiError
 	}{
 		{
 			name: "No objects",
-			objs: &objects.Raw{},
+			objs: &fileobjects.Raw{},
 		},
 		{
 			name: "One ClusterSelector",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterSelector(core.Name("first")),
+					k8sobjects.ClusterSelector(core.Name("first")),
 				},
 			},
 		},
 		{
 			name: "Two ClusterSelectors",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterSelector(core.Name("first")),
-					fake.ClusterSelector(core.Name("second")),
+					k8sobjects.ClusterSelector(core.Name("first")),
+					k8sobjects.ClusterSelector(core.Name("second")),
 				},
 			},
 		},
 		{
 			name: "Duplicate ClusterSelectors",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterSelector(core.Name("first")),
-					fake.ClusterSelector(core.Name("first")),
+					k8sobjects.ClusterSelector(core.Name("first")),
+					k8sobjects.ClusterSelector(core.Name("first")),
 				},
 			},
-			wantErrs: nonhierarchical.SelectorMetadataNameCollisionError(kinds.ClusterSelector().Kind, "first", fake.ClusterSelector()),
+			wantErrs: nonhierarchical.SelectorMetadataNameCollisionError(kinds.ClusterSelector().Kind, "first", k8sobjects.ClusterSelector()),
 		},
 		{
 			name: "Objects with no cluster selector",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterRole(),
-					fake.CustomResourceDefinitionV1(),
-					fake.CustomResourceDefinitionV1Beta1(),
+					k8sobjects.ClusterRole(),
+					k8sobjects.CustomResourceDefinitionV1(),
+					k8sobjects.CustomResourceDefinitionV1Beta1(),
 				},
 			},
 		},
 		{
 			name: "Objects with legacy cluster selector",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterRole(legacyClusterSelectorAnnotation),
-					fake.CustomResourceDefinitionV1(legacyClusterSelectorAnnotation),
-					fake.CustomResourceDefinitionV1Beta1(legacyClusterSelectorAnnotation),
+					k8sobjects.ClusterRole(legacyClusterSelectorAnnotation),
+					k8sobjects.CustomResourceDefinitionV1(legacyClusterSelectorAnnotation),
+					k8sobjects.CustomResourceDefinitionV1Beta1(legacyClusterSelectorAnnotation),
 				},
 			},
 		},
 		{
 			name: "Objects with inline cluster selector",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterRole(inlineClusterSelectorAnnotation),
-					fake.CustomResourceDefinitionV1(inlineClusterSelectorAnnotation),
-					fake.CustomResourceDefinitionV1Beta1(inlineClusterSelectorAnnotation),
+					k8sobjects.ClusterRole(inlineClusterSelectorAnnotation),
+					k8sobjects.CustomResourceDefinitionV1(inlineClusterSelectorAnnotation),
+					k8sobjects.CustomResourceDefinitionV1Beta1(inlineClusterSelectorAnnotation),
 				},
 			},
 		},
 		{
 			name: "Non-selectable objects with no cluster selectors",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Cluster(),
-					fake.ClusterSelector(),
-					fake.NamespaceSelector(),
+					k8sobjects.Cluster(),
+					k8sobjects.ClusterSelector(),
+					k8sobjects.NamespaceSelector(),
 				},
 			},
 		},
 		{
 			name: "Non-selectable objects with legacy cluster selectors",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Cluster(legacyClusterSelectorAnnotation),
-					fake.ClusterSelector(legacyClusterSelectorAnnotation),
-					fake.NamespaceSelector(legacyClusterSelectorAnnotation),
+					k8sobjects.Cluster(legacyClusterSelectorAnnotation),
+					k8sobjects.ClusterSelector(legacyClusterSelectorAnnotation),
+					k8sobjects.NamespaceSelector(legacyClusterSelectorAnnotation),
 				},
 			},
 			wantErrs: status.Wrap(
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.Cluster(), "legacy"),
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.ClusterSelector(), "legacy"),
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.NamespaceSelector(), "legacy"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.Cluster(), "legacy"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.ClusterSelector(), "legacy"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.NamespaceSelector(), "legacy"),
 			),
 		},
 		{
 			name: "Non-selectable objects with inline cluster selectors",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Cluster(inlineClusterSelectorAnnotation),
-					fake.ClusterSelector(inlineClusterSelectorAnnotation),
-					fake.NamespaceSelector(inlineClusterSelectorAnnotation),
+					k8sobjects.Cluster(inlineClusterSelectorAnnotation),
+					k8sobjects.ClusterSelector(inlineClusterSelectorAnnotation),
+					k8sobjects.NamespaceSelector(inlineClusterSelectorAnnotation),
 				},
 			},
 			wantErrs: status.Wrap(
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.Cluster(), "inline"),
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.ClusterSelector(), "inline"),
-				nonhierarchical.IllegalClusterSelectorAnnotationError(fake.NamespaceSelector(), "inline"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.Cluster(), "inline"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.ClusterSelector(), "inline"),
+				nonhierarchical.IllegalClusterSelectorAnnotationError(k8sobjects.NamespaceSelector(), "inline"),
 			),
 		},
 		{
 			name: "Cluster and legacy cluster selector in wrong directory",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterAtPath("system/cluster.yaml"),
-					fake.ClusterSelectorAtPath("cluster/cs.yaml"),
+					k8sobjects.ClusterAtPath("system/cluster.yaml"),
+					k8sobjects.ClusterSelectorAtPath("cluster/cs.yaml"),
 				},
 			},
 			wantErrs: status.Wrap(
-				validation.ShouldBeInClusterRegistryError(fake.Cluster()),
-				validation.ShouldBeInClusterRegistryError(fake.ClusterSelector()),
+				validation.ShouldBeInClusterRegistryError(k8sobjects.Cluster()),
+				validation.ShouldBeInClusterRegistryError(k8sobjects.ClusterSelector()),
 			),
 		},
 	}
@@ -169,17 +169,17 @@ func TestClusterSelectorsForHierarchical(t *testing.T) {
 func TestClusterSelectorsForUnstructured(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Raw
+		objs     *fileobjects.Raw
 		wantErrs status.MultiError
 	}{
 		// We really just need to verify that unstructured does not care about the
 		// directory of the files.
 		{
 			name: "Cluster and legacy cluster selector in wrong directory",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.ClusterAtPath("system/cluster.yaml"),
-					fake.ClusterSelectorAtPath("cluster/cs.yaml"),
+					k8sobjects.ClusterAtPath("system/cluster.yaml"),
+					k8sobjects.ClusterSelectorAtPath("cluster/cs.yaml"),
 				},
 			},
 		},

--- a/pkg/validate/raw/validate/crd_name_test.go
+++ b/pkg/validate/raw/validate/crd_name_test.go
@@ -22,33 +22,33 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func crdv1beta1(name string, gvk schema.GroupVersionKind) ast.FileObject {
-	result := fake.CustomResourceDefinitionV1Beta1Object()
+	result := k8sobjects.CustomResourceDefinitionV1Beta1Object()
 	result.Name = name
 	result.Spec.Group = gvk.Group
 	result.Spec.Names = apiextensionsv1beta1.CustomResourceDefinitionNames{
 		Plural: strings.ToLower(gvk.Kind) + "s",
 		Kind:   gvk.Kind,
 	}
-	return fake.FileObject(result, "crd.yaml")
+	return k8sobjects.FileObject(result, "crd.yaml")
 }
 
 func crdv1(name string, gvk schema.GroupVersionKind) ast.FileObject {
-	result := fake.CustomResourceDefinitionV1Object()
+	result := k8sobjects.CustomResourceDefinitionV1Object()
 	result.Name = name
 	result.Spec.Group = gvk.Group
 	result.Spec.Names = apiextensionsv1.CustomResourceDefinitionNames{
 		Plural: strings.ToLower(gvk.Kind) + "s",
 		Kind:   gvk.Kind,
 	}
-	return fake.FileObject(result, "crd.yaml")
+	return k8sobjects.FileObject(result, "crd.yaml")
 }
 
 func TestValidCRDName(t *testing.T) {
@@ -65,12 +65,12 @@ func TestValidCRDName(t *testing.T) {
 		{
 			name: "v1beta1 non plural",
 			obj:  crdv1beta1("anvil.acme.com", kinds.Anvil()),
-			want: fake.Error(nonhierarchical.InvalidCRDNameErrorCode),
+			want: status.FakeError(nonhierarchical.InvalidCRDNameErrorCode),
 		},
 		{
 			name: "v1beta1 missing group",
 			obj:  crdv1beta1("anvils", kinds.Anvil()),
-			want: fake.Error(nonhierarchical.InvalidCRDNameErrorCode),
+			want: status.FakeError(nonhierarchical.InvalidCRDNameErrorCode),
 		},
 		// v1 CRDs
 		{
@@ -80,12 +80,12 @@ func TestValidCRDName(t *testing.T) {
 		{
 			name: "v1 non plural",
 			obj:  crdv1("anvil.acme.com", kinds.Anvil()),
-			want: fake.Error(nonhierarchical.InvalidCRDNameErrorCode),
+			want: status.FakeError(nonhierarchical.InvalidCRDNameErrorCode),
 		},
 		{
 			name: "v1 missing group",
 			obj:  crdv1("anvils", kinds.Anvil()),
-			want: fake.Error(nonhierarchical.InvalidCRDNameErrorCode),
+			want: status.FakeError(nonhierarchical.InvalidCRDNameErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/validate/crd_removal_validator.go
+++ b/pkg/validate/raw/validate/crd_removal_validator.go
@@ -20,12 +20,12 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/importer/customresources"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // RemovedCRDs verifies that the Raw objects do not remove any CRDs that still
 // have CRs using them.
-func RemovedCRDs(objs *objects.Raw) status.MultiError {
+func RemovedCRDs(objs *fileobjects.Raw) status.MultiError {
 	current, errs := customresources.GetCRDs(objs.Objects)
 	if errs != nil {
 		return errs

--- a/pkg/validate/raw/validate/deprecated_kind_validator_test.go
+++ b/pkg/validate/raw/validate/deprecated_kind_validator_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 
 	"k8s.io/api/extensions/v1beta1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestDeprecatedKinds(t *testing.T) {
@@ -33,22 +33,22 @@ func TestDeprecatedKinds(t *testing.T) {
 	}{
 		{
 			name: "Non-deprecated Deployment",
-			obj:  fake.Deployment("namespaces/foo"),
+			obj:  k8sobjects.Deployment("namespaces/foo"),
 		},
 		{
 			name:    "Deprecated Deployment",
-			obj:     fake.Unstructured(v1beta1.SchemeGroupVersion.WithKind("Deployment")),
-			wantErr: fake.Error(nonhierarchical.DeprecatedGroupKindErrorCode),
+			obj:     k8sobjects.Unstructured(v1beta1.SchemeGroupVersion.WithKind("Deployment")),
+			wantErr: status.FakeError(nonhierarchical.DeprecatedGroupKindErrorCode),
 		},
 		{
 			name:    "Deprecated PodSecurityPolicy",
-			obj:     fake.Unstructured(v1beta1.SchemeGroupVersion.WithKind("PodSecurityPolicy")),
-			wantErr: fake.Error(nonhierarchical.DeprecatedGroupKindErrorCode),
+			obj:     k8sobjects.Unstructured(v1beta1.SchemeGroupVersion.WithKind("PodSecurityPolicy")),
+			wantErr: status.FakeError(nonhierarchical.DeprecatedGroupKindErrorCode),
 		},
 		{
 			name:    "Deprecated Ingress",
-			obj:     fake.Unstructured(v1beta1.SchemeGroupVersion.WithKind("Ingress")),
-			wantErr: fake.Error(nonhierarchical.DeprecatedGroupKindErrorCode),
+			obj:     k8sobjects.Unstructured(v1beta1.SchemeGroupVersion.WithKind("Ingress")),
+			wantErr: status.FakeError(nonhierarchical.DeprecatedGroupKindErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/validate/directory_validator_test.go
+++ b/pkg/validate/raw/validate/directory_validator_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestDirectory(t *testing.T) {
@@ -33,30 +33,30 @@ func TestDirectory(t *testing.T) {
 	}{
 		{
 			name: "Role with unspecified namespace",
-			obj:  fake.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("")),
+			obj:  k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("")),
 		},
 		{
 			name: "Role under valid directory",
-			obj:  fake.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("hello")),
+			obj:  k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("hello")),
 		},
 		{
 			name:    "Role under invalid directory",
-			obj:     fake.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("world")),
-			wantErr: metadata.IllegalMetadataNamespaceDeclarationError(fake.Role(core.Namespace("world")), "hello"),
+			obj:     k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Namespace("world")),
+			wantErr: metadata.IllegalMetadataNamespaceDeclarationError(k8sobjects.Role(core.Namespace("world")), "hello"),
 		},
 		{
 			name: "Namespace under valid directory",
-			obj:  fake.Namespace("namespaces/hello"),
+			obj:  k8sobjects.Namespace("namespaces/hello"),
 		},
 		{
 			name:    "Namespace under invalid directory",
-			obj:     fake.Namespace("namespaces/hello", core.Name("world")),
-			wantErr: metadata.InvalidNamespaceNameError(fake.Namespace("namespaces/hello", core.Name("world")), "hello"),
+			obj:     k8sobjects.Namespace("namespaces/hello", core.Name("world")),
+			wantErr: metadata.InvalidNamespaceNameError(k8sobjects.Namespace("namespaces/hello", core.Name("world")), "hello"),
 		},
 		{
 			name:    "Namespace under top-level namespaces directory",
-			obj:     fake.Namespace("namespaces", core.Name("hello")),
-			wantErr: metadata.IllegalTopLevelNamespaceError(fake.Namespace("namespaces", core.Name("hello"))),
+			obj:     k8sobjects.Namespace("namespaces", core.Name("hello")),
+			wantErr: metadata.IllegalTopLevelNamespaceError(k8sobjects.Namespace("namespaces", core.Name("hello"))),
 		},
 	}
 

--- a/pkg/validate/raw/validate/disallowed_fields_validator.go
+++ b/pkg/validate/raw/validate/disallowed_fields_validator.go
@@ -18,12 +18,12 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/syntax"
 	"kpt.dev/configsync/pkg/importer/id"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // DisallowedFields verifies if the given Raw objects contain any fields which
 // are not allowed to be declared in Git.
-func DisallowedFields(objs *objects.Raw) status.MultiError {
+func DisallowedFields(objs *fileobjects.Raw) status.MultiError {
 	var errs status.MultiError
 	for _, obj := range objs.Objects {
 		if len(obj.GetOwnerReferences()) > 0 {

--- a/pkg/validate/raw/validate/disallowed_fields_validator_test.go
+++ b/pkg/validate/raw/validate/disallowed_fields_validator_test.go
@@ -21,33 +21,33 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/syntax"
 	"kpt.dev/configsync/pkg/importer/id"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestDisallowedFields(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Raw
+		objs     *fileobjects.Raw
 		wantErrs status.MultiError
 	}{
 		{
 			name: "Deployment with allowed fields passes",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Deployment("hello"),
+					k8sobjects.Deployment("hello"),
 				},
 			},
 		},
 		{
 			name: "Deployment with disallowed fields fails",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Deployment("hello",
+					k8sobjects.Deployment("hello",
 						core.OwnerReference([]metav1.OwnerReference{{}}),
 						core.SelfLink("this-is-me"),
 						core.UID("my-uid"),
@@ -60,14 +60,14 @@ func TestDisallowedFields(t *testing.T) {
 				},
 			},
 			wantErrs: status.Wrap(
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.OwnerReference),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.SelfLink),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.UID),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.ResourceVersion),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.Generation),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.CreationTimestamp),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.DeletionTimestamp),
-				syntax.IllegalFieldsInConfigError(fake.Deployment("hello"), id.DeletionGracePeriodSeconds),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.OwnerReference),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.SelfLink),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.UID),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.ResourceVersion),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.Generation),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.CreationTimestamp),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.DeletionTimestamp),
+				syntax.IllegalFieldsInConfigError(k8sobjects.Deployment("hello"), id.DeletionGracePeriodSeconds),
 			),
 		},
 	}

--- a/pkg/validate/raw/validate/hnc_validator_test.go
+++ b/pkg/validate/raw/validate/hnc_validator_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/hnc"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 const (
@@ -39,32 +39,32 @@ func TestHNCLabels(t *testing.T) {
 	}{
 		{
 			name: "no labels",
-			obj:  fake.RoleAtPath("namespaces/hello/role.yaml"),
+			obj:  k8sobjects.RoleAtPath("namespaces/hello/role.yaml"),
 		},
 		{
 			name: "one legal label",
-			obj: fake.RoleAtPath("namespaces/hello/role.yaml",
+			obj: k8sobjects.RoleAtPath("namespaces/hello/role.yaml",
 				core.Label(legalLabel, "")),
 		},
 		{
 			name: "one illegal label",
-			obj: fake.RoleAtPath("namespaces/hello/role.yaml",
+			obj: k8sobjects.RoleAtPath("namespaces/hello/role.yaml",
 				core.Label(illegalSuffixedLabel, "")),
-			wantErr: hnc.IllegalDepthLabelError(fake.Role(), []string{illegalSuffixedLabel}),
+			wantErr: hnc.IllegalDepthLabelError(k8sobjects.Role(), []string{illegalSuffixedLabel}),
 		},
 		{
 			name: "two illegal labels",
-			obj: fake.RoleAtPath("namespaces/hello/role.yaml",
+			obj: k8sobjects.RoleAtPath("namespaces/hello/role.yaml",
 				core.Label(illegalSuffixedLabel, ""),
 				core.Label(illegalSuffixedLabel2, "")),
-			wantErr: hnc.IllegalDepthLabelError(fake.Role(), []string{illegalSuffixedLabel, illegalSuffixedLabel2}),
+			wantErr: hnc.IllegalDepthLabelError(k8sobjects.Role(), []string{illegalSuffixedLabel, illegalSuffixedLabel2}),
 		},
 		{
 			name: "one legal and one illegal label",
-			obj: fake.RoleAtPath("namespaces/hello/role.yaml",
+			obj: k8sobjects.RoleAtPath("namespaces/hello/role.yaml",
 				core.Label(legalLabel, ""),
 				core.Label(illegalSuffixedLabel, "")),
-			wantErr: hnc.IllegalDepthLabelError(fake.Role(), []string{illegalSuffixedLabel}),
+			wantErr: hnc.IllegalDepthLabelError(k8sobjects.Role(), []string{illegalSuffixedLabel}),
 		},
 	}
 

--- a/pkg/validate/raw/validate/illegal_crd_validator_test.go
+++ b/pkg/validate/raw/validate/illegal_crd_validator_test.go
@@ -22,7 +22,6 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestIllegalCRD(t *testing.T) {
@@ -38,22 +37,22 @@ func TestIllegalCRD(t *testing.T) {
 		{
 			name:    "ClusterConfig v1beta1 CRD",
 			obj:     crdv1beta1("crd", kinds.ClusterConfig()),
-			wantErr: fake.Error(nonhierarchical.UnsupportedObjectErrorCode),
+			wantErr: status.FakeError(nonhierarchical.UnsupportedObjectErrorCode),
 		},
 		{
 			name:    "ClusterConfig v1 CRD",
 			obj:     crdv1("crd", kinds.ClusterConfig()),
-			wantErr: fake.Error(nonhierarchical.UnsupportedObjectErrorCode),
+			wantErr: status.FakeError(nonhierarchical.UnsupportedObjectErrorCode),
 		},
 		{
 			name:    "RepoSync v1beta1 CRD",
 			obj:     crdv1beta1("crd", kinds.RepoSyncV1Beta1()),
-			wantErr: fake.Error(nonhierarchical.UnsupportedObjectErrorCode),
+			wantErr: status.FakeError(nonhierarchical.UnsupportedObjectErrorCode),
 		},
 		{
 			name:    "RepoSync v1 CRD",
 			obj:     crdv1("crd", kinds.RepoSyncV1Beta1()),
-			wantErr: fake.Error(nonhierarchical.UnsupportedObjectErrorCode),
+			wantErr: status.FakeError(nonhierarchical.UnsupportedObjectErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/validate/illegal_kind_validator_test.go
+++ b/pkg/validate/raw/validate/illegal_kind_validator_test.go
@@ -18,11 +18,11 @@ import (
 	"errors"
 	"testing"
 
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestIllegalKindsForHierarchical(t *testing.T) {
@@ -33,16 +33,16 @@ func TestIllegalKindsForHierarchical(t *testing.T) {
 	}{
 		{
 			name: "Non-hierarchical object passes",
-			obj:  fake.ClusterSelector(),
+			obj:  k8sobjects.ClusterSelector(),
 		},
 		{
 			name: "Hiearchical object passes",
-			obj:  fake.HierarchyConfig(),
+			obj:  k8sobjects.HierarchyConfig(),
 		},
 		{
 			name:    "Sync object fails",
-			obj:     fake.FileObject(fake.SyncObject(kinds.Role().GroupKind()), "sync.yaml"),
-			wantErr: nonhierarchical.UnsupportedObjectError(fake.SyncObject(kinds.Role().GroupKind())),
+			obj:     k8sobjects.FileObject(k8sobjects.SyncObject(kinds.Role().GroupKind()), "sync.yaml"),
+			wantErr: nonhierarchical.UnsupportedObjectError(k8sobjects.SyncObject(kinds.Role().GroupKind())),
 		},
 	}
 
@@ -64,22 +64,22 @@ func TestIllegalKindsForUnstructured(t *testing.T) {
 	}{
 		{
 			name: "Non-hierarchical object passes",
-			obj:  fake.ClusterSelector(),
+			obj:  k8sobjects.ClusterSelector(),
 		},
 		{
 			name:    "HierarchyConfig object fails",
-			obj:     fake.HierarchyConfig(),
-			wantErr: nonhierarchical.IllegalHierarchicalKind(fake.HierarchyConfig()),
+			obj:     k8sobjects.HierarchyConfig(),
+			wantErr: nonhierarchical.IllegalHierarchicalKind(k8sobjects.HierarchyConfig()),
 		},
 		{
 			name:    "Repo object fails",
-			obj:     fake.Repo(),
-			wantErr: nonhierarchical.IllegalHierarchicalKind(fake.Repo()),
+			obj:     k8sobjects.Repo(),
+			wantErr: nonhierarchical.IllegalHierarchicalKind(k8sobjects.Repo()),
 		},
 		{
 			name:    "Sync object fails",
-			obj:     fake.FileObject(fake.SyncObject(kinds.Role().GroupKind()), "sync.yaml"),
-			wantErr: nonhierarchical.UnsupportedObjectError(fake.SyncObject(kinds.Role().GroupKind())),
+			obj:     k8sobjects.FileObject(k8sobjects.SyncObject(kinds.Role().GroupKind()), "sync.yaml"),
+			wantErr: nonhierarchical.UnsupportedObjectError(k8sobjects.SyncObject(kinds.Role().GroupKind())),
 		},
 	}
 

--- a/pkg/validate/raw/validate/label_validator_test.go
+++ b/pkg/validate/raw/validate/label_validator_test.go
@@ -20,11 +20,11 @@ import (
 
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/metadata"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 const (
@@ -41,21 +41,21 @@ func TestLabels(t *testing.T) {
 	}{
 		{
 			name: "no labels",
-			obj:  fake.Role(),
+			obj:  k8sobjects.Role(),
 		},
 		{
 			name: "legal label",
-			obj:  fake.Role(core.Label(legalLabel, "a")),
+			obj:  k8sobjects.Role(core.Label(legalLabel, "a")),
 		},
 		{
 			name:    "illegal ConfigManagement label",
-			obj:     fake.Role(core.Label(cmLabel, "a")),
-			wantErr: metadata.IllegalLabelDefinitionError(fake.Role(), []string{cmLabel}),
+			obj:     k8sobjects.Role(core.Label(cmLabel, "a")),
+			wantErr: metadata.IllegalLabelDefinitionError(k8sobjects.Role(), []string{cmLabel}),
 		},
 		{
 			name:    "illegal ConfigSync label",
-			obj:     fake.RoleBinding(core.Label(csLabel, "a")),
-			wantErr: metadata.IllegalLabelDefinitionError(fake.RoleBinding(), []string{csLabel}),
+			obj:     k8sobjects.RoleBinding(core.Label(csLabel, "a")),
+			wantErr: metadata.IllegalLabelDefinitionError(k8sobjects.RoleBinding(), []string{csLabel}),
 		},
 	}
 

--- a/pkg/validate/raw/validate/management_annotation_test.go
+++ b/pkg/validate/raw/validate/management_annotation_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestValidManagementAnnotation(t *testing.T) {
@@ -35,21 +35,21 @@ func TestValidManagementAnnotation(t *testing.T) {
 	}{
 		{
 			name: "no management annotation",
-			obj:  fake.Role(),
+			obj:  k8sobjects.Role(),
 		},
 		{
 			name: "disabled management passes",
-			obj:  fake.Role(syncertest.ManagementDisabled),
+			obj:  k8sobjects.Role(syncertest.ManagementDisabled),
 		},
 		{
 			name: "enabled management fails",
-			obj:  fake.Role(syncertest.ManagementEnabled),
-			want: fake.Error(nonhierarchical.IllegalManagementAnnotationErrorCode),
+			obj:  k8sobjects.Role(syncertest.ManagementEnabled),
+			want: status.FakeError(nonhierarchical.IllegalManagementAnnotationErrorCode),
 		},
 		{
 			name: "invalid management fails",
-			obj:  fake.Role(core.Annotation(metadata.ResourceManagementKey, "invalid")),
-			want: fake.Error(nonhierarchical.IllegalManagementAnnotationErrorCode),
+			obj:  k8sobjects.Role(core.Annotation(metadata.ResourceManagementKey, "invalid")),
+			want: status.FakeError(nonhierarchical.IllegalManagementAnnotationErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/validate/name_validator_test.go
+++ b/pkg/validate/raw/validate/name_validator_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestName(t *testing.T) {
@@ -33,26 +33,26 @@ func TestName(t *testing.T) {
 	}{
 		{
 			name: "object with name",
-			obj:  fake.Deployment("/", core.Name("foo")),
+			obj:  k8sobjects.Deployment("/", core.Name("foo")),
 		},
 		{
 			name:    "object with empty name fails",
-			obj:     fake.Deployment("/", core.Name("")),
-			wantErr: fake.Error(nonhierarchical.MissingObjectNameErrorCode),
+			obj:     k8sobjects.Deployment("/", core.Name("")),
+			wantErr: status.FakeError(nonhierarchical.MissingObjectNameErrorCode),
 		},
 		{
 			name:    "object with invalid name fails",
-			obj:     fake.Deployment("/", core.Name("FOO:BAR")),
-			wantErr: fake.Error(nonhierarchical.InvalidMetadataNameErrorCode),
+			obj:     k8sobjects.Deployment("/", core.Name("FOO:BAR")),
+			wantErr: status.FakeError(nonhierarchical.InvalidMetadataNameErrorCode),
 		},
 		{
 			name: "object with valid name for RBAC",
-			obj:  fake.Role(core.Name("FOO:BAR")),
+			obj:  k8sobjects.Role(core.Name("FOO:BAR")),
 		},
 		{
 			name:    "object with invalid name for RBAC fails",
-			obj:     fake.Role(core.Name("FOO/BAR")),
-			wantErr: fake.Error(nonhierarchical.InvalidMetadataNameErrorCode),
+			obj:     k8sobjects.Role(core.Name("FOO/BAR")),
+			wantErr: status.FakeError(nonhierarchical.InvalidMetadataNameErrorCode),
 		},
 	}
 

--- a/pkg/validate/raw/validate/namespace_validator_test.go
+++ b/pkg/validate/raw/validate/namespace_validator_test.go
@@ -20,10 +20,10 @@ import (
 
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestNamespace(t *testing.T) {
@@ -34,39 +34,39 @@ func TestNamespace(t *testing.T) {
 	}{
 		{
 			name: "Role with unspecified namespace",
-			obj:  fake.Role(core.Namespace("")),
+			obj:  k8sobjects.Role(core.Namespace("")),
 		},
 		{
 			name: "Role with valid namespace",
-			obj:  fake.Role(core.Namespace("hello")),
+			obj:  k8sobjects.Role(core.Namespace("hello")),
 		},
 		{
 			name:    "Role with invalid namespace",
-			obj:     fake.Role(core.Namespace("..invalid..")),
-			wantErr: nonhierarchical.InvalidNamespaceError(fake.Role()),
+			obj:     k8sobjects.Role(core.Namespace("..invalid..")),
+			wantErr: nonhierarchical.InvalidNamespaceError(k8sobjects.Role()),
 		},
 		{
 			name: "RootSync with config-management-system namespace",
-			obj:  fake.RootSyncV1Beta1("foo"),
+			obj:  k8sobjects.RootSyncV1Beta1("foo"),
 		},
 		{
 			name: "Valid namespace",
-			obj:  fake.Namespace("hello"),
+			obj:  k8sobjects.Namespace("hello"),
 		},
 		{
 			name:    "Illegal namespace " + configmanagement.ControllerNamespace,
-			obj:     fake.Namespace(configmanagement.ControllerNamespace),
-			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.ControllerNamespace)),
+			obj:     k8sobjects.Namespace(configmanagement.ControllerNamespace),
+			wantErr: nonhierarchical.IllegalNamespace(k8sobjects.Namespace(configmanagement.ControllerNamespace)),
 		},
 		{
 			name:    "Illegal namespace " + configmanagement.RGControllerNamespace,
-			obj:     fake.Namespace(configmanagement.RGControllerNamespace),
-			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.RGControllerNamespace)),
+			obj:     k8sobjects.Namespace(configmanagement.RGControllerNamespace),
+			wantErr: nonhierarchical.IllegalNamespace(k8sobjects.Namespace(configmanagement.RGControllerNamespace)),
 		},
 		{
 			name:    "Illegal namespace " + configmanagement.MonitoringNamespace,
-			obj:     fake.Namespace(configmanagement.MonitoringNamespace),
-			wantErr: nonhierarchical.IllegalNamespace(fake.Namespace(configmanagement.MonitoringNamespace)),
+			obj:     k8sobjects.Namespace(configmanagement.MonitoringNamespace),
+			wantErr: nonhierarchical.IllegalNamespace(k8sobjects.Namespace(configmanagement.MonitoringNamespace)),
 		},
 	}
 

--- a/pkg/validate/raw/validate/repo_validator.go
+++ b/pkg/validate/raw/validate/repo_validator.go
@@ -21,7 +21,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/repo"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,7 +35,7 @@ var allowedRepoVersions = map[string]bool{
 
 // Repo verifies that there is exactly one Repo object and that it has the
 // correct version.
-func Repo(objs *objects.Raw) status.MultiError {
+func Repo(objs *fileobjects.Raw) status.MultiError {
 	var found []client.Object
 	for _, obj := range objs.Objects {
 		if obj.GetObjectKind().GroupVersionKind().GroupKind() == kinds.Repo().GroupKind() {

--- a/pkg/validate/raw/validate/repo_validator_test.go
+++ b/pkg/validate/raw/validate/repo_validator_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/util/repo"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 const notAllowedRepoVersion = "0.0.0"
@@ -32,53 +32,53 @@ const notAllowedRepoVersion = "0.0.0"
 func TestRepo(t *testing.T) {
 	testCases := []struct {
 		name    string
-		objs    *objects.Raw
+		objs    *fileobjects.Raw
 		wantErr status.Error
 	}{
 		{
 			name: "Repo with current version",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(fake.RepoVersion(repo.CurrentVersion)),
+					k8sobjects.Repo(k8sobjects.RepoVersion(repo.CurrentVersion)),
 				},
 			},
 		},
 		{
 			name: "Repo with supported old version",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(fake.RepoVersion(system.OldAllowedRepoVersion)),
+					k8sobjects.Repo(k8sobjects.RepoVersion(system.OldAllowedRepoVersion)),
 				},
 			},
 		},
 		{
 			name: "Repo with unsupported old version",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(fake.RepoVersion(notAllowedRepoVersion)),
+					k8sobjects.Repo(k8sobjects.RepoVersion(notAllowedRepoVersion)),
 				},
 			},
-			wantErr: system.UnsupportedRepoSpecVersion(fake.Repo(fake.RepoVersion(notAllowedRepoVersion)), notAllowedRepoVersion),
+			wantErr: system.UnsupportedRepoSpecVersion(k8sobjects.Repo(k8sobjects.RepoVersion(notAllowedRepoVersion)), notAllowedRepoVersion),
 		},
 		{
 			name: "Missing Repo",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Role(),
-					fake.RoleBinding(),
+					k8sobjects.Role(),
+					k8sobjects.RoleBinding(),
 				},
 			},
 			wantErr: system.MissingRepoError(),
 		},
 		{
 			name: "Multiple Repos",
-			objs: &objects.Raw{
+			objs: &fileobjects.Raw{
 				Objects: []ast.FileObject{
-					fake.Repo(core.Name("first")),
-					fake.Repo(core.Name("second")),
+					k8sobjects.Repo(core.Name("first")),
+					k8sobjects.Repo(core.Name("second")),
 				},
 			},
-			wantErr: status.MultipleSingletonsError(fake.Repo(), fake.Repo()),
+			wantErr: status.MultipleSingletonsError(k8sobjects.Repo(), k8sobjects.Repo()),
 		},
 	}
 

--- a/pkg/validate/raw/validate/self_reconcile_validator.go
+++ b/pkg/validate/raw/validate/self_reconcile_validator.go
@@ -19,13 +19,13 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SelfReconcile checks if the given RootSync or RepoSync is the one that
 // configures the reconciler.
-func SelfReconcile(reconcilerName string) objects.ObjectVisitor {
+func SelfReconcile(reconcilerName string) fileobjects.ObjectVisitor {
 	return func(obj ast.FileObject) status.Error {
 		switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
 		case kinds.RootSyncV1Beta1().GroupKind():

--- a/pkg/validate/scoped/hydrate/namespace_hydrator.go
+++ b/pkg/validate/scoped/hydrate/namespace_hydrator.go
@@ -34,7 +34,7 @@ import (
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,8 +45,8 @@ import (
 // into namespaces that are dynamically present on the cluster. It also sets a
 // default namespace on any namespace-scoped object that does not already
 // have a namespace or namespace selector set.
-func NamespaceSelectors(ctx context.Context, c client.Client, fieldManager string) objects.ScopedVisitor {
-	return func(objs *objects.Scoped) status.MultiError {
+func NamespaceSelectors(ctx context.Context, c client.Client, fieldManager string) fileobjects.ScopedVisitor {
+	return func(objs *fileobjects.Scoped) status.MultiError {
 		nsSelectors, errs := buildSelectorMap(ctx, c, fieldManager, objs)
 		if errs != nil {
 			return errs
@@ -84,7 +84,7 @@ func NamespaceSelectors(ctx context.Context, c client.Client, fieldManager strin
 // of NamespaceSelector names to the namespaces that are selected by each one.
 // Note that this modifies the Scoped objects to filter out the
 // NamespaceSelectors since they are no longer needed after this point.
-func buildSelectorMap(ctx context.Context, c client.Client, fieldManager string, objs *objects.Scoped) (map[string][]string, status.MultiError) {
+func buildSelectorMap(ctx context.Context, c client.Client, fieldManager string, objs *fileobjects.Scoped) (map[string][]string, status.MultiError) {
 	var namespaces, others []ast.FileObject
 	nsSelectorMap := make(map[string]labels.Selector)
 	selectedNamespaceMap := make(map[string][]labels.Selector)

--- a/pkg/validate/scoped/hydrate/unknown_scope_hydrator.go
+++ b/pkg/validate/scoped/hydrate/unknown_scope_hydrator.go
@@ -18,13 +18,13 @@ import (
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // UnknownScope hydrates the given Scoped objects by adding an annotation
 // `configsync.gke.io/unknown-scope: true` into every object whose scope is
 // unknown.
-func UnknownScope(objs *objects.Scoped) status.MultiError {
+func UnknownScope(objs *fileobjects.Scoped) status.MultiError {
 	for _, obj := range objs.Unknown {
 		core.SetAnnotation(obj, metadata.UnknownScopeAnnotationKey, metadata.UnknownScopeAnnotationValue)
 	}

--- a/pkg/validate/scoped/hydrate/unknown_scope_hydrator_test.go
+++ b/pkg/validate/scoped/hydrate/unknown_scope_hydrator_test.go
@@ -20,70 +20,70 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestUnknownScope(t *testing.T) {
 	testCases := []struct {
 		name string
-		objs *objects.Scoped
-		want *objects.Scoped
+		objs *fileobjects.Scoped
+		want *fileobjects.Scoped
 	}{
 		{
 			name: "No objects",
-			objs: &objects.Scoped{},
-			want: &objects.Scoped{},
+			objs: &fileobjects.Scoped{},
+			want: &fileobjects.Scoped{},
 		},
 		{
 			name: "no unknown scope objects",
-			objs: &objects.Scoped{
+			objs: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(core.Namespace("prod")),
+					k8sobjects.Role(core.Namespace("prod")),
 				},
 			},
-			want: &objects.Scoped{
+			want: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(core.Namespace("prod")),
+					k8sobjects.Role(core.Namespace("prod")),
 				},
 			},
 		},
 		{
 			name: "has unknown scope objects",
-			objs: &objects.Scoped{
+			objs: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
-					fake.Namespace("namespaces/dev2", core.Label("environment", "dev")),
+					k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					k8sobjects.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+					k8sobjects.Namespace("namespaces/dev2", core.Label("environment", "dev")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(core.Namespace("prod")),
+					k8sobjects.Role(core.Namespace("prod")),
 				},
 				Unknown: []ast.FileObject{
-					fake.FileObject(fake.RootSyncObjectV1Beta1(configsync.RootSyncName), "rootsync.yaml"),
+					k8sobjects.FileObject(k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName), "rootsync.yaml"),
 				},
 			},
-			want: &objects.Scoped{
+			want: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.Namespace("namespaces/prod", core.Label("environment", "prod")),
-					fake.Namespace("namespaces/dev1", core.Label("environment", "dev")),
-					fake.Namespace("namespaces/dev2", core.Label("environment", "dev")),
+					k8sobjects.Namespace("namespaces/prod", core.Label("environment", "prod")),
+					k8sobjects.Namespace("namespaces/dev1", core.Label("environment", "dev")),
+					k8sobjects.Namespace("namespaces/dev2", core.Label("environment", "dev")),
 				},
 				Namespace: []ast.FileObject{
-					fake.Role(
+					k8sobjects.Role(
 						core.Namespace("prod"),
 					),
 				},
 				Unknown: []ast.FileObject{
-					fake.FileObject(fake.RootSyncObjectV1Beta1(configsync.RootSyncName,
+					k8sobjects.FileObject(k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName,
 						core.Annotation(metadata.UnknownScopeAnnotationKey, metadata.UnknownScopeAnnotationValue),
 					), "rootsync.yaml"),
 				},

--- a/pkg/validate/scoped/validate/namespace_selector_validator.go
+++ b/pkg/validate/scoped/validate/namespace_selector_validator.go
@@ -18,12 +18,12 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NamespaceSelectors validates that all NamespaceSelectors have a unique name.
-func NamespaceSelectors(objs *objects.Scoped) status.MultiError {
+func NamespaceSelectors(objs *fileobjects.Scoped) status.MultiError {
 	var errs status.MultiError
 	gk := kinds.NamespaceSelector().GroupKind()
 	matches := make(map[string][]client.Object)

--- a/pkg/validate/scoped/validate/namespace_selector_validator_test.go
+++ b/pkg/validate/scoped/validate/namespace_selector_validator_test.go
@@ -19,50 +19,50 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestNamespaceSelectors(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Scoped
+		objs     *fileobjects.Scoped
 		wantErrs status.MultiError
 	}{
 		{
 			name: "No objects",
-			objs: &objects.Scoped{},
+			objs: &fileobjects.Scoped{},
 		},
 		{
 			name: "One NamespaceSelector",
-			objs: &objects.Scoped{
+			objs: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.NamespaceSelector(core.Name("first")),
+					k8sobjects.NamespaceSelector(core.Name("first")),
 				},
 			},
 		},
 		{
 			name: "Two NamespaceSelectors",
-			objs: &objects.Scoped{
+			objs: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.NamespaceSelector(core.Name("first")),
-					fake.NamespaceSelector(core.Name("second")),
+					k8sobjects.NamespaceSelector(core.Name("first")),
+					k8sobjects.NamespaceSelector(core.Name("second")),
 				},
 			},
 		},
 		{
 			name: "Duplicate NamespaceSelectors",
-			objs: &objects.Scoped{
+			objs: &fileobjects.Scoped{
 				Cluster: []ast.FileObject{
-					fake.NamespaceSelector(core.Name("first")),
-					fake.NamespaceSelector(core.Name("first")),
+					k8sobjects.NamespaceSelector(core.Name("first")),
+					k8sobjects.NamespaceSelector(core.Name("first")),
 				},
 			},
-			wantErrs: nonhierarchical.SelectorMetadataNameCollisionError(kinds.NamespaceSelector().Kind, "first", fake.NamespaceSelector()),
+			wantErrs: nonhierarchical.SelectorMetadataNameCollisionError(kinds.NamespaceSelector().Kind, "first", k8sobjects.NamespaceSelector()),
 		},
 	}
 

--- a/pkg/validate/scoped/validate/scope_validator_test.go
+++ b/pkg/validate/scoped/validate/scope_validator_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/nonhierarchical"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
 )
 
 func TestClusterScoped(t *testing.T) {
@@ -34,18 +34,18 @@ func TestClusterScoped(t *testing.T) {
 	}{
 		{
 			name: "Object without metadata.namespace passes",
-			obj:  fake.ClusterRole(),
+			obj:  k8sobjects.ClusterRole(),
 		},
 		{
 			name:    "Object with metadata.namespace fails",
-			obj:     fake.ClusterRole(core.Namespace("hello")),
-			wantErr: nonhierarchical.IllegalNamespaceOnClusterScopedResourceError(fake.ClusterRole()),
+			obj:     k8sobjects.ClusterRole(core.Namespace("hello")),
+			wantErr: nonhierarchical.IllegalNamespaceOnClusterScopedResourceError(k8sobjects.ClusterRole()),
 		},
 		{
 			name: "Object with namespace selector fails",
-			obj: fake.ClusterRole(
+			obj: k8sobjects.ClusterRole(
 				core.Annotation(metadata.NamespaceSelectorAnnotationKey, "value")),
-			wantErr: nonhierarchical.IllegalNamespaceSelectorAnnotationError(fake.ClusterRole()),
+			wantErr: nonhierarchical.IllegalNamespaceSelectorAnnotationError(k8sobjects.ClusterRole()),
 		},
 	}
 
@@ -67,8 +67,8 @@ func TestClusterScopedForNamespaceReconciler(t *testing.T) {
 	}{
 		{
 			name:    "Cluster scoped object fails",
-			obj:     fake.ClusterRole(),
-			wantErr: shouldBeInRootErr(fake.ClusterRole()),
+			obj:     k8sobjects.ClusterRole(),
+			wantErr: shouldBeInRootErr(k8sobjects.ClusterRole()),
 		},
 	}
 
@@ -90,23 +90,23 @@ func TestNamespaceScoped(t *testing.T) {
 	}{
 		{
 			name: "Object without metadata.namespace passes",
-			obj:  fake.Role(),
+			obj:  k8sobjects.Role(),
 		},
 		{
 			name: "Object with metadata.namespace passes",
-			obj:  fake.Role(core.Namespace("hello")),
+			obj:  k8sobjects.Role(core.Namespace("hello")),
 		},
 		{
 			name: "Object with namespace selector passes",
-			obj: fake.Role(
+			obj: k8sobjects.Role(
 				core.Annotation(metadata.NamespaceSelectorAnnotationKey, "value")),
 		},
 		{
 			name: "Object with namespace and namespace selector fails",
-			obj: fake.Role(
+			obj: k8sobjects.Role(
 				core.Namespace("hello"),
 				core.Annotation(metadata.NamespaceSelectorAnnotationKey, "value")),
-			wantErr: nonhierarchical.NamespaceAndSelectorResourceError(fake.Role()),
+			wantErr: nonhierarchical.NamespaceAndSelectorResourceError(k8sobjects.Role()),
 		},
 	}
 

--- a/pkg/validate/tree/hydrate/inheritance_hydrator.go
+++ b/pkg/validate/tree/hydrate/inheritance_hydrator.go
@@ -23,14 +23,14 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/syntax"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 type inheritanceSpecs map[schema.GroupKind]transform.InheritanceSpec
 
 // Inheritance hydrates the given Tree objects by copying inherited objects from
 // abstract namespaces down into child namespaces.
-func Inheritance(objs *objects.Tree) status.MultiError {
+func Inheritance(objs *fileobjects.Tree) status.MultiError {
 	if objs.Tree == nil {
 		return nil
 	}

--- a/pkg/validate/tree/hydrate/inheritance_hydrator_test.go
+++ b/pkg/validate/tree/hydrate/inheritance_hydrator_test.go
@@ -21,76 +21,76 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast/node"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation"
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestInheritance(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Tree
-		want     *objects.Tree
+		objs     *fileobjects.Tree
+		want     *fileobjects.Tree
 		wantErrs status.MultiError
 	}{
 		{
 			name: "Preserve non-namespace objects",
-			objs: &objects.Tree{
-				Repo: fake.Repo(),
+			objs: &fileobjects.Tree{
+				Repo: k8sobjects.Repo(),
 				Cluster: []ast.FileObject{
-					fake.ClusterRole(core.Name("hello-reader")),
-					fake.ClusterRoleBinding(core.Name("hello-binding")),
+					k8sobjects.ClusterRole(core.Name("hello-reader")),
+					k8sobjects.ClusterRoleBinding(core.Name("hello-binding")),
 				},
 			},
-			want: &objects.Tree{
-				Repo: fake.Repo(),
+			want: &fileobjects.Tree{
+				Repo: k8sobjects.Repo(),
 				Cluster: []ast.FileObject{
-					fake.ClusterRole(core.Name("hello-reader")),
-					fake.ClusterRoleBinding(core.Name("hello-binding")),
+					k8sobjects.ClusterRole(core.Name("hello-reader")),
+					k8sobjects.ClusterRoleBinding(core.Name("hello-binding")),
 				},
 			},
 		},
 		{
 			name: "Propagate abstract namespace objects",
-			objs: &objects.Tree{
-				Repo: fake.Repo(),
+			objs: &fileobjects.Tree{
+				Repo: k8sobjects.Repo(),
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigResource(v1.HierarchyModeDefault, kinds.Role().GroupVersion(), kinds.Role().Kind),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigResource(v1.HierarchyModeDefault, kinds.Role().GroupVersion(), kinds.Role().Kind),
 					),
 				},
 				Tree: &ast.TreeNode{
 					Relative: cmpath.RelativeSlash("namespaces"),
 					Type:     node.AbstractNamespace,
 					Objects: []ast.FileObject{
-						fake.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
+						k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
 					},
 					Children: []*ast.TreeNode{
 						{
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.AbstractNamespace,
 							Objects: []ast.FileObject{
-								fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
+								k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
 							},
 							Children: []*ast.TreeNode{
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
+										k8sobjects.Namespace("namespaces/hello/world"),
 									},
 								},
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/moon"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/moon"),
-										fake.Deployment("namespaces/hello/moon"),
+										k8sobjects.Namespace("namespaces/hello/moon"),
+										k8sobjects.Deployment("namespaces/hello/moon"),
 									},
 								},
 							},
@@ -99,51 +99,51 @@ func TestInheritance(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/goodbye"),
 							Type:     node.Namespace,
 							Objects: []ast.FileObject{
-								fake.Namespace("namespaces/goodbye"),
-								fake.Deployment("namespaces/goodbye"),
+								k8sobjects.Namespace("namespaces/goodbye"),
+								k8sobjects.Deployment("namespaces/goodbye"),
 							},
 						},
 					},
 				},
 			},
-			want: &objects.Tree{
-				Repo: fake.Repo(),
+			want: &fileobjects.Tree{
+				Repo: k8sobjects.Repo(),
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigResource(v1.HierarchyModeDefault, kinds.Role().GroupVersion(), kinds.Role().Kind),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigResource(v1.HierarchyModeDefault, kinds.Role().GroupVersion(), kinds.Role().Kind),
 					),
 				},
 				Tree: &ast.TreeNode{
 					Relative: cmpath.RelativeSlash("namespaces"),
 					Type:     node.AbstractNamespace,
 					Objects: []ast.FileObject{
-						fake.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
+						k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
 					},
 					Children: []*ast.TreeNode{
 						{
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.AbstractNamespace,
 							Objects: []ast.FileObject{
-								fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
+								k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
 							},
 							Children: []*ast.TreeNode{
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
-										fake.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
-										fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
+										k8sobjects.Namespace("namespaces/hello/world"),
+										k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
+										k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
 									},
 								},
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/moon"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/moon"),
-										fake.Deployment("namespaces/hello/moon"),
-										fake.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
-										fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
+										k8sobjects.Namespace("namespaces/hello/moon"),
+										k8sobjects.Deployment("namespaces/hello/moon"),
+										k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
+										k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
 									},
 								},
 							},
@@ -152,9 +152,9 @@ func TestInheritance(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/goodbye"),
 							Type:     node.Namespace,
 							Objects: []ast.FileObject{
-								fake.Namespace("namespaces/goodbye"),
-								fake.Deployment("namespaces/goodbye"),
-								fake.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
+								k8sobjects.Namespace("namespaces/goodbye"),
+								k8sobjects.Deployment("namespaces/goodbye"),
+								k8sobjects.RoleAtPath("namespaces/role.yaml", core.Name("reader")),
 							},
 						},
 					},
@@ -163,7 +163,7 @@ func TestInheritance(t *testing.T) {
 		},
 		{
 			name: "Validate Namespace can not have child Namespaces",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Tree: &ast.TreeNode{
 					Relative: cmpath.RelativeSlash("namespaces"),
 					Type:     node.AbstractNamespace,
@@ -172,21 +172,21 @@ func TestInheritance(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.Namespace,
 							Objects: []ast.FileObject{
-								fake.Namespace("namespaces/hello"),
+								k8sobjects.Namespace("namespaces/hello"),
 							},
 							Children: []*ast.TreeNode{
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
+										k8sobjects.Namespace("namespaces/hello/world"),
 									},
 								},
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/moon"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/moon"),
+										k8sobjects.Namespace("namespaces/hello/moon"),
 									},
 								},
 							},
@@ -207,11 +207,11 @@ func TestInheritance(t *testing.T) {
 		},
 		{
 			name: "Validate abstract namespace can not have invalid objects",
-			objs: &objects.Tree{
-				Repo: fake.Repo(),
+			objs: &fileobjects.Tree{
+				Repo: k8sobjects.Repo(),
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigResource(v1.HierarchyModeNone, kinds.Role().GroupVersion(), kinds.Role().Kind),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigResource(v1.HierarchyModeNone, kinds.Role().GroupVersion(), kinds.Role().Kind),
 					),
 				},
 				Tree: &ast.TreeNode{
@@ -222,14 +222,14 @@ func TestInheritance(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.AbstractNamespace,
 							Objects: []ast.FileObject{
-								fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
+								k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer")),
 							},
 							Children: []*ast.TreeNode{
 								{
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
+										k8sobjects.Namespace("namespaces/hello/world"),
 									},
 								},
 							},
@@ -237,7 +237,7 @@ func TestInheritance(t *testing.T) {
 					},
 				},
 			},
-			wantErrs: validation.IllegalAbstractNamespaceObjectKindError(fake.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer"))),
+			wantErrs: validation.IllegalAbstractNamespaceObjectKindError(k8sobjects.RoleAtPath("namespaces/hello/role.yaml", core.Name("writer"))),
 		},
 	}
 

--- a/pkg/validate/tree/hydrate/namespace_selector_hydrator.go
+++ b/pkg/validate/tree/hydrate/namespace_selector_hydrator.go
@@ -23,14 +23,14 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // NamespaceSelectors hydrates the given Tree objects by performing namespace
 // selection to filter out inactive objects that were copied into namespaces by
 // the Inheritance hydrator. It also validates that objects only specify legacy
 // NamespaceSelectors that are defined in an ancestor abstract namespace.
-func NamespaceSelectors(objs *objects.Tree) status.MultiError {
+func NamespaceSelectors(objs *fileobjects.Tree) status.MultiError {
 	nsSelectors, errs := selectorMap(objs.NamespaceSelectors)
 	if errs != nil {
 		return errs

--- a/pkg/validate/tree/tree.go
+++ b/pkg/validate/tree/tree.go
@@ -16,7 +16,7 @@ package tree
 
 import (
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"kpt.dev/configsync/pkg/validate/tree/hydrate"
 	"kpt.dev/configsync/pkg/validate/tree/validate"
 )
@@ -24,10 +24,10 @@ import (
 // Hierarchical performs validation and hydration for a structured hierarchical
 // repo against the given Tree objects. Note that this will modify the Tree
 // objects in-place.
-func Hierarchical(objs *objects.Tree) status.MultiError {
+func Hierarchical(objs *fileobjects.Tree) status.MultiError {
 	var errs status.MultiError
 	// See the note about ordering in raw.Hierarchical().
-	validators := []objects.TreeVisitor{
+	validators := []fileobjects.TreeVisitor{
 		validate.HierarchyConfig,
 		validate.Inheritance,
 		validate.NamespaceSelector,
@@ -42,7 +42,7 @@ func Hierarchical(objs *objects.Tree) status.MultiError {
 	// We perform inheritance first so that we copy all abstract objects into
 	// their potential namespaces, and then we perform namespace selection to
 	// filter out the copies which are not selected.
-	hydrators := []objects.TreeVisitor{
+	hydrators := []fileobjects.TreeVisitor{
 		hydrate.Inheritance,
 		hydrate.NamespaceSelectors,
 	}

--- a/pkg/validate/tree/validate/hierarchy_config_validator.go
+++ b/pkg/validate/tree/validate/hierarchy_config_validator.go
@@ -22,12 +22,12 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/hierarchyconfig"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 // HierarchyConfig verifies that all HierarchyConfig objects specify valid
 // namespace-scoped resource kinds and valid inheritance modes.
-func HierarchyConfig(tree *objects.Tree) status.MultiError {
+func HierarchyConfig(tree *fileobjects.Tree) status.MultiError {
 	clusterGKs := make(map[schema.GroupKind]bool)
 	for _, obj := range tree.Cluster {
 		clusterGKs[obj.GetObjectKind().GroupVersionKind().GroupKind()] = true

--- a/pkg/validate/tree/validate/hierarchy_config_validator_test.go
+++ b/pkg/validate/tree/validate/hierarchy_config_validator_test.go
@@ -20,12 +20,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/hierarchyconfig"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 var (
@@ -37,84 +37,84 @@ var (
 func TestHierarchyConfig(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Tree
+		objs     *fileobjects.Tree
 		wantErrs status.MultiError
 	}{
 		{
 			name: "Rolebinding allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.RoleBinding())),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.RoleBinding())),
 				},
 			},
 		},
 		{
 			name: "Missing Group allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(v1.HierarchyModeDefault, missingGroup)),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(v1.HierarchyModeDefault, missingGroup)),
 				},
 			},
 		},
 		{
 			name: "Missing Kind not allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(v1.HierarchyModeDefault, missingKind)),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(v1.HierarchyModeDefault, missingKind)),
 				},
 			},
-			wantErrs: fake.Errors(hierarchyconfig.UnsupportedResourceInHierarchyConfigErrorCode),
+			wantErrs: status.FakeMultiError(hierarchyconfig.UnsupportedResourceInHierarchyConfigErrorCode),
 		},
 		{
 			name: "Cluster-scoped objects not allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.ClusterRoleBinding())),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.ClusterRoleBinding())),
 				},
 			},
-			wantErrs: fake.Errors(hierarchyconfig.ClusterScopedResourceInHierarchyConfigErrorCode),
+			wantErrs: status.FakeMultiError(hierarchyconfig.ClusterScopedResourceInHierarchyConfigErrorCode),
 		},
 		{
 			name: "ConfigManagement objects not allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.Sync())),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(v1.HierarchyModeDefault, kinds.Sync())),
 				},
 			},
-			wantErrs: fake.Errors(hierarchyconfig.UnsupportedResourceInHierarchyConfigErrorCode),
+			wantErrs: status.FakeMultiError(hierarchyconfig.UnsupportedResourceInHierarchyConfigErrorCode),
 		},
 		{
 			name: "Unknown mode not allowed",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				Cluster: []ast.FileObject{
-					fake.ClusterRoleBinding(),
+					k8sobjects.ClusterRoleBinding(),
 				},
 				HierarchyConfigs: []ast.FileObject{
-					fake.HierarchyConfig(
-						fake.HierarchyConfigKind(unknownMode, kinds.Role())),
+					k8sobjects.HierarchyConfig(
+						k8sobjects.HierarchyConfigKind(unknownMode, kinds.Role())),
 				},
 			},
-			wantErrs: fake.Errors(hierarchyconfig.IllegalHierarchyModeErrorCode),
+			wantErrs: status.FakeMultiError(hierarchyconfig.IllegalHierarchyModeErrorCode),
 		},
 	}
 

--- a/pkg/validate/tree/validate/inheritance_validator.go
+++ b/pkg/validate/tree/validate/inheritance_validator.go
@@ -20,13 +20,13 @@ import (
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/semantic"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Inheritance verifies that all syncable resources in an abstract namespace
 // have a concrete Namespace as a descendant.
-func Inheritance(tree *objects.Tree) status.MultiError {
+func Inheritance(tree *fileobjects.Tree) status.MultiError {
 	_, err := validateTreeNode(tree.Tree)
 	return err
 }

--- a/pkg/validate/tree/validate/namespace_selector_validator.go
+++ b/pkg/validate/tree/validate/namespace_selector_validator.go
@@ -23,7 +23,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,7 +31,7 @@ import (
 // selector annotations. This one verifies that legacy NamespaceSelectors are
 // only declared in abstract namespace and that objects only reference legacy
 // NamespaceSelectors that are in an ancestor abstract namespace.
-func NamespaceSelector(tree *objects.Tree) status.MultiError {
+func NamespaceSelector(tree *fileobjects.Tree) status.MultiError {
 	return validateSelectorsInNode(tree.Tree, tree.NamespaceSelectors)
 }
 

--- a/pkg/validate/tree/validate/namespace_selector_validator_test.go
+++ b/pkg/validate/tree/validate/namespace_selector_validator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/analyzer/ast/node"
 	"kpt.dev/configsync/pkg/importer/analyzer/transform/selectors"
@@ -26,21 +27,20 @@ import (
 	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/status"
-	"kpt.dev/configsync/pkg/testing/fake"
-	"kpt.dev/configsync/pkg/validate/objects"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 )
 
 func TestNamespaceSelector(t *testing.T) {
 	testCases := []struct {
 		name     string
-		objs     *objects.Tree
+		objs     *fileobjects.Tree
 		wantErrs status.MultiError
 	}{
 		{
 			name: "NamespaceSelector in abstract namespace",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				NamespaceSelectors: map[string]ast.FileObject{
-					"dev": fake.NamespaceSelectorAtPath("namespaces/sel.yaml",
+					"dev": k8sobjects.NamespaceSelectorAtPath("namespaces/sel.yaml",
 						core.Name("dev")),
 				},
 				Tree: &ast.TreeNode{
@@ -51,7 +51,7 @@ func TestNamespaceSelector(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.Namespace,
 							Objects: []ast.FileObject{
-								fake.Namespace("namespaces/hello"),
+								k8sobjects.Namespace("namespaces/hello"),
 							},
 						},
 					},
@@ -60,9 +60,9 @@ func TestNamespaceSelector(t *testing.T) {
 		},
 		{
 			name: "NamespaceSelector in Namespace",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				NamespaceSelectors: map[string]ast.FileObject{
-					"dev": fake.NamespaceSelectorAtPath("namespaces/hello/sel.yaml",
+					"dev": k8sobjects.NamespaceSelectorAtPath("namespaces/hello/sel.yaml",
 						core.Name("dev")),
 				},
 				Tree: &ast.TreeNode{
@@ -73,19 +73,19 @@ func TestNamespaceSelector(t *testing.T) {
 							Relative: cmpath.RelativeSlash("namespaces/hello"),
 							Type:     node.Namespace,
 							Objects: []ast.FileObject{
-								fake.Namespace("namespaces/hello"),
+								k8sobjects.Namespace("namespaces/hello"),
 							},
 						},
 					},
 				},
 			},
-			wantErrs: fake.Errors(syntax.IllegalKindInNamespacesErrorCode),
+			wantErrs: status.FakeMultiError(syntax.IllegalKindInNamespacesErrorCode),
 		},
 		{
 			name: "Object references ancestor NamespaceSelector",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				NamespaceSelectors: map[string]ast.FileObject{
-					"dev": fake.NamespaceSelectorAtPath("namespaces/hello/sel.yaml",
+					"dev": k8sobjects.NamespaceSelectorAtPath("namespaces/hello/sel.yaml",
 						core.Name("dev")),
 				},
 				Tree: &ast.TreeNode{
@@ -100,8 +100,8 @@ func TestNamespaceSelector(t *testing.T) {
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
-										fake.RoleAtPath("namespaces/hello/world/role.yaml",
+										k8sobjects.Namespace("namespaces/hello/world"),
+										k8sobjects.RoleAtPath("namespaces/hello/world/role.yaml",
 											core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev")),
 									},
 								},
@@ -113,9 +113,9 @@ func TestNamespaceSelector(t *testing.T) {
 		},
 		{
 			name: "Object references non-ancestor NamespaceSelector",
-			objs: &objects.Tree{
+			objs: &fileobjects.Tree{
 				NamespaceSelectors: map[string]ast.FileObject{
-					"dev": fake.NamespaceSelectorAtPath("namespaces/goodbye/sel.yaml",
+					"dev": k8sobjects.NamespaceSelectorAtPath("namespaces/goodbye/sel.yaml",
 						core.Name("dev")),
 				},
 				Tree: &ast.TreeNode{
@@ -130,8 +130,8 @@ func TestNamespaceSelector(t *testing.T) {
 									Relative: cmpath.RelativeSlash("namespaces/hello/world"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/hello/world"),
-										fake.RoleAtPath("namespaces/hello/world/role.yaml",
+										k8sobjects.Namespace("namespaces/hello/world"),
+										k8sobjects.RoleAtPath("namespaces/hello/world/role.yaml",
 											core.Annotation(metadata.NamespaceSelectorAnnotationKey, "dev")),
 									},
 								},
@@ -145,8 +145,8 @@ func TestNamespaceSelector(t *testing.T) {
 									Relative: cmpath.RelativeSlash("namespaces/goodbye/moon"),
 									Type:     node.Namespace,
 									Objects: []ast.FileObject{
-										fake.Namespace("namespaces/goodbye/moon"),
-										fake.RoleAtPath("namespaces/goodbye/moon/role.yaml"),
+										k8sobjects.Namespace("namespaces/goodbye/moon"),
+										k8sobjects.RoleAtPath("namespaces/goodbye/moon/role.yaml"),
 									},
 								},
 							},
@@ -154,7 +154,7 @@ func TestNamespaceSelector(t *testing.T) {
 					},
 				},
 			},
-			wantErrs: fake.Errors(selectors.ObjectHasUnknownSelectorCode),
+			wantErrs: status.FakeMultiError(selectors.ObjectHasUnknownSelectorCode),
 		},
 	}
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -24,8 +24,8 @@ import (
 	"kpt.dev/configsync/pkg/reconciler/namespacecontroller"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/discovery"
+	"kpt.dev/configsync/pkg/validate/fileobjects"
 	"kpt.dev/configsync/pkg/validate/final"
-	"kpt.dev/configsync/pkg/validate/objects"
 	"kpt.dev/configsync/pkg/validate/raw"
 	"kpt.dev/configsync/pkg/validate/scoped"
 	"kpt.dev/configsync/pkg/validate/tree"
@@ -97,7 +97,7 @@ func Hierarchical(objs []ast.FileObject, opts Options) ([]ast.FileObject, status
 	// We also perform initial hydration which includes:
 	//   - filtering out resources whose cluster selector does not match
 	//   - adding metadata to resources (such as their filepath in the repo)
-	rawObjects := &objects.Raw{
+	rawObjects := &fileobjects.Raw{
 		ClusterName:       opts.ClusterName,
 		Scope:             opts.Scope,
 		SyncName:          opts.SyncName,
@@ -141,7 +141,7 @@ func Hierarchical(objs []ast.FileObject, opts Options) ([]ast.FileObject, status
 	// We also perform hydration which includes:
 	//   - copying "abstract" resources down into child namespaces and filtering
 	//     based upon their namespace selector
-	treeObjects, errs := objects.BuildTree(scopedObjects)
+	treeObjects, errs := fileobjects.BuildTree(scopedObjects)
 	if errs != nil {
 		return nil, status.Append(nonBlockingErrs, errs)
 	}
@@ -179,7 +179,7 @@ func Unstructured(ctx context.Context, c client.Client, objs []ast.FileObject, o
 	// We also perform initial hydration which includes:
 	//   - filtering out resources whose cluster selector does not match
 	//   - adding metadata to resources (such as their filepath in the repo)
-	rawObjects := &objects.Raw{
+	rawObjects := &fileobjects.Raw{
 		ClusterName:              opts.ClusterName,
 		Scope:                    opts.Scope,
 		SyncName:                 opts.SyncName,

--- a/pkg/webhook/fields_test.go
+++ b/pkg/webhook/fields_test.go
@@ -20,8 +20,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -131,7 +131,7 @@ func TestObjectDiffer_Structured(t *testing.T) {
 }
 
 func roleForTest(muts ...core.MetaMutator) *rbacv1.Role {
-	role := fake.RoleObject(
+	role := k8sobjects.RoleObject(
 		core.Name("hello"),
 		core.Namespace("world"),
 		core.Label("this", "that"))

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -28,9 +28,9 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/importer"
 	csmetadata "kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/testing/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,7 +68,7 @@ func TestValidator_Handle(t *testing.T) {
 			// The Config Sync Importer is allowed to do anything it likes, so we just
 			// have one test for it.
 			name: "Importer creates a object whose configmanagement.gke.io/managed annotation is set to enabled but whose configsync.gke.io/resource-id annotation is unset",
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -86,7 +86,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Root reconciler deletes an object it manages",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -105,7 +105,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Root reconciler deletes an object managed by a namespace reconciler",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -124,7 +124,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Namespace reconciler deletes an object it manages",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -143,7 +143,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Namespace reconciler deletes an object it does not manage",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -163,7 +163,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Namespace reconciler deletes an object it does not manage",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -183,7 +183,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates an unmanaged object, which does not have the configmanagement.gke.io/managed and configsync.gke.io/resource-id annotations.",
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				setRules([]rbacv1.PolicyRule{
@@ -198,7 +198,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates an unmanaged object, whose configmanagement.gke.io/managed annotation is set to enabled, but whose configsync.gke.io/resource-id annotation is unset.",
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -214,7 +214,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates an unmanaged object, whose configmanagement.gke.io/managed annotation is unset, but whose configsync.gke.io/resource-id annotation is set.",
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_world_hello"),
@@ -230,7 +230,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes an unmanaged object, which does not have the configmanagement.gke.io/managed and configsync.gke.io/resource-id annotations.",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				setRules([]rbacv1.PolicyRule{
@@ -245,7 +245,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes an unmanaged object, whose configmanagement.gke.io/managed annotation is set to enabled, but whose configsync.gke.io/resource-id annotation is unset.",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -261,7 +261,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes an unmanaged object, whose configmanagement.gke.io/managed annotation is unset, but whose configsync.gke.io/resource-id annotation is set.",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_world_hello"),
@@ -277,7 +277,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates an unmanaged object, oldObj and newObj both do not have the configmanagement.gke.io/managed and configsync.gke.io/resource-id annotations.",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				setRules([]rbacv1.PolicyRule{
@@ -288,7 +288,7 @@ func TestValidator_Handle(t *testing.T) {
 					},
 				}),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				setRules([]rbacv1.PolicyRule{
@@ -303,7 +303,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates an unmanaged object, oldObj has the configmanagement.gke.io/managed  annotation, newObj has the configsync.gke.io/resource-id annotation.",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -315,7 +315,7 @@ func TestValidator_Handle(t *testing.T) {
 					},
 				}),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_world_hello"),
@@ -331,7 +331,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates a managed object",
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -351,7 +351,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes a managed object",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -371,7 +371,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates a managed object: undeclared fields",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -386,7 +386,7 @@ func TestValidator_Handle(t *testing.T) {
 				}),
 				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:labels":{"f:app.kubernetes.io/managed-by":{}},"f:annotations":{"f:configmanagement.gke.io/managed":{}}},"f:rules":{}}`),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -406,7 +406,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates a managed object: declared fields",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -421,7 +421,7 @@ func TestValidator_Handle(t *testing.T) {
 				}),
 				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:labels":{"f:app.kubernetes.io/managed-by":{}},"f:annotations":{"f:configmanagement.gke.io/managed":{}}},"f:rules":{}}`),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -441,7 +441,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates a managed object: Config Sync metadata",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -456,7 +456,7 @@ func TestValidator_Handle(t *testing.T) {
 				}),
 				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:labels":{"f:app.kubernetes.io/managed-by":{}},"f:annotations":{"f:configmanagement.gke.io/managed":{}}},"f:rules":{}}`),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				// Removed managed-by label
@@ -476,7 +476,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates a object (whose configmanagement.gke.io/managed annotation is unset, but whose configsync.gke.io/resource-id annotation is set): Config Sync metadata",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				core.Label(csmetadata.ManagedByKey, csmetadata.ManagedByValue),
@@ -490,7 +490,7 @@ func TestValidator_Handle(t *testing.T) {
 				}),
 				core.Annotation(csmetadata.DeclaredFieldsKey, `{"f:metadata":{"f:labels":{"f:app.kubernetes.io/managed-by":{}},"f:annotations":{"f:configmanagement.gke.io/managed":{}}},"f:rules":{}}`),
 			),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Name("hello"),
 				core.Namespace("world"),
 				// Removed managed-by label
@@ -508,7 +508,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates a ResourceGroup generated by ConfigSync",
-			newObj: fake.ResourceGroupObject(
+			newObj: k8sobjects.ResourceGroupObject(
 				core.Name("repo-sync"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -518,7 +518,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes a ResourceGroup generated by ConfigSync",
-			oldObj: fake.ResourceGroupObject(
+			oldObj: k8sobjects.ResourceGroupObject(
 				core.Name("repo-sync"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -528,12 +528,12 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates a ResourceGroup generated by ConfigSync",
-			oldObj: fake.ResourceGroupObject(
+			oldObj: k8sobjects.ResourceGroupObject(
 				core.Name("repo-sync"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Label(common.InventoryLabel, applier.InventoryID("repo-sync", "bookstore"))),
-			newObj: fake.ResourceGroupObject(
+			newObj: k8sobjects.ResourceGroupObject(
 				core.Name("repo-sync"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -544,7 +544,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob creates an independent ResourceGroup",
-			newObj: fake.ResourceGroupObject(
+			newObj: k8sobjects.ResourceGroupObject(
 				core.Name("user-created"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled)),
@@ -552,7 +552,7 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob deletes an independent ResourceGroup",
-			oldObj: fake.ResourceGroupObject(
+			oldObj: k8sobjects.ResourceGroupObject(
 				core.Name("user-created"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled)),
@@ -560,11 +560,11 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob updates an independent ResourceGroup",
-			oldObj: fake.ResourceGroupObject(
+			oldObj: k8sobjects.ResourceGroupObject(
 				core.Name("user-created"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled)),
-			newObj: fake.ResourceGroupObject(
+			newObj: k8sobjects.ResourceGroupObject(
 				core.Name("user-created"),
 				core.Namespace("bookstore"),
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
@@ -573,31 +573,31 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob manually modifies lifecycle annotation of an object, whose configmanagement.gke.io/managed annotation is set to enabled, but whose configsync.gke.io/resource-id annotation is unset",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, csmetadata.IgnoreMutation)),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, "other")),
 		},
 		{
 			name: "Bob manually modifies lifecycle annotation of an object, whose configsync.gke.io/resource-id annotation is incorrect",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_world_hello"),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, csmetadata.IgnoreMutation)),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_world_hello"),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, "other")),
 		},
 		{
 			name: "Bob manually modifies lifecycle annotation of a managed object",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_default-name"),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, csmetadata.IgnoreMutation)),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_default-name"),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, "other")),
@@ -605,10 +605,10 @@ func TestValidator_Handle(t *testing.T) {
 		},
 		{
 			name: "Bob manually adds lifecycle annotation",
-			oldObj: fake.RoleObject(
+			oldObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_default-name")),
-			newObj: fake.RoleObject(
+			newObj: k8sobjects.RoleObject(
 				core.Annotation(csmetadata.ResourceManagementKey, csmetadata.ResourceManagementEnabled),
 				core.Annotation(csmetadata.ResourceIDKey, "rbac.authorization.k8s.io_role_default-name"),
 				core.Annotation(csmetadata.LifecycleMutationAnnotation, csmetadata.IgnoreMutation)),


### PR DESCRIPTION
This package is not only used in testing, so the path/naming is a bit misleading. This package primarily contains helper functions to construct k8s objects.