### PR TITLE
e2e: simplify test sync setup more

### DIFF
--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -59,22 +59,11 @@ type MultiRepo struct {
 	RepoSyncPermissions []rbacv1.PolicyRule
 }
 
-// RepoSyncWithGitSource tells the test case that a RepoSync should be applied
-// that points to an empty Git Repository.
+// SyncWithGitSource tells the test case that a RootSync or RepoSync should be
+// applied that points to an empty Git Repository.
 // TODO: Add another option that allows specifying an existing Repository
-func RepoSyncWithGitSource(ns, name string) func(opt *New) {
+func SyncWithGitSource(id core.ID) func(opt *New) {
 	return func(opt *New) {
-		id := core.RepoSyncID(name, ns)
-		opt.SyncSources[id] = &syncsource.GitSyncSource{}
-	}
-}
-
-// RootSyncWithGitSource tells the test case that a RootSync should be applied
-// that points to an empty Git Repository.
-// TODO: Add another option that allows specifying an existing Repository
-func RootSyncWithGitSource(name string) func(opt *New) {
-	return func(opt *New) {
-		id := core.RootSyncID(name)
 		opt.SyncSources[id] = &syncsource.GitSyncSource{}
 	}
 }

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -224,10 +224,10 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 }
 
 func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource,
-		ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName),
-		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(repoSyncID),
+		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
 	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(namespaceRepo))

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1186,18 +1186,17 @@ func TestNomosVersion(t *testing.T) {
 
 func TestNomosStatusNameFilter(t *testing.T) {
 	bookinfoNS := "bookinfo"
-	bookinfoRS := "bookinfo-repo-sync"
-	crontab := "crontab-sync"
-	bookRepo := nomostest.RepoSyncNN(bookinfoNS, bookinfoRS)
-	crontabRepo := nomostest.RepoSyncNN(bookinfoNS, crontab)
+	rootSync1ID := core.RootSyncID("crontab-sync")
+	repoSync1ID := core.RepoSyncID("bookinfo-repo-sync", bookinfoNS)
+	repoSync2ID := core.RepoSyncID("crontab-sync", bookinfoNS)
 	nt := nomostest.New(
 		t,
 		nomostesting.NomosCLI,
 		ntopts.Unstructured,
-		ntopts.RootSyncWithGitSource(crontab),
+		ntopts.SyncWithGitSource(rootSync1ID),
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin()),
-		ntopts.RepoSyncWithGitSource(bookRepo.Namespace, bookRepo.Name),
-		ntopts.RepoSyncWithGitSource(crontabRepo.Namespace, crontabRepo.Name),
+		ntopts.SyncWithGitSource(repoSync1ID),
+		ntopts.SyncWithGitSource(repoSync2ID),
 	)
 
 	// get status with only name filter crontab-sync

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -602,12 +602,12 @@ func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 }
 
 func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	nt := nomostest.New(t,
 		nomostesting.Selector,
-		ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages rolebindings
 	)
