### PR TITLE
feat: remove kube-system from nomos bugreport

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -973,8 +973,6 @@ func TestNomosBugreport(t *testing.T) {
 		"cluster/configmanagement/namespaceselectors.yaml",
 		"cluster/configmanagement/config-sync-validating-webhhook-configuration.json",
 		"cluster/configmanagement/config-sync-validating-webhhook-configuration.yaml",
-		"namespaces/kube-system/pods.json",
-		"namespaces/kube-system/pods.yaml",
 		"namespaces/config-management-system/pods.json",
 		"namespaces/config-management-system/pods.yaml",
 		"namespaces/config-management-system/ConfigMaps.json",


### PR DESCRIPTION
config-management-operator has not been installed in the kube-system namespace since before 1.9.0. 1.9.0 was released in 2021, so it should not be necessary to include kube-system logs in current versions of nomos bugreport.

See: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/release-notes#September_23_2021