### PR TITLE
fix: conflict metric on watched resource not found

### DIFF
--- a/pkg/remediator/fake/remediator.go
+++ b/pkg/remediator/fake/remediator.go
@@ -63,7 +63,7 @@ func (r *Remediator) Resume() {
 }
 
 // AddWatches fakes remediator.Remediator.AddWatches
-func (r *Remediator) AddWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
+func (r *Remediator) AddWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}, _ string) status.MultiError {
 	r.Watching = true
 	if r.Watches == nil {
 		r.Watches = watches
@@ -76,7 +76,7 @@ func (r *Remediator) AddWatches(_ context.Context, watches map[schema.GroupVersi
 }
 
 // UpdateWatches fakes remediator.Remediator.UpdateWatches
-func (r *Remediator) UpdateWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}) status.MultiError {
+func (r *Remediator) UpdateWatches(_ context.Context, watches map[schema.GroupVersionKind]struct{}, _ string) status.MultiError {
 	r.Watching = true
 	r.Watches = watches
 	r.needsUpdate = false

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -81,10 +81,10 @@ type Interface interface {
 	NeedsUpdate() bool
 	// AddWatches starts server-side watches based upon the given map of GVKs
 	// which should be watched.
-	AddWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
+	AddWatches(context.Context, map[schema.GroupVersionKind]struct{}, string) status.MultiError
 	// UpdateWatches starts and stops server-side watches based upon the given map
 	// of GVKs which should be watched.
-	UpdateWatches(context.Context, map[schema.GroupVersionKind]struct{}) status.MultiError
+	UpdateWatches(context.Context, map[schema.GroupVersionKind]struct{}, string) status.MultiError
 }
 
 var _ Interface = &Remediator{}
@@ -228,11 +228,11 @@ func (r *Remediator) NeedsUpdate() bool {
 }
 
 // AddWatches implements Interface.
-func (r *Remediator) AddWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
-	return r.watchMgr.AddWatches(ctx, gvks)
+func (r *Remediator) AddWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}, commit string) status.MultiError {
+	return r.watchMgr.AddWatches(ctx, gvks, commit)
 }
 
 // UpdateWatches implements Interface.
-func (r *Remediator) UpdateWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}) status.MultiError {
-	return r.watchMgr.UpdateWatches(ctx, gvks)
+func (r *Remediator) UpdateWatches(ctx context.Context, gvks map[schema.GroupVersionKind]struct{}, commit string) status.MultiError {
+	return r.watchMgr.UpdateWatches(ctx, gvks, commit)
 }

--- a/pkg/remediator/watch/watcher.go
+++ b/pkg/remediator/watch/watcher.go
@@ -40,6 +40,7 @@ type watcherConfig struct {
 	startWatch      WatchFunc
 	conflictHandler conflict.Handler
 	labelSelector   labels.Selector
+	commit          string
 }
 
 // watcherFactory knows how to build watch.Runnables.


### PR DESCRIPTION
This is intended to fix a scenario where watched CRD is deleted and the watch ends and attempts to restart. In this scenario a conflict metric may not have been reported if the watch fails before receiving a deleted event.

Follow up to https://github.com/GoogleContainerTools/kpt-config-sync/pull/1366