### PR TITLE
e2e: simplify RSync test setup

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/gitproviders"
@@ -95,7 +94,7 @@ var (
 	// DefaultRootRepoNamespacedName is the NamespacedName of the default RootSync object.
 	DefaultRootRepoNamespacedName = RootSyncNN(configsync.RootSyncName)
 	// DefaultRootSyncID is the ID of the default RootSync object.
-	DefaultRootSyncID = RootSyncID(configsync.RootSyncName)
+	DefaultRootSyncID = core.RootSyncID(configsync.RootSyncName)
 )
 
 // RootSyncNN returns the NamespacedName of the RootSync object.
@@ -111,34 +110,6 @@ func RepoSyncNN(ns, name string) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: ns,
 		Name:      name,
-	}
-}
-
-// RootSyncID returns an ID for the specified RootSync object.
-func RootSyncID(name string) core.ID {
-	return core.ID{
-		GroupKind: schema.GroupKind{
-			Group: v1beta1.SchemeGroupVersion.Group,
-			Kind:  configsync.RootSyncKind,
-		},
-		ObjectKey: client.ObjectKey{
-			Name:      name,
-			Namespace: configsync.ControllerNamespace,
-		},
-	}
-}
-
-// RepoSyncID returns an ID for the specified RepoSync object.
-func RepoSyncID(name, namespace string) core.ID {
-	return core.ID{
-		GroupKind: schema.GroupKind{
-			Group: v1beta1.SchemeGroupVersion.Group,
-			Kind:  configsync.RepoSyncKind,
-		},
-		ObjectKey: client.ObjectKey{
-			Name:      name,
-			Namespace: namespace,
-		},
 	}
 }
 
