### PR TITLE
fix: CRD deletion race not reporting conflict

### DIFF
--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
+	syncerclient "kpt.dev/configsync/pkg/syncer/client"
 	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
@@ -337,12 +338,13 @@ func TestManager_UpdateWatches(t *testing.T) {
 			wantWatchedTypes: []schema.GroupVersionKind{
 				kinds.Namespace(),
 			},
-			wantErr: status.APIServerErrorWrap(&meta.NoKindMatchError{
-				GroupKind: kinds.Role().GroupKind(),
-				SearchedVersions: []string{
-					kinds.Role().Version,
-				},
-			}),
+			wantErr: syncerclient.ConflictWatchResourceDoesNotExist(
+				&meta.NoKindMatchError{
+					GroupKind: kinds.Role().GroupKind(),
+					SearchedVersions: []string{
+						kinds.Role().Version,
+					},
+				}, kinds.Role()),
 		},
 	}
 

--- a/pkg/syncer/client/retriable_errors.go
+++ b/pkg/syncer/client/retriable_errors.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -68,4 +69,13 @@ func ConflictUpdateOldVersion(err error, resource client.Object) status.Error {
 		Wrap(err).
 		Sprintf("tried to update object with stale resource version").
 		BuildWithResources(resource)
+}
+
+// ConflictWatchResourceDoesNotExist means we tried to watch an object whose
+// resource group or kind does not exist.
+func ConflictWatchResourceDoesNotExist(err error, gvk schema.GroupVersionKind) status.Error {
+	return retriableConflictBuilder.
+		Wrap(err).
+		Sprintf("tried to watch resource type that does not exist: %s", gvk).
+		Build()
 }


### PR DESCRIPTION
- Now that UpdateWatches checks for the resource to exist before starting the watch, it can prevent remediator unpause. This is intentional, but it caused TestCRDDeleteBeforeRemoveCustomResourceV1 to become flaky, due to the resource conflict metric not always being recorded, after deleting a non-managed CRD required for a managed CR.
- This fix adds a new resource conflict error type for watches and records a conflict metric if it's returned by UpdateWatches.