-	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -83,7 +83,7 @@ func TestComposition(t *testing.T) {
 		ntopts.Unstructured,
 		ntopts.WithDelegatedControl,
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin(), policy.CoreAdmin()), // NS reconciler manages RepoSyncs and ConfigMaps
-		ntopts.RootSyncWithGitSource(lvl0ID.Name))
+		ntopts.SyncWithGitSource(lvl0ID))
 
 	lvl0NN := lvl0ID.ObjectKey
 	lvl1NN := nomostest.RootSyncNN("level-1")

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -51,14 +51,14 @@ const (
 // Public documentation:
 // https://cloud.google.com/anthos-config-management/docs/how-to/installing-config-sync#git-creds-secret
 func TestGCENodeCSR(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireCloudSourceRepository(t),
-		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
@@ -112,10 +112,11 @@ func TestGCENodeCSR(t *testing.T) {
 //   - `roles/artifactregistry.reader` for access image in Artifact Registry.
 //   - `roles/containerregistry.ServiceAgent` for access image in Container Registry.
 func TestGCENodeOCI(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireOCIArtifactRegistry(t),
-		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 
@@ -138,7 +139,7 @@ func TestGCENodeOCI(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	repoSyncRef := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
+	repoSyncRef := repoSyncID.ObjectKey
 	nsImage, err := nt.BuildAndPushOCIImage(
 		repoSyncRef,
 		registryproviders.ImageSourcePackage("hydration/namespace-repo"),
@@ -187,10 +188,11 @@ func TestGCENodeOCI(t *testing.T) {
 // 2. The Compute Engine default service account `PROJECT_ID-compute@developer.gserviceaccount.com` needs to have the following role:
 //   - `roles/artifactregistry.reader` for access image in Artifact Registry.
 func TestGCENodeHelm(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireHelmArtifactRegistry(t),
-		ntopts.RepoSyncWithGitSource(testNs, configsync.RepoSyncName),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
 
@@ -209,7 +211,7 @@ func TestGCENodeHelm(t *testing.T) {
 	rootSyncHelm.Spec.Helm.ReleaseName = "my-coredns"
 	nt.Must(nt.KubeClient.Apply(rootSyncHelm))
 
-	repoSyncRef := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
+	repoSyncRef := repoSyncID.ObjectKey
 	nsChart, err := nt.BuildAndPushHelmPackage(repoSyncRef,
 		registryproviders.HelmSourceChart("ns-chart"))
 	if err != nil {

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -460,10 +460,11 @@ func TestHelmVersionRange(t *testing.T) {
 // Running this test on Artifact Registry has following pre-requisites:
 // Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
 func TestHelmNamespaceRepo(t *testing.T) {
-	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
+	repoSyncNN := repoSyncID.ObjectKey
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
-		ntopts.RepoSyncWithGitSource(repoSyncNN.Namespace, repoSyncNN.Name))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Build a Helm chart with cluster-scoped resources")
@@ -503,10 +504,11 @@ func TestHelmNamespaceRepo(t *testing.T) {
 // This test will work only with following pre-requisites:
 // Google service account `e2e-test-ar-reader@${GCP_PROJECT}.iam.gserviceaccount.com` is created with `roles/artifactregistry.reader` for accessing images in Artifact Registry.
 func TestHelmConfigMapNamespaceRepo(t *testing.T) {
-	repoSyncNN := nomostest.RepoSyncNN(testNs, configsync.RepoSyncName)
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
+	repoSyncNN := repoSyncID.ObjectKey
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()),
-		ntopts.RepoSyncWithGitSource(repoSyncNN.Namespace, repoSyncNN.Name))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	cmName := "helm-cm-ns-repo-1"
 

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -66,9 +66,10 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 }
 
 func TestInvalidRepoSyncBranchStatus(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RepoSyncWithGitSource(namespaceRepo, configsync.RepoSyncName))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(repoSyncID))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -83,14 +83,14 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	repoSync5Key := repoSync5ID.ObjectKey
 	testNs2 := "ns-2"
 	repoSync6ID := core.RepoSyncID(repoSync1ID.Name, testNs2)
-	repoSync6Key := repoSync6ID.ObjectKey
 
 	nt := nomostest.New(t, nomostesting.MultiRepos, ntopts.Unstructured,
-		ntopts.WithDelegatedControl, ntopts.RootSyncWithGitSource(rootSync1ID.Name),
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(rootSync1ID),
 		// NS reconciler allowed to manage RepoSyncs but not RoleBindings
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin()),
-		ntopts.RepoSyncWithGitSource(repoSync1Key.Namespace, repoSync1Key.Name),
-		ntopts.RepoSyncWithGitSource(repoSync6Key.Namespace, repoSync6Key.Name))
+		ntopts.SyncWithGitSource(repoSync1ID),
+		ntopts.SyncWithGitSource(repoSync6ID))
 	rootSync0GitRepo := nt.SyncSourceGitRepository(rootSync0ID)
 	rootSync1GitRepo := nt.SyncSourceGitRepository(rootSync1ID)
 
@@ -301,7 +301,7 @@ func TestConflictingDefinitions_RootToNamespace(t *testing.T) {
 	rootSyncKey := rootSyncID.ObjectKey
 	repoSyncKey := repoSyncID.ObjectKey
 	nt := nomostest.New(t, nomostesting.MultiRepos,
-		ntopts.RepoSyncWithGitSource(repoSyncKey.Namespace, repoSyncKey.Name),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS Reconciler manages Roles
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
@@ -422,7 +422,7 @@ func TestConflictingDefinitions_NamespaceToRoot(t *testing.T) {
 	rootSyncKey := rootSyncID.ObjectKey
 	repoSyncKey := repoSyncID.ObjectKey
 	nt := nomostest.New(t, nomostesting.MultiRepos,
-		ntopts.RepoSyncWithGitSource(repoSyncKey.Namespace, repoSyncKey.Name),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages Roles
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
@@ -555,7 +555,7 @@ func TestConflictingDefinitions_RootToRoot(t *testing.T) {
 	// If declaring RootSync in a Root repo, the source format has to be unstructured.
 	// Otherwise, the hierarchical validator will complain that the config-management-system has configs but missing a Namespace config.
 	nt := nomostest.New(t, nomostesting.MultiRepos, ntopts.Unstructured,
-		ntopts.RootSyncWithGitSource(rootSync2ID.Name))
+		ntopts.SyncWithGitSource(rootSync2ID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)
 
@@ -678,8 +678,8 @@ func TestConflictingDefinitions_NamespaceToNamespace(t *testing.T) {
 
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages Roles
-		ntopts.RepoSyncWithGitSource(repoSync1ID.Namespace, repoSync1ID.Name),
-		ntopts.RepoSyncWithGitSource(repoSync2ID.Namespace, repoSync2ID.Name))
+		ntopts.SyncWithGitSource(repoSync1ID),
+		ntopts.SyncWithGitSource(repoSync2ID))
 
 	repoSync1GitRepo := nt.SyncSourceGitRepository(repoSync1ID)
 	repoSync2GitRepo := nt.SyncSourceGitRepository(repoSync2ID)

--- a/e2e/testcases/namespace_strategy_test.go
+++ b/e2e/testcases/namespace_strategy_test.go
@@ -173,9 +173,9 @@ func TestNamespaceStrategyMultipleRootSyncs(t *testing.T) {
 	rootSyncYID := core.RootSyncID("sync-y")
 	namespaceA := k8sobjects.NamespaceObject("namespace-a")
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.RootSyncWithGitSource(rootSyncAID.Name), // will declare namespace-a explicitly
-		ntopts.RootSyncWithGitSource(rootSyncXID.Name), // will declare resources in namespace-a, but not namespace-a itself
-		ntopts.RootSyncWithGitSource(rootSyncYID.Name), // will declare resources in namespace-a, but not namespace-a itself
+		ntopts.SyncWithGitSource(rootSyncAID), // will declare namespace-a explicitly
+		ntopts.SyncWithGitSource(rootSyncXID), // will declare resources in namespace-a, but not namespace-a itself
+		ntopts.SyncWithGitSource(rootSyncYID), // will declare resources in namespace-a, but not namespace-a itself
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSyncAGitRepo := nt.SyncSourceGitRepository(rootSyncAID)

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -33,8 +33,9 @@ import (
 )
 
 func TestNoSSLVerifyV1Alpha1(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -47,7 +48,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
-		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
+		Name:      core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name),
 		Namespace: configsync.ControllerNamespace,
 	}
 
@@ -65,8 +66,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 
-	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
-	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
+	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, repoSyncID.ObjectKey)
 
 	// Set noSSLVerify to true for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"git": {"noSSLVerify": true}}}`)
@@ -78,7 +78,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 	// Set noSSLVerify to true for ns-reconciler-backend
 	repoSyncBackend.Spec.NoSSLVerify = true
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -100,7 +100,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 
 	// Set noSSLVerify to false from repoSyncBackend
 	repoSyncBackend.Spec.NoSSLVerify = false
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -114,8 +114,9 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 }
 
 func TestNoSSLVerifyV1Beta1(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -128,7 +129,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
-		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
+		Name:      core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name),
 		Namespace: configsync.ControllerNamespace,
 	}
 
@@ -146,7 +147,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
-	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
+	nn := nomostest.RepoSyncNN(repoSyncID.Namespace, repoSyncID.Name)
 	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
 
 	// Set noSSLVerify to true for root-reconciler
@@ -159,7 +160,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 	// Set noSSLVerify to true for ns-reconciler-backend
 	repoSyncBackend.Spec.NoSSLVerify = true
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to true"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -181,7 +182,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 	// Set noSSLVerify to false from repoSyncBackend
 	repoSyncBackend.Spec.NoSSLVerify = false
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync NoSSLVerify to false"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -35,8 +35,9 @@ import (
 )
 
 func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -49,7 +50,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
-		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
+		Name:      core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name),
 		Namespace: configsync.ControllerNamespace,
 	}
 
@@ -67,8 +68,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 
 	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 
-	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
-	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, nn)
+	repoSyncBackend := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, repoSyncID.ObjectKey)
 
 	// Override the git sync depth setting for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"gitSyncDepth": 5}}}`)
@@ -81,7 +81,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend
 	var depth int64 = 33
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 33"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -107,7 +107,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend to 0
 	depth = 0
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 0"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -121,7 +121,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = &v1alpha1.RepoSyncOverrideSpec{}
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -135,8 +135,9 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 }
 
 func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
+	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
-		ntopts.RepoSyncWithGitSource(backendNamespace, configsync.RepoSyncName))
+		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
@@ -149,7 +150,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 		Namespace: configsync.ControllerNamespace,
 	}
 	nsReconcilerNN := types.NamespacedName{
-		Name:      core.NsReconcilerName(backendNamespace, configsync.RepoSyncName),
+		Name:      core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name),
 		Namespace: configsync.ControllerNamespace,
 	}
 
