### PR TITLE
test: fix autopilot bursting check

### DIFF
--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -922,7 +922,7 @@ func (nt *NT) autopilotClusterSupportsBursting() (bool, error) {
 }
 
 func (nt *NT) detectClusterSupportsBursting() {
-	if nt.IsGKEAutopilot {
+	if *e2e.GKEAutopilot {
 		var err error
 		nt.ClusterSupportsBursting, err = nt.autopilotClusterSupportsBursting()
 		if err != nil {


### PR DESCRIPTION
detectGKEAutopilot is called later, so the IsGKEAutopilot variable is not set. This switches to use the command line flag instead.