### PR TITLE
feat: add github app auth to git-sync api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ HELM_VERSION := v3.15.3-gke.0
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
-GIT_SYNC_VERSION := v4.2.3-gke.5__linux_amd64
+GIT_SYNC_VERSION := v4.2.4-gke.2__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.103.0-gke.3

--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -95,6 +95,16 @@ var KCC = flag.Bool("kcc", false,
 var GceNode = flag.Bool("gcenode", false,
 	"If true, run test with 'gcenode' auth type.")
 
+// GitHubApp enables running the e2e tests for 'githubapp' auth type
+var GitHubApp = flag.Bool("githubapp", false,
+	"If true, run test with 'githubapp' auth type.")
+
+// GitHubAppConfigFile specifies a file path to read GitHub App config from.
+// If unset, defaults to fetching the GitHub App config from Secret Manager.
+var GitHubAppConfigFile = flag.String("githubapp-config-file",
+	util.EnvString("E2E_GITHUBAPP_CONFIG_FILE", ""),
+	"Local file path to GitHub App configuration file.")
+
 // Debug enables running the test in debug mode.
 // In debug mode:
 //  1. Test execution immediately stops on a call to t.Fatal.

--- a/e2e/nomostest/gitproviders/bitbucket.go
+++ b/e2e/nomostest/gitproviders/bitbucket.go
@@ -202,6 +202,9 @@ func (b *BitbucketClient) refreshAccessToken() (string, error) {
 
 // FetchCloudSecret fetches secret from Google Cloud Secret Manager.
 func FetchCloudSecret(name string) (string, error) {
+	if *e2e.GCPProject == "" {
+		return "", fmt.Errorf("gcp-project must be set to fetch cloud secret")
+	}
 	out, err := exec.Command("gcloud", "secrets", "versions",
 		"access", "latest", "--project", *e2e.GCPProject, "--secret", name).CombinedOutput()
 	if err != nil {

--- a/e2e/nomostest/gitproviders/github.go
+++ b/e2e/nomostest/gitproviders/github.go
@@ -1,0 +1,119 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitproviders
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+)
+
+const (
+	// githubAppSecretManagerSecretName is the name of the secret in GCP Secret Manager
+	githubAppSecretManagerSecretName = "github-app-configuration"
+)
+
+// RawGithubAppConfiguration represents the JSON format for the githubapp
+// configuration stored in Secret Manager.
+type RawGithubAppConfiguration struct {
+	AppID          string `json:"appID"`
+	InstallationID string `json:"installationID"`
+	ClientID       string `json:"clientID"`
+	PrivateKey     string `json:"privateKey"`
+	TestingRepo    string `json:"testingRepo"`
+}
+
+func (r RawGithubAppConfiguration) toInternal() *GithubAppConfiguration {
+	return &GithubAppConfiguration{
+		appID:          r.AppID,
+		installationID: r.InstallationID,
+		clientID:       r.ClientID,
+		privateKey:     r.PrivateKey,
+		testingRepo:    r.TestingRepo,
+	}
+}
+
+// GithubAppConfiguration is the internal representation of the githubapp
+// configuration. The fields are private to constrain usage of sensitive values.
+type GithubAppConfiguration struct {
+	appID          string
+	installationID string
+	clientID       string
+	privateKey     string
+	testingRepo    string
+}
+
+// FetchGithubAppConfiguration fetches the githubapp configuration and returns
+// the internal representation. Uses a local file path if provided, otherwise
+// defaults to fetching from Secret Manager.
+func FetchGithubAppConfiguration() (*GithubAppConfiguration, error) {
+	var outputBytes []byte
+	var err error
+	if *e2e.GitHubAppConfigFile != "" {
+		outputBytes, err = os.ReadFile(*e2e.GitHubAppConfigFile)
+	} else {
+		var out string
+		out, err = FetchCloudSecret(githubAppSecretManagerSecretName)
+		outputBytes = []byte(out)
+	}
+	if err != nil {
+		return nil, err
+	}
+	raw := &RawGithubAppConfiguration{}
+	if err := json.Unmarshal(outputBytes, raw); err != nil {
+		return nil, fmt.Errorf("encountered error unmarshalling %s secret", githubAppSecretManagerSecretName)
+	}
+	return raw.toInternal(), nil
+}
+
+// Repo returns the repository URL for the githubapp configuration
+func (g *GithubAppConfiguration) Repo() string {
+	return g.testingRepo
+}
+
+// SecretWithClientID returns the githubapp auth Secret using client ID
+func (g *GithubAppConfiguration) SecretWithClientID(nn types.NamespacedName) (*corev1.Secret, error) {
+	secret := k8sobjects.SecretObject(nn.Name, core.Namespace(nn.Namespace))
+	if g.clientID == "" || g.installationID == "" || g.privateKey == "" {
+		return nil, fmt.Errorf("missing required values for Secret")
+	}
+	secret.Data = map[string][]byte{
+		controllers.GitSecretGithubAppClientID:       []byte(g.clientID),
+		controllers.GitSecretGithubAppInstallationID: []byte(g.installationID),
+		controllers.GitSecretGithubAppPrivateKey:     []byte(g.privateKey),
+	}
+	return secret, nil
+}
+
+// SecretWithApplicationID returns the githubapp auth Secret using app ID
+func (g *GithubAppConfiguration) SecretWithApplicationID(nn types.NamespacedName) (*corev1.Secret, error) {
+	secret := k8sobjects.SecretObject(nn.Name, core.Namespace(nn.Namespace))
+	if g.appID == "" || g.installationID == "" || g.privateKey == "" {
+		return nil, fmt.Errorf("missing required values for Secret")
+	}
+	secret.Data = map[string][]byte{
+		controllers.GitSecretGithubAppApplicationID:  []byte(g.appID),
+		controllers.GitSecretGithubAppInstallationID: []byte(g.installationID),
+		controllers.GitSecretGithubAppPrivateKey:     []byte(g.privateKey),
+	}
+	return secret, nil
+}

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -109,6 +109,14 @@ func (optsStruct *New) EvaluateSkipOptions(t testing.NTB) {
 		t.Skip("Test skipped since the '--gcenode' flag should only select GCENode tests")
 	}
 
+	// GitHub App tests should run if and only if the --githubapp flag is specified.
+	if !*e2e.GitHubApp && optsStruct.GitHubAppTest {
+		t.Skip("Test skipped since the GitHubApp test requires the '--githubapp' flag")
+	}
+	if *e2e.GitHubApp && !optsStruct.GitHubAppTest {
+		t.Skip("Test skipped since the '--githubapp' flag should only select GitHubApp tests")
+	}
+
 	if *e2e.GitProvider != e2e.Local && optsStruct.RequireLocalGitProvider {
 		t.Skip("Test skipped for non-local GitProvider types")
 	}

--- a/e2e/nomostest/ntopts/test_type.go
+++ b/e2e/nomostest/ntopts/test_type.go
@@ -29,6 +29,9 @@ type TestType struct {
 	// GCENodeTest specifies the test is for verifying the gcenode auth type.
 	// It requires a GKE cluster with workload identity disabled.
 	GCENodeTest bool
+
+	// GitHubAppTest specifies the test is for verifying the githubapp auth type.
+	GitHubAppTest bool
 }
 
 // StressTest specifies the test is a stress test.
@@ -49,4 +52,9 @@ func KCCTest(opt *New) {
 // GCENodeTest specifies the test is for verifying the gcenode auth type.
 func GCENodeTest(opt *New) {
 	opt.GCENodeTest = true
+}
+
+// GitHubAppTest specifies the test is for verifying the githubapp auth type.
+func GitHubAppTest(opt *New) {
+	opt.GitHubAppTest = true
 }

--- a/e2e/testcases/github_test.go
+++ b/e2e/testcases/github_test.go
@@ -1,0 +1,283 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/gitproviders"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	"kpt.dev/configsync/e2e/nomostest/policy"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+	"kpt.dev/configsync/pkg/status"
+)
+
+const (
+	githubAppRepoBranch              = "main"
+	githubAppRepoNamespace           = "github-app-test"
+	githubAppRepoConfigMap           = "test-cm"
+	githubAppRepoNamespacedConfigDir = "namespaced"
+)
+
+// Manual provisioning steps required for the githubapp tests to be runnable:
+// - Private Github repository created containing expected resources
+// - Github app created
+// - Github configured with read access to the private repository
+// - GitHub app configuration stored on local filesystem or GCP Secret Manager
+//
+// Expected format of repository (see above constants for expected NN values):
+//
+//	.
+//	├── LICENSE
+//	├── namespaced
+//	│         └── cm.yaml
+//	├── namespace-github-app-test.yaml
+//	└── README.md
+//
+// TODO: implement a gitprovider for github and replace these one-off tests
+func TestGithubAppRootSync(t *testing.T) {
+	rootSyncID := nomostest.DefaultRootSyncID
+	rootSyncNN := rootSyncID.ObjectKey
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.GitHubAppTest)
+	githubApp, err := gitproviders.FetchGithubAppConfiguration()
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// Verify the repo is private
+	nt.T.Log("The repository should not be publicly accessible")
+	rs := k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rs.Spec.Git = &v1beta1.Git{
+		Repo: githubApp.Repo(),
+		Auth: configsync.AuthNone,
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.WaitForRootSyncSourceError(rootSyncNN.Name, status.SourceErrorCode,
+		`Authentication failed`)
+	// Verify reconciler-manager checks existence of Secret
+	nt.T.Log("The reconciler-manager should report a validation error for missing Secret")
+	emptySecretNN := types.NamespacedName{Name: "empty-secret", Namespace: rootSyncNN.Namespace}
+	rs = k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rs.Spec = v1beta1.RootSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: emptySecretNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation",
+		`Secret empty-secret not found: create one to allow client authentication`)
+	// Verify reconciler-manager checks validity of Secret data fields
+	nt.T.Log("The reconciler-manager should report a validation error for invalid Secret")
+	emptySecret := k8sobjects.SecretObject(emptySecretNN.Name, core.Namespace(rootSyncNN.Namespace))
+	nt.T.Cleanup(func() {
+		nt.Must(nt.KubeClient.Delete(emptySecret))
+	})
+	nt.Must(nt.KubeClient.Create(emptySecret))
+	nt.WaitForRootSyncStalledError(rs.Name, "Validation",
+		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`)
+	// Verify reconciler can sync using client ID
+	nt.T.Log("The reconciler should successfully sync using githubapp auth with client ID")
+	secretWithClientIDNN := types.NamespacedName{Name: "githubapp-creds-clientid", Namespace: rootSyncNN.Namespace}
+	nt.Must(createGithubSecretWithClientID(nt, githubApp, secretWithClientIDNN))
+	rs = k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rs.Spec = v1beta1.RootSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: secretWithClientIDNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), githubAppRepoNamespace, "", nil))
+	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace, nil))
+	// This hack exists because we don't have a way to authenticate to the repo from
+	// the test framework. The branch is not expected to change, so just trust the
+	// SHA reported on the RootSync.
+	// TODO: replace this if we implement a gitprovider interface
+	rs = k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	nt.Must(nt.KubeClient.Get(rs.Name, rs.Namespace, rs))
+	commitSha := rs.Status.Source.Commit
+	nomostest.SetExpectedSyncPath(nt, rootSyncID, controllers.DefaultSyncDir)
+	nt.Must(nt.WatchForAllSyncs(
+		nomostest.WithRootSha1Func(fakeSha1Fn(commitSha)),
+	))
+	// Verify reconciler can sync using application ID
+	nt.T.Log("The reconciler should successfully sync using githubapp auth with application ID")
+	nt.Must(nt.KubeClient.Delete(rs)) // Recreate RootSync to ensure status is current
+	nt.Must(nt.Watcher.WatchForNotFound(kinds.RootSyncV1Beta1(), rootSyncNN.Name, rootSyncNN.Namespace))
+	secretWithAppIDNN := types.NamespacedName{Name: "githubapp-creds-appid", Namespace: rootSyncNN.Namespace}
+	nt.Must(createGithubSecretWithApplicationID(nt, githubApp, secretWithAppIDNN))
+	rs = k8sobjects.RootSyncObjectV1Beta1(rootSyncNN.Name)
+	rs.Spec = v1beta1.RootSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: secretWithAppIDNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.Must(nt.WatchForAllSyncs(
+		nomostest.WithRootSha1Func(fakeSha1Fn(commitSha)),
+	))
+}
+
+func TestGithubAppRepoSync(t *testing.T) {
+	repoSyncNN := nomostest.RepoSyncNN(githubAppRepoNamespace, "rs-test")
+	repoSyncID := core.RepoSyncID(repoSyncNN.Name, repoSyncNN.Namespace)
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.GitHubAppTest,
+		ntopts.WithDelegatedControl,                    // DelegatedControl to simplify updating RepoSync
+		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // RepoSync manages ConfigMap
+		ntopts.SyncWithGitSource(repoSyncID))
+	githubApp, err := gitproviders.FetchGithubAppConfiguration()
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+	// Verify the repo is private
+	nt.T.Log("The repository should not be publicly accessible")
+	rs := k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	rs.Spec.Git = &v1beta1.Git{
+		Repo: githubApp.Repo(),
+		Auth: configsync.AuthNone,
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.WaitForRepoSyncSourceError(repoSyncNN.Namespace, repoSyncNN.Name, status.SourceErrorCode,
+		`Authentication failed`)
+	// Verify reconciler-manager checks existence of Secret
+	nt.T.Log("The reconciler-manager should report a validation error for missing Secret")
+	emptySecretNN := types.NamespacedName{
+		Name:      "empty-secret",
+		Namespace: repoSyncNN.Namespace,
+	}
+	rs = k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	rs.Spec = v1beta1.RepoSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: emptySecretNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.WaitForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
+		`Secret empty-secret not found: create one to allow client authentication`)
+	// Verify reconciler-manager checks validity of Secret data fields
+	nt.T.Log("The reconciler-manager should report a validation error for invalid Secret")
+	emptySecret := k8sobjects.SecretObject(emptySecretNN.Name, core.Namespace(repoSyncNN.Namespace))
+	nt.T.Cleanup(func() {
+		nt.Must(nt.KubeClient.Delete(emptySecret))
+	})
+	nt.Must(nt.KubeClient.Create(emptySecret))
+	nt.WaitForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
+		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`)
+	// Verify reconciler can sync using client ID
+	nt.T.Log("The reconciler should successfully sync using githubapp auth with client ID")
+	secretWithClientIDNN := types.NamespacedName{
+		Name:      "githubapp-creds-clientid",
+		Namespace: repoSyncNN.Namespace,
+	}
+	nt.Must(createGithubSecretWithClientID(nt, githubApp, secretWithClientIDNN))
+	rs = k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	rs.Spec = v1beta1.RepoSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Dir:       githubAppRepoNamespacedConfigDir,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: secretWithClientIDNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace, nil))
+	// This hack exists because we don't have a way to authenticate to the repo from
+	// the test framework. The branch is not expected to change, so just trust the
+	// SHA reported on the RepoSync.
+	// TODO: replace this if we implement a gitprovider interface
+	rs = k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	nt.Must(nt.KubeClient.Get(rs.Name, rs.Namespace, rs))
+	commitSha := rs.Status.Source.Commit
+	nomostest.SetExpectedSyncPath(nt, repoSyncID, githubAppRepoNamespacedConfigDir)
+	nt.Must(nt.WatchForAllSyncs(
+		nomostest.WithRepoSha1Func(fakeSha1Fn(commitSha)),
+	))
+	// Verify reconciler can sync using application ID
+	nt.T.Log("The reconciler should successfully sync using githubapp auth with application ID")
+	nt.Must(nt.KubeClient.Delete(rs)) // Recreate RepoSync to ensure status is current
+	nt.Must(nt.Watcher.WatchForNotFound(kinds.RepoSyncV1Beta1(), repoSyncNN.Name, repoSyncNN.Namespace))
+	secretWithAppIDNN := types.NamespacedName{
+		Name:      "githubapp-creds-appid",
+		Namespace: repoSyncNN.Namespace,
+	}
+	nt.Must(createGithubSecretWithApplicationID(nt, githubApp, secretWithAppIDNN))
+	rs = k8sobjects.RepoSyncObjectV1Beta1(repoSyncNN.Namespace, repoSyncNN.Name)
+	rs.Spec = v1beta1.RepoSyncSpec{
+		SourceFormat: configsync.SourceFormatUnstructured,
+		Git: &v1beta1.Git{
+			Repo:      githubApp.Repo(),
+			Branch:    githubAppRepoBranch,
+			Dir:       githubAppRepoNamespacedConfigDir,
+			Auth:      configsync.AuthGithubApp,
+			SecretRef: &v1beta1.SecretReference{Name: secretWithAppIDNN.Name},
+		},
+	}
+	nt.Must(nt.KubeClient.Apply(rs))
+	nt.Must(nt.WatchForAllSyncs(
+		nomostest.WithRepoSha1Func(fakeSha1Fn(commitSha)),
+	))
+}
+
+func fakeSha1Fn(commit string) nomostest.Sha1Func {
+	return func(_ *nomostest.NT, _ types.NamespacedName) (string, error) {
+		return commit, nil
+	}
+}
+
+func createGithubSecretWithClientID(nt *nomostest.NT, githubApp *gitproviders.GithubAppConfiguration, nn types.NamespacedName) error {
+	secret, err := githubApp.SecretWithClientID(nn)
+	if err != nil {
+		return err
+	}
+	nt.T.Cleanup(func() {
+		nt.Must(nt.KubeClient.Delete(k8sobjects.SecretObject(nn.Name, core.Namespace(nn.Namespace))))
+	})
+	return nt.KubeClient.Create(secret)
+}
+
+func createGithubSecretWithApplicationID(nt *nomostest.NT, githubApp *gitproviders.GithubAppConfiguration, nn types.NamespacedName) error {
+	secret, err := githubApp.SecretWithApplicationID(nn)
+	if err != nil {
+		return err
+	}
+	nt.T.Cleanup(func() {
+		nt.Must(nt.KubeClient.Delete(k8sobjects.SecretObject(nn.Name, core.Namespace(nn.Namespace))))
+	})
+	return nt.KubeClient.Create(secret)
+}

