### PR TITLE
fix: remediator deleting objects after adoption

### DIFF
--- a/pkg/diff/precedence.go
+++ b/pkg/diff/precedence.go
@@ -124,9 +124,13 @@ func ValidateManager(reconciler, manager string, id core.ID, op admissionv1.Oper
 		}
 	}
 
-	if isRootReconciler(reconciler) && syncScope != declared.RootScope {
-		// RootReconciler is allowed to adopt an object as long as it's not
-		// managed by another RootReconciler.
+	if isRootReconciler(reconciler) && syncScope != declared.RootScope && op != admissionv1.Delete {
+		// RootReconciler is allowed to adopt an object as long, as it's not
+		// managed by another RootReconciler. This allows transfer from
+		// namespace to root reconciler.
+		// RootReconciler is NOT allowed to delete an object managed by another
+		// reconciler. This allows transfer from root to namespace reconciler.
+		// Transfer between root reconcilers only happens through the applier.
 		return nil
 	}
 

--- a/pkg/diff/precedence_test.go
+++ b/pkg/diff/precedence_test.go
@@ -151,18 +151,41 @@ func TestValidateManager(t *testing.T) {
 		want       error
 	}{
 		{
-			name:       "Root reconciler can manage its own object",
+			name:       "Root reconciler can create its own object",
 			reconciler: "root-reconciler",
 			manager:    ":root",
+			operation:  admissionv1.Create,
 			want:       nil,
 		},
 		{
-			name:       "Root reconciler can manage object with any namespace manager",
+			name:       "Root reconciler can update its own object",
+			reconciler: "root-reconciler",
+			manager:    ":root",
+			operation:  admissionv1.Update,
+			want:       nil,
+		},
+		{
+			name:       "Root reconciler can delete its own object",
+			reconciler: "root-reconciler",
+			manager:    ":root",
+			operation:  admissionv1.Delete,
+			want:       nil,
+		},
+		{
+			name:       "Root reconciler can update object with any namespace manager",
 			reconciler: "root-reconciler",
 			manager:    "bookstore",
 			id:         cmID,
 			operation:  admissionv1.Update,
 			want:       nil,
+		},
+		{
+			name:       "Root reconciler can not delete object with any namespace manager",
+			reconciler: "root-reconciler",
+			manager:    "bookstore",
+			id:         cmID,
+			operation:  admissionv1.Delete,
+			want:       fmt.Errorf(`config sync "root-reconciler" can not DELETE object "ConfigMap.example.com, ns-1/cm-1" managed by config sync "ns-reconciler-bookstore"`),
 		},
 		{
 			name:       "Root reconciler can update its own RootSync",


### PR DESCRIPTION
- Root reconciler's remediator should not delete objects that have been adopted by another manager. This allows a namespace reconciler to adopt objects previously managed by a root reconciler without deleting the object first.
- This fixes a race condition that was causing TestConflictingDefinitions_RootToNamespace to be flaky.

Release Note:
- Fixed a bug where RootSync reconcilers could delete objects managed by RepoSync reconcilers. This simplifies the adoption process of handing off objects between reconcilers.