### PR TITLE
Update otelcontribcol to 0.118.0-gke.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ COSIGN := $(BIN_DIR)/cosign
 GIT_SYNC_VERSION := v4.3.0-gke.11__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.103.0-gke.8
+OTELCONTRIBCOL_VERSION := v0.118.0-gke.3
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.

--- a/e2e/testdata/otel-collector/otel-cm-full-gcm.yaml
+++ b/e2e/testdata/otel-collector/otel-cm-full-gcm.yaml
@@ -17,9 +17,10 @@ data:
   otel-collector-config.yaml: |-
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       prometheus:
-        endpoint: :8675
+        endpoint: 0.0.0.0:8675
         namespace: config_sync
         resource_to_telemetry_conversion:
           enabled: true
@@ -303,6 +304,7 @@ data:
                 aggregation_type: max
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:

--- a/e2e/testdata/otel-collector/otel-cm-kustomize-rejected-labels.yaml
+++ b/e2e/testdata/otel-collector/otel-cm-kustomize-rejected-labels.yaml
@@ -21,9 +21,10 @@ data:
   otel-collector-config.yaml: |-
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       prometheus:
-        endpoint: :8675
+        endpoint: 0.0.0.0:8675
         namespace: config_sync
         resource_to_telemetry_conversion:
           enabled: true
@@ -258,6 +259,7 @@ data:
                 aggregation_type: max
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:

--- a/e2e/testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml
+++ b/e2e/testdata/otel-collector/otel-cm-monarch-rejected-labels.yaml
@@ -21,9 +21,10 @@ data:
   otel-collector-config.yaml: |-
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       prometheus:
-        endpoint: :8675
+        endpoint: 0.0.0.0:8675
         namespace: config_sync
         resource_to_telemetry_conversion:
           enabled: true
@@ -167,6 +168,7 @@ data:
           new_name: no_ssl_verify_count
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
 - ../ns-reconciler-base-cluster-role.yaml
 - ../root-reconciler-base-cluster-role.yaml
 - ../otel-agent-cm.yaml
+- ../otel-agent-reconciler-cm.yaml
 - ../reconciler-manager-service-account.yaml
 - ../reposync-crd.yaml
 - ../rootsync-crd.yaml

--- a/manifests/otel-agent-reconciler-cm.yaml
+++ b/manifests/otel-agent-reconciler-cm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This ConfigMap is used in the reconciler manager pod and the resource group controller pod.
-# It contains the OpenTelemetry (OTEL) agent configuration for metrics and resource detection.
+# This ConfigMap is used in the reconciler pod.
+# It contains the OpenTelemetry (OTEL) agent configuration for metrics and resource detection, with sync specific attributes.
 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-agent
+  name: otel-agent-reconciler
   namespace: config-management-system
   labels:
     app: opentelemetry
@@ -26,7 +26,7 @@ metadata:
     configmanagement.gke.io/system: "true"
     configmanagement.gke.io/arch: "csmr"
 data:
-  otel-agent-config.yaml: |
+  otel-agent-reconciler-config.yaml: |
     receivers:
       opencensus:
         endpoint: 0.0.0.0:55678
@@ -36,7 +36,27 @@ data:
         tls:
           insecure: true
     processors:
+      # Attributes processor adds custom configsync metric labels to applicable
+      # metrics to identify the sync object used to configure this deployment.
+      #
+      # Note: configsync.sync.generation is explicitly excluded here, because it
+      # is high cardinality. So we don't want to send it as a label, only as a
+      # resource attribute. That way it's only propagated to Prometheus, and not
+      # Monarch or Cloud Monitoring, which ignore custom resource attributes.
+      attributes:
+        actions:
+          - key: configsync.sync.kind
+            action: upsert
+            value: ${CONFIGSYNC_SYNC_KIND}
+          - key: configsync.sync.name
+            action: upsert
+            value: ${CONFIGSYNC_SYNC_NAME}
+          - key: configsync.sync.namespace
+            action: upsert
+            value: ${CONFIGSYNC_SYNC_NAMESPACE}
       batch:
+      # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
+      # the GCE metadata service, if available.
       resourcedetection:
         detectors: [env, gcp]
     extensions:
@@ -47,7 +67,7 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch, resourcedetection]
+          processors: [batch, resourcedetection, attributes]
           exporters: [opencensus]
       telemetry:
         logs:

--- a/manifests/templates/otel-collector.yaml
+++ b/manifests/templates/otel-collector.yaml
@@ -26,9 +26,10 @@ data:
   otel-collector-config.yaml: |
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       prometheus:
-        endpoint: :8675
+        endpoint: 0.0.0.0:8675
         namespace: config_sync
         resource_to_telemetry_conversion:
           enabled: true
