### PR TITLE
Align otel-agent feature gate in resource group controller

### DIFF
--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -231,6 +231,7 @@ spec:
             - ALL
       - args:
         - --config=/conf/otel-agent-config.yaml
+        - --feature-gates=-pkg.translator.prometheus.NormalizeName
         command:
         - /otelcontribcol
         env:


### PR DESCRIPTION
This is to align the feature behavior with reconciler & reconciler-manager.

Currently we see no difference without the flag as

- there are no test coverage on resourcegroup controller metrics
- the naming convention obeys Prometheus rules so no trimming is happening