### PR TITLE
refactor: WaitForRootSyncStalledError ns arg

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -1355,7 +1355,7 @@ func SetupFakeSSHCreds(nt *NT, rsKind string, rsRef types.NamespacedName, auth c
 	nt.T.Logf("The %s/%s Secret doesn't exist with auth %q, so creating a fake one", rsRef.Namespace, secretName, auth)
 	msg := fmt.Sprintf("Secret %s not found: create one to allow client authentication", secretName)
 	if rsKind == kinds.RootSyncV1Beta1().Kind {
-		nt.WaitForRootSyncStalledError(rsRef.Namespace, rsRef.Name, "Validation", msg)
+		nt.WaitForRootSyncStalledError(rsRef.Name, "Validation", msg)
 	} else {
 		nt.WaitForRepoSyncStalledError(rsRef.Namespace, rsRef.Name, "Validation", msg)
 	}

--- a/e2e/nomostest/wait_for_sync.go
+++ b/e2e/nomostest/wait_for_sync.go
@@ -431,17 +431,17 @@ func (nt *NT) WaitForRepoImportErrorCode(code string, opts ...WaitOption) {
 }
 
 // WaitForRootSyncStalledError waits until the given Stalled error is present on the RootSync resource.
-func (nt *NT) WaitForRootSyncStalledError(rsNamespace, rsName, reason, message string) {
-	Wait(nt.T, fmt.Sprintf("RootSync %s/%s stalled error", rsNamespace, rsName), nt.DefaultWaitTimeout,
+func (nt *NT) WaitForRootSyncStalledError(rsName, reason, message string) {
+	Wait(nt.T, fmt.Sprintf("RootSync %s/%s stalled error", configsync.ControllerNamespace, rsName), nt.DefaultWaitTimeout,
 		func() error {
 			rs := &v1beta1.RootSync{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rsName,
-					Namespace: rsNamespace,
+					Namespace: configsync.ControllerNamespace,
 				},
 				TypeMeta: k8sobjects.ToTypeMeta(kinds.RootSyncV1Beta1()),
 			}
-			if err := nt.KubeClient.Get(rsName, rsNamespace, rs); err != nil {
+			if err := nt.KubeClient.Get(rsName, configsync.ControllerNamespace, rs); err != nil {
 				return err
 			}
 			stalledCondition := rootsync.GetCondition(rs.Status.Conditions, v1beta1.RootSyncStalled)

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -149,7 +149,7 @@ func TestHelmWatchConfigMap(t *testing.T) {
 	}
 	nt.Must(nt.KubeClient.Apply(rs))
 
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" not found")
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" not found")
 
 	cmName := "helm-watch-config-map"
 	nt.T.Log("Apply valid ConfigMap that is not immutable (which should not be allowed)")
@@ -169,7 +169,7 @@ image:
 		}
 	})
 	nt.Must(nt.KubeClient.Create(cm0))
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" in namespace \"config-management-system\" is not immutable")
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" in namespace \"config-management-system\" is not immutable")
 
 	nt.T.Log("Apply the ConfigMap with values to the cluster with incorrect data key")
 	cm1 := k8sobjects.ConfigMapObject(core.Name(cmName), core.Namespace(configsync.ControllerNamespace))
@@ -181,11 +181,11 @@ image:
 `,
 	}
 	nt.Must(nt.KubeClient.Update(cm1))
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" in namespace \"config-management-system\" does not have data key \"values.yaml\"")
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" in namespace \"config-management-system\" does not have data key \"values.yaml\"")
 
 	// delete the ConfigMap
 	nt.Must(nt.KubeClient.Delete(cm1))
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" not found")
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", "KNV1061: RootSyncs must reference valid ConfigMaps in spec.helm.valuesFileRefs: ConfigMap \"helm-watch-config-map\" not found")
 
 	nt.T.Log("Apply valid ConfigMap with values: imagePullPolicy: Always; wordpressUserName: test-user-1")
 	cm2 := k8sobjects.ConfigMapObject(core.Name(cmName), core.Namespace(configsync.ControllerNamespace))

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -51,7 +51,7 @@ func TestSyncingThroughAProxy(t *testing.T) {
 	}
 	nt.T.Log("Verify the NoOpProxyError")
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", `KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`)
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`)
 
 	nt.T.Log("Set auth type to cookiefile")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "cookiefile"}}}`)
@@ -59,12 +59,12 @@ func TestSyncingThroughAProxy(t *testing.T) {
 	if err = nomostest.SetupFakeSSHCreds(nt, rs.Kind, nomostest.RootSyncNN(rs.Name), configsync.AuthCookieFile, controllers.GitCredentialVolume); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", `git secretType was set as "cookiefile" but cookie_file key is not present`)
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `git secretType was set as "cookiefile" but cookie_file key is not present`)
 
 	nt.T.Log("Set auth type to token")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "token"}}}`)
 	nt.T.Log("Verify the secretRef error")
-	nt.WaitForRootSyncStalledError(rs.Namespace, rs.Name, "Validation", `git secretType was set as "token" but token key is not present`)
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `git secretType was set as "token" but token key is not present`)
 
 	nt.T.Log("Set auth type to none")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "none", "secretRef": {"name":""}}}}`)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -155,7 +155,7 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 	if err = nomostest.SetupFakeSSHCreds(nt, rootSync.Kind, nomostest.RootSyncNN(rootSync.Name), configsync.AuthToken, controllers.GitCredentialVolume); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRootSyncStalledError(rootSync.Namespace, rootSync.Name,
+	nt.WaitForRootSyncStalledError(rootSync.Name,
 		"Validation", `git secretType was set as "token" but token key is not present in git-creds secret`)
 
 	t.Log("Validate the RepoSync")


### PR DESCRIPTION
RootSyncs are always in the c-m-s namespace, so the namespace argument is redundant. This makes the function consistent with the other WaitForRootSync* functions.