### PR TITLE
fix: RepoSync management conflict reporting

### DIFF
--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -57,8 +57,16 @@ func (u *Updater) needToUpdateWatch() bool {
 	return u.Remediator.NeedsUpdate()
 }
 
-func (u *Updater) managementConflict() bool {
-	return u.Remediator.ManagementConflict()
+// HasManagementConflict returns true when conflict errors have been encountered
+// by the Applier or Remediator for at least one currently managed object.
+func (u *Updater) HasManagementConflict() bool {
+	return u.SyncErrorCache.conflictHandler.HasConflictErrors()
+}
+
+// ManagementConflicts returns a list of conflict errors encountered by the
+// Applier or Remediator.
+func (u *Updater) ManagementConflicts() []status.ManagementConflictError {
+	return u.SyncErrorCache.conflictHandler.ConflictErrors()
 }
 
 // Remediating returns true if the Remediator is remediating.

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -85,8 +85,6 @@ type Interface interface {
 	// UpdateWatches starts and stops server-side watches based upon the given map
 	// of GVKs which should be watched.
 	UpdateWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
-	// ManagementConflict returns true if one of the watchers noticed a management conflict.
-	ManagementConflict() bool
 }
 
 var _ Interface = &Remediator{}
@@ -237,9 +235,4 @@ func (r *Remediator) AddWatches(ctx context.Context, gvks map[schema.GroupVersio
 // UpdateWatches implements Interface.
 func (r *Remediator) UpdateWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
 	return r.watchMgr.UpdateWatches(ctx, gvks)
-}
-
-// ManagementConflict implements Interface.
-func (r *Remediator) ManagementConflict() bool {
-	return r.watchMgr.ManagementConflict()
 }

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -122,24 +122,6 @@ func (m *Manager) NeedsUpdate() bool {
 	return m.needsUpdate
 }
 
-// ManagementConflict returns true if any watcher notices any management conflicts. This function is threadsafe.
-func (m *Manager) ManagementConflict() bool {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-
-	managementConflict := false
-	// If one of the watchers noticed a management conflict, the remediator will indicate that
-	// it needs an update so that the parse-apply-watch loop can also detect the conflict and
-	//report it as an error status.
-	for _, watcher := range m.watcherMap {
-		if watcher.ManagementConflict() {
-			managementConflict = true
-			watcher.ClearManagementConflicts()
-		}
-	}
-	return managementConflict
-}
-
 // AddWatches accepts a map of GVKs that should be watched and takes the
 // following actions:
 //   - start watchers for any GroupVersionKind that is present in the given map

--- a/pkg/syncer/syncertest/fake/conflict_handler.go
+++ b/pkg/syncer/syncertest/fake/conflict_handler.go
@@ -36,6 +36,11 @@ func (h *ConflictHandler) ConflictErrors() []status.ManagementConflictError {
 	return nil
 }
 
+// HasConflictErrors is a fake implementation of HasConflictErrors of conflict.Handler.
+func (h *ConflictHandler) HasConflictErrors() bool {
+	return false
+}
+
 // ClearConflictErrorsWithKind is a fake implementation of ClearConflictErrorsWithKind of conflict.Handler.
 func (h *ConflictHandler) ClearConflictErrorsWithKind(schema.GroupKind) {
 }


### PR DESCRIPTION
- Change the run loop retry handler to check the conflict handler for errors, instead of using a flag in the remediator watchers. This fixes a bug where the applier may only be triggered once after a conflict, even if the conflict was not resolved.
- Change the remediator to treat namespace reconcilers the same as root reconcilers when reporting a management conflict error. This fixes a bug which could happen when the applier succeeded and then a new conflict was discovered, which wouldn't report the conflict until the next resync or source change.
- Use a RWMutex in the conflict handler, to allows parallel reads.
- Change the remote reporting (RootSync -> RootSync) of conflict status errors to read the errors from the conflict handler, instead of the applier errors. This just simplifies the code. The reported errors should be identical.