@@ -36,6 +37,7 @@ data:
       batch:
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -66,6 +68,8 @@ spec:
     port: 8888
   - name: metrics # Prometheus exporter metrics.
     port: 8675
+  - name: health-check
+    port: 13133
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -112,6 +116,7 @@ spec:
         - containerPort: 55678 # Default endpoint for OpenCensus receiver.
         - containerPort: 8888  # Default endpoint for querying metrics.
         - containerPort: 8675  # Prometheus exporter metrics.
+        - containerPort: 13133 # Health check
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/manifests/templates/reconciler-manager-configmap.yaml
+++ b/manifests/templates/reconciler-manager-configmap.yaml
@@ -175,7 +175,7 @@ data:
            command:
            - /otelcontribcol
            args:
-           - "--config=/conf/otel-agent-config.yaml"
+           - "--config=/conf/otel-agent-reconciler-config.yaml"
            # The prometheus transformer appends `_ratio` to gauge metrics: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.86.0/pkg/translator/prometheus/normalize_name.go#L149
            # Add the feature gate to enable metric suffix trimming.
            - "--feature-gates=-pkg.translator.prometheus.NormalizeName"
@@ -190,8 +190,10 @@ data:
              protocol: TCP
            - containerPort: 8888  # Metrics.
              protocol: TCP
+           - containerPort: 13133 # Health check
+             protocol: TCP
            volumeMounts:
-           - name: otel-agent-config-vol
+           - name: otel-agent-config-reconciler-vol
              mountPath: /conf
            readinessProbe:
              httpGet:
@@ -282,9 +284,9 @@ data:
            secret:
              secretName: git-creds
              defaultMode: 288
-         - name: otel-agent-config-vol
+         - name: otel-agent-config-reconciler-vol
            configMap:
-             name: otel-agent
+             name: otel-agent-reconciler
              defaultMode: 420
          - name: service-account
            emptyDir: {}

--- a/manifests/templates/reconciler-manager.yaml
+++ b/manifests/templates/reconciler-manager.yaml
@@ -81,6 +81,7 @@ spec:
         ports:
         - containerPort: 55678 # Default OpenCensus receiver port.
         - containerPort: 8888  # Metrics.
+        - containerPort: 13133 # Health check
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/manifests/templates/resourcegroup-manifest.yaml
+++ b/manifests/templates/resourcegroup-manifest.yaml
@@ -155,6 +155,7 @@ data:
   otel-agent-config.yaml: |
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       opencensus:
         endpoint: otel-collector.config-management-monitoring:55678
@@ -168,6 +169,7 @@ data:
         detectors: [env, gcp]
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -272,6 +274,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 8888
+        - containerPort: 13133
         readinessProbe:
           httpGet:
             path: /
