### PR TITLE
test: Set fake parser FileObjects output to nil

### DIFF
--- a/pkg/parse/root_test.go
+++ b/pkg/parse/root_test.go
@@ -1267,7 +1267,10 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 			fakeConfigParser := &fsfake.ConfigParser{
 				Outputs: []fsfake.ParserOutputs{
 					// One Parse call, with errors
-					{Errors: tc.parseErrors},
+					{
+						Errors:      tc.parseErrors,
+						FileObjects: nil,
+					},
 				},
 			}
 			fakeApplier := &applierfake.Applier{


### PR DESCRIPTION
See sample failed run https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/pr-logs/pull/GoogleContainerTools_kpt-config-sync/1364/kpt-config-sync-presubmit/1818393399972073472 where an unknown scoped object was returned from Parse and triggers unknown kind error.

Explicitly setting the output to nil and see if it helps.