### PR TITLE
e2e: add options to SyncWithGitSource

### DIFF
--- a/e2e/nomostest/syncsource/syncsource.go
+++ b/e2e/nomostest/syncsource/syncsource.go
@@ -38,6 +38,7 @@ type GitSyncSource struct {
 	// the current/latest commit.
 	Repository *gitproviders.Repository
 	// TODO: Add SyncPath and Branch/Revision to uniquely identify part of a repo
+	SourceFormat configsync.SourceFormat
 }
 
 // Type returns the SourceType of this source.

--- a/e2e/testcases/acme_test.go
+++ b/e2e/testcases/acme_test.go
@@ -183,7 +183,8 @@ func TestAcmeCorpRepo(t *testing.T) {
 
 // TestObjectInCMSNamespace will test that user can sync object to CMS namespace
 func TestObjectInCMSNamespace(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Reconciliation1,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 

--- a/e2e/testcases/apiservice_test.go
+++ b/e2e/testcases/apiservice_test.go
@@ -31,7 +31,8 @@ const (
 )
 
 func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.Reconciliation1,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.
 		ntopts.WithReconcileTimeout(5*time.Minute))
@@ -76,7 +77,7 @@ func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 
 func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.
 		ntopts.WithReconcileTimeout(5*time.Minute))

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -547,17 +547,20 @@ func testSyncFromNomosHydrateOutput(nt *nomostest.NT, config string) {
 }
 
 func TestSyncFromNomosHydrateOutputYAMLDir(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.NomosCLI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.NomosCLI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	testSyncFromNomosHydrateOutput(nt, "../../examples/repo-with-cluster-selectors-compiled/cluster-dev/.")
 }
 
 func TestSyncFromNomosHydrateOutputJSONDir(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.NomosCLI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.NomosCLI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	testSyncFromNomosHydrateOutput(nt, "../../examples/repo-with-cluster-selectors-compiled-json/cluster-dev/.")
 }
 
 func testSyncFromNomosHydrateOutputFlat(t *testing.T, sourceFormat configsync.SourceFormat, outputFormat string) {
-	nt := nomostest.New(t, nomostesting.NomosCLI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.NomosCLI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	configPath := fmt.Sprintf("../../examples/%s-repo-with-cluster-selectors", sourceFormat)
 	compiledConfigFile := fmt.Sprintf("%s/compiled.%s", nt.TmpDir, outputFormat)
@@ -1192,8 +1195,8 @@ func TestNomosStatusNameFilter(t *testing.T) {
 	nt := nomostest.New(
 		t,
 		nomostesting.NomosCLI,
-		ntopts.Unstructured,
-		ntopts.SyncWithGitSource(rootSync1ID),
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
+		ntopts.SyncWithGitSource(rootSync1ID, ntopts.Unstructured),
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin()),
 		ntopts.SyncWithGitSource(repoSync1ID),
 		ntopts.SyncWithGitSource(repoSync2ID),

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -80,10 +80,9 @@ func TestComposition(t *testing.T) {
 	lvl0ID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t,
 		nomostesting.MultiRepos,
-		ntopts.Unstructured,
 		ntopts.WithDelegatedControl,
-		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin(), policy.CoreAdmin()), // NS reconciler manages RepoSyncs and ConfigMaps
-		ntopts.SyncWithGitSource(lvl0ID))
+		ntopts.SyncWithGitSource(lvl0ID, ntopts.Unstructured),
+		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin(), policy.CoreAdmin())) // NS reconciler manages RepoSyncs and ConfigMaps
 
 	lvl0NN := lvl0ID.ObjectKey
 	lvl1NN := nomostest.RootSyncNN("level-1")