@@ -167,8 +168,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 
 	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
-	nn := nomostest.RepoSyncNN(backendNamespace, configsync.RepoSyncName)
-	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, nn)
+	repoSyncBackend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSyncID.ObjectKey)
 
 	// Override the git sync depth setting for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"gitSyncDepth": 5}}}`)
@@ -181,7 +181,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend
 	var depth int64 = 33
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 33"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -207,7 +207,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	// Override the git sync depth setting for ns-reconciler-backend to 0
 	depth = 0
 	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 0"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -221,7 +221,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 
 	// Clear `spec.override` from repoSyncBackend
 	repoSyncBackend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{}
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(backendNamespace, configsync.RepoSyncName), repoSyncBackend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Clear `spec.override` from repoSyncBackend"))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -144,14 +144,14 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 }
 
 func TestOverrideRepoSyncLogLevel(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.RepoSyncWithGitSource(frontendNamespace, configsync.RepoSyncName))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, frontendNamespace)
+	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
+		ntopts.SyncWithGitSource(repoSyncID))
+	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 
-	frontendReconcilerNN := core.NsReconcilerObjectKey(frontendNamespace, configsync.RepoSyncName)
+	frontendReconcilerNN := core.NsReconcilerObjectKey(repoSyncID.Namespace, repoSyncID.Name)
 	repoSyncFrontend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSyncKey)
 
 	// add kustomize to enable hydration controller container in repo-sync