@@ -770,14 +741,14 @@ func RootSyncObjectV1Alpha1(name, repoURL string, sourceFormat configsync.Source
 // uses a RootSync repo from nt.SyncSources.
 func RootSyncObjectV1Alpha1FromRootRepo(nt *NT, name string) *v1alpha1.RootSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	id := RootSyncID(name)
+	id := core.RootSyncID(name)
 	source, found := nt.SyncSources[id]
 	if !found {
-		nt.T.Fatal("nonexistent %s source: %s", id.Kind, id.ObjectKey)
+		nt.T.Fatalf("nonexistent %s source: %s", id.Kind, id.ObjectKey)
 	}
 	gitSource, ok := source.(*syncsource.GitSyncSource)
 	if !ok {
-		nt.T.Fatal("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
+		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
 	}
 	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
 	sourceFormat := gitSource.Repository.Format
@@ -825,14 +796,14 @@ func RootSyncObjectV1Beta1(name, repoURL string, sourceFormat configsync.SourceF
 // uses a RootSync repo from nt.SyncSources.
 func RootSyncObjectV1Beta1FromRootRepo(nt *NT, name string) *v1beta1.RootSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	id := RootSyncID(name)
+	id := core.RootSyncID(name)
 	source, found := nt.SyncSources[id]
 	if !found {
-		nt.T.Fatal("nonexistent %s source: %s", id.Kind, id.ObjectKey)
+		nt.T.Fatalf("nonexistent %s source: %s", id.Kind, id.ObjectKey)
 	}
 	gitSource, ok := source.(*syncsource.GitSyncSource)
 	if !ok {
-		nt.T.Fatal("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
+		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
 	}
 	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
 	sourceFormat := gitSource.Repository.Format
@@ -849,14 +820,14 @@ func RootSyncObjectV1Beta1FromRootRepo(nt *NT, name string) *v1beta1.RootSync {
 // uses a repo from a specific nt.RootRepo.
 func RootSyncObjectV1Beta1FromOtherRootRepo(nt *NT, syncName, repoName string) *v1beta1.RootSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	repoID := RootSyncID(repoName)
+	repoID := core.RootSyncID(repoName)
 	source, found := nt.SyncSources[repoID]
 	if !found {
-		nt.T.Fatal("nonexistent %s source: %s", repoID.Kind, repoID.ObjectKey)
+		nt.T.Fatalf("nonexistent %s source: %s", repoID.Kind, repoID.ObjectKey)
 	}
 	gitSource, ok := source.(*syncsource.GitSyncSource)
 	if !ok {
-		nt.T.Fatal("expected SyncSources for %s to have *GitSyncSource, but got %T", repoID, source)
+		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", repoID, source)
 	}
 	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
 	sourceFormat := gitSource.Repository.Format
@@ -909,14 +880,14 @@ func RepoSyncObjectV1Alpha1(nn types.NamespacedName, repoURL string) *v1alpha1.R
 // uses a RepoSync repo from nt.SyncSources.
 func RepoSyncObjectV1Alpha1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1alpha1.RepoSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	id := RepoSyncID(nn.Name, nn.Namespace)
+	id := core.RepoSyncID(nn.Name, nn.Namespace)
 	source, found := nt.SyncSources[id]
 	if !found {
-		nt.T.Fatal("nonexistent %s source: %s", id.Kind, id.ObjectKey)
+		nt.T.Fatalf("nonexistent %s source: %s", id.Kind, id.ObjectKey)
 	}
 	gitSource, ok := source.(*syncsource.GitSyncSource)
 	if !ok {
-		nt.T.Fatal("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
+		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
 	}
 	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
 	// RepoSync is always Unstructured. So ignore repo.Format.
@@ -1028,7 +999,7 @@ func (nt *NT) RepoSyncObjectOCI(nn types.NamespacedName, image *registryprovider
 
 // RootSyncObjectHelm returns a RootSync object that syncs the provided HelmPackage
 func (nt *NT) RootSyncObjectHelm(name string, chartID registryproviders.HelmChartID) *v1beta1.RootSync {
-	id := RootSyncID(name)
+	id := core.RootSyncID(name)
 	source, found := nt.SyncSources[id]
 	if found {
 		if helmSource, ok := source.(*syncsource.HelmSyncSource); ok {
@@ -1085,7 +1056,7 @@ func (nt *NT) RootSyncObjectHelm(name string, chartID registryproviders.HelmChar
 
 // RepoSyncObjectHelm returns a RepoSync object that syncs the provided HelmPackage
 func (nt *NT) RepoSyncObjectHelm(nn types.NamespacedName, chartID registryproviders.HelmChartID) *v1beta1.RepoSync {
-	id := RepoSyncID(nn.Name, nn.Namespace)
+	id := core.RepoSyncID(nn.Name, nn.Namespace)
 	source, found := nt.SyncSources[id]
 	if found {
 		if helmSource, ok := source.(*syncsource.HelmSyncSource); ok {
@@ -1148,7 +1119,7 @@ func (nt *NT) RepoSyncObjectHelm(nn types.NamespacedName, chartID registryprovid
 // uses a RepoSync repo from nt.SyncSources.
 func RepoSyncObjectV1Beta1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1beta1.RepoSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	id := RepoSyncID(nn.Name, nn.Namespace)
+	id := core.RepoSyncID(nn.Name, nn.Namespace)
 	source, found := nt.SyncSources[id]
 	if !found {
 		nt.T.Fatal("nonexistent %s source: %s", id.Kind, id.ObjectKey)
@@ -1176,7 +1147,7 @@ func RepoSyncObjectV1Beta1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1be
 // uses a RootSync repo from nt.SyncSources.
 func RepoSyncObjectV1Beta1FromOtherRootRepo(nt *NT, nn types.NamespacedName, repoName string) *v1beta1.RepoSync {
 	// TODO: Allow supplying the Repository, instead of requiring it to already exist
-	repoID := RootSyncID(repoName)
+	repoID := core.RootSyncID(repoName)
 	source, found := nt.SyncSources[repoID]
 	if !found {
 		nt.T.Fatal("nonexistent %s source: %s", repoID.Kind, repoID.ObjectKey)
@@ -1205,7 +1176,7 @@ func RepoSyncObjectV1Beta1FromOtherRootRepo(nt *NT, nn types.NamespacedName, rep
 func setupCentralizedControl(nt *NT) {
 	nt.T.Log("[SETUP] Centralized control")
 
-	rootSyncID := RootSyncID(configsync.RootSyncName)
+	rootSyncID := core.RootSyncID(configsync.RootSyncName)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 
 	// Add any RootSyncs specified by the test options

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -407,7 +407,7 @@ func (nt *NT) SyncSourceGitRepository(id core.ID) *gitproviders.Repository {
 // DefaultRootSha1Fn is the default function to retrieve the commit hash of the root repo.
 func DefaultRootSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 	// Get the repository this RootSync is syncing to, and ensure it is synced to HEAD.
-	source, exists := nt.SyncSources[RootSyncID(nn.Name)]
+	source, exists := nt.SyncSources[core.RootSyncID(nn.Name)]
 	if !exists {
 		return "", fmt.Errorf("nt.SyncSources doesn't include RootSync %q", nn)
 	}
@@ -418,7 +418,7 @@ func DefaultRootSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 func DefaultRepoSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 	// Get the repository this RepoSync is syncing to, and ensure it is synced
 	// to HEAD.
-	source, exists := nt.SyncSources[RepoSyncID(nn.Name, nn.Namespace)]
+	source, exists := nt.SyncSources[core.RepoSyncID(nn.Name, nn.Namespace)]
 	if !exists {
 		return "", fmt.Errorf("nt.SyncSources doesn't include RepoSync %q", nn)
 	}

--- a/e2e/nomostest/prometheus_metrics.go
+++ b/e2e/nomostest/prometheus_metrics.go
@@ -28,6 +28,7 @@ import (
 	testmetrics "kpt.dev/configsync/e2e/nomostest/metrics"
 	"kpt.dev/configsync/e2e/nomostest/retry"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metrics"
 	ocmetrics "kpt.dev/configsync/pkg/metrics"
@@ -132,7 +133,7 @@ func MetricLabelsForRepoSync(nt *NT, syncNN types.NamespacedName) (prometheusmod
 // ValidateStandardMetricsForRootSync validates the set of standard metrics for
 // the specified RootSync.
 func ValidateStandardMetricsForRootSync(nt *NT, summary testmetrics.Summary) error {
-	id := RootSyncID(summary.Sync.Name)
+	id := core.RootSyncID(summary.Sync.Name)
 	source, found := nt.SyncSources[id]
 	if !found {
 		return fmt.Errorf("SyncSource not found for %s: %s", id.Kind, id.ObjectKey)
@@ -151,7 +152,7 @@ func ValidateStandardMetricsForRootSync(nt *NT, summary testmetrics.Summary) err
 // ValidateStandardMetricsForRepoSync validates the set of standard metrics for
 // the specified RootSync.
 func ValidateStandardMetricsForRepoSync(nt *NT, summary testmetrics.Summary) error {
-	id := RepoSyncID(summary.Sync.Name, summary.Sync.Namespace)
+	id := core.RepoSyncID(summary.Sync.Name, summary.Sync.Namespace)
 	source, found := nt.SyncSources[id]
 	if !found {
 		return fmt.Errorf("SyncSource not found for %s: %s", id.Kind, id.ObjectKey)

--- a/e2e/nomostest/syncsource/syncsource.go
+++ b/e2e/nomostest/syncsource/syncsource.go
@@ -29,6 +29,7 @@ type SyncSource interface {
 	// Commit returns the current/latest "commit" for this source.
 	// The commit value is used to validate RSync status and metrics.
 	Commit() (string, error)
+	// TODO: Add SourceFormat
 }
 
 // GitSyncSource is the "git" source, backed by a Git repository.

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -224,8 +224,10 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 }
 
 func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.NamespaceRepo(namespaceRepo, configsync.RepoSyncName), ntopts.RepoSyncPermissions(policy.CoreAdmin()))
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName),
+		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
 	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(namespaceRepo))

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1194,10 +1194,10 @@ func TestNomosStatusNameFilter(t *testing.T) {
 		t,
 		nomostesting.NomosCLI,
 		ntopts.Unstructured,
-		ntopts.RootRepo(crontab),
+		ntopts.RootSyncWithGitSource(crontab),
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin()),
-		ntopts.NamespaceRepo(bookRepo.Namespace, bookRepo.Name),
-		ntopts.NamespaceRepo(crontabRepo.Namespace, crontabRepo.Name),
+		ntopts.RepoSyncWithGitSource(bookRepo.Namespace, bookRepo.Name),
+		ntopts.RepoSyncWithGitSource(crontabRepo.Namespace, crontabRepo.Name),
 	)
 
 	// get status with only name filter crontab-sync

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -604,10 +604,10 @@ func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Selector,
-		ntopts.NamespaceRepo(namespaceRepo, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages rolebindings
 	)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -83,7 +83,7 @@ func TestComposition(t *testing.T) {
 		ntopts.Unstructured,
 		ntopts.WithDelegatedControl,
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin(), policy.CoreAdmin()), // NS reconciler manages RepoSyncs and ConfigMaps
-		ntopts.RootRepo(lvl0ID.Name))
+		ntopts.RootSyncWithGitSource(lvl0ID.Name))
 
 	lvl0NN := lvl0ID.ObjectKey
 	lvl1NN := nomostest.RootSyncNN("level-1")

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testutils"
 	"kpt.dev/configsync/e2e/nomostest/workloadidentity"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 )
@@ -53,11 +54,11 @@ func TestGCENodeCSR(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireCloudSourceRepository(t),
-		ntopts.NamespaceRepo(testNs, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, testNs)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
@@ -114,7 +115,7 @@ func TestGCENodeOCI(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireOCIArtifactRegistry(t),
-		ntopts.NamespaceRepo(testNs, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 
@@ -189,7 +190,7 @@ func TestGCENodeHelm(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireHelmArtifactRegistry(t),
-		ntopts.NamespaceRepo(testNs, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -463,7 +463,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
-		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+		ntopts.RepoSyncWithGitSource(repoSyncNN.Namespace, repoSyncNN.Name))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Build a Helm chart with cluster-scoped resources")
@@ -506,7 +506,7 @@ func TestHelmConfigMapNamespaceRepo(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()),
-		ntopts.NamespaceRepo(repoSyncNN.Namespace, repoSyncNN.Name))
+		ntopts.RepoSyncWithGitSource(repoSyncNN.Namespace, repoSyncNN.Name))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	cmName := "helm-cm-ns-repo-1"
 

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -24,6 +24,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/status"
 )
@@ -65,9 +66,9 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 }
 
 func TestInvalidRepoSyncBranchStatus(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.NamespaceRepo(namespaceRepo, configsync.RepoSyncName))
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -52,11 +52,11 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(bsNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(bsNamespace, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 		ntopts.WithCentralizedControl,
 	)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, bsNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, bsNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
@@ -324,11 +324,11 @@ func TestNamespaceRepo_Delegated(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(bsNamespaceRepo, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(bsNamespaceRepo, configsync.RepoSyncName),
 		ntopts.WithDelegatedControl,
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 	)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, bsNamespaceRepo)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, bsNamespaceRepo)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
@@ -369,7 +369,7 @@ func TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(bsNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(bsNamespace, configsync.RepoSyncName),
 		ntopts.WithDelegatedControl,
 	)
 
@@ -403,11 +403,11 @@ func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(bsNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(bsNamespace, configsync.RepoSyncName),
 		ntopts.WithCentralizedControl,
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, bsNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, bsNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 
 	secretNames := getNsReconcilerSecrets(nt, bsNamespace)
@@ -472,8 +472,8 @@ func TestManageSelfRepoSync(t *testing.T) {
 	bsNamespace := "bookstore"
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
-		ntopts.NamespaceRepo(bsNamespace, configsync.RepoSyncName))
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, bsNamespace)
+		ntopts.RepoSyncWithGitSource(bsNamespace, configsync.RepoSyncName))
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, bsNamespace)
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
 	rs := &v1beta1.RepoSync{}
@@ -540,13 +540,13 @@ func TestDeleteNamespaceReconcilerDeployment(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(bsNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(bsNamespace, configsync.RepoSyncName),
 		ntopts.WithCentralizedControl,
 	)
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, bsNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, bsNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/namespace_strategy_test.go
+++ b/e2e/testcases/namespace_strategy_test.go
@@ -168,14 +168,14 @@ func TestNamespaceStrategy(t *testing.T) {
 // the namespace should only be created if declared explicitly in a sync source.
 func TestNamespaceStrategyMultipleRootSyncs(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	rootSyncAID := nomostest.RootSyncID("sync-a")
-	rootSyncXID := nomostest.RootSyncID("sync-x")
-	rootSyncYID := nomostest.RootSyncID("sync-y")
+	rootSyncAID := core.RootSyncID("sync-a")
+	rootSyncXID := core.RootSyncID("sync-x")
+	rootSyncYID := core.RootSyncID("sync-y")
 	namespaceA := k8sobjects.NamespaceObject("namespace-a")
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.RootRepo(rootSyncAID.Name), // will declare namespace-a explicitly
-		ntopts.RootRepo(rootSyncXID.Name), // will declare resources in namespace-a, but not namespace-a itself
-		ntopts.RootRepo(rootSyncYID.Name), // will declare resources in namespace-a, but not namespace-a itself
+		ntopts.RootSyncWithGitSource(rootSyncAID.Name), // will declare namespace-a explicitly
+		ntopts.RootSyncWithGitSource(rootSyncXID.Name), // will declare resources in namespace-a, but not namespace-a itself
+		ntopts.RootSyncWithGitSource(rootSyncYID.Name), // will declare resources in namespace-a, but not namespace-a itself
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSyncAGitRepo := nt.SyncSourceGitRepository(rootSyncAID)

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -115,7 +115,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -113,13 +113,13 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 	namespace := testNs
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireOCIProvider,
-		ntopts.NamespaceRepo(namespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(namespace, configsync.RepoSyncName),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount
 		ntopts.RepoSyncPermissions(policy.RBACAdmin(), policy.CoreAdmin()),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
@@ -179,12 +179,12 @@ func TestSwitchFromGitToOciDelegated(t *testing.T) {
 	namespace := testNs
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.WithDelegatedControl, ntopts.RequireOCIProvider,
-		ntopts.NamespaceRepo(namespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(namespace, configsync.RepoSyncName),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount
 		ntopts.RepoSyncPermissions(policy.RBACAdmin(), policy.CoreAdmin()),
 	)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, namespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -136,7 +136,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 
 func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -145,9 +145,9 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 
 func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(frontendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, frontendNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, frontendNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -38,8 +38,8 @@ import (
 
 func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
-		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(frontendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
@@ -407,8 +407,8 @@ func lookupAlphaRepoSyncReconcilerContainerResources(nt *nomostest.NT, rs *v1alp
 
 func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
-		ntopts.NamespaceRepo(frontendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(frontendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestRootSyncRoleRefs(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.RootRepo("sync-a"),
+		ntopts.RootSyncWithGitSource("sync-a"),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, "sync-a")

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -68,9 +68,9 @@ func secretDataDeletePatch(key string) string {
 
 func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, backendNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
@@ -190,9 +190,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 
 func TestCACertSecretRefV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, backendNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
@@ -317,9 +317,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 
 func TestCACertSecretWatch(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, backendNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
@@ -441,10 +441,10 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireLocalOCIProvider,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, backendNamespace)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncReconcilerName := core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name)
 
@@ -559,7 +559,7 @@ func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireLocalHelmProvider,
-		ntopts.NamespaceRepo(backendNamespace, configsync.RepoSyncName),
+		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -230,10 +230,10 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 // finalizer correctly handles multiple layers of Foreground deletion propagation.
 func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	repoSyncID := nomostest.RepoSyncID("rs-test", testNs)
+	repoSyncID := core.RepoSyncID("rs-test", testNs)
 	nt := nomostest.New(t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
@@ -360,10 +360,10 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 // The RootSync has Foreground policy, but manages a RepoSync with Orphan policy.
 func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	repoSyncID := nomostest.RepoSyncID("rs-test", testNs)
+	repoSyncID := core.RepoSyncID("rs-test", testNs)
 	nt := nomostest.New(t,
 		nomostesting.MultiRepos,
-		ntopts.NamespaceRepo(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
@@ -511,14 +511,14 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 // RootSync should be blocked until the Namespace finalizer is removed.
 func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	rootSync2ID := nomostest.RootSyncID("nested-root-sync")
+	rootSync2ID := core.RootSyncID("nested-root-sync")
 	namespaceNN := types.NamespacedName{Name: "managed-ns"}
 	contrivedFinalizer := "e2e-test"
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.Unstructured,
-		ntopts.RootRepo(rootSync2ID.Name),           // Create a nested RootSync to delete mid-test
-		ntopts.WithCentralizedControl,               // This test assumes centralized control
-		ntopts.WithReconcileTimeout(10*time.Second), // Reconcile expected to fail, so use a short timeout
+		ntopts.RootSyncWithGitSource(rootSync2ID.Name), // Create a nested RootSync to delete mid-test
+		ntopts.WithCentralizedControl,                  // This test assumes centralized control
+		ntopts.WithReconcileTimeout(10*time.Second),    // Reconcile expected to fail, so use a short timeout
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -63,7 +63,7 @@ func TestReconcilerManagerNormalTeardown(t *testing.T) {
 	testNamespace := "teardown"
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.WithDelegatedControl, ntopts.Unstructured,
-		ntopts.NamespaceRepo(testNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(testNamespace, configsync.RepoSyncName))
 
 	t.Log("Validate the reconciler-manager deployment")
 	reconcilerManager := &appsv1.Deployment{}
@@ -122,7 +122,7 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 	testNamespace := "invalid-teardown"
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.WithDelegatedControl, ntopts.Unstructured,
-		ntopts.NamespaceRepo(testNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(testNamespace, configsync.RepoSyncName))
 
 	t.Log("Validate the reconciler-manager deployment")
 	reconcilerManager := &appsv1.Deployment{}
@@ -295,7 +295,7 @@ func TestReconcilerManagerTeardownRepoSyncWithReconcileTimeout(t *testing.T) {
 	testNamespace := "reconcile-timeout"
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.WithDelegatedControl, ntopts.Unstructured,
-		ntopts.NamespaceRepo(testNamespace, configsync.RepoSyncName))
+		ntopts.RepoSyncWithGitSource(testNamespace, configsync.RepoSyncName))
 
 	repoSync := &v1beta1.RepoSync{}
 	repoSync.Name = configsync.RepoSyncName
@@ -1171,11 +1171,11 @@ func filterResourceMap(resourceMap map[string]v1beta1.ContainerResourcesSpec, co
 func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	repoSyncNS := "bookstore"
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, repoSyncNS)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, repoSyncNS)
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.WithDelegatedControl, // Delegated so deleting the RootSync doesn't delete the RepoSyncs.
 		ntopts.Unstructured,
-		ntopts.NamespaceRepo(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 	)
 	rootSyncKey := rootSyncID.ObjectKey

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -127,9 +127,11 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 }
 
 func TestRepoSyncSSHKnownHost(t *testing.T) {
-	repoSyncID := nomostest.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider, ntopts.Unstructured,
-		ntopts.NamespaceRepo(repoSyncID.Namespace, repoSyncID.Name), ntopts.WithDelegatedControl,
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
+	nt := nomostest.New(t,
+		nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+		ntopts.Unstructured, ntopts.WithDelegatedControl,
+		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -274,7 +274,7 @@ func TestWorkloadIdentity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
 			opts := []ntopts.Opt{ntopts.Unstructured, ntopts.RequireGKE(t),
-				ntopts.NamespaceRepo(testNs, configsync.RepoSyncName),
+				ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
 				ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 				ntopts.WithDelegatedControl}
 			if tc.requireHelmGAR {
@@ -352,7 +352,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			case configsync.GitSource:
 				rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 				rootMeta = updateRSyncWithGitSourceConfig(nt, rootSync, rootSyncGitRepo, tc.rootSrcCfg)
-				repoSyncGitRepo := nt.SyncSourceGitRepository(nomostest.RepoSyncID(nsRef.Name, nsRef.Namespace))
+				repoSyncGitRepo := nt.SyncSourceGitRepository(core.RepoSyncID(nsRef.Name, nsRef.Namespace))
 				nsMeta = updateRSyncWithGitSourceConfig(nt, repoSync, repoSyncGitRepo, tc.nsSrcCfg)
 			case configsync.HelmSource:
 				rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rsRef, tc.rootSrcCfg)

--- a/pkg/core/id.go
+++ b/pkg/core/id.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -67,4 +69,32 @@ func GKNNs(objs []client.Object) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+// RootSyncID returns an ID for the specified RootSync object.
+func RootSyncID(name string) ID {
+	return ID{
+		GroupKind: schema.GroupKind{
+			Group: v1beta1.SchemeGroupVersion.Group,
+			Kind:  configsync.RootSyncKind,
+		},
+		ObjectKey: client.ObjectKey{
+			Name:      name,
+			Namespace: configsync.ControllerNamespace,
+		},
+	}
+}
+
+// RepoSyncID returns an ID for the specified RepoSync object.
+func RepoSyncID(name, namespace string) ID {
+	return ID{
+		GroupKind: schema.GroupKind{
+			Group: v1beta1.SchemeGroupVersion.Group,
+			Kind:  configsync.RepoSyncKind,
+		},
+		ObjectKey: client.ObjectKey{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
 }


### PR DESCRIPTION
- Combine RootRepos and NonRootRepos to use syncsource.Set.
- Rename NT.New options to be more clear about what they do.
- Move RootSyncID and RepoSyncID to the core package, to allow use in ntopts without import cycle.