@@ -301,3 +304,4 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -34,9 +34,10 @@ const (
 	// the googlecloud exporter.
 	CollectorConfigGooglecloud = `receivers:
   opencensus:
+    endpoint: 0.0.0.0:55678
 exporters:
   prometheus:
-    endpoint: :8675
+    endpoint: 0.0.0.0:8675
     namespace: config_sync
     resource_to_telemetry_conversion:
       enabled: true
@@ -332,6 +333,7 @@ processors:
             aggregation_type: max
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 service:
   extensions: [health_check]
   pipelines:

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -49,7 +49,7 @@ const (
 	// otel-collector ConfigMap.
 	// See `CollectorConfigGooglecloud` in `pkg/metrics/otel.go`
 	// Used by TestOtelReconcilerGooglecloud.
-	depAnnotationGooglecloud = "c2f6078a9afe1f32721173e9e15bbab5"
+	depAnnotationGooglecloud = "e2fc77f25de5df75866195ff0d00f6df"
 	// depAnnotationGooglecloud is the expected hash of the custom
 	// otel-collector ConfigMap test artifact.
 	// Used by TestOtelReconcilerCustom.

--- a/test/kustomization/expected.yaml
+++ b/test/kustomization/expected.yaml
@@ -5618,9 +5618,10 @@ data:
   otel-collector-config.yaml: |
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       prometheus:
-        endpoint: :8675
+        endpoint: 0.0.0.0:8675
         namespace: config_sync
         resource_to_telemetry_conversion:
           enabled: true
@@ -5628,6 +5629,7 @@ data:
       batch:
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -5650,6 +5652,45 @@ data:
   otel-agent-config.yaml: |
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
+    exporters:
+      opencensus:
+        endpoint: otel-collector.config-management-monitoring:55678
+        tls:
+          insecure: true
+    processors:
+      batch:
+      resourcedetection:
+        detectors: [env, gcp]
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [opencensus]
+          processors: [batch, resourcedetection]
+          exporters: [opencensus]
+      telemetry:
+        logs:
+          level: "INFO"
+kind: ConfigMap
+metadata:
+  labels:
+    app: opentelemetry
+    component: otel-agent
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: otel-agent
+  namespace: config-management-system
+---
+apiVersion: v1
+data:
+  otel-agent-reconciler-config.yaml: |
+    receivers:
+      opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       opencensus:
         endpoint: otel-collector.config-management-monitoring:55678
@@ -5667,13 +5708,13 @@ data:
         actions:
           - key: configsync.sync.kind
             action: upsert
-            value: $CONFIGSYNC_SYNC_KIND
+            value: ${CONFIGSYNC_SYNC_KIND}
           - key: configsync.sync.name
             action: upsert
-            value: $CONFIGSYNC_SYNC_NAME
+            value: ${CONFIGSYNC_SYNC_NAME}
           - key: configsync.sync.namespace
             action: upsert
-            value: $CONFIGSYNC_SYNC_NAMESPACE
+            value: ${CONFIGSYNC_SYNC_NAMESPACE}
       batch:
       # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
       # the GCE metadata service, if available.
@@ -5681,6 +5722,7 @@ data:
         detectors: [env, gcp]
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -5698,7 +5740,7 @@ metadata:
     component: otel-agent
     configmanagement.gke.io/arch: csmr
     configmanagement.gke.io/system: "true"
-  name: otel-agent
+  name: otel-agent-reconciler
   namespace: config-management-system
 ---
 apiVersion: v1
@@ -5857,7 +5899,7 @@ data:
             command:
             - /otelcontribcol
             args:
-            - "--config=/conf/otel-agent-config.yaml"
+            - "--config=/conf/otel-agent-reconciler-config.yaml"
             # The prometheus transformer appends `_ratio` to gauge metrics: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.86.0/pkg/translator/prometheus/normalize_name.go#L149
             # Add the feature gate to enable metric suffix trimming.
             - "--feature-gates=-pkg.translator.prometheus.NormalizeName"
@@ -5872,8 +5914,10 @@ data:
               protocol: TCP
             - containerPort: 8888  # Metrics.
               protocol: TCP
+            - containerPort: 13133 # Health check
+              protocol: TCP
             volumeMounts:
-            - name: otel-agent-config-vol
+            - name: otel-agent-config-reconciler-vol
               mountPath: /conf
             readinessProbe:
               httpGet:
@@ -5964,9 +6008,9 @@ data:
             secret:
               secretName: git-creds
               defaultMode: 288
-          - name: otel-agent-config-vol
+          - name: otel-agent-config-reconciler-vol
             configMap:
-              name: otel-agent
+              name: otel-agent-reconciler
               defaultMode: 420
           - name: service-account
             emptyDir: {}
@@ -5990,6 +6034,7 @@ data:
   otel-agent-config.yaml: |
     receivers:
       opencensus:
+        endpoint: 0.0.0.0:55678
     exporters:
       opencensus:
         endpoint: otel-collector.config-management-monitoring:55678
@@ -6003,6 +6048,7 @@ data:
         detectors: [env, gcp]
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
     service:
       extensions: [health_check]
       pipelines:
@@ -6049,6 +6095,8 @@ spec:
     port: 8888
   - name: metrics
     port: 8675
+  - name: health-check
+    port: 13133
   selector:
     app: opentelemetry
     component: otel-collector
@@ -6121,6 +6169,7 @@ spec:
         - containerPort: 55678
         - containerPort: 8888
         - containerPort: 8675
+        - containerPort: 13133
         readinessProbe:
           httpGet:
             path: /
@@ -6332,6 +6381,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 8888
+        - containerPort: 13133
         readinessProbe:
           httpGet:
             path: /
@@ -6455,6 +6505,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 8888
+        - containerPort: 13133
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Updating otelcontribcol to latest to include fix of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35006 and other essential security updates in components like Prometheus exporter.

The upgrade covers a breaking change in otelcontribcol of defaulting to local host instead of 0.0.0.0, the feature is now stable and [feature gate](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30702) has been [removed](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36589), Config Sync should explicitly set endpoint to host 0.0.0.0 to expose port for external pod access. This applies to the metric receiver `opencensus`, and the exporter `prometheus`.

This update also separates the ConfigMap for the otel-agent, distinguishing the one used by the reconcilers from the ConfigMap used by the reconciler manager and the resource group controller. As a result, only the ConfigMap for the reconcilers will include the Config Sync-related resource tags.

go/cs-upgrade-otelcontribcol-from-103