--- a/manifests/reposync-crd.yaml
+++ b/manifests/reposync-crd.yaml
@@ -89,6 +89,7 @@ spec:
                     - cookiefile
                     - gcenode
                     - gcpserviceaccount
+                    - githubapp
                     - token
                     - none
                     type: string
@@ -1205,6 +1206,7 @@ spec:
                     - gcenode
                     - gcpserviceaccount
                     - token
+                    - githubapp
                     - none
                     type: string
                   branch:

--- a/manifests/rootsync-crd.yaml
+++ b/manifests/rootsync-crd.yaml
@@ -89,6 +89,7 @@ spec:
                     - cookiefile
                     - gcenode
                     - gcpserviceaccount
+                    - githubapp
                     - token
                     - none
                     type: string
@@ -1265,6 +1266,7 @@ spec:
                     - gcenode
                     - gcpserviceaccount
                     - token
+                    - githubapp
                     - none
                     type: string
                   branch:

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -140,6 +140,8 @@ const (
 	// AuthK8sServiceAccount indicates using a Kubernetes service account with
 	// GKE or Fleet Workload Identity to authenticate to GCP services.
 	AuthK8sServiceAccount AuthType = "k8sserviceaccount"
+	// AuthGithubApp indicates using a GitHub app to authenticate with Git.
+	AuthGithubApp AuthType = "githubapp"
 )
 
 // NamespaceStrategy specifies the strategy used by the reconciler for undeclared

