### PR TITLE
test: update test expectations for autopilot bursting

### DIFF
--- a/e2e/nomostest/clusterversion/cluster_version.go
+++ b/e2e/nomostest/clusterversion/cluster_version.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 const clusterVersionPattern = `^(v?([0-9]+)(\.([0-9]+))?(\.([0-9]+))?([+-_].*)?)$`
@@ -37,6 +38,19 @@ func (cv ClusterVersion) String() string {
 			cv.Major, cv.Minor, cv.Patch, cv.Suffix)
 	}
 	return fmt.Sprintf("v%d.%d.%d", cv.Major, cv.Minor, cv.Patch)
+}
+
+// GKESuffix returns the GKE patch version integer from the -gke suffix
+func (cv ClusterVersion) GKESuffix() (int, error) {
+	if !strings.HasPrefix(cv.Suffix, "-gke.") {
+		return -1, fmt.Errorf("missing -gke suffix")
+	}
+	val := strings.TrimPrefix(cv.Suffix, "-gke.")
+	intVal, err := strconv.Atoi(val)
+	if err != nil {
+		return -1, fmt.Errorf("invalid suffix value: gke suffix must be an integer: %v", err)
+	}
+	return intVal, nil
 }
 
 // ParseClusterVersion parses the string "gitVersion" of a Kubernetes cluster.

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -161,6 +161,8 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		Watcher:                 sharedNt.Watcher,
 		WatchClient:             sharedNt.WatchClient,
 		IsGKEAutopilot:          sharedNt.IsGKEAutopilot,
+		ClusterVersion:          sharedNt.ClusterVersion,
+		ClusterSupportsBursting: sharedNt.ClusterSupportsBursting,
 		DefaultWaitTimeout:      sharedNt.DefaultWaitTimeout,
 		DefaultReconcileTimeout: opts.ReconcileTimeout,
 		kubeconfigPath:          sharedNt.kubeconfigPath,
@@ -182,7 +184,6 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		OCIClient:               sharedNt.OCIClient,
 	}
 
-	nt.detectClusterVersion()
 	t.Logf("using shared test env: %s, cluster version: %s, cluster hash: %s", sharedNt.ClusterName, nt.ClusterVersion, nt.ClusterHash)
 
 	if opts.SkipConfigSyncInstall {
@@ -278,6 +279,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 	}
 
 	nt.detectClusterVersion()
+	nt.detectClusterSupportsBursting()
 
 	// TODO: Try speeding up the reconciler and hydration polling.
 	// It seems that speeding them up too much can cause failures in

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -75,7 +75,7 @@ func TestPublicHelm(t *testing.T) {
 	var expectedCPULimit string
 	var expectedMemoryRequest string
 	var expectedMemoryLimit string
-	if nt.IsGKEAutopilot {
+	if nt.IsGKEAutopilot && !nt.ClusterSupportsBursting {
 		expectedCPURequest = "250m"
 		expectedCPULimit = expectedCPURequest
 		expectedMemoryRequest = "512Mi"
@@ -244,7 +244,7 @@ service:
 	var expectedCPULimit string
 	var expectedMemoryRequest string
 	var expectedMemoryLimit string
-	if nt.IsGKEAutopilot {
+	if nt.IsGKEAutopilot && !nt.ClusterSupportsBursting {
 		expectedCPURequest = "250m"
 		expectedCPULimit = expectedCPURequest
 		expectedMemoryRequest = "512Mi"


### PR DESCRIPTION
New versions of GKE autopilot support burstable Pods, which invalidates some of the previous test expectations for container resources on autopilot. This change adds a check for autopilot resource bursting and updates test expectations accodirngly.