### PR TITLE
e2e: Simplify tracking of RSync sources

### DIFF
--- a/e2e/nomostest/registryproviders/helm_chart.go
+++ b/e2e/nomostest/registryproviders/helm_chart.go
@@ -168,6 +168,11 @@ type HelmChartID struct {
 	Version string
 }
 
+// String returns NAME/VERSION.
+func (id HelmChartID) String() string {
+	return fmt.Sprintf("%s/%s", id.Name, id.Version)
+}
+
 // HelmPackage represents a helm package that is pushed to a remote registry by the
 // test scaffolding. It uses git references as version tags to enable straightforward
 // integration with the git e2e tooling and to mimic how a user might leverage

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -131,12 +131,9 @@ func Reset(nt *NT) error {
 		return err
 	}
 
-	// NOTE: These git repos are not actually being deleted here, just
-	// unassigned to a specific RSync. All remote repos are cached in
-	// nt.RemoteRepositories and then reassigned in `resetRepository`.
-	// Repos are actually deleted by `Clean` in environment setup and teardown.
-	nt.NonRootRepos = make(map[types.NamespacedName]*gitproviders.Repository)
-	nt.RootRepos = make(map[string]*gitproviders.Repository)
+	// NOTE: These sources are not actually being deleted here, just
+	// unassigned from a specific RSync.
+	nt.SyncSources.Reset()
 
 	// Reset expected objects
 	nt.MetricsExpectations.Reset()

--- a/e2e/nomostest/syncsource/set.go
+++ b/e2e/nomostest/syncsource/set.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncsource
+
+import (
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+)
+
+// Set of RootSync & RepoSync IDs that map to SyncSources.
+type Set map[core.ID]SyncSource
+
+// Reset clears the Set.
+func (s *Set) Reset() {
+	clear(*s)
+}
+
+// RootSyncs returns a Set that only contains the RootSync IDs and their SyncSources.
+func (s Set) RootSyncs() Set {
+	set := make(map[core.ID]SyncSource)
+	for id, source := range s {
+		if id.Kind == configsync.RootSyncKind {
+			set[id] = source
+		}
+	}
+	return set
+}
+
+// RepoSyncs returns a Set that only contains the RepoSync IDs and their SyncSources.
+func (s Set) RepoSyncs() Set {
+	set := make(map[core.ID]SyncSource)
+	for id, source := range s {
+		if id.Kind == configsync.RepoSyncKind {
+			set[id] = source
+		}
+	}
+	return set
+}
+
+// GitSyncSources returns a Set that only contains RootSyncs & RepoSyncs using GitSyncSources.
+func (s Set) GitSyncSources() Set {
+	set := make(map[core.ID]SyncSource)
+	for id, source := range s {
+		if _, ok := source.(*GitSyncSource); ok {
+			set[id] = source
+		}
+	}
+	return set
+}
+
+// HelmSyncSources returns a Set that only contains RootSyncs & RepoSyncs using HelmSyncSources.
+func (s Set) HelmSyncSources() Set {
+	set := make(map[core.ID]SyncSource)
+	for id, source := range s {
+		if _, ok := source.(*HelmSyncSource); ok {
+			set[id] = source
+		}
+	}
+	return set
+}
+
+// OCISyncSources returns a Set that only contains RootSyncs & RepoSyncs using OCISyncSources.
+func (s Set) OCISyncSources() Set {
+	set := make(map[core.ID]SyncSource)
+	for id, source := range s {
+		if _, ok := source.(*OCISyncSource); ok {
+			set[id] = source
+		}
+	}
+	return set
+}