--- a/pkg/api/configsync/v1alpha1/gitconfig.go
+++ b/pkg/api/configsync/v1alpha1/gitconfig.go
@@ -57,7 +57,7 @@ type Git struct {
 	// Must be one of ssh, cookiefile, gcenode, token, or none.
 	// The validation of this is case-sensitive. Required.
 	//
-	// +kubebuilder:validation:Enum=ssh;cookiefile;gcenode;gcpserviceaccount;token;none
+	// +kubebuilder:validation:Enum=ssh;cookiefile;gcenode;gcpserviceaccount;githubapp;token;none
 	Auth configsync.AuthType `json:"auth"`
 
 	// gcpServiceAccountEmail specifies the GCP service account used to annotate

--- a/pkg/api/configsync/v1beta1/gitconfig.go
+++ b/pkg/api/configsync/v1beta1/gitconfig.go
@@ -57,7 +57,7 @@ type Git struct {
 	// Must be one of ssh, cookiefile, gcenode, token, or none.
 	// The validation of this is case-sensitive. Required.
 	//
-	// +kubebuilder:validation:Enum=ssh;cookiefile;gcenode;gcpserviceaccount;token;none
+	// +kubebuilder:validation:Enum=ssh;cookiefile;gcenode;gcpserviceaccount;token;githubapp;none
 	Auth configsync.AuthType `json:"auth"`
 
 	// gcpServiceAccountEmail specifies the GCP service account used to annotate

--- a/pkg/reconcilermanager/controllers/constants.go
+++ b/pkg/reconcilermanager/controllers/constants.go
@@ -38,6 +38,17 @@ const (
 	GitSecretConfigKeyToken = "token"
 	// GitSecretConfigKeyTokenUsername is the key at which a token's username is stored
 	GitSecretConfigKeyTokenUsername = "username"
+
+	// GitSecretGithubAppPrivateKey is the key at which the githubapp private key is stored
+	GitSecretGithubAppPrivateKey = "github-app-private-key"
+	// GitSecretGithubAppInstallationID is the key at which the githubapp installation id is stored
+	GitSecretGithubAppInstallationID = "github-app-installation-id"
+	// GitSecretGithubAppApplicationID is the key at which the githubapp app id is stored
+	GitSecretGithubAppApplicationID = "github-app-application-id"
+	// GitSecretGithubAppClientID is the key at which the githubapp client id is stored
+	GitSecretGithubAppClientID = "github-app-client-id"
+	// GitSecretGithubAppBaseURL is the key at which the optional githubapp base url is stored
+	GitSecretGithubAppBaseURL = "github-app-base-url"
 )
 
 // Helm secret data key names

--- a/pkg/reconcilermanager/controllers/gitsync_env_test.go
+++ b/pkg/reconcilermanager/controllers/gitsync_env_test.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+)
+
+func TestGithubAppFromSecret(t *testing.T) {
+	testCases := map[string]struct {
+		secretData        map[string][]byte
+		expectedGithubApp githubAppSpec
+	}{
+		"should parse the correct data keys for client ID": {
+			secretData: map[string][]byte{
+				"github-app-client-id":       []byte("client-id-0"),
+				"github-app-installation-id": []byte("installation-id-0"),
+			},
+			expectedGithubApp: githubAppSpec{
+				clientID:       "client-id-0",
+				installationID: "installation-id-0",
+			},
+		},
+		"should parse the correct data keys for application ID": {
+			secretData: map[string][]byte{
+				"github-app-application-id":  []byte("application-id-0"),
+				"github-app-installation-id": []byte("installation-id-0"),
+			},
+			expectedGithubApp: githubAppSpec{
+				appID:          "application-id-0",
+				installationID: "installation-id-0",
+			},
+		},
+		"should parse the correct data keys for optional base URL": {
+			secretData: map[string][]byte{
+				"github-app-application-id":  []byte("application-id-0"),
+				"github-app-installation-id": []byte("installation-id-0"),
+				"github-app-base-url":        []byte("base-url-0"),
+			},
+			expectedGithubApp: githubAppSpec{
+				appID:          "application-id-0",
+				installationID: "installation-id-0",
+				baseURL:        "base-url-0",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			secretObject := k8sobjects.SecretObject("foo")
+			secretObject.Data = tc.secretData
+			assert.Equal(t, tc.expectedGithubApp, githubAppFromSecret(secretObject))
+		})
+	}
+}
+
+func TestGitSyncEnvVars(t *testing.T) {
+	privateKeyEnvVar := corev1.EnvVar{
+		Name: "GITSYNC_GITHUB_APP_PRIVATE_KEY",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "foo",
+				},
+				Key: "github-app-private-key",
+			},
+		},
+	}
+	testCases := map[string]struct {
+		secretName      string
+		githubApp       githubAppSpec
+		expectedEnvVars []corev1.EnvVar
+	}{
+		"empty githubapp should return empty env vars": {
+			secretName: "foo",
+			githubApp:  githubAppSpec{},
+			expectedEnvVars: []corev1.EnvVar{
+				privateKeyEnvVar,
+			},
+		},
+		"githubapp should map to the expected git-sync env vars for client ID": {
+			secretName: "foo",
+			githubApp: githubAppSpec{
+				clientID:       "client-id-0",
+				installationID: "installation-id-0",
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				privateKeyEnvVar,
+				{
+					Name:  "GITSYNC_GITHUB_APP_CLIENT_ID",
+					Value: "client-id-0",
+				},
+				{
+					Name:  "GITSYNC_GITHUB_APP_INSTALLATION_ID",
+					Value: "installation-id-0",
+				},
+			},
+		},
+		"githubapp should map to the expected git-sync env vars for application ID": {
+			secretName: "foo",
+			githubApp: githubAppSpec{
+				appID:          "app-id-0",
+				installationID: "installation-id-0",
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				privateKeyEnvVar,
+				{
+					Name:  "GITSYNC_GITHUB_APP_APPLICATION_ID",
+					Value: "app-id-0",
+				},
+				{
+					Name:  "GITSYNC_GITHUB_APP_INSTALLATION_ID",
+					Value: "installation-id-0",
+				},
+			},
+		},
+		"githubapp should map to the expected git-sync env vars for optional base URL": {
+			secretName: "foo",
+			githubApp: githubAppSpec{
+				appID:          "app-id-0",
+				installationID: "installation-id-0",
+				baseURL:        "base-url-0",
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				privateKeyEnvVar,
+				{
+					Name:  "GITSYNC_GITHUB_APP_APPLICATION_ID",
+					Value: "app-id-0",
+				},
+				{
+					Name:  "GITSYNC_GITHUB_APP_INSTALLATION_ID",
+					Value: "installation-id-0",
+				},
+				{
+					Name:  "GITSYNC_GITHUB_BASE_URL",
+					Value: "base-url-0",
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEnvVars, tc.githubApp.GitSyncEnvVars(tc.secretName))
+		})
+	}
+}

