### PR TITLE
test: fix logging to print correct line numbers

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -101,7 +101,7 @@ func PrintFeatureDurations() {
 // Usually tests should use nomostest.New but this is surfaced as a public
 // method for test cases which do not need all the features of NT, such
 // as access to a k8s cluster.
-func NewTestWrapper(t *testing.T, testFeature nomostesting.Feature, ntOptions ...ntopts.Opt) (*nomostesting.Wrapper, *ntopts.New) {
+func NewTestWrapper(t *testing.T, testFeature nomostesting.Feature, ntOptions ...ntopts.Opt) (nomostesting.NTB, *ntopts.New) {
 	e2e.EnableParallel(t)
 	tw := nomostesting.New(t, testFeature)
 	optsStruct := newOptStruct(TestClusterName(tw), TestDir(tw), ntOptions...)

--- a/e2e/nomostest/testing/ntb.go
+++ b/e2e/nomostest/testing/ntb.go
@@ -58,12 +58,13 @@ func NewFakeNTB(name string) *FakeNTB {
 
 // Error is equivalent to Log followed by Fail.
 func (t *FakeNTB) Error(args ...interface{}) {
-	t.Log(args...)
+	t.Log(injectErrorPrefix(args...)...)
 	t.Fail()
 }
 
 // Errorf is equivalent to Logf followed by Fail.
 func (t *FakeNTB) Errorf(format string, args ...interface{}) {
+	format, args = injectErrorPrefixF(format, args...)
 	t.Logf(format, args...)
 	t.Fail()
 }
@@ -90,12 +91,13 @@ func (t *FakeNTB) Failed() bool {
 
 // Fatal is equivalent to Log followed by FailNow.
 func (t *FakeNTB) Fatal(args ...interface{}) {
-	t.Log(args...)
+	t.Log(injectErrorPrefix(args...)...)
 	t.FailNow()
 }
 
 // Fatalf is equivalent to Logf followed by FailNow.
 func (t *FakeNTB) Fatalf(format string, args ...interface{}) {
+	format, args = injectErrorPrefixF(format, args...)
 	t.Logf(format, args...)
 	t.FailNow()
 }
@@ -176,11 +178,12 @@ func (t *FakeNTB) Skipped() bool {
 
 // Log generates the output. It's always at the same stack depth.
 func (t *FakeNTB) Log(args ...interface{}) {
-	fmt.Println(fmt.Sprintf("[%s]", t.name), fmt.Sprint(args...))
+	fmt.Println(fmt.Sprintf("[%s]", t.name), fmt.Sprint(injectTimePrefix(args...)...))
 }
 
 // Logf formats its arguments according to the format, analogous to Printf, and
 // records the text in the error log.
 func (t *FakeNTB) Logf(format string, args ...interface{}) {
+	format, args = injectTimePrefixF(format, args...)
 	fmt.Println(fmt.Sprintf("[%s]", t.name), fmt.Sprintf(format, args...))
 }

--- a/e2e/nomostest/testlogger/testlogger.go
+++ b/e2e/nomostest/testlogger/testlogger.go
@@ -14,7 +14,9 @@
 
 package testlogger
 
-import "kpt.dev/configsync/e2e/nomostest/testing"
+import (
+	"kpt.dev/configsync/e2e/nomostest/testing"
+)
 
 // TestLogger wraps testing.NTB to add optional debug logging, without exposing
 // the ability to error or fatally terminate the test.
@@ -53,6 +55,7 @@ func (tl *TestLogger) IsDebugEnabled() bool {
 // Debug only prints the log message if debug is enabled.
 // Use for verbose logs that can be enabled by developers, but won't show in CI.
 func (tl *TestLogger) Debug(args ...interface{}) {
+	tl.t.Helper()
 	if tl.debugEnabled {
 		tl.t.Log(args...)
 	}
@@ -62,6 +65,7 @@ func (tl *TestLogger) Debug(args ...interface{}) {
 // enabled.
 // Use for verbose logs that can be enabled by developers, but won't show in CI.
 func (tl *TestLogger) Debugf(format string, args ...interface{}) {
+	tl.t.Helper()
 	if tl.debugEnabled {
 		tl.t.Logf(format, args...)
 	}
@@ -69,10 +73,12 @@ func (tl *TestLogger) Debugf(format string, args ...interface{}) {
 
 // Info prints the message to the test log.
 func (tl *TestLogger) Info(args ...interface{}) {
+	tl.t.Helper()
 	tl.t.Log(args...)
 }
 
 // Infof prints the message to the test log, with Sprintf-like formatting.
 func (tl *TestLogger) Infof(format string, args ...interface{}) {
+	tl.t.Helper()
 	tl.t.Logf(format, args...)
 }

--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -145,6 +145,7 @@ func syncDirectory(syncDirectoryMap map[types.NamespacedName]string, nn types.Na
 // If you want to validate specific fields of a Sync object, use
 // nt.Watcher.WatchObject() instead.
 func (nt *NT) WatchForAllSyncs(options ...WatchForAllSyncsOptions) error {
+	nt.T.Helper()
 	waitForRepoSyncsOptions := watchForAllSyncsOptions{
 		timeout:            nt.DefaultWaitTimeout,
 		readyCheck:         true,
@@ -223,6 +224,7 @@ func (nt *NT) WatchForSync(
 	syncDirPair *SyncDirPredicatePair,
 	opts ...testwatcher.WatchOption,
 ) error {
+	nt.T.Helper()
 	if namespace == "" {
 		// If namespace is empty, use the default namespace
 		namespace = configsync.ControllerNamespace


### PR DESCRIPTION
The Wrapper struct was unnecessary and broke the Helper method of the testing struct. The Helper method inspects the stack trace and adds the caller as a helper function, but this breaks when the Helper call is invoked in a nested helper function.

With this change the Helper calls work as expected and the correct line numbers are logged.