### PR TITLE
clean up stale references to the importer

### DIFF
--- a/pkg/diff/precedence.go
+++ b/pkg/diff/precedence.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/importer"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
@@ -31,7 +30,6 @@ import (
 )
 
 const (
-	saImporter             = importer.Name
 	saRootReconcilerPrefix = core.RootReconcilerPrefix
 	saReconcilerManager    = reconcilermanager.ManagerName
 
@@ -79,12 +77,6 @@ func CanManage(scope declared.Scope, syncName string, obj client.Object, op admi
 func ValidateManager(reconciler, manager string, id core.ID, op admissionv1.Operation) error {
 	if manager == "" {
 		// All managers are allowed to manage an object without a specified manager
-		return nil
-	}
-
-	// TODO: Remove this check when we turn down the old importer deployment.
-	if isImporter(reconciler) {
-		// Config Sync importer (legacy) is allowed to manage any object.
 		return nil
 	}
 
@@ -143,10 +135,6 @@ func ValidateManager(reconciler, manager string, id core.ID, op admissionv1.Oper
 			reconciler, op, id, oldReconciler)
 	}
 	return nil
-}
-
-func isImporter(reconcilerName string) bool {
-	return reconcilerName == saImporter
 }
 
 func isRootReconciler(reconcilerName string) bool {

--- a/pkg/diff/precedence_test.go
+++ b/pkg/diff/precedence_test.go
@@ -316,22 +316,6 @@ func TestValidateManager(t *testing.T) {
 			operation:  admissionv1.Delete,
 			want:       fmt.Errorf(`config sync "reconciler-manager" can not DELETE object "RepoSync.configsync.gke.io, ns-1/reposync-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
-		{
-			name:       "Importer can manage object with a root manager",
-			reconciler: "importer",
-			manager:    "bookstore",
-			id:         repoSyncID,
-			operation:  admissionv1.Update,
-			want:       nil,
-		},
-		{
-			name:       "Importer can manage object with a manager",
-			reconciler: "importer",
-			manager:    "root-reconciler",
-			id:         repoSyncID,
-			operation:  admissionv1.Update,
-			want:       nil,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -379,38 +363,6 @@ func TestIsRootReconciler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isRootReconciler(tc.reconcilerName); got != tc.want {
 				t.Errorf("isRootReconciler() got %v; want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestIsImporter(t *testing.T) {
-	testCases := []struct {
-		name     string
-		username string
-		want     bool
-	}{
-		{
-			name:     "Config Sync importer service account",
-			username: "importer",
-			want:     true,
-		},
-		{
-			name:     "Config Sync monitor service account",
-			username: "monitor",
-			want:     false,
-		},
-		{
-			name:     "Empty username",
-			username: "",
-			want:     false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isImporter(tc.username); got != tc.want {
-				t.Errorf("isImporter() got %v; want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/importer/metrics.go
+++ b/pkg/importer/metrics.go
@@ -20,32 +20,14 @@ import (
 )
 
 // Name is the name of the importer Deployment.
+// Deprecated
 const Name = "importer"
 
 // Metrics contains the Prometheus metrics for the Importer.
+// TODO: Do we still need these metrics?
 var Metrics = struct {
-	CycleDuration    *prometheus.HistogramVec
-	NamespaceConfigs prometheus.Gauge
-	Violations       prometheus.Counter
+	Violations prometheus.Counter
 }{
-	CycleDuration: prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Help:      "Distribution of durations of cycles that the importer has attempted to complete",
-			Namespace: configmanagement.MetricsNamespace,
-			Subsystem: Name,
-			Name:      "cycle_duration_seconds",
-		},
-		// status: success, error
-		[]string{"status"},
-	),
-	NamespaceConfigs: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Help:      "Number of namespace configs present in current state",
-			Namespace: configmanagement.MetricsNamespace,
-			Subsystem: Name,
-			Name:      "namespace_configs",
-		},
-	),
 	Violations: prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Help:      "Total number of safety violations that the importer has encountered.",
@@ -57,8 +39,6 @@ var Metrics = struct {
 
 func init() {
 	prometheus.MustRegister(
-		Metrics.CycleDuration,
-		Metrics.NamespaceConfigs,
 		Metrics.Violations,
 	)
 }

--- a/pkg/importer/reader/parse_file.go
+++ b/pkg/importer/reader/parse_file.go
@@ -41,6 +41,7 @@ func parseFile(path string) ([]*unstructured.Unstructured, error) {
 		contents, err := os.ReadFile(path)
 		if err != nil {
 			klog.Errorf("Failed to read file declared in git from mounted filesystem: %s", path)
+			// TODO: This uses the old importer metric. Should this be changed?
 			importer.Metrics.Violations.Inc()
 			return nil, err
 		}
@@ -49,6 +50,7 @@ func parseFile(path string) ([]*unstructured.Unstructured, error) {
 		contents, err := os.ReadFile(path)
 		if err != nil {
 			klog.Errorf("Failed to read file declared in git from mounted filesystem: %s", path)
+			// TODO: This uses the old importer metric. Should this be changed?
 			importer.Metrics.Violations.Inc()
 			return nil, err
 		}


### PR DESCRIPTION
The importer Deployment is related to the legacy architecture which has been deprecated and removed.