### PR TITLE
test: fix reset enabling deletion propagation after update

### DIFF
--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -169,7 +169,10 @@ func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
 		// Enable deletion propagation, if not enabled
 		if EnableDeletionPropagation(rs) {
 			nt.T.Logf("[RESET] Enabling deletion propagation on RootSync %s", rsNN)
-			if err := nt.KubeClient.Update(rs); err != nil {
+			// Use MergePatch instead of Update in case modified since list
+			patch := fmt.Sprintf(`{"metadata": {"annotations": {"%s": "%s"}}}`,
+				metadata.DeletionPropagationPolicyAnnotationKey, metadata.DeletionPropagationPolicyForeground)
+			if err := nt.KubeClient.MergePatch(rs, patch); err != nil {
 				return err
 			}
 			if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace, []testpredicates.Predicate{
@@ -241,7 +244,10 @@ func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
 		// Enable deletion propagation, if not enabled
 		if EnableDeletionPropagation(rs) {
 			nt.T.Logf("[RESET] Enabling deletion propagation on RepoSync %s", rsNN)
-			if err := nt.KubeClient.Update(rs); err != nil {
+			// Use MergePatch instead of Update in case modified since list
+			patch := fmt.Sprintf(`{"metadata": {"annotations": {"%s": "%s"}}}`,
+				metadata.DeletionPropagationPolicyAnnotationKey, metadata.DeletionPropagationPolicyForeground)
+			if err := nt.KubeClient.MergePatch(rs, patch); err != nil {
 				return err
 			}
 			if err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), rs.Name, rs.Namespace, []testpredicates.Predicate{

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -887,6 +887,7 @@ func generateServiceAccountKey(nt *nomostest.NT, projectID, gsaKeySecretID, gsaE
 
 func rootSyncForWordpressHelmChart(nt *nomostest.NT, valuesMutator func(map[string]interface{})) *v1beta1.RootSync {
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
+	nomostest.EnableDeletionPropagation(rs)
 	values := map[string]interface{}{
 		"image": map[string]interface{}{
 			"digest":     "sha256:362cb642db481ebf6f14eb0244fbfb17d531a84ecfe099cd3bba6810db56694e",


### PR DESCRIPTION
If the RSync is modified between the List call and the Update call, then the Update fails. Using MergePatch to inject the annotation makes the reset more robust.

Example failure: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-autopilot-rapid/1821388389237133312