### PR TITLE
fix: syncer client not handling resource not found

### DIFF
--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -123,9 +123,8 @@ func (r *reconciler) remediate(ctx context.Context, id core.ID, objDiff diff.Dif
 	case diff.NoOp:
 		return nil
 	case diff.ManagementConflict:
-		oldManager := core.GetAnnotation(objDiff.Actual, metadata.ResourceManagerKey)
+		// Error logged by conflict.Record AND worker.Run. So don't log here.
 		newManager := declared.ResourceManager(r.scope, r.syncName)
-		klog.Warningf("Remediator skipping object %v: management conflict detected (current: %s, desired: %s)", id, oldManager, newManager)
 		return status.ManagementConflictErrorWrap(objDiff.Actual, newManager)
 	case diff.Create:
 		declared, err := objDiff.UnstructuredDeclared()


### PR DESCRIPTION
- Refactor the syncer Client and clientApplier to handle errors more consistently.
- Handle both NotFound and NoMatchFound errors everywhere they can be returned by the controller-runtime client.