--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -100,6 +100,7 @@ type reconcilerBase struct {
 	hydrationPollingPeriod  time.Duration
 	membership              *hubv1.Membership
 	knownHostExist          bool
+	githubApp               githubAppSpec
 	webhookEnabled          bool
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.

--- a/pkg/validate/raw/validate/source_spec_validator.go
+++ b/pkg/validate/raw/validate/source_spec_validator.go
@@ -94,7 +94,7 @@ func GitSpec(git *v1beta1.Git, rs client.Object) status.Error {
 	// Note that Auth is a case-sensitive field, so ones with arbitrary capitalization
 	// will fail to apply.
 	switch git.Auth {
-	case configsync.AuthSSH, configsync.AuthCookieFile, configsync.AuthGCENode, configsync.AuthToken, configsync.AuthNone:
+	case configsync.AuthSSH, configsync.AuthCookieFile, configsync.AuthGCENode, configsync.AuthToken, configsync.AuthNone, configsync.AuthGithubApp:
 	case configsync.AuthGCPServiceAccount:
 		if git.GCPServiceAccountEmail == "" {
 			return MissingGCPSAEmail(configsync.GitSource, rs)
@@ -254,7 +254,7 @@ func MissingGitRepo(o client.Object) status.Error {
 // InvalidGitAuthType reports that a RootSync/RepoSync doesn't use one of the known auth
 // methods.
 func InvalidGitAuthType(o client.Object) status.Error {
-	types := []string{string(configsync.AuthSSH), string(configsync.AuthCookieFile), string(configsync.AuthGCENode), string(configsync.AuthToken), string(configsync.AuthNone), string(configsync.AuthGCPServiceAccount)}
+	types := []string{string(configsync.AuthSSH), string(configsync.AuthCookieFile), string(configsync.AuthGCENode), string(configsync.AuthToken), string(configsync.AuthNone), string(configsync.AuthGCPServiceAccount), string(configsync.AuthGithubApp)}
 	kind := o.GetObjectKind().GroupVersionKind().Kind
 	return invalidSyncBuilder.
 		Sprintf("%ss must specify spec.git.auth to be one of %s", kind,
@@ -287,8 +287,8 @@ func IllegalSecretRef(sourceType configsync.SourceType, o client.Object) status.
 func MissingSecretRef(sourceType configsync.SourceType, o client.Object) status.Error {
 	kind := o.GetObjectKind().GroupVersionKind().Kind
 	return invalidSyncBuilder.
-		Sprintf("%ss which specify spec.%s.auth as one of %q, %q or %q must also specify spec.%s.secretRef",
-			kind, sourceType, configsync.AuthSSH, configsync.AuthCookieFile, configsync.AuthToken, sourceType).
+		Sprintf("%ss which specify spec.%s.auth as one of %q, %q, %q, or %q must also specify spec.%s.secretRef",
+			kind, sourceType, configsync.AuthSSH, configsync.AuthCookieFile, configsync.AuthGithubApp, configsync.AuthToken, sourceType).
 		BuildWithResources(o)
 }
 


### PR DESCRIPTION
This change adds support for a new git-sync auth type named githubapp. The auth type maps GitHub App configuration from the Secret referenced by secretRef to environment variables in the git-sync container. The git-sync version is upgraded to a new version that supports these new environment variables and GitHub app based authentication.

End to end tests are implemented as one off tests similar to the kcc/gcenode tests. This is because these tests are inherently non-hermetic and require secrets which are generally not accessible when running the tests locally or in presubmits. This could alternatively be implemented as a gitprovider interface, however that was decided against for the initial implementation to reduce scope. These tests will be executed by the prowjob added in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2337