--- a/e2e/testcases/declared_fields_test.go
+++ b/e2e/testcases/declared_fields_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestDeclaredFieldsPod(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Reconciliation1,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")

--- a/e2e/testcases/gatekeeper_test.go
+++ b/e2e/testcases/gatekeeper_test.go
@@ -50,7 +50,8 @@ func emptyConstraintTemplate() unstructured.Unstructured {
 }
 
 func TestConstraintTemplateAndConstraintInSameCommit(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Reconciliation1,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	crdName := "k8sallowedrepos.constraints.gatekeeper.sh"

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -52,9 +52,10 @@ const (
 // https://cloud.google.com/anthos-config-management/docs/how-to/installing-config-sync#git-creds-secret
 func TestGCENodeCSR(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireCloudSourceRepository(t),
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
@@ -113,9 +114,10 @@ func TestGCENodeCSR(t *testing.T) {
 //   - `roles/containerregistry.ServiceAgent` for access image in Container Registry.
 func TestGCENodeOCI(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireOCIArtifactRegistry(t),
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
@@ -189,9 +191,10 @@ func TestGCENodeOCI(t *testing.T) {
 //   - `roles/artifactregistry.reader` for access image in Artifact Registry.
 func TestGCENodeHelm(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireHelmArtifactRegistry(t),
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -62,7 +62,8 @@ const (
 // TestPublicHelm can run on both Kind and GKE clusters.
 // It tests Config Sync can pull from public Helm repo without any authentication.
 func TestPublicHelm(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rs := rootSyncForWordpressHelmChart(nt, nil)
 	nt.T.Log("Update RootSync to sync from a public Helm Chart with specified release namespace and multiple inline values")
@@ -140,7 +141,8 @@ func TestPublicHelm(t *testing.T) {
 // It tests that helm-sync properly watches ConfigMaps in the RSync namespace if the RSync is created before
 // the ConfigMap.
 func TestHelmWatchConfigMap(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rs := rootSyncForWordpressHelmChart(nt, func(m map[string]interface{}) {
 		delete(m, "wordpressUsername") // omit username so it can be set with values file
@@ -258,7 +260,8 @@ service:
 // TestHelmConfigMapOverride can run on both Kind and GKE clusters.
 // It tests ConfigSync behavior when multiple valuesFiles are provided
 func TestHelmConfigMapOverride(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	cmName := "helm-config-map-override"
 
 	cm := k8sobjects.ConfigMapObject(core.Name(cmName), core.Namespace(configsync.ControllerNamespace))
@@ -318,7 +321,7 @@ image:
 func TestHelmDefaultNamespace(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireHelmProvider,
 	)
 
@@ -360,7 +363,7 @@ func TestHelmLatestVersion(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t,
 		nomostesting.WorkloadIdentity,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireHelmProvider,
 	)
 
@@ -428,7 +431,8 @@ func TestHelmLatestVersion(t *testing.T) {
 // TestHelmVersionRange verifies the Config Sync behavior for helm charts when helm.spec.version is specified as a range.
 // Helm-sync should pull the latest helm chart version within the range.
 func TestHelmVersionRange(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	nt.T.Log("Create RootSync to sync from a public Helm Chart with specified version range")
 	rs := rootSyncForWordpressHelmChart(nt, nil)
@@ -615,7 +619,7 @@ type ServiceAccountFile struct {
 func TestHelmARTokenAuth(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireGKE(t),
 		ntopts.RequireHelmArtifactRegistry(t),
 	)
@@ -674,7 +678,7 @@ func TestHelmARTokenAuth(t *testing.T) {
 func TestHelmEmptyChart(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.SyncSource,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireHelmProvider,
 	)
 

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -44,7 +44,7 @@ var expectedBuiltinOrigin = "configuredIn: kustomization.yaml\nconfiguredBy:\n  
 func TestHydrateKustomizeComponents(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -174,7 +174,7 @@ func TestHydrateKustomizeComponents(t *testing.T) {
 func TestHydrateExternalFiles(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -206,7 +206,7 @@ func TestHydrateExternalFiles(t *testing.T) {
 func TestHydrateHelmComponents(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -267,7 +267,7 @@ func TestHydrateHelmComponents(t *testing.T) {
 func TestHydrateHelmOverlay(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -325,7 +325,7 @@ func TestHydrateHelmOverlay(t *testing.T) {
 func TestHydrateRemoteResources(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -398,7 +398,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 func TestHydrateResourcesInRelativePath(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Hydration,
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -315,7 +315,8 @@ func skipAutopilotManagedNamespace(nt *nomostest.NT, ns string) bool {
 }
 
 func TestPreventDeletionSpecialNamespaces(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Lifecycle, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Lifecycle,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Build list of special namespaces to test.

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -54,7 +54,8 @@ import (
 // TestDriftKubectlApplyClusterScoped tests drift correction after
 // cluster-scoped changes are made with kubectl.
 func TestDriftKubectlApplyClusterScoped(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
@@ -244,7 +245,8 @@ func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 // TestDriftKubectlApplyNamespaceScoped tests drift correction after
 // namespace-scoped changes are made with kubectl.
 func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
@@ -493,7 +495,8 @@ func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 // TestDriftKubectlDelete deletes an object managed by Config Sync, and verifies
 // that Config Sync recreates the deleted object.
 func TestDriftKubectlDelete(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
@@ -554,7 +557,8 @@ func TestDriftKubectlDelete(t *testing.T) {
 // by Config Sync that has the `client.lifecycle.config.k8s.io/mutation`
 // annotation, and verifies that Config Sync recreates the deleted object.
 func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
@@ -615,7 +619,8 @@ func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
 // resource managed by Config Sync, and verifies that Config Sync
 // does not remove this field.
 func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
@@ -676,7 +681,8 @@ func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
 // `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
 // Config Sync does not remove this field.
 func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
@@ -706,7 +712,8 @@ func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testi
 // TestDriftKubectlAnnotateManagedField modifies a managed field, and verifies
 // that Config Sync corrects it.
 func TestDriftKubectlAnnotateManagedField(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
@@ -769,7 +776,8 @@ func TestDriftKubectlAnnotateManagedField(t *testing.T) {
 // `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
 // Config Sync does not correct it.
 func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
@@ -817,7 +825,8 @@ func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing
 // TestDriftKubectlAnnotateDeleteManagedFields deletes a managed field, and
 // verifies that Config Sync corrects it.
 func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
@@ -880,7 +889,8 @@ func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 // `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
 // Config Sync does not correct it.
 func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
@@ -929,7 +939,8 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 // `applyset.kubernetes.io/part-of` label, and verifies that
 // Config Sync re-adds it.
 func TestDriftRemoveApplySetPartOfLabel(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.DriftControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)

--- a/e2e/testcases/namespace_selectors_test.go
+++ b/e2e/testcases/namespace_selectors_test.go
@@ -123,7 +123,8 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 }
 
 func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Selector, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Selector,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))

--- a/e2e/testcases/namespace_strategy_test.go
+++ b/e2e/testcases/namespace_strategy_test.go
@@ -47,7 +47,8 @@ import (
 // - Prune "foo-implicit" from git. Should error because cm1 depends on the Namespace
 // - Prune "cm1" from git. The Namespace and ConfigMap should be successfully pruned.
 func TestNamespaceStrategy(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
@@ -172,10 +173,11 @@ func TestNamespaceStrategyMultipleRootSyncs(t *testing.T) {
 	rootSyncXID := core.RootSyncID("sync-x")
 	rootSyncYID := core.RootSyncID("sync-y")
 	namespaceA := k8sobjects.NamespaceObject("namespace-a")
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.SyncWithGitSource(rootSyncAID), // will declare namespace-a explicitly
-		ntopts.SyncWithGitSource(rootSyncXID), // will declare resources in namespace-a, but not namespace-a itself
-		ntopts.SyncWithGitSource(rootSyncYID), // will declare resources in namespace-a, but not namespace-a itself
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
+		ntopts.SyncWithGitSource(rootSyncAID, ntopts.Unstructured), // will declare namespace-a explicitly
+		ntopts.SyncWithGitSource(rootSyncXID, ntopts.Unstructured), // will declare resources in namespace-a, but not namespace-a itself
+		ntopts.SyncWithGitSource(rootSyncYID, ntopts.Unstructured), // will declare resources in namespace-a, but not namespace-a itself
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSyncAGitRepo := nt.SyncSourceGitRepository(rootSyncAID)

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -590,7 +590,8 @@ func TestDoNotRemoveManagedByLabelExceptForConfigManagement(t *testing.T) {
 }
 
 func TestDeclareImplicitNamespace(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation2, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Reconciliation2,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	var unixMilliseconds = time.Now().UnixNano() / 1000000

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -79,7 +79,8 @@ func gsaGCRReaderEmail() string {
 // TestPublicOCI can run on both Kind and GKE clusters.
 // It tests Config Sync can pull from public OCI images without any authentication.
 func TestPublicOCI(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	nt.T.Log("Update RootSync to sync from a public OCI image in AR")
@@ -112,8 +113,9 @@ func TestPublicOCI(t *testing.T) {
 func TestSwitchFromGitToOciCentralized(t *testing.T) {
 	namespace := testNs
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireOCIProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount
@@ -178,8 +180,9 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 func TestSwitchFromGitToOciDelegated(t *testing.T) {
 	namespace := testNs
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.WithDelegatedControl, ntopts.RequireOCIProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		// bookinfo image contains RoleBinding
 		// bookinfo repo contains ServiceAccount
@@ -267,7 +270,8 @@ func isSourceType(sourceType configsync.SourceType) testpredicates.Predicate {
 
 func TestOciSyncWithDigest(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireOCIProvider,
 	)
 	var err error
@@ -344,7 +348,7 @@ func TestOciSyncWithDigest(t *testing.T) {
 // and permission to push new image to `config-sync-test-public` in the Container Registry.
 // The test uses the current credentials (gcloud auth) when running on the GKE clusters to push new images.
 func TestDigestUpdate(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured, ntopts.RequireGKE(t))
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured), ntopts.RequireGKE(t))
 
 	rs := fake.RootSyncObjectV1Beta1(configsync.RootSyncName)
 

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -114,7 +114,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Reconciliation1,
 		ntopts.RequireGKE(t),
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {
@@ -236,7 +236,7 @@ func TestGCMMetrics(t *testing.T) {
 	nt := nomostest.New(t,
 		nomostesting.Reconciliation1,
 		ntopts.RequireGKE(t),
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -33,7 +33,8 @@ import (
 )
 
 func TestOverrideRootSyncLogLevel(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncName := nomostest.RootSyncNN(configsync.RootSyncName)
@@ -145,7 +146,8 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 
 func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, frontendNamespace)
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -36,7 +36,8 @@ import (
 
 // TestOverrideReconcileTimeout tests that a misconfigured pod will never reconcile (timeout).
 func TestOverrideReconcileTimeout(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -35,8 +35,9 @@ import (
 
 func TestRootSyncRoleRefs(t *testing.T) {
 	rootSyncAID := core.RootSyncID("sync-a")
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured,
-		ntopts.SyncWithGitSource(rootSyncAID),
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
+		ntopts.SyncWithGitSource(rootSyncAID, ntopts.Unstructured),
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncAID.Name)

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -404,7 +404,8 @@ func TestCACertSecretWatch(t *testing.T) {
 // TestOCICACertSecretRefRootRepo can run only run on KinD clusters.
 // It tests RootSyncs can pull from OCI images using a CA certificate.
 func TestOCICACertSecretRefRootRepo(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireLocalOCIProvider)
 
 	caCertSecret := nomostest.PublicCertSecretName(nomostest.RegistrySyncSource)
@@ -440,8 +441,9 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 // It tests RepoSyncs can pull from OCI images using a CA certificate.
 func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireLocalOCIProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
@@ -517,7 +519,8 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 // TestHelmCACertSecretRefRootRepo can run only run on KinD clusters.
 // It tests RootSyncs can pull from OCI images using a CA certificate.
 func TestHelmCACertSecretRefRootRepo(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.RequireLocalHelmProvider)
 
 	caCertSecret := nomostest.PublicCertSecretName(nomostest.RegistrySyncSource)
@@ -558,8 +561,9 @@ func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 // It tests RepoSyncs can pull from OCI images using a CA certificate.
 func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.RequireLocalHelmProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)

--- a/e2e/testcases/profiling_test.go
+++ b/e2e/testcases/profiling_test.go
@@ -41,8 +41,8 @@ import (
 // managed objects.
 // Skipped by default, because it needs cluster autoscaling and a lot of quota.
 func TestProfilingResourcesByObjectCount(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.ProfilingTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -107,8 +107,8 @@ func TestProfilingResourcesByObjectCount(t *testing.T) {
 // relative to the number of managed objects.
 // Skipped by default, because it needs cluster autoscaling and a lot of quota.
 func TestProfilingResourcesByObjectCountWithMultiSync(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.ProfilingTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -235,8 +235,8 @@ func TestProfilingResourcesByObjectCountWithMultiSync(t *testing.T) {
 // cluster.
 // Skipped by default, because it needs cluster autoscaling and a lot of quota.
 func TestProfilingByObjectCountAndSyncCount(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.ProfilingTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -341,8 +341,8 @@ func TestProfilingByObjectCountAndSyncCount(t *testing.T) {
 // resource type, in the same namespace.
 // Skipped by default, because it needs cluster autoscaling and a lot of quota.
 func TestProfilingResourcesByRootSyncCount(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.ProfilingTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -515,10 +515,10 @@ func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 	namespaceNN := types.NamespacedName{Name: "managed-ns"}
 	contrivedFinalizer := "e2e-test"
 	nt := nomostest.New(t, nomostesting.MultiRepos,
-		ntopts.Unstructured,
-		ntopts.SyncWithGitSource(rootSync2ID),       // Create a nested RootSync to delete mid-test
-		ntopts.WithCentralizedControl,               // This test assumes centralized control
-		ntopts.WithReconcileTimeout(10*time.Second), // Reconcile expected to fail, so use a short timeout
+		ntopts.WithCentralizedControl, // This test assumes centralized control
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
+		ntopts.SyncWithGitSource(rootSync2ID, ntopts.Unstructured), // Create a nested RootSync to delete mid-test
+		ntopts.WithReconcileTimeout(10*time.Second),                // Reconcile expected to fail, so use a short timeout
 	)
 	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
 	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -64,7 +64,8 @@ func TestReconcilerManagerNormalTeardown(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNamespace)
 	nt := nomostest.New(t, nomostesting.ACMController,
-		ntopts.WithDelegatedControl, ntopts.Unstructured,
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID))
 
 	t.Log("Validate the reconciler-manager deployment")
@@ -124,7 +125,8 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 	testNamespace := "invalid-teardown"
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNamespace)
 	nt := nomostest.New(t, nomostesting.ACMController,
-		ntopts.WithDelegatedControl, ntopts.Unstructured,
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID))
 
 	t.Log("Validate the reconciler-manager deployment")
@@ -214,7 +216,8 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 // the deletions fail to reconcile.
 func TestReconcilerManagerTeardownRootSyncWithReconcileTimeout(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController,
-		ntopts.WithDelegatedControl, ntopts.Unstructured)
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rootSync := &v1beta1.RootSync{}
 	rootSync.Name = configsync.RootSyncName
@@ -298,7 +301,8 @@ func TestReconcilerManagerTeardownRepoSyncWithReconcileTimeout(t *testing.T) {
 	testNamespace := "reconcile-timeout"
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNamespace)
 	nt := nomostest.New(t, nomostesting.ACMController,
-		ntopts.WithDelegatedControl, ntopts.Unstructured,
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID))
 
 	repoSync := &v1beta1.RepoSync{}
@@ -882,7 +886,8 @@ func totalExpectedContainerResources(resourceMap map[string]v1beta1.ContainerRes
 }
 
 func TestAutopilotReconcilerAdjustment(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.ACMController, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.ACMController,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	reconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)
@@ -1177,7 +1182,7 @@ func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, repoSyncNS)
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.WithDelegatedControl, // Delegated so deleting the RootSync doesn't delete the RepoSyncs.
-		ntopts.Unstructured,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 	)

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -370,7 +370,8 @@ func TestRootSyncReconcilingStatus(t *testing.T) {
 }
 
 func TestManageSelfRootSync(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.ACMController, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.ACMController,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	rs := &v1beta1.RootSync{}
 	if err := nt.KubeClient.Get(configsync.RootSyncName, configsync.ControllerNamespace, rs); err != nil {

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -33,7 +33,8 @@ import (
 )
 
 func TestRootSyncSSHKnownHost(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	var err error
@@ -130,7 +131,8 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t,
 		nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
-		ntopts.Unstructured, ntopts.WithDelegatedControl,
+		ntopts.WithDelegatedControl,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
 	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -38,7 +38,8 @@ import (
 // or disable status in the kpt applier.
 
 func TestStatusEnabledAndDisabled(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.OverrideAPI,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 	id := applier.InventoryID(configsync.RootSyncName, configsync.ControllerNamespace)
 

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -75,7 +75,8 @@ func crontabCR(namespace, name string) (*unstructured.Unstructured, error) {
 // TestStressCRD tests Config Sync can sync one CRD and 1000 namespaces successfully.
 // Every namespace includes a ConfigMap and a CR.
 func TestStressCRD(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -138,7 +139,8 @@ func TestStressCRD(t *testing.T) {
 
 // TestStressLargeNamespace tests that Config Sync can sync a namespace including 5000 resources successfully.
 func TestStressLargeNamespace(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -177,7 +179,8 @@ func TestStressLargeNamespace(t *testing.T) {
 
 // TestStressFrequentGitCommits adds 100 Git commits, and verifies that Config Sync can sync the changes in these commits successfully.
 func TestStressFrequentGitCommits(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -216,7 +219,8 @@ func TestStressFrequentGitCommits(t *testing.T) {
 // This test creates a RootSync pointed at https://github.com/config-sync-examples/crontab-crs
 // This repository contains 13,000+ objects, which takes a long time to reconcile
 func TestStressLargeRequest(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 
 	crdName := "crontabs.stable.example.com"
@@ -294,7 +298,8 @@ func TestStressLargeRequest(t *testing.T) {
 // This simulates a scenario similar to using Config Connector or Crossplane.
 // This test also validates that nomos status does not use client-side throttling.
 func TestStress100CRDs(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -348,8 +353,8 @@ func TestStress100CRDs(t *testing.T) {
 // plane is autoscaling up to meet demand. This requires cluster autoscaling to
 // be enabled.
 func TestStressManyDeployments(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured,
-		ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -396,7 +401,8 @@ func TestStressManyDeployments(t *testing.T) {
 // resource. This stressed both the number of watches and the number of objects,
 // which increases memory usage.
 func TestStressMemoryUsageGit(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.Unstructured, ntopts.StressTest,
+	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
@@ -470,8 +476,9 @@ func TestStressMemoryUsageGit(t *testing.T) {
 // 6. IAM for the GSA to read from the Artifact Registry repo
 // 7. IAM for the test runner to write to Artifact Registry repo
 func TestStressMemoryUsageOCI(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.Unstructured,
-		ntopts.StressTest, ntopts.RequireOCIProvider,
+	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.StressTest,
+		ntopts.RequireOCIProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
 
 	if err := workloadidentity.ValidateEnabled(nt); err != nil {
@@ -577,8 +584,9 @@ func TestStressMemoryUsageOCI(t *testing.T) {
 func TestStressMemoryUsageHelm(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.Unstructured,
-		ntopts.StressTest, ntopts.RequireHelmProvider,
+	nt := nomostest.New(t, nomostesting.WorkloadIdentity, ntopts.StressTest,
+		ntopts.RequireHelmProvider,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(30*time.Second))
 
 	if err := workloadidentity.ValidateEnabled(nt); err != nil {

--- a/e2e/testcases/sync_ordering_test.go
+++ b/e2e/testcases/sync_ordering_test.go
@@ -44,7 +44,8 @@ import (
 // The sync ordering feature is only supported in the multi-repo mode.
 
 func TestMultiDependencies(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Lifecycle, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Lifecycle,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespaceName := "bookstore"
@@ -337,7 +338,8 @@ func TestMultiDependencies(t *testing.T) {
 }
 
 func TestExternalDependencyError(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.Lifecycle, ntopts.Unstructured)
+	nt := nomostest.New(t, nomostesting.Lifecycle,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	namespaceName := "bookstore"
@@ -447,7 +449,8 @@ func TestExternalDependencyError(t *testing.T) {
 
 func TestDependencyWithReconciliation(t *testing.T) {
 	// Increase reconcile timeout to account for slow pod scheduling due to cluster autoscaling.
-	nt := nomostest.New(t, nomostesting.Lifecycle, ntopts.Unstructured,
+	nt := nomostest.New(t, nomostesting.Lifecycle,
+		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(5*time.Minute))
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -277,10 +277,13 @@ func TestWorkloadIdentity(t *testing.T) {
 			rootSyncKey := rootSyncID.ObjectKey
 			repoSyncKey := repoSyncID.ObjectKey
 			var err error
-			opts := []ntopts.Opt{ntopts.Unstructured, ntopts.RequireGKE(t),
+			opts := []ntopts.Opt{
+				ntopts.RequireGKE(t),
+				ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 				ntopts.SyncWithGitSource(repoSyncID),
 				ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
-				ntopts.WithDelegatedControl}
+				ntopts.WithDelegatedControl,
+			}
 			if tc.requireHelmGAR {
 				opts = append(opts, ntopts.RequireHelmArtifactRegistry(t))
 			}


### PR DESCRIPTION
- Replace MultiRepo.SourceFormat with GitSyncSource.SourceFormat.
- Use ntopts.Unstructured on individual SyncWithGitSource now, instead of on the whole parent NT.New. This should make it more obvious that the setting only applies to RootSyncs, and allow more granular configurations.
- Move default SourceFormats for e2e tests into ntopts/multi_repo.go, instead of spread across multiple files.
- Add GitSourceOptions for SyncWithGitSource to further configure individual RSync Git source configs.
- Add RSync Kind validation to setupTestCase, to enforce RootSync and RepoSync.
- Change Repository to use SyncKind, to simplify usage, instead of its own enum type.