### PR TITLE
test: delete GAR repositories on teardown

### DIFF
--- a/e2e/nomostest/registryproviders/artifact_registry.go
+++ b/e2e/nomostest/registryproviders/artifact_registry.go
@@ -61,9 +61,18 @@ func (a *ArtifactRegistryProvider) Type() string {
 }
 
 // Teardown preforms teardown
-// Does nothing currently. We may want to have this delete the repository to
-// minimize side effects.
+// This deletes the repository to prevent side effects across executions.
 func (a *ArtifactRegistryProvider) Teardown() error {
+	out, err := a.gcloudClient.Gcloud("artifacts", "repositories",
+		"delete", a.repositoryName,
+		"--quiet",
+		"--location", a.location,
+		"--project", a.project)
+	if err != nil {
+		if !strings.Contains(string(out), "NOT_FOUND") {
+			return fmt.Errorf("failed to delete repository: %w", err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Some side effects have been noticed in the periodic jobs, such as an image never getting deleted if the cleanup fails on a prior execution. As an example this can cause TestHelmLatestVersion to become flaky, since the 3.0.0 helm chart already exists before the test starts.

Tearing down the entire GAR repository allows the periodic jobs to self heal side effects after a failed cleanup.

Example failure: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-regular/1823419274467741696