### PR TITLE
feat: remove PoCo from nomos bugreport

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -989,8 +989,6 @@ func TestNomosBugreport(t *testing.T) {
 		"namespaces/config-management-monitoring/pods.json",
 		"namespaces/config-management-monitoring/pods.yaml",
 		"namespaces/config-management-monitoring/otel-collector.*/otel-collector.log",
-		"namespaces/gatekeeper-system/pods.json",
-		"namespaces/gatekeeper-system/pods.yaml",
 		"namespaces/resource-group-system/pods.json",
 		"namespaces/resource-group-system/pods.yaml",
 	}

--- a/pkg/bugreport/constants.go
+++ b/pkg/bugreport/constants.go
@@ -16,15 +16,12 @@ package bugreport
 
 import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
-	"kpt.dev/configsync/pkg/policycontroller"
 )
 
 // Product describes an ACM Product
 type Product string
 
 const (
-	// PolicyController policy controller
-	PolicyController = Product("Policy Controller")
 	// ConfigSync config sync, AKA Nomos, AKA original ACM
 	ConfigSync = Product("Config Sync")
 	// ConfigSyncMonitoring controller
@@ -35,7 +32,6 @@ const (
 
 var (
 	productNamespaces = map[Product]string{
-		PolicyController:     policycontroller.NamespaceSystem,
 		ConfigSync:           configmanagement.ControllerNamespace,
 		ResourceGroup:        configmanagement.RGControllerNamespace,
 		ConfigSyncMonitoring: configmanagement.MonitoringNamespace,


### PR DESCRIPTION
PoCo is no longer included with ACM, so there is no longer a need to bundle the PoCo logs with nomos bugreport.