### PR TITLE
Bump Helm version to v3.15.3-gke.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ KUSTOMIZE_VERSION := v5.4.2-gke.0
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
-HELM_VERSION := v3.14.4-gke.2
+HELM_VERSION := v3.15.3-gke.0
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.14.4-gke.2"
+	HelmVersion = "v3.15.3-gke.0"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.4.2-gke.0"
 	// Helm is the binary name of the installed Helm.


### PR DESCRIPTION
For vulnerability fix.