### PR TITLE
test: cleanup monorepo CRDs after migrate test

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1443,6 +1443,20 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 		}
 	})
 	nt.T.Cleanup(func() {
+		crds := []string{
+			"repos.configmanagement.gke.io",
+			"syncs.configmanagement.gke.io",
+			"namespaceconfigs.configmanagement.gke.io",
+			"clusterconfigs.configmanagement.gke.io",
+		}
+		for _, crdName := range crds {
+			crd := k8sobjects.CustomResourceDefinitionV1Object(core.Name(crdName))
+			if err := nt.KubeClient.Delete(crd); err != nil && !apierrors.IsNotFound(err) {
+				nt.T.Error(err)
+			}
+		}
+	})
+	nt.T.Cleanup(func() {
 		cmObj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "configmanagement.gke.io/v1",


### PR DESCRIPTION
These CRDs were not being removed and left lingering on the cluster after the test.

This is causing a side effect for the nomos bugreport test which is outputting files for these CRDs.