### PR TITLE
test: also expect askpass for gcpserviceaccount

### DIFF
--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -54,6 +54,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -981,9 +982,8 @@ func TestNomosBugreport(t *testing.T) {
 		"namespaces/resource-group-system/resource-group-controller-manager-.*/otel-agent.log",
 	}
 
-	var rootSync v1beta1.RootSync
-	nt.Must(nt.KubeClient.Get(configsync.RootSyncName, configsync.ControllerNamespace, &rootSync))
-	if rootSync.Spec.Git.Auth == configsync.AuthGCENode {
+	rs := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, configsync.RootSyncName)
+	if controllers.EnableAskpassSidecar(configsync.GitSource, rs.Spec.Git.Auth) {
 		multiRepoBugReportFiles = append(multiRepoBugReportFiles,
 			"namespaces/config-management-system/root-reconciler-.*/gcenode-askpass-sidecar.log")
 	}

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -920,7 +920,7 @@ func (r *RepoSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			caCertSecretRef: v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef),
 			knownHost:       r.isKnownHostsEnabled(rs.Spec.Git.Auth),
 		})
-		if enableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
+		if EnableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
 			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
 		}
 	case configsync.OciSource:
@@ -1249,7 +1249,7 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
 				}
 			case reconcilermanager.GCENodeAskpassSidecar:
-				if !enableAskpassSidecar(rs.Spec.SourceType, auth) {
+				if !EnableAskpassSidecar(rs.Spec.SourceType, auth) {
 					addContainer = false
 				} else {
 					container.Env = append(container.Env, containerEnvs[container.Name]...)
@@ -1276,7 +1276,9 @@ func (r *RepoSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RepoS
 	}
 }
 
-func enableAskpassSidecar(sourceType configsync.SourceType, auth configsync.AuthType) bool {
+// EnableAskpassSidecar indicates whether the gcenode-askpass-sidecar container
+// is enabled.
+func EnableAskpassSidecar(sourceType configsync.SourceType, auth configsync.AuthType) bool {
 	if sourceType == configsync.GitSource &&
 		(auth == configsync.AuthGCPServiceAccount || auth == configsync.AuthGCENode) {
 		return true

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -798,7 +798,7 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 			caCertSecretRef: v1beta1.GetSecretName(rs.Spec.Git.CACertSecretRef),
 			knownHost:       r.isKnownHostsEnabled(rs.Spec.Git.Auth),
 		})
-		if enableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
+		if EnableAskpassSidecar(rs.Spec.SourceType, rs.Spec.Git.Auth) {
 			result[reconcilermanager.GCENodeAskpassSidecar] = gceNodeAskPassSidecarEnvs(rs.Spec.GCPServiceAccountEmail)
 		}
 	case configsync.OciSource:
@@ -1302,7 +1302,7 @@ func (r *RootSyncReconciler) mutationsFor(ctx context.Context, rs *v1beta1.RootS
 					container.Env = append(container.Env, gitSyncHTTPSProxyEnv(secretName, keys)...)
 				}
 			case reconcilermanager.GCENodeAskpassSidecar:
-				if !enableAskpassSidecar(rs.Spec.SourceType, auth) {
+				if !EnableAskpassSidecar(rs.Spec.SourceType, auth) {
 					addContainer = false
 				} else {
 					container.Env = append(container.Env, containerEnvs[container.Name]...)


### PR DESCRIPTION
The askpass sidecar is also present for the gcpserviceaccount git auth type, and thus the logs are expected.