--- a/e2e/nomostest/syncsource/syncsource.go
+++ b/e2e/nomostest/syncsource/syncsource.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncsource
+
+import (
+	"fmt"
+
+	"kpt.dev/configsync/e2e/nomostest/gitproviders"
+	"kpt.dev/configsync/e2e/nomostest/registryproviders"
+	"kpt.dev/configsync/pkg/api/configsync"
+)
+
+// SyncSource describes the common methods available on all sources of truth.
+type SyncSource interface {
+	// Type returns the SourceType of this source.
+	Type() configsync.SourceType
+	// Commit returns the current/latest "commit" for this source.
+	// The commit value is used to validate RSync status and metrics.
+	Commit() (string, error)
+}
+
+// GitSyncSource is the "git" source, backed by a Git repository.
+type GitSyncSource struct {
+	// Repository is a local clone of the remote Git repository that contains
+	// the current/latest commit.
+	Repository *gitproviders.Repository
+	// TODO: Add SyncPath and Branch/Revision to uniquely identify part of a repo
+}
+
+// Type returns the SourceType of this source.
+func (s *GitSyncSource) Type() configsync.SourceType {
+	return configsync.GitSource
+}
+
+// Commit returns the current commit hash targeted by the local git repository.
+func (s *GitSyncSource) Commit() (string, error) {
+	return s.Repository.Hash()
+}
+
+// HelmSyncSource is the "helm" source, backed by a Helm chart.
+type HelmSyncSource struct {
+	ChartID registryproviders.HelmChartID
+	// TODO: Add HelmRegistryProvider to allow for chart modifications
+}
+
+// Type returns the SourceType of this source.
+func (s *HelmSyncSource) Type() configsync.SourceType {
+	return configsync.HelmSource
+}
+
+// Commit returns the version of the current chart.
+func (s *HelmSyncSource) Commit() (string, error) {
+	return s.ChartID.Version, nil
+}
+
+// OCISyncSource is the "oci" source, backed by an OCI image.
+type OCISyncSource struct {
+	// TODO: add an OCI-specific image ID & migrate OCI RSyncs to use OCISyncSource
+	// TODO: Add OCIRegistryProvider to allow for chart modifications
+}
+
+// Type returns the SourceType of this source.
+func (s *OCISyncSource) Type() configsync.SourceType {
+	return configsync.OciSource
+}
+
+// Commit is not yet implemented.
+func (s *OCISyncSource) Commit() (string, error) {
+	return "", fmt.Errorf("not yet implemented: OCISyncSource.Commit")
+}

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -489,6 +489,8 @@ func testNomosHydrateWithClusterSelectors(t *testing.T, configPath string, sourc
 }
 
 func testSyncFromNomosHydrateOutput(nt *nomostest.NT, config string) {
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+
 	if err := nt.ValidateNotFound("bookstore1", "", &corev1.Namespace{}); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -497,8 +499,8 @@ func testSyncFromNomosHydrateOutput(nt *nomostest.NT, config string) {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy(config, "acme"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add cluster-dev configs"))
+	nt.Must(rootSyncGitRepo.Copy(config, "acme"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add cluster-dev configs"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -75,6 +75,7 @@ func managerFieldsNonEmpty() testpredicates.Predicate {
 // changes to cluster-scoped objects.
 func TestRevertClusterRole(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	crName := "e2e-test-clusterrole"
 
@@ -93,8 +94,8 @@ func TestRevertClusterRole(t *testing.T) {
 	}
 	declaredCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	declaredCr.Rules = declaredRules
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/clusterrole.yaml", declaredCr))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add get/list/create ClusterRole"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -143,6 +144,7 @@ func TestRevertClusterRole(t *testing.T) {
 // resources.
 func TestClusterRoleLifecycle(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	crName := "e2e-test-clusterrole"
 
@@ -161,8 +163,8 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	}
 	declaredCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	declaredCr.Rules = declaredRules
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", declaredCr))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add get/list/create ClusterRole"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/clusterrole.yaml", declaredCr))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add get/list/create ClusterRole"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -194,8 +196,8 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	}
 	updatedCr := k8sobjects.ClusterRoleObject(core.Name(crName))
 	updatedCr.Rules = updatedRules
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/clusterrole.yaml", updatedCr))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("update ClusterRole to get/list"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/clusterrole.yaml", updatedCr))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update ClusterRole to get/list"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -216,8 +218,8 @@ func TestClusterRoleLifecycle(t *testing.T) {
 	}
 
 	// Delete the ClusterRole from the SOT.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/clusterrole.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("deleting ClusterRole"))
+	nt.Must(rootSyncGitRepo.Remove("acme/cluster/clusterrole.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("deleting ClusterRole"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -103,14 +103,15 @@ func namespaceObject(name string, annotations map[string]string) *corev1.Namespa
 func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	configMapName := clusterNameConfigMapName(nt)
 
 	nt.T.Log("Add test cluster, and cluster registry data")
 	testCluster := clusterObject(testClusterName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-test.yaml", testCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-test.yaml", testCluster))
 	testClusterSelector := clusterSelector(testClusterSelectorName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add test cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add test cluster and cluster registry data"))
 
 	nt.T.Log("Add a valid cluster selector annotation to a resource quota")
 	resourceQuotaName := "pod-quota"
@@ -119,11 +120,11 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	rqInline := resourceQuota(resourceQuotaName, frontendNamespace, prodPodsQuota, inlineProdClusterSelectorAnnotation)
 	rqLegacy := resourceQuota(resourceQuotaName, frontendNamespace, testPodsQuota, legacyTestClusterSelectorAnnotation)
 	nsObj := namespaceObject(frontendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", frontendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/frontend/quota-inline.yaml", rqInline))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/frontend/quota-legacy.yaml", rqLegacy))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a resource quota"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/frontend/quota-inline.yaml", rqInline))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/frontend/quota-legacy.yaml", rqLegacy))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a resource quota"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -180,16 +181,17 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 func TestClusterSelectorOnObjects(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, backendNamespace, inlineProdClusterSelectorAnnotation)
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -199,15 +201,15 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 
 	nt.T.Log("Add test cluster, and cluster registry data")
 	testCluster := clusterObject(testClusterName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-test.yaml", testCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-test.yaml", testCluster))
 	testClusterSelector := clusterSelector(testClusterSelectorName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add test cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add test cluster and cluster registry data"))
 
 	nt.T.Log("Change cluster selector to match test cluster")
 	rb.Annotations = legacyTestClusterSelectorAnnotation
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change cluster selector to match test cluster"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Change cluster selector to match test cluster"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -233,8 +235,8 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 
 	nt.T.Log("Revert cluster selector to match prod cluster")
 	rb.Annotations = inlineProdClusterSelectorAnnotation
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Revert cluster selector to match prod cluster"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Revert cluster selector to match prod cluster"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -272,15 +274,16 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 
 func TestClusterSelectorOnNamespaces(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 
 	nt.T.Log("Add a valid cluster selector annotation to a namespace")
 	namespace := namespaceObject(backendNamespace, inlineProdClusterSelectorAnnotation)
 	rb := roleBinding(roleBindingName, backendNamespace, inlineProdClusterSelectorAnnotation)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a namespace and a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a namespace and a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -305,15 +308,15 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	nt.T.Log("Add test cluster, and cluster registry data")
 	testCluster := clusterObject(testClusterName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-test.yaml", testCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-test.yaml", testCluster))
 	testClusterSelector := clusterSelector(testClusterSelectorName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add test cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add test cluster and cluster registry data"))
 
 	nt.T.Log("Change namespace to match test cluster")
 	namespace.Annotations = legacyTestClusterSelectorAnnotation
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Change namespace to match test cluster"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Change namespace to match test cluster"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -371,8 +374,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	nt.T.Log("Updating bob-rolebinding to NOT have cluster-selector")
 	rb.Annotations = map[string]string{}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update bob-rolebinding to NOT have cluster-selector"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update bob-rolebinding to NOT have cluster-selector"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -392,8 +395,8 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 	nt.T.Log("Revert namespace to match prod cluster")
 	namespace.Annotations = inlineProdClusterSelectorAnnotation
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Revert namespace to match prod cluster"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/namespace.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Revert namespace to match prod cluster"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -451,14 +454,15 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, backendNamespace, inlineProdClusterSelectorAnnotation)
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -480,8 +484,8 @@ func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 
 	nt.T.Log("Modify the cluster selector to select an excluded cluster list")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a, b, c"}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modify the cluster selector to select an excluded cluster list"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Modify the cluster selector to select an excluded cluster list"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -502,21 +506,22 @@ func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 
 func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add prod cluster, and cluster registry data")
 	prodCluster := clusterObject(prodClusterName, environmentLabelKey, prodEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-prod.yaml", prodCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-prod.yaml", prodCluster))
 	prodClusterSelector := clusterSelector(prodClusterSelectorName, environmentLabelKey, prodEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add prod cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add prod cluster and cluster registry data"))
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, backendNamespace, map[string]string{metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName})
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a valid cluster selector annotation to a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -537,8 +542,8 @@ func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 
 	nt.T.Log("Modify the cluster selector to select a different environment")
 	prodClusterWithADifferentSelector := clusterSelector(prodClusterSelectorName, environmentLabelKey, "other")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterWithADifferentSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modify the cluster selector to select a different environment"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterWithADifferentSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Modify the cluster selector to select a different environment"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -559,25 +564,26 @@ func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 
 func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add test cluster, and cluster registry data")
 	testCluster := clusterObject(testClusterName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-test.yaml", testCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-test.yaml", testCluster))
 	testClusterSelector := clusterSelector(testClusterSelectorName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add test cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add test cluster and cluster registry data"))
 
 	nt.T.Log("Add CRs (not targeted to this cluster) without its CRD")
 	cr := anvilCR("v1", "e2e-test-anvil", 10)
 	cr.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: testClusterSelectorName})
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/anvil.yaml", cr))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/anvil.yaml", cr))
 	cr2 := anvilCR("v1", "e2e-test-anvil-2", 10)
 	cr2.SetAnnotations(legacyTestClusterSelectorAnnotation)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/anvil-2.yaml", cr2))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource without its CRD"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/anvil-2.yaml", cr2))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource without its CRD"))
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -601,12 +607,14 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 		ntopts.NamespaceRepo(namespaceRepo, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages rolebindings
 	)
