### PR TITLE
fix: remediator ignores no resource/kind match

### DIFF
--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -345,8 +345,10 @@ func Generate() AllExamples {
 
 	// 2008
 	result.add(client.ConflictCreateAlreadyExists(errors.New("already exists"), k8sobjects.RoleObject()))
+	result.add(client.ConflictCreateResourceDoesNotExist(errors.New("no resource match"), k8sobjects.RoleObject()))
 	result.add(client.ConflictUpdateOldVersion(errors.New("old version"), k8sobjects.RoleObject()))
-	result.add(client.ConflictUpdateDoesNotExist(errors.New("does not exist"), k8sobjects.RoleObject()))
+	result.add(client.ConflictUpdateObjectDoesNotExist(errors.New("does not exist"), k8sobjects.RoleObject()))
+	result.add(client.ConflictUpdateResourceDoesNotExist(errors.New("no resource match"), k8sobjects.RoleObject()))
 
 	// 2009
 	result.add(applier.Error(errors.New("failed to initialize an error")))

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -295,14 +295,14 @@ func TestRemediator_Reconcile_Metrics(t *testing.T) {
 			// Object on cluster has no label and is unmanaged
 			actual: k8sobjects.RoleObject(core.Namespace("example"), core.Name("example")),
 			// Object update fails, because it was deleted by another client
-			updateError: syncerclient.ConflictUpdateDoesNotExist(
+			updateError: syncerclient.ConflictUpdateObjectDoesNotExist(
 				apierrors.NewNotFound(schema.GroupResource{Group: "rbac", Resource: "roles"}, "example"),
 				k8sobjects.RoleObject(core.Namespace("example"), core.Name("example"))),
 			// Object NOT updated on cluster, because update failed with conflict error
 			want: k8sobjects.RoleObject(core.Namespace("example"), core.Name("example"),
 				core.UID("1"), core.ResourceVersion("1"), core.Generation(1)),
 			// Expect update error returned from Remediate
-			wantError: syncerclient.ConflictUpdateDoesNotExist(
+			wantError: syncerclient.ConflictUpdateObjectDoesNotExist(
 				apierrors.NewNotFound(schema.GroupResource{Group: "rbac", Resource: "roles"}, "example"),
 				k8sobjects.RoleObject(core.Namespace("example"), core.Name("example"))),
 			// Expect resource conflict error

--- a/pkg/syncer/client/client.go
+++ b/pkg/syncer/client/client.go
@@ -159,7 +159,7 @@ func (c *Client) apply(ctx context.Context, obj client.Object, updateFn update,
 		err := c.Client.Get(ctx, namespacedName, workingObj)
 		switch {
 		case apierrors.IsNotFound(err):
-			return nil, ConflictUpdateDoesNotExist(err, obj)
+			return nil, ConflictUpdateObjectDoesNotExist(err, obj)
 		case err != nil:
 			return nil, status.ResourceWrap(err, "failed to get object to update", obj)
 		}
@@ -220,7 +220,7 @@ func (c *Client) Update(ctx context.Context, obj client.Object, opts ...client.U
 	m.RecordAPICallDuration(ctx, "update", m.StatusTagKey(err), start)
 	switch {
 	case apierrors.IsNotFound(err):
-		return ConflictUpdateDoesNotExist(err, obj)
+		return ConflictUpdateObjectDoesNotExist(err, obj)
 	case err != nil:
 		return status.ResourceWrap(err, "failed to update", obj)
 	}

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -84,7 +84,7 @@ func TestClient_Apply(t *testing.T) {
 			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewErrorClient(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin")),
-			wantErr: syncerclient.ConflictUpdateDoesNotExist(
+			wantErr: syncerclient.ConflictUpdateObjectDoesNotExist(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "billing/admin"),
 				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},
@@ -128,7 +128,7 @@ func TestClient_Update(t *testing.T) {
 			declared: k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewErrorClient(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin")),
-			wantErr: syncerclient.ConflictUpdateDoesNotExist(
+			wantErr: syncerclient.ConflictUpdateObjectDoesNotExist(
 				apierrors.NewNotFound(rbacv1.Resource("Role"), "admin"),
 				k8sobjects.RoleObject(core.Name("admin"), core.Namespace("billing"))),
 		},

--- a/pkg/syncer/client/retriable_errors.go
+++ b/pkg/syncer/client/retriable_errors.go
@@ -30,16 +30,34 @@ var retriableConflictBuilder = status.NewErrorBuilder(ResourceConflictCode)
 func ConflictCreateAlreadyExists(err error, resource client.Object) status.Error {
 	return retriableConflictBuilder.
 		Wrap(err).
-		Sprint("tried to create resource that already exists").
+		Sprint("tried to create object that already exists").
 		BuildWithResources(resource)
 }
 
-// ConflictUpdateDoesNotExist means we tried to update an object which does not
-// exist.
-func ConflictUpdateDoesNotExist(err error, resource client.Object) status.Error {
+// ConflictCreateResourceDoesNotExist means we tried to create an object whose
+// resource group or kind does not exist.
+func ConflictCreateResourceDoesNotExist(err error, resource client.Object) status.Error {
 	return retriableConflictBuilder.
 		Wrap(err).
-		Sprint("tried to update resource which does not exist").
+		Sprint("tried to create object whose resource type does not exist").
+		BuildWithResources(resource)
+}
+
+// ConflictUpdateObjectDoesNotExist means we tried to update an object which does not
+// exist.
+func ConflictUpdateObjectDoesNotExist(err error, resource client.Object) status.Error {
+	return retriableConflictBuilder.
+		Wrap(err).
+		Sprint("tried to update object which does not exist").
+		BuildWithResources(resource)
+}
+
+// ConflictUpdateResourceDoesNotExist means we tried to update an object whose
+// resource group or kind does not exist.
+func ConflictUpdateResourceDoesNotExist(err error, resource client.Object) status.Error {
+	return retriableConflictBuilder.
+		Wrap(err).
+		Sprint("tried to update object whose resource type does not exist").
 		BuildWithResources(resource)
 }
 
@@ -48,6 +66,6 @@ func ConflictUpdateDoesNotExist(err error, resource client.Object) status.Error 
 func ConflictUpdateOldVersion(err error, resource client.Object) status.Error {
 	return retriableConflictBuilder.
 		Wrap(err).
-		Sprintf("tried to update with stale version of resource").
+		Sprintf("tried to update object with stale resource version").
 		BuildWithResources(resource)
 }


### PR DESCRIPTION
- Update remediator to record NoMatchErrors as a resource conflict.
  These are reported as metrics and cause retry, but are still not
  reported as sync errors, for now.
- Update comments in TestCRDDeleteBeforeRemoveCustomResourceV1
  to explain why a conflict is expected and which ones might be
  encountered due to race condition.