### PR TITLE
fix: bugreport logs for resourcegroup and askpass

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -977,6 +977,15 @@ func TestNomosBugreport(t *testing.T) {
 		"namespaces/config-management-monitoring/pods.yaml",
 		"namespaces/config-management-monitoring/otel-collector.*/otel-collector.log",
 		"namespaces/resource-group-system/pods.yaml",
+		"namespaces/resource-group-system/resource-group-controller-manager-.*/manager.log",
+		"namespaces/resource-group-system/resource-group-controller-manager-.*/otel-agent.log",
+	}
+
+	var rootSync v1beta1.RootSync
+	nt.Must(nt.KubeClient.Get(configsync.RootSyncName, configsync.ControllerNamespace, &rootSync))
+	if rootSync.Spec.Git.Auth == configsync.AuthGCENode {
+		multiRepoBugReportFiles = append(multiRepoBugReportFiles,
+			"namespaces/config-management-system/root-reconciler-.*/gcenode-askpass-sidecar.log")
 	}
 
 	// check expected files exist in folder

--- a/pkg/bugreport/bugreport.go
+++ b/pkg/bugreport/bugreport.go
@@ -162,7 +162,7 @@ func (b *BugReporter) FetchLogSources(ctx context.Context) []Readable {
 
 	// for each namespace, generate a list of logSources
 	listOps := client.ListOptions{}
-	nsLabels := map[string]string{"configmanagement.gke.io/configmanagement": "config-management"}
+	nsLabels := map[string]string{"configmanagement.gke.io/system": "true"}
 	productAndLabels := map[Product]map[string]string{
 		ResourceGroup:        nsLabels,
 		ConfigSyncMonitoring: nil,


### PR DESCRIPTION
- The resource-group-controller logs were only collected when the config-management label was on the Namespace. This meant they were only collected when the operator-applied label was on the Namespace. Now it will consistently collect the ResourceGroup logs whenever the configmanagement "system" label is on the Namespace. This fixes a flake that could happen if the bugreport test ran after the nomos migrate test, and also improves the behavior.
- Update test expectations to expect the askpass logs if the gcenode auth type is in use. This fixes a test failure on the CSR tests.