+	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	repoSyncKey := repoSyncID.ObjectKey
+	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, namespaceRepo, inlineProdClusterSelectorAnnotation)
-	nn := nomostest.RepoSyncNN(namespaceRepo, configsync.RepoSyncName)
-	nt.Must(nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb))
-	nt.Must(nt.NonRootRepos[nn].CommitAndPush("Add a valid cluster selector annotation to a role binding"))
+	nt.Must(repoSyncGitRepo.Add("acme/bob-rolebinding.yaml", rb))
+	nt.Must(repoSyncGitRepo.CommitAndPush("Add a valid cluster selector annotation to a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -614,11 +622,11 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	nt.MetricsExpectations.AddObjectApply(configsync.RepoSyncKind, nn, rb)
+	nt.MetricsExpectations.AddObjectApply(configsync.RepoSyncKind, repoSyncKey, rb)
 
 	// Validate metrics.
 	err := nomostest.ValidateStandardMetricsForRepoSync(nt, metrics.Summary{
-		Sync: nn,
+		Sync: repoSyncKey,
 	})
 	if err != nil {
 		nt.T.Fatal(err)
@@ -626,8 +634,8 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 
 	nt.T.Log("Modify the cluster selector to select an excluded cluster list")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a,b,,,c,d"}
-	nt.Must(nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb))
-	nt.Must(nt.NonRootRepos[nn].CommitAndPush("Modify the cluster selector to select an excluded cluster list"))
+	nt.Must(repoSyncGitRepo.Add("acme/bob-rolebinding.yaml", rb))
+	nt.Must(repoSyncGitRepo.CommitAndPush("Modify the cluster selector to select an excluded cluster list"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -636,11 +644,11 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 	}
 
 	// Delete the object, since it's no longer specified for this cluster
-	nt.MetricsExpectations.AddObjectDelete(configsync.RepoSyncKind, nn, rb)
+	nt.MetricsExpectations.AddObjectDelete(configsync.RepoSyncKind, repoSyncKey, rb)
 
 	// Validate metrics.
 	err = nomostest.ValidateStandardMetricsForRepoSync(nt, metrics.Summary{
-		Sync: nn,
+		Sync: repoSyncKey,
 	})
 	if err != nil {
 		nt.T.Fatal(err)
@@ -648,12 +656,12 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 
 	nt.T.Log("Switch to use ClusterSelector objects")
 	clusterObj := clusterObject(prodClusterName, environmentLabelKey, prodEnvironment)
-	nt.Must(nt.NonRootRepos[nn].Add("acme/cluster.yaml", clusterObj))
+	nt.Must(repoSyncGitRepo.Add("acme/cluster.yaml", clusterObj))
 	clusterSelectorObj := clusterSelector(prodClusterSelectorName, environmentLabelKey, prodEnvironment)
-	nt.Must(nt.NonRootRepos[nn].Add("acme/clusterselector.yaml", clusterSelectorObj))
+	nt.Must(repoSyncGitRepo.Add("acme/clusterselector.yaml", clusterSelectorObj))
 	rb.Annotations = map[string]string{metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName}
-	nt.Must(nt.NonRootRepos[nn].Add("acme/bob-rolebinding.yaml", rb))
-	nt.Must(nt.NonRootRepos[nn].CommitAndPush("Add cluster registry data and use the legacy ClusterSelector"))
+	nt.Must(repoSyncGitRepo.Add("acme/bob-rolebinding.yaml", rb))
+	nt.Must(repoSyncGitRepo.CommitAndPush("Add cluster registry data and use the legacy ClusterSelector"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -663,11 +671,11 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 
 	// Expect ClusterObject & ClusterSelector to be excluded from declared
 	// resources and not applied.
-	nt.MetricsExpectations.AddObjectApply(configsync.RepoSyncKind, nn, rb)
+	nt.MetricsExpectations.AddObjectApply(configsync.RepoSyncKind, repoSyncKey, rb)
 
 	// Validate metrics.
 	err = nomostest.ValidateStandardMetricsForRepoSync(nt, metrics.Summary{
-		Sync: nn,
+		Sync: repoSyncKey,
 	})
 	if err != nil {
 		nt.T.Fatal(err)
@@ -676,6 +684,7 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 
 func TestInlineClusterSelectorFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 	renameCluster(nt, configMapName, "")
@@ -683,10 +692,10 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 	nt.T.Log("Add a role binding without any cluster selectors")
 	rb := roleBinding(roleBindingName, backendNamespace, map[string]string{})
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a role binding without any cluster selectors"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a role binding without any cluster selectors"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -708,8 +717,8 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 	nt.T.Logf("Add a prod cluster selector to the role binding")
 	rb.Annotations = inlineProdClusterSelectorAnnotation
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a prod cluster selector to the role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a prod cluster selector to the role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -755,8 +764,8 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 	nt.T.Log("Add an empty cluster selector annotation to a role binding")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: ""}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add an empty cluster selector annotation to a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add an empty cluster selector annotation to a role binding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -776,8 +785,8 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 	nt.T.Log("Add a cluster selector annotation to a role binding with a list of included clusters")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: fmt.Sprintf("a,%s,b", prodClusterName)}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -797,8 +806,8 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 	nt.T.Log("Add a cluster selector annotation to a role binding that does not include the current cluster")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: "a,,b"}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of excluded clusters"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a cluster selector annotation to a role binding with a list of excluded clusters"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -818,8 +827,8 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 	nt.T.Log("Add a cluster selector annotation to a role binding with a list of included clusters (with spaces)")
 	rb.Annotations = map[string]string{metadata.ClusterNameSelectorAnnotationKey: fmt.Sprintf("a , %s , b", prodClusterName)}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters (with spaces)"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a cluster selector annotation to a role binding with a list of included clusters (with spaces)"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -840,17 +849,18 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add both cluster selector annotations to a role binding")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace),
 		namespaceObject(backendNamespace, map[string]string{})))
 	rb := roleBinding(roleBindingName, backendNamespace, map[string]string{
 		metadata.ClusterNameSelectorAnnotationKey:   prodClusterName,
 		metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName,
 	})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add both cluster selector annotations to a role binding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/bob-rolebinding.yaml", rb))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add both cluster selector annotations to a role binding"))
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, selectors.ClusterSelectorAnnotationConflictErrorCode, "")
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
@@ -858,7 +868,7 @@ func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	commitHash := nt.RootRepos[configsync.RootSyncName].MustHash(nt.T)
+	commitHash := rootSyncGitRepo.MustHash(nt.T)
 
 	err = nomostest.ValidateMetrics(nt,
 		nomostest.ReconcilerErrorMetrics(nt, rootSyncLabels, commitHash, metrics.ErrorSummary{
@@ -871,11 +881,12 @@ func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 
 func TestClusterSelectorForCRD(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add CRD without ClusterSelectors or cluster-name-selector annotation")
 	crd := anvilV1CRD()
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource definition"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -897,8 +908,8 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	// Test inline cluster-name-selector annotation
 	nt.T.Log("Set the cluster-name-selector annotation to a not-selected cluster")
 	crd.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: testClusterName})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an unselected cluster-name-selector annotation"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource definition with an unselected cluster-name-selector annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -921,8 +932,8 @@ func TestClusterSelectorForCRD(t *testing.T) {
 
 	nt.T.Log("Set the cluster-name-selector annotation to a selected cluster")
 	crd.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: prodClusterName})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an selected cluster-name-selector annotation"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource definition with an selected cluster-name-selector annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -943,17 +954,17 @@ func TestClusterSelectorForCRD(t *testing.T) {
 	// Test legacy ClusterSelectors
 	nt.T.Log("Add cluster, and cluster registry data")
 	prodCluster := clusterObject(prodClusterName, environmentLabelKey, prodEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/cluster-prod.yaml", prodCluster))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/cluster-prod.yaml", prodCluster))
 	prodClusterSelector := clusterSelector(prodClusterSelectorName, environmentLabelKey, prodEnvironment)
 	testClusterSelector := clusterSelector(testClusterSelectorName, environmentLabelKey, testEnvironment)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add cluster and cluster registry data"))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-prod.yaml", prodClusterSelector))