@@ -161,7 +161,7 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 
 	nt.T.Log("Update RepoSync to sync from the kustomize-components directory")
 	repoSyncFrontend.Spec.Git.Dir = "kustomize-components"
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncFrontend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update RepoSync to sync from the kustomize directory"))
 
 	// Verify ns-reconciler-frontend uses the default log level
@@ -191,7 +191,7 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncFrontend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update log level of frontend Reposync"))
 
 	// validate override and make sure other containers are unaffected
@@ -231,7 +231,7 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncFrontend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update log level of frontend Reposync"))
 
 	// validate override for all containers
@@ -250,7 +250,7 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 
 	// Clear override from repoSync Frontend
 	repoSyncFrontend.Spec.Override = nil
-	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(frontendNamespace, configsync.RepoSyncName), repoSyncFrontend))
+	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncFrontend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Clear override from repoSync Frontend"))
 
 	// validate log level value are back to default for all containers

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -34,16 +34,14 @@ import (
 )
 
 func TestRootSyncRoleRefs(t *testing.T) {
+	rootSyncAID := core.RootSyncID("sync-a")
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.RootSyncWithGitSource("sync-a"),
+		ntopts.SyncWithGitSource(rootSyncAID),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
-	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, "sync-a")
+	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncAID.Name)
 	syncAReconcilerName := core.RootReconcilerName(rootSyncA.Name)
-	syncANN := types.NamespacedName{
-		Name:      rootSyncA.Name,
-		Namespace: rootSyncA.Namespace,
-	}
+	syncANN := rootSyncAID.ObjectKey
 	if err := nt.Validate(controllers.RootSyncLegacyClusterRoleBindingName, "", &rbacv1.ClusterRoleBinding{},
 		testpredicates.ClusterRoleBindingSubjectNamesEqual(nomostest.DefaultRootReconcilerName, syncAReconcilerName)); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -233,7 +233,7 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 	repoSyncID := core.RepoSyncID("rs-test", testNs)
 	nt := nomostest.New(t,
 		nomostesting.MultiRepos,
-		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
@@ -363,7 +363,7 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	repoSyncID := core.RepoSyncID("rs-test", testNs)
 	nt := nomostest.New(t,
 		nomostesting.MultiRepos,
-		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
@@ -516,9 +516,9 @@ func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 	contrivedFinalizer := "e2e-test"
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.Unstructured,
-		ntopts.RootSyncWithGitSource(rootSync2ID.Name), // Create a nested RootSync to delete mid-test
-		ntopts.WithCentralizedControl,                  // This test assumes centralized control
-		ntopts.WithReconcileTimeout(10*time.Second),    // Reconcile expected to fail, so use a short timeout
+		ntopts.SyncWithGitSource(rootSync2ID),       // Create a nested RootSync to delete mid-test
+		ntopts.WithCentralizedControl,               // This test assumes centralized control
+		ntopts.WithReconcileTimeout(10*time.Second), // Reconcile expected to fail, so use a short timeout
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -131,7 +131,7 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.Unstructured, ntopts.WithDelegatedControl,
-		ntopts.RepoSyncWithGitSource(repoSyncID.Namespace, repoSyncID.Name),
+		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
 


### PR DESCRIPTION
- Combine RootSyncWithGitSource & RepoSyncWithGitSource into SyncWithGitSource that takes an ID. This helps avoid ambiguity about name & namespace argument order.