### PR TITLE
fix: treat IsNotFound as conflict on Create

### DIFF
--- a/pkg/syncer/client/client.go
+++ b/pkg/syncer/client/client.go
@@ -75,7 +75,7 @@ func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.C
 		switch {
 		case apierrors.IsAlreadyExists(err):
 			return ConflictCreateAlreadyExists(err, obj)
-		case meta.IsNoMatchError(err):
+		case meta.IsNoMatchError(err), apierrors.IsNotFound(err):
 			return ConflictCreateResourceDoesNotExist(err, obj)
 		default:
 			return status.APIServerError(err, "failed to create object", obj)

--- a/pkg/syncer/client/client_test.go
+++ b/pkg/syncer/client/client_test.go
@@ -46,12 +46,21 @@ func TestClient_Create(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
-			name:     "Conflict error if resource not found",
+			name:     "Conflict error if resource IsNoMatchError",
 			declared: k8sobjects.UnstructuredObject(kinds.Anvil(), core.Name("admin"), core.Namespace("billing")),
 			client: syncertestfake.NewErrorClient(
 				&meta.NoResourceMatchError{PartialResource: kinds.Anvil().GroupVersion().WithResource("anvils")}),
 			wantErr: syncerclient.ConflictCreateResourceDoesNotExist(
 				&meta.NoResourceMatchError{PartialResource: kinds.Anvil().GroupVersion().WithResource("anvils")},
+				k8sobjects.UnstructuredObject(kinds.Anvil(), core.Name("admin"), core.Namespace("billing"))),
+		},
+		{
+			name:     "Conflict error if resource IsNotFound",
+			declared: k8sobjects.UnstructuredObject(kinds.Anvil(), core.Name("admin"), core.Namespace("billing")),
+			client: syncertestfake.NewErrorClient(
+				apierrors.NewNotFound(kinds.Anvil().GroupVersion().WithResource("anvils").GroupResource(), "admin")),
+			wantErr: syncerclient.ConflictCreateResourceDoesNotExist(
+				apierrors.NewNotFound(kinds.Anvil().GroupVersion().WithResource("anvils").GroupResource(), "admin"),
 				k8sobjects.UnstructuredObject(kinds.Anvil(), core.Name("admin"), core.Namespace("billing"))),
 		},
 		{

--- a/pkg/syncer/reconcile/apply.go
+++ b/pkg/syncer/reconcile/apply.go
@@ -113,7 +113,7 @@ func (c *clientApplier) Create(ctx context.Context, intendedState *unstructured.
 	} else {
 		if err1 := c.client.Patch(ctx, intendedState, client.Apply, client.FieldOwner(configsync.FieldManager)); err1 != nil {
 			switch {
-			case meta.IsNoMatchError(err1):
+			case meta.IsNoMatchError(err1), apierrors.IsNotFound(err1):
 				err = syncerclient.ConflictCreateResourceDoesNotExist(err1, intendedState)
 			default:
 				err = status.ResourceWrap(err1, "unable to apply resource", intendedState)


### PR DESCRIPTION
If the CRD does not exist, the create/apply call may return IsNotFound error. This should be treated as a conflict so that the conflict metric is recorded.

Follow up to https://github.com/GoogleContainerTools/kpt-config-sync/pull/1365