+	nt.Must(rootSyncGitRepo.Add("acme/clusterregistry/clusterselector-test.yaml", testClusterSelector))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add cluster and cluster registry data"))
 
 	nt.T.Log("Set ClusterSelector to a not-selected cluster")
 	crd.SetAnnotations(legacyTestClusterSelectorAnnotation)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an unselected ClusterSelector"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource definition with an unselected ClusterSelector"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -976,8 +987,8 @@ func TestClusterSelectorForCRD(t *testing.T) {
 
 	nt.T.Log("Set ClusterSelector to a selected cluster")
 	crd.SetAnnotations(map[string]string{metadata.LegacyClusterSelectorAnnotationKey: prodClusterSelectorName})
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crd))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a custom resource definition with an selected ClusterSelector"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource definition with an selected ClusterSelector"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/custom_resource_definitions_schema_test.go
+++ b/e2e/testcases/custom_resource_definitions_schema_test.go
@@ -23,12 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kpt.dev/configsync/e2e/nomostest"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
-	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 )
 
 func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	oldCRDFile := filepath.Join(".", "..", "testdata", "customresources", "changed_schema_crds", "old_schema_crd.yaml")
 	newCRDFile := filepath.Join(".", "..", "testdata", "customresources", "changed_schema_crds", "new_schema_crd.yaml")
@@ -44,10 +44,10 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/crd.yaml", crdContent))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", k8sobjects.NamespaceObject("foo")))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/cr.yaml", crContent))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a CRD and CR"))
+	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/crd.yaml", crdContent))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", k8sobjects.NamespaceObject("foo")))
+	nt.Must(rootSyncGitRepo.AddFile("acme/namespaces/foo/cr.yaml", crContent))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding a CRD and CR"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -73,9 +73,9 @@ func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/crd.yaml", crdContent))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/cr.yaml", crContent))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding the CRD with new schema and a CR using the new schema"))
+	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/crd.yaml", crdContent))
+	nt.Must(rootSyncGitRepo.AddFile("acme/namespaces/foo/cr.yaml", crContent))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding the CRD with new schema and a CR using the new schema"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/invalid_auth_test.go
+++ b/e2e/testcases/invalid_auth_test.go
@@ -55,7 +55,9 @@ func TestInvalidAuth(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	commitHash := nt.RootRepos[configsync.RootSyncName].MustHash(nt.T)
+	// TODO: Fix commit to be UNKNOWN (b/361182373)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	commitHash := rootSyncGitRepo.MustHash(nt.T)
 
 	err = nomostest.ValidateMetrics(nt,
 		nomostest.ReconcilerErrorMetrics(nt, rootSyncLabels, commitHash, metrics.ErrorSummary{

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -26,14 +26,15 @@ import (
 
 func TestIgnoreKptfiles(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Add multiple Kptfiles
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/cluster/Kptfile", []byte("random content")))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/Kptfile", nil))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].AddFile("acme/namespaces/foo/subdir/Kptfile", []byte("# some comment")))
+	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/Kptfile", []byte("random content")))
+	nt.Must(rootSyncGitRepo.AddFile("acme/namespaces/foo/Kptfile", nil))
+	nt.Must(rootSyncGitRepo.AddFile("acme/namespaces/foo/subdir/Kptfile", []byte("# some comment")))
 	nsObj := k8sobjects.NamespaceObject("foo")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding multiple Kptfiles"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding multiple Kptfiles"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -39,6 +39,7 @@ var preventDeletion = core.Annotation(common.LifecycleDeleteAnnotation, common.P
 func TestPreventDeletionNamespace(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the Namespace doesn't already exist.
 	err := nt.ValidateNotFound("shipping", "", &corev1.Namespace{})
@@ -55,9 +56,9 @@ func TestPreventDeletionNamespace(t *testing.T) {
 
 	// Declare the Namespace with the lifecycle annotation, and ensure it is created.
 	nsObj := k8sobjects.NamespaceObject("shipping", preventDeletion)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Namespace with prevent deletion lifecycle annotation"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/role.yaml", role))
+	nt.Must(rootSyncGitRepo.CommitAndPush("declare Namespace with prevent deletion lifecycle annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -81,9 +82,9 @@ func TestPreventDeletionNamespace(t *testing.T) {
 	}
 
 	// Delete the declaration and ensure the Namespace isn't deleted.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/ns.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/role.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove Namespace shipping declaration"))
+	nt.Must(rootSyncGitRepo.Remove("acme/namespaces/shipping/ns.yaml"))
+	nt.Must(rootSyncGitRepo.Remove("acme/namespaces/shipping/role.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove Namespace shipping declaration"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -114,8 +115,8 @@ func TestPreventDeletionNamespace(t *testing.T) {
 
 	// Remove the lifecycle annotation from the namespace so that the namespace can be deleted after the test case.
 	nsObj = k8sobjects.NamespaceObject("shipping")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from Namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove the lifecycle annotation from Namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -134,6 +135,7 @@ func TestPreventDeletionNamespace(t *testing.T) {
 func TestPreventDeletionRole(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the Namespace doesn't already exist.
 	err := nt.ValidateNotFound("shipping-admin", "shipping", &rbacv1.Role{})
@@ -149,9 +151,9 @@ func TestPreventDeletionRole(t *testing.T) {
 		Verbs:     []string{"get"},
 	}}
 	nsObj := k8sobjects.NamespaceObject("shipping")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare Role with prevent deletion lifecycle annotation"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/role.yaml", role))
+	nt.Must(rootSyncGitRepo.CommitAndPush("declare Role with prevent deletion lifecycle annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -177,8 +179,8 @@ func TestPreventDeletionRole(t *testing.T) {
 	}
 
 	// Delete the declaration and ensure the Namespace isn't deleted.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/shipping/role.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove Role declaration"))
+	nt.Must(rootSyncGitRepo.Remove("acme/namespaces/shipping/role.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove Role declaration"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -208,8 +210,8 @@ func TestPreventDeletionRole(t *testing.T) {
 
 	// Remove the lifecycle annotation from the role so that the role can be deleted after the test case.
 	delete(role.Annotations, common.LifecycleDeleteAnnotation)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shipping/role.yaml", role))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from Role"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shipping/role.yaml", role))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove the lifecycle annotation from Role"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -236,6 +238,7 @@ func TestPreventDeletionRole(t *testing.T) {
 func TestPreventDeletionClusterRole(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the ClusterRole doesn't already exist.
 	err := nt.ValidateNotFound("test-admin", "", &rbacv1.ClusterRole{})
@@ -250,8 +253,8 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 		Resources: []string{"configmaps"},
 		Verbs:     []string{"get"},
 	}}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/cr.yaml", clusterRole))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("declare ClusterRole with prevent deletion lifecycle annotation"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/cr.yaml", clusterRole))
+	nt.Must(rootSyncGitRepo.CommitAndPush("declare ClusterRole with prevent deletion lifecycle annotation"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -265,8 +268,8 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 	}
 
 	// Delete the declaration and ensure the ClusterRole isn't deleted.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/cluster/cr.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove ClusterRole bar declaration"))
+	nt.Must(rootSyncGitRepo.Remove("acme/cluster/cr.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove ClusterRole bar declaration"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -281,8 +284,8 @@ func TestPreventDeletionClusterRole(t *testing.T) {
 
 	// Remove the lifecycle annotation from the cluster-role so that it can be deleted after the test case.
 	delete(clusterRole.Annotations, common.LifecycleDeleteAnnotation)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/cr.yaml", clusterRole))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("remove the lifecycle annotation from ClusterRole"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/cr.yaml", clusterRole))
+	nt.Must(rootSyncGitRepo.CommitAndPush("remove the lifecycle annotation from ClusterRole"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -313,6 +316,7 @@ func skipAutopilotManagedNamespace(nt *nomostest.NT, ns string) bool {
 
 func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Build list of special namespaces to test.
 	// Skip namespaces managed by GKE Autopilot, if on an Autopilot cluster
@@ -325,11 +329,11 @@ func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 
 	for ns := range specialNamespaces {
 		checkpointProtectedNamespace(nt, ns)
-		nt.Must(nt.RootRepos[configsync.RootSyncName].Add(fmt.Sprintf("acme/ns-%s.yaml", ns), k8sobjects.NamespaceObject(ns)))
+		nt.Must(rootSyncGitRepo.Add(fmt.Sprintf("acme/ns-%s.yaml", ns), k8sobjects.NamespaceObject(ns)))
 	}
 	bookstoreNS := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns-bookstore.yaml", bookstoreNS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add special namespaces and one non-special namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns-bookstore.yaml", bookstoreNS))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add special namespaces and one non-special namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -354,10 +358,10 @@ func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 	}
 
 	for ns := range specialNamespaces {
-		nt.Must(nt.RootRepos[configsync.RootSyncName].Remove(fmt.Sprintf("acme/ns-%s.yaml", ns)))
+		nt.Must(rootSyncGitRepo.Remove(fmt.Sprintf("acme/ns-%s.yaml", ns)))
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/ns-bookstore.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Remove namespaces"))
+	nt.Must(rootSyncGitRepo.Remove("acme/ns-bookstore.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Remove namespaces"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -55,6 +55,7 @@ import (
 // cluster-scoped changes are made with kubectl.
 func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
@@ -63,8 +64,8 @@ func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 	rootSync2Manager := declared.ResourceManager(declared.RootScope, rootSync2Name)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	nt.Must(nt.WatchForAllSyncs())
 
 	/* A new test */
@@ -244,6 +245,7 @@ func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 // namespace-scoped changes are made with kubectl.
 func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
@@ -252,14 +254,14 @@ func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 	rootSync2Manager := declared.ResourceManager(declared.RootScope, rootSync2Name)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
+	nt.Must(rootSyncGitRepo.Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -492,16 +494,17 @@ func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 // that Config Sync recreates the deleted object.
 func TestDriftKubectlDelete(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
+	nt.Must(rootSyncGitRepo.Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -552,16 +555,17 @@ func TestDriftKubectlDelete(t *testing.T) {
 // annotation, and verifies that Config Sync recreates the deleted object.
 func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a configmap"))
+	nt.Must(rootSyncGitRepo.Add("acme/cm.yaml", k8sobjects.ConfigMapObject(core.Name("cm-1"), core.Namespace("bookstore"))))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -612,10 +616,11 @@ func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
 // does not remove this field.
 func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -672,10 +677,11 @@ func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
 // Config Sync does not remove this field.
 func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -701,10 +707,11 @@ func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testi
 // that Config Sync corrects it.
 func TestDriftKubectlAnnotateManagedField(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -763,12 +770,13 @@ func TestDriftKubectlAnnotateManagedField(t *testing.T) {
 // Config Sync does not correct it.
 func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -810,10 +818,11 @@ func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing
 // verifies that Config Sync corrects it.
 func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -872,12 +881,13 @@ func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 // Config Sync does not correct it.
 func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespace))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -920,6 +930,7 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 // Config Sync re-adds it.
 func TestDriftRemoveApplySetPartOfLabel(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
 
@@ -932,8 +943,8 @@ func TestDriftRemoveApplySetPartOfLabel(t *testing.T) {
 
 	nsObj := k8sobjects.NamespaceObject(namespace,
 		core.Annotation("season", "summer"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("add a namespace"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Changing the ApplySet ID label value")

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -36,11 +36,12 @@ import (
 func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Add the Anvil CRD.
 	crdObj := anvilV1CRD()
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cluster/anvil-crd.yaml", crdObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding Anvil CRD"))
+	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crdObj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding Anvil CRD"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -48,12 +49,12 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 
 	// Add the v1 Anvils and verify they are created.
 	nsObj := k8sobjects.NamespaceObject("foo")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
 	anvilv1Obj := anvilCR("v1", "first", 10)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
 	anvilv2Obj := anvilCR("v2", "second", 100)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 and v2 Anvil CRs"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding v1 and v2 Anvil CRs"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -69,10 +70,10 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 
 	// Modify the v1 Anvils and verify they are updated.
 	anvilv1Obj = anvilCR("v1", "first", 20)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
 	anvilv2Obj = anvilCR("v2", "second", 200)
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modifying v1 and v2 Anvil CRs"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Modifying v1 and v2 Anvil CRs"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -185,6 +186,7 @@ func anvilGVK(version string) schema.GroupVersionKind {
 func TestMultipleVersions_RoleBinding(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rbV1 := k8sobjects.RoleBindingObject(core.Name("v1user"))
 	rbV1.RoleRef = rbacv1.RoleRef{
@@ -200,9 +202,9 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 
 	// Add the v1 RoleBinding and verify it is created.
 	nsObj := k8sobjects.NamespaceObject("foo")
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/ns.yaml", nsObj))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/rbv1.yaml", rbV1))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding v1 RoleBinding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/rbv1.yaml", rbV1))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding v1 RoleBinding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -231,8 +233,8 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 		Name:     "v1admin@acme.com",
 	})
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/foo/rbv1.yaml", rbV1))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Modifying v1 RoleBinding"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/rbv1.yaml", rbV1))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Modifying v1 RoleBinding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -254,8 +256,8 @@ func TestMultipleVersions_RoleBinding(t *testing.T) {
 	}
 
 	// Remove the v1 RoleBinding and verify that it is also deleted.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Remove("acme/namespaces/foo/rbv1.yaml"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Removing v1 RoleBinding"))
+	nt.Must(rootSyncGitRepo.Remove("acme/namespaces/foo/rbv1.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Removing v1 RoleBinding"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/namespace_selectors_test.go
+++ b/e2e/testcases/namespace_selectors_test.go
@@ -77,6 +77,7 @@ var (
 
 func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
 	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),
@@ -95,21 +96,21 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 
 	shoestoreNSS.Spec.Selector.MatchLabels = map[string]string{"app": shoestoreNS}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/namespace-selector-shoestore.yaml", shoestoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/bookstore/ns.yaml", k8sobjects2.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/shoestore/ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/cm-bookstore.yaml", bookstoreCM))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/rq-bookstore.yaml", bookstoreRQ))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/cm-shoestore.yaml", shoestoreCM))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add Namespaces, NamespaceSelectors and Namespace-scoped resources"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/namespace-selector-shoestore.yaml", shoestoreNSS))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/bookstore/ns.yaml", k8sobjects2.NamespaceObject(bookstoreNS, core.Label("app", bookstoreNS))))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/shoestore/ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/cm-bookstore.yaml", bookstoreCM))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/rq-bookstore.yaml", bookstoreRQ))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/cm-shoestore.yaml", shoestoreCM))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add Namespaces, NamespaceSelectors and Namespace-scoped resources"))
 
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, selectors.InvalidSelectorErrorCode, "NamespaceSelector MUST NOT use the dynamic mode with the hierarchy source format")
 
 	nt.T.Log("Update NamespaceSelector to use static mode with the hierarchy format")
 	bookstoreNSS.Spec.Mode = v1.NSSelectorStaticMode
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespaces/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update NamespaceSelector to use static mode"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use static mode"))
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -123,6 +124,7 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 
 func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
 	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),
@@ -140,13 +142,13 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 
 	shoestoreNSS.Spec.Selector.MatchLabels = map[string]string{"app": shoestoreNS}
 
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-shoestore.yaml", shoestoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/shoestore-ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm-bookstore.yaml", bookstoreCM))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/rq-bookstore.yaml", bookstoreRQ))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm-shoestore.yaml", shoestoreCM))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add Namespaces, NamespaceSelectors and Namespace-scoped resources"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-shoestore.yaml", shoestoreNSS))
+	nt.Must(rootSyncGitRepo.Add("acme/shoestore-ns.yaml", k8sobjects2.NamespaceObject(shoestoreNS, core.Label("app", shoestoreNS))))
+	nt.Must(rootSyncGitRepo.Add("acme/cm-bookstore.yaml", bookstoreCM))
+	nt.Must(rootSyncGitRepo.Add("acme/rq-bookstore.yaml", bookstoreRQ))
+	nt.Must(rootSyncGitRepo.Add("acme/cm-shoestore.yaml", shoestoreCM))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add Namespaces, NamespaceSelectors and Namespace-scoped resources"))
 
 	nt.Logger.Info("Only resources in shoestore are created because bookstore Namespace is not declared")
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -176,8 +178,8 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 
 	nt.Logger.Info("Update NamespaceSelector to use dynamic mode")
 	bookstoreNSS.Spec.Mode = v1.NSSelectorDynamicMode
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update NamespaceSelector to use dynamic mode"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use dynamic mode"))
 	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
@@ -241,8 +243,8 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 
 	nt.Logger.Info("Update NamespaceSelector to use static mode")
 	bookstoreNSS.Spec.Mode = v1.NSSelectorStaticMode
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update NamespaceSelector to use static mode"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use static mode"))
 
 	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
@@ -273,8 +275,8 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 
 	nt.Logger.Info("Update NamespaceSelector back to use dynamic mode")
 	bookstoreNSS.Spec.Mode = v1.NSSelectorDynamicMode
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update NamespaceSelector to use dynamic mode again"))
+	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use dynamic mode again"))
 	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -35,6 +35,8 @@ import (
 func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -76,8 +78,8 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 	// Set noSSLVerify to true for ns-reconciler-backend
 	repoSyncBackend.Spec.NoSSLVerify = true
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -98,8 +100,8 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 	// Set noSSLVerify to false from repoSyncBackend
 	repoSyncBackend.Spec.NoSSLVerify = false
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -114,6 +116,8 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -155,8 +159,8 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 	// Set noSSLVerify to true for ns-reconciler-backend
 	repoSyncBackend.Spec.NoSSLVerify = true
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -177,8 +181,8 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 	// Set noSSLVerify to false from repoSyncBackend
 	repoSyncBackend.Spec.NoSSLVerify = false
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -37,6 +37,8 @@ import (
 func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -79,8 +81,8 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend
 	var depth int64 = 33
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 33"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 33"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -105,8 +107,8 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend to 0
 	depth = 0
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 0"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 0"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -119,8 +121,8 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = &v1alpha1.RepoSyncOverrideSpec{}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -135,6 +137,8 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -177,8 +181,8 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend
 	var depth int64 = 33
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 33"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 33"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -203,8 +207,8 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend to 0
 	depth = 0
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend RepoSync git sync depth to 0"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 0"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -217,8 +221,8 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -40,6 +40,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
 		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)
@@ -169,7 +170,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
 
 	// Override the CPU/memory requests and limits of the reconciler container of ns-reconciler-frontend
 	repoSyncFrontend.Spec.Override = &v1alpha1.RepoSyncOverrideSpec{
@@ -192,8 +193,8 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend and frontend RepoSync resource limits"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend and frontend RepoSync resource limits"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -324,8 +325,8 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = nil
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -363,8 +364,8 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncFrontend
 	repoSyncFrontend.Spec.Override = nil
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -408,6 +409,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
 		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)
@@ -537,7 +539,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
 
 	// Override the CPU/memory requests and limits of the reconciler container of ns-reconciler-frontend
 	repoSyncFrontend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{
@@ -560,8 +562,8 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Update backend and frontend RepoSync resource limits"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend and frontend RepoSync resource limits"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -690,8 +692,8 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = nil
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncBackend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -729,8 +731,8 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncFrontend
 	repoSyncFrontend.Spec.Override = nil
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncFrontend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/policy_dir_test.go
+++ b/e2e/testcases/policy_dir_test.go
@@ -35,6 +35,7 @@ func TestMissingRepoErrorWithHierarchicalFormat(t *testing.T) {
 
 func TestPolicyDirUnset(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	// There are 6 cluster-scoped objects under `../../examples/acme/cluster`.
 	//
 	// Copying the whole `../../examples/acme/cluster` dir would cause the Config Sync mono-repo mode CI job to fail,
@@ -45,10 +46,10 @@ func TestPolicyDirUnset(t *testing.T) {
 	// and generates a KNV 2006 error (as shown in http://b/210525686#comment3 and http://b/210525686#comment5).
 	//
 	// Therefore, we only copy `../../examples/acme/cluster/admin-clusterrole.yaml` here.
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme/cluster/admin-clusterrole.yaml", "./cluster"))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme/namespaces", "."))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Copy("../../examples/acme/system", "."))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Initialize the root directory"))
+	nt.Must(rootSyncGitRepo.Copy("../../examples/acme/cluster/admin-clusterrole.yaml", "./cluster"))
+	nt.Must(rootSyncGitRepo.Copy("../../examples/acme/namespaces", "."))
+	nt.Must(rootSyncGitRepo.Copy("../../examples/acme/system", "."))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Initialize the root directory"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -39,17 +39,18 @@ import (
 
 func TestResourceGroupController(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	ns := "rg-test"
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(
+	nt.Must(rootSyncGitRepo.Add(
 		"acme/namespaces/rg-test/ns.yaml",
 		k8sobjects.NamespaceObject(ns)))
 
 	cmName := "e2e-test-configmap"
 	cmPath := "acme/namespaces/rg-test/configmap.yaml"
 	cm := k8sobjects.ConfigMapObject(core.Name(cmName), core.Namespace(ns))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add(cmPath, cm))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Adding a ConfigMap to repo"))
+	nt.Must(rootSyncGitRepo.Add(cmPath, cm))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Adding a ConfigMap to repo"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -39,6 +39,7 @@ import (
 
 func TestStatusEnabledAndDisabled(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	id := applier.InventoryID(configsync.RootSyncName, configsync.ControllerNamespace)
 
 	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
@@ -49,9 +50,9 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 	}
 
 	namespaceName := "status-test"
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/ns.yaml", namespaceObject(namespaceName, nil)))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].Add("acme/cm1.yaml", k8sobjects.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName))))
-	nt.Must(nt.RootRepos[configsync.RootSyncName].CommitAndPush("Add a namespace and a configmap"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespaceObject(namespaceName, nil)))
+	nt.Must(rootSyncGitRepo.Add("acme/cm1.yaml", k8sobjects.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName))))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Add a namespace and a configmap"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -350,8 +350,10 @@ func TestWorkloadIdentity(t *testing.T) {
 			nt.T.Logf("Update RootSync and RepoSync to sync from %s", tc.sourceType)
 			switch tc.sourceType {
 			case configsync.GitSource:
-				rootMeta = updateRSyncWithGitSourceConfig(nt, rootSync, nt.RootRepos[configsync.RootSyncName], tc.rootSrcCfg)
-				nsMeta = updateRSyncWithGitSourceConfig(nt, repoSync, nt.NonRootRepos[nsRef], tc.nsSrcCfg)
+				rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+				rootMeta = updateRSyncWithGitSourceConfig(nt, rootSync, rootSyncGitRepo, tc.rootSrcCfg)
+				repoSyncGitRepo := nt.SyncSourceGitRepository(nomostest.RepoSyncID(nsRef.Name, nsRef.Namespace))
+				nsMeta = updateRSyncWithGitSourceConfig(nt, repoSync, repoSyncGitRepo, tc.nsSrcCfg)
 			case configsync.HelmSource:
 				rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rsRef, tc.rootSrcCfg)
 				if err != nil {


### PR DESCRIPTION
Merge the 4 maps tracking git and helm sources into a map of SyncSources.

For now, the OCISyncSource is a placeholder, since this PR is already a mega huge refactor.