### PR TITLE
e2e: Add SyncSource.Path

### DIFF
--- a/e2e/nomostest/config_sync_sources.go
+++ b/e2e/nomostest/config_sync_sources.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nomostest
+
+import (
+	"kpt.dev/configsync/e2e/nomostest/gitproviders"
+	"kpt.dev/configsync/e2e/nomostest/registryproviders"
+	"kpt.dev/configsync/e2e/nomostest/syncsource"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+)
+
+// SetExpectedSyncPath updates the SyncSource for the specified RootSync or
+// RepoSync with the provided Git dir, OCI dir.
+func SetExpectedSyncPath(nt *NT, syncID core.ID, syncPath string) {
+	source, exists := nt.SyncSources[syncID]
+	if !exists {
+		nt.T.Fatalf("Failed to update expectation for %s %s: nt.SyncSources not registered", syncID.Kind, syncID.ObjectKey)
+	}
+	switch tSource := source.(type) {
+	case *syncsource.GitSyncSource:
+		tSource.Directory = syncPath
+	case *syncsource.OCISyncSource:
+		tSource.Directory = syncPath
+	case *syncsource.HelmSyncSource:
+		nt.T.Fatalf("Failed to update expectation for %s %s: Use SetExpectedHelmChart instead", syncID.Kind, syncID.ObjectKey)
+	default:
+		nt.T.Fatalf("Invalid %s source %T: %s", syncID.Kind, source, syncID.Name)
+	}
+}
+
+// SetExpectedGitSource creates, updates, or replaces the SyncSource for the
+// specified RootSync or RepoSync with the provided Git repo.
+func SetExpectedGitSource(nt *NT, syncID core.ID, repo *gitproviders.Repository, syncPath string, sourceFormat configsync.SourceFormat) {
+	source, exists := nt.SyncSources[syncID]
+	if !exists {
+		nt.T.Logf("Creating expectation for %s %s to sync with Git repo (repository: %q, directory: %q, sourceFormat: %q)",
+			syncID.Kind, syncID.ObjectKey, repo.Name, syncPath, sourceFormat)
+		nt.SyncSources[syncID] = &syncsource.GitSyncSource{
+			Repository:   repo,
+			SourceFormat: sourceFormat,
+			Directory:    syncPath,
+		}
+		return
+	}
+	switch tSource := source.(type) {
+	case *syncsource.GitSyncSource:
+		nt.T.Logf("Updating expectation for %s %s to sync with Git repo (repository: %q, directory: %q, sourceFormat: %q)",
+			syncID.Kind, syncID.ObjectKey, repo.Name, syncPath, sourceFormat)
+		tSource.Repository = repo
+		tSource.SourceFormat = sourceFormat
+		tSource.Directory = syncPath
+	case *syncsource.OCISyncSource, *syncsource.HelmSyncSource:
+		nt.T.Logf("Replacing expectation for %s %s to sync with Git repo (repository: %q, directory: %q, sourceFormat: %q), instead of %T",
+			syncID.Kind, syncID.ObjectKey, repo.Name, syncPath, sourceFormat, source)
+		nt.SyncSources[syncID] = &syncsource.GitSyncSource{
+			Repository:   repo,
+			SourceFormat: sourceFormat,
+			Directory:    syncPath,
+		}
+	default:
+		nt.T.Fatalf("Invalid %s source %T: %s", syncID.Kind, source, syncID.Name)
+	}
+}
+
+// SetExpectedOCISource creates, updates, or replaces the SyncSource for the
+// specified RootSync or RepoSync with the provided OCI image.
+// ImageID is used for pulling. ImageDigest is used for validating the result.
+func SetExpectedOCISource(nt *NT, syncID core.ID, imageID registryproviders.OCIImageID, imageDigest, syncPath string) {
+	source, exists := nt.SyncSources[syncID]
+	if !exists {
+		nt.T.Logf("Creating expectation for %s %s to sync with OCI image (image: %q, directory: %q)",
+			syncID.Kind, syncID.ObjectKey, imageID, syncPath)
+		nt.SyncSources[syncID] = &syncsource.OCISyncSource{
+			ImageID:   imageID,
+			Digest:    imageDigest,
+			Directory: syncPath,
+		}
+		return
+	}
+	switch tSource := source.(type) {
+	case *syncsource.OCISyncSource:
+		nt.T.Logf("Updating expectation for %s %s to sync with OCI image (image: %q, directory: %q)",
+			syncID.Kind, syncID.ObjectKey, imageID, syncPath)
+		tSource.ImageID = imageID
+		tSource.Digest = imageDigest
+		tSource.Directory = syncPath
+	case *syncsource.GitSyncSource, *syncsource.HelmSyncSource:
+		nt.T.Logf("Replacing expectation for %s %s to sync with OCI image (image: %q, directory: %q), instead of %T",
+			syncID.Kind, syncID.ObjectKey, imageID, syncPath, source)
+		nt.SyncSources[syncID] = &syncsource.OCISyncSource{
+			ImageID:   imageID,
+			Digest:    imageDigest,
+			Directory: syncPath,
+		}
+	default:
+		nt.T.Fatalf("Invalid %s source %T: %s", syncID.Kind, source, syncID.Name)
+	}
+}
+
+// SetExpectedHelmSource creates, updates, or replaces the SyncSource for the
+// specified RootSync or RepoSync with the provided Helm chart ID.
+func SetExpectedHelmSource(nt *NT, syncID core.ID, chartID registryproviders.HelmChartID) {
+	source, exists := nt.SyncSources[syncID]
+	if !exists {
+		nt.T.Logf("Creating expectation for %s %s to sync with helm chart (id: %q)",
+			syncID.Kind, syncID.ObjectKey, chartID)
+		nt.SyncSources[syncID] = &syncsource.HelmSyncSource{
+			ChartID: chartID,
+		}
+		return
+	}
+	switch tSource := source.(type) {
+	case *syncsource.HelmSyncSource:
+		nt.T.Logf("Updating expectation for %s %s to sync with helm chart (id: %q)",
+			syncID.Kind, syncID.ObjectKey, chartID)
+		tSource.ChartID = chartID
+	case *syncsource.GitSyncSource, *syncsource.OCISyncSource:
+		nt.T.Logf("Replacing expectation for %s %s to sync with helm chart (id: %q), instead of %T",
+			syncID.Kind, syncID.ObjectKey, chartID, source)
+		nt.SyncSources[syncID] = &syncsource.HelmSyncSource{
+			ChartID: chartID,
+		}
+	default:
+		nt.T.Fatalf("Invalid %s source %T: %s", syncID.Kind, source, syncID.Name)
+	}
+}

--- a/e2e/nomostest/git-server.go
+++ b/e2e/nomostest/git-server.go
@@ -34,9 +34,9 @@ import (
 const testGitNamespace = "config-management-system-test"
 const testGitServer = "test-git-server"
 
-const testGitServerImage = testing.TestInfraArtifactRegistry + "/git-server:v1.0.0-68df304c"
+const testGitServerImage = testing.TestInfraArtifactRepositoryAddress + "/git-server:v1.0.0-68df304c"
 const testGitHTTPServer = "http-git-server"
-const testGitHTTPServerImage = testing.TestInfraArtifactRegistry + "/http-git-server:v1.0.0-b3b4984cd"
+const testGitHTTPServerImage = testing.TestInfraArtifactRepositoryAddress + "/http-git-server:v1.0.0-b3b4984cd"
 const safeToEvictAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 
 func testGitServerSelector() map[string]string {

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -952,13 +952,6 @@ func RemoteRootRepoSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 	return commit, nil
 }
 
-// HelmChartVersionShaFn returns the provided chart version as a function.
-func HelmChartVersionShaFn(chartVersion string) Sha1Func {
-	return func(*NT, types.NamespacedName) (string, error) {
-		return chartVersion, nil
-	}
-}
-
 // RemoteNsRepoSha1Fn returns the latest commit from a RepoSync Git spec.
 func RemoteNsRepoSha1Fn(nt *NT, nn types.NamespacedName) (string, error) {
 	rs := &v1beta1.RepoSync{}

--- a/e2e/nomostest/ntopts/multi_repo.go
+++ b/e2e/nomostest/ntopts/multi_repo.go
@@ -71,15 +71,6 @@ func Unstructured(source *syncsource.GitSyncSource) {
 func SyncWithGitSource(id core.ID, gitOpts ...GitSourceOption) func(opt *New) {
 	return func(opt *New) {
 		source := &syncsource.GitSyncSource{}
-		// Set the default source options
-		switch id.Kind {
-		case configsync.RootSyncKind:
-			// RootSyncs use Hierarchy by default
-			source.SourceFormat = configsync.SourceFormatHierarchy
-		case configsync.RepoSyncKind:
-			// RepoSync only ever use unstructured
-			source.SourceFormat = configsync.SourceFormatUnstructured
-		}
 		// Modify the default source with user specified options
 		for _, gitOpt := range gitOpts {
 			gitOpt(source)

--- a/e2e/nomostest/registryproviders/registry_provider.go
+++ b/e2e/nomostest/registryproviders/registry_provider.go
@@ -61,9 +61,16 @@ type ProxiedRegistryProvider interface {
 type OCIRegistryProvider interface {
 	RegistryProvider
 
+	// RegistryRemoteAddress returns the address of the registry.
+	RegistryRemoteAddress() string
+
+	// RepositoryPath returns the name or path of the repository, without the
+	// registry or image details.
+	RepositoryPath() string
+
 	// ImageRemoteAddress returns the address of the image in the registry.
 	// For pulling with RSync's `.spec.oci.image`
-	ImageRemoteAddress(imageName string) (string, error)
+	ImageRemoteAddress(imageName string) string
 
 	// PushImage pushes a local tarball as an OCI image to the remote registry.
 	PushImage(imageName, tag, localSourceTgzPath string) (*OCIImage, error)
@@ -81,7 +88,7 @@ type HelmRegistryProvider interface {
 
 	// RepositoryRemoteURL is the RepositoryRemoteAddress prepended with oci://
 	// For pulling with RSync's `.spec.helm.repo`
-	RepositoryRemoteURL() (string, error)
+	RepositoryRemoteURL() string
 
 	// PushPackage pushes a local helm chart as an OCI image to the remote registry.
 	PushPackage(localChartTgzPath string) (*HelmPackage, error)

--- a/e2e/nomostest/sync.go
+++ b/e2e/nomostest/sync.go
@@ -28,9 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// RootSyncHasStatusSyncDirectory creates a Predicate that ensures that the
+// RootSyncHasStatusSyncPath creates a Predicate that ensures that the
 // .status.sync.gitStatus.dir field on the passed RootSync matches the provided dir.
-func RootSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
+func RootSyncHasStatusSyncPath(syncPath string) testpredicates.Predicate {
 	return func(o client.Object) error {
 		if o == nil {
 			return testpredicates.ErrObjectNotFound
@@ -51,7 +51,7 @@ func RootSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
 					configsync.RootSyncKind, i, log.AsJSON(condition), log.AsYAML(rs))
 			}
 		}
-		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, dir)
+		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, syncPath)
 		if err != nil {
 			return fmt.Errorf("%s %w:\n%s", configsync.RootSyncKind, err, log.AsYAML(rs))
 		}
@@ -59,9 +59,9 @@ func RootSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
 	}
 }
 
-// RepoSyncHasStatusSyncDirectory creates a Predicate that ensures that the
+// RepoSyncHasStatusSyncPath creates a Predicate that ensures that the
 // .status.sync.gitStatus.dir field on the passed RepoSync matches the provided dir.
-func RepoSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
+func RepoSyncHasStatusSyncPath(syncPath string) testpredicates.Predicate {
 	return func(o client.Object) error {
 		if o == nil {
 			return testpredicates.ErrObjectNotFound
@@ -82,7 +82,7 @@ func RepoSyncHasStatusSyncDirectory(dir string) testpredicates.Predicate {
 					configsync.RepoSyncKind, i, log.AsJSON(condition), log.AsYAML(rs))
 			}
 		}
-		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, dir)
+		err := statusHasSyncDirAndNoErrors(rs.Status.Status, rs.Spec.SourceType, syncPath)
 		if err != nil {
 			return fmt.Errorf("%s %w:\n%s", configsync.RepoSyncKind, err, log.AsYAML(rs))
 		}
@@ -161,35 +161,35 @@ func RepoSyncHasStatusSyncCommit(sha1 string) testpredicates.Predicate {
 	}
 }
 
-func statusHasSyncCommitAndNoErrors(status v1beta1.Status, sha1 string) error {
+func statusHasSyncCommitAndNoErrors(status v1beta1.Status, commit string) error {
 	if status.Source.ErrorSummary != nil && status.Source.ErrorSummary.TotalCount > 0 {
 		return fmt.Errorf("status.source contains %d errors", status.Source.ErrorSummary.TotalCount)
 	}
-	if commit := status.Source.Commit; commit != sha1 {
-		return fmt.Errorf("status.source.commit %q does not match git revision %q", commit, sha1)
+	if srcCommit := status.Source.Commit; srcCommit != commit {
+		return fmt.Errorf("status.source.commit %q does not match git revision %q", srcCommit, commit)
 	}
 	if status.Sync.ErrorSummary != nil && status.Sync.ErrorSummary.TotalCount > 0 {
 		return fmt.Errorf("status.sync contains %d errors", status.Sync.ErrorSummary.TotalCount)
 	}
-	if commit := status.Sync.Commit; commit != sha1 {
-		return fmt.Errorf("status.sync.commit %q does not match git revision %q", commit, sha1)
+	if syncCommit := status.Sync.Commit; syncCommit != commit {
+		return fmt.Errorf("status.sync.commit %q does not match git revision %q", syncCommit, commit)
 	}
 	if status.Rendering.ErrorSummary != nil && status.Rendering.ErrorSummary.TotalCount > 0 {
 		return fmt.Errorf("status.rendering contains %d errors", status.Rendering.ErrorSummary.TotalCount)
 	}
-	if commit := status.Rendering.Commit; commit != sha1 {
-		return fmt.Errorf("status.rendering.commit %q does not match git revision %q", commit, sha1)
+	if renderCommit := status.Rendering.Commit; renderCommit != commit {
+		return fmt.Errorf("status.rendering.commit %q does not match git revision %q", renderCommit, commit)
 	}
 	if message := status.Rendering.Message; message != parse.RenderingSucceeded && message != parse.RenderingSkipped {
 		return fmt.Errorf("status.rendering.message %q does not indicate a successful state", message)
 	}
-	if commit := status.LastSyncedCommit; commit != sha1 {
-		return fmt.Errorf("status.lastSyncedCommit %q does not match commit hash %q", commit, sha1)
+	if lastSyncedCommit := status.LastSyncedCommit; lastSyncedCommit != commit {
+		return fmt.Errorf("status.lastSyncedCommit %q does not match commit hash %q", lastSyncedCommit, commit)
 	}
 	return nil
 }
 
-func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType configsync.SourceType, dir string) error {
+func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType configsync.SourceType, syncPath string) error {
 	if status.Source.ErrorSummary != nil && status.Source.ErrorSummary.TotalCount > 0 {
 		return fmt.Errorf("status.source contains %d errors", status.Source.ErrorSummary.TotalCount)
 	}
@@ -207,58 +207,58 @@ func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType configsync.So
 		if status.Source.Oci == nil {
 			return fmt.Errorf("status.source.oci is nil")
 		}
-		if ociDir := status.Source.Oci.Dir; ociDir != dir {
-			return fmt.Errorf("status.source.oci.dir %q does not match the provided directory %q", ociDir, dir)
+		if ociDir := status.Source.Oci.Dir; ociDir != syncPath {
+			return fmt.Errorf("status.source.oci.dir %q does not match the expected directory %q", ociDir, syncPath)
 		}
 		if status.Sync.Oci == nil {
 			return fmt.Errorf("status.sync.oci is nil")
 		}
-		if ociDir := status.Sync.Oci.Dir; ociDir != dir {
-			return fmt.Errorf("status.sync.oci.dir %q does not match the provided directory %q", ociDir, dir)
+		if ociDir := status.Sync.Oci.Dir; ociDir != syncPath {
+			return fmt.Errorf("status.sync.oci.dir %q does not match the expected directory %q", ociDir, syncPath)
 		}
 		if status.Rendering.Oci == nil {
 			return fmt.Errorf("status.rendering.oci is nil")
 		}
-		if ociDir := status.Rendering.Oci.Dir; ociDir != dir {
-			return fmt.Errorf("status.rendering.oci.dir %q does not match the provided directory %q", ociDir, dir)
+		if ociDir := status.Rendering.Oci.Dir; ociDir != syncPath {
+			return fmt.Errorf("status.rendering.oci.dir %q does not match the expected directory %q", ociDir, syncPath)
 		}
 	case configsync.GitSource:
 		if status.Source.Git == nil {
 			return fmt.Errorf("status.source.git is nil")
 		}
-		if gitDir := status.Source.Git.Dir; gitDir != dir {
-			return fmt.Errorf("status.source.git.dir %q does not match the provided directory %q", gitDir, dir)
+		if gitDir := status.Source.Git.Dir; gitDir != syncPath {
+			return fmt.Errorf("status.source.git.dir %q does not match the expected directory %q", gitDir, syncPath)
 		}
 		if status.Sync.Git == nil {
 			return fmt.Errorf("status.sync.git is nil")
 		}
-		if gitDir := status.Sync.Git.Dir; gitDir != dir {
-			return fmt.Errorf("status.sync.git.dir %q does not match the provided directory %q", gitDir, dir)
+		if gitDir := status.Sync.Git.Dir; gitDir != syncPath {
+			return fmt.Errorf("status.sync.git.dir %q does not match the expected directory %q", gitDir, syncPath)
 		}
 		if status.Rendering.Git == nil {
 			return fmt.Errorf("status.rendering.git is nil")
 		}
-		if gitDir := status.Rendering.Git.Dir; gitDir != dir {
-			return fmt.Errorf("status.rendering.git.dir %q does not match the provided directory %q", gitDir, dir)
+		if gitDir := status.Rendering.Git.Dir; gitDir != syncPath {
+			return fmt.Errorf("status.rendering.git.dir %q does not match the expected directory %q", gitDir, syncPath)
 		}
 	case configsync.HelmSource:
 		if status.Source.Helm == nil {
 			return fmt.Errorf("status.source.helm is nil")
 		}
-		if helmChart := status.Source.Helm.Chart; helmChart != dir {
-			return fmt.Errorf("status.source.helm.chart %q does not match the provided chart %q", helmChart, dir)
+		if helmChart := status.Source.Helm.Chart; helmChart != syncPath {
+			return fmt.Errorf("status.source.helm.chart %q does not match the expected chart %q", helmChart, syncPath)
 		}
 		if status.Sync.Helm == nil {
 			return fmt.Errorf("status.sync.helm is nil")
 		}
-		if helmChart := status.Sync.Helm.Chart; helmChart != dir {
-			return fmt.Errorf("status.sync.helm.chart %q does not match the provided chart %q", helmChart, dir)
+		if helmChart := status.Sync.Helm.Chart; helmChart != syncPath {
+			return fmt.Errorf("status.sync.helm.chart %q does not match the expected chart %q", helmChart, syncPath)
 		}
 		if status.Rendering.Helm == nil {
 			return fmt.Errorf("status.rendering.helm is nil")
 		}
-		if helmChart := status.Rendering.Helm.Chart; helmChart != dir {
-			return fmt.Errorf("status.rendering.helm.chart %q does not match the provided chart %q", helmChart, dir)
+		if helmChart := status.Rendering.Helm.Chart; helmChart != syncPath {
+			return fmt.Errorf("status.rendering.helm.chart %q does not match the expected chart %q", helmChart, syncPath)
 		}
 	}
 	return nil

--- a/e2e/nomostest/syncsource/syncsource.go
+++ b/e2e/nomostest/syncsource/syncsource.go
@@ -15,7 +15,7 @@
 package syncsource
 
 import (
-	"fmt"
+	"strings"
 
 	"kpt.dev/configsync/e2e/nomostest/gitproviders"
 	"kpt.dev/configsync/e2e/nomostest/registryproviders"
@@ -27,9 +27,13 @@ type SyncSource interface {
 	// Type returns the SourceType of this source.
 	Type() configsync.SourceType
 	// Commit returns the current/latest "commit" for this source.
-	// The commit value is used to validate RSync status and metrics.
+	// The value is used to validate RSync status and metrics.
 	Commit() (string, error)
-	// TODO: Add SourceFormat
+	// Path within the source to sync to the cluster.
+	// For Helm charts, the value represents the chart name instead.
+	// The value is used to validate RSync status.
+	Path() string
+	// TODO: Add SourceFormat?
 }
 
 // GitSyncSource is the "git" source, backed by a Git repository.
@@ -39,6 +43,8 @@ type GitSyncSource struct {
 	Repository *gitproviders.Repository
 	// TODO: Add SyncPath and Branch/Revision to uniquely identify part of a repo
 	SourceFormat configsync.SourceFormat
+	// Directory is the path within the source to sync to the cluster.
+	Directory string
 }
 
 // Type returns the SourceType of this source.
@@ -49,6 +55,11 @@ func (s *GitSyncSource) Type() configsync.SourceType {
 // Commit returns the current commit hash targeted by the local git repository.
 func (s *GitSyncSource) Commit() (string, error) {
 	return s.Repository.Hash()
+}
+
+// Path within the git repository to sync to the cluster.
+func (s *GitSyncSource) Path() string {
+	return s.Directory
 }
 
 // HelmSyncSource is the "helm" source, backed by a Helm chart.
@@ -67,8 +78,26 @@ func (s *HelmSyncSource) Commit() (string, error) {
 	return s.ChartID.Version, nil
 }
 
+// Path returns the name of the current chart.
+func (s *HelmSyncSource) Path() string {
+	return s.ChartID.Name
+}
+
 // OCISyncSource is the "oci" source, backed by an OCI image.
 type OCISyncSource struct {
+	// ImageID is the ID of the OCI image.
+	//
+	// This must use the "remote" address used by the reconciler, not the
+	// "local" address using the kubectl proxy.
+	//
+	// Since this is used to configure syncing, the image digest should only be
+	// specified if it should be used when pulling.
+	ImageID registryproviders.OCIImageID
+	// Digest of the OCI image, including "sha256:" prefix.
+	// This is the digest used for validating the image after pulling/syncing.
+	Digest string
+	// Directory is the path within the OCI image to sync to the cluster.
+	Directory string
 	// TODO: add an OCI-specific image ID & migrate OCI RSyncs to use OCISyncSource
 	// TODO: Add OCIRegistryProvider to allow for chart modifications
 }
@@ -80,5 +109,10 @@ func (s *OCISyncSource) Type() configsync.SourceType {
 
 // Commit is not yet implemented.
 func (s *OCISyncSource) Commit() (string, error) {
-	return "", fmt.Errorf("not yet implemented: OCISyncSource.Commit")
+	return strings.TrimPrefix(s.Digest, "sha256:"), nil
+}
+
+// Path within the OCI image to sync to the cluster.
+func (s *OCISyncSource) Path() string {
+	return s.Directory
 }

--- a/e2e/nomostest/testing/env.go
+++ b/e2e/nomostest/testing/env.go
@@ -15,21 +15,27 @@
 package testing
 
 const (
-	// ARHost is the host address of the Artifact Registry
-	ARHost = "us-docker.pkg.dev"
-
-	// GCRHost is the host address of the Container Registry
-	GCRHost = "gcr.io"
-
+	// ArtifactRegistryHost is the host address of the Artifact Registry
+	ArtifactRegistryHost = "us-docker.pkg.dev"
+	// GoogleContainerRegistryHost is the host address of the Container Registry
+	GoogleContainerRegistryHost = "gcr.io"
 	// CSRHost is the host address of the Cloud Source Repositories
 	CSRHost = "https://source.developers.google.com"
 
-	// TestInfraContainerRegistry is the Config Sync test-infra registry hosted on GCR
-	TestInfraContainerRegistry = GCRHost + "/kpt-config-sync-ci-artifacts"
-	// TestInfraArtifactRegistry is the Config Sync test-infra registry hosted on GAR
-	TestInfraArtifactRegistry = ARHost + "/kpt-config-sync-ci-artifacts/test-infra"
-	// ConfigSyncTestPublicRegistry is the Config Sync config-sync-test-public registry hosted on GAR
-	ConfigSyncTestPublicRegistry = ARHost + "/kpt-config-sync-ci-artifacts/config-sync-test-public"
+	// TestInfraContainerRepositoryPath is the Config Sync test-infra repository path
+	TestInfraContainerRepositoryPath = "kpt-config-sync-ci-artifacts"
+	// TestInfraArtifactRepositoryPath is the Config Sync test-infra repository path
+	TestInfraArtifactRepositoryPath = "kpt-config-sync-ci-artifacts/test-infra"
+	// ConfigSyncTestPublicRepositoryPath is the Config Sync config-sync-test-public repository path
+	ConfigSyncTestPublicRepositoryPath = "kpt-config-sync-ci-artifacts/config-sync-test-public"
+
+	// TestInfraContainerRepositoryAddress is the Config Sync test-infra repository hosted on GCR
+	TestInfraContainerRepositoryAddress = GoogleContainerRegistryHost + "/" + TestInfraContainerRepositoryPath
+	// TestInfraArtifactRepositoryAddress is the Config Sync test-infra repository hosted on GAR
+	TestInfraArtifactRepositoryAddress = ArtifactRegistryHost + "/" + TestInfraArtifactRepositoryPath
+	// ConfigSyncTestPublicRepositoryAddress is the Config Sync config-sync-test-public repository hosted on GAR
+	ConfigSyncTestPublicRepositoryAddress = ArtifactRegistryHost + "/" + ConfigSyncTestPublicRepositoryPath
+
 	// HTTPDImage is the httpd image used by on-cluster test components
 	HTTPDImage = "httpd:2"
 	// RegistryImage is the registry image used by on-cluster test components

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1680,9 +1680,9 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 	err = nt.WatchForSync(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName, configsync.ControllerNamespace,
 		nomostest.RemoteRootRepoSha1Fn, nomostest.RootSyncHasStatusSyncCommit,
-		&nomostest.SyncDirPredicatePair{
-			Dir:       expectedRootSyncSpec.Dir,
-			Predicate: nomostest.RootSyncHasStatusSyncDirectory,
+		&nomostest.SyncPathPredicatePair{
+			Path:      expectedRootSyncSpec.Dir,
+			Predicate: nomostest.RootSyncHasStatusSyncPath,
 		}, testwatcher.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -366,18 +366,18 @@ func waitForSync(nt *nomostest.NT, sha1Func nomostest.Sha1Func, objs ...client.O
 			tg.Go(func() error {
 				return nt.WatchForSync(kinds.RootSyncV1Beta1(), rsync.Name, rsync.Namespace,
 					sha1Func, nomostest.RootSyncHasStatusSyncCommit,
-					&nomostest.SyncDirPredicatePair{
-						Dir:       rsync.Spec.Git.Dir,
-						Predicate: nomostest.RootSyncHasStatusSyncDirectory,
+					&nomostest.SyncPathPredicatePair{
+						Path:      rsync.Spec.Git.Dir,
+						Predicate: nomostest.RootSyncHasStatusSyncPath,
 					})
 			})
 		case *v1beta1.RepoSync:
 			tg.Go(func() error {
 				return nt.WatchForSync(kinds.RepoSyncV1Beta1(), rsync.Name, rsync.Namespace,
 					sha1Func, nomostest.RepoSyncHasStatusSyncCommit,
-					&nomostest.SyncDirPredicatePair{
-						Dir:       rsync.Spec.Git.Dir,
-						Predicate: nomostest.RepoSyncHasStatusSyncDirectory,
+					&nomostest.SyncPathPredicatePair{
+						Path:      rsync.Spec.Git.Dir,
+						Predicate: nomostest.RepoSyncHasStatusSyncPath,
 					})
 			})
 		default:

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -38,7 +38,6 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/policy"
 	"kpt.dev/configsync/e2e/nomostest/registryproviders"
-	"kpt.dev/configsync/e2e/nomostest/syncsource"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -400,9 +399,7 @@ func TestHelmLatestVersion(t *testing.T) {
 	}
 
 	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chart.HelmChartID)
-	nt.SyncSources[rootSyncID] = &syncsource.HelmSyncSource{
-		ChartID: chart.HelmChartID,
-	}
+	nomostest.SetExpectedHelmSource(nt, rootSyncID, chart.HelmChartID)
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate version label of a deployment from the helm chart")
@@ -418,9 +415,7 @@ func TestHelmLatestVersion(t *testing.T) {
 	}
 
 	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chart.HelmChartID)
-	nt.SyncSources[rootSyncID] = &syncsource.HelmSyncSource{
-		ChartID: chart.HelmChartID,
-	}
+	nomostest.SetExpectedHelmSource(nt, rootSyncID, chart.HelmChartID)
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate version label of a deployment from the helm chart")
@@ -450,9 +445,7 @@ func TestHelmVersionRange(t *testing.T) {
 		Version: "15.4.1", // latest minor+patch with the same major version
 	}
 	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chartID)
-	nt.SyncSources[rootSyncID] = &syncsource.HelmSyncSource{
-		ChartID: chartID,
-	}
+	nomostest.SetExpectedHelmSource(nt, rootSyncID, chartID)
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate Deployment from chart exists")

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -34,7 +34,7 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
 
 	// Update RootSync to invalid branch name
-	nomostest.SetGitBranch(nt, configsync.RootSyncName, "invalid-branch")
+	nomostest.SetRootSyncGitBranch(nt, configsync.RootSyncName, "invalid-branch")
 
 	nt.WaitForRootSyncSourceError(configsync.RootSyncName, status.SourceErrorCode, "")
 
@@ -54,7 +54,7 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 	}
 
 	// Update RootSync to valid branch name
-	nomostest.SetGitBranch(nt, configsync.RootSyncName, gitproviders.MainBranch)
+	nomostest.SetRootSyncGitBranch(nt, configsync.RootSyncName, gitproviders.MainBranch)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -138,7 +138,7 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 	nt.T.Cleanup(func() {
 		nt.T.Log("Resetting all RootSync branches to main")
 		nt.Must(rootSyncGitRepo.CheckoutBranch(gitproviders.MainBranch))
-		nomostest.SetGitBranch(nt, configsync.RootSyncName, gitproviders.MainBranch)
+		nomostest.SetRootSyncGitBranch(nt, configsync.RootSyncName, gitproviders.MainBranch)
 		if err := nt.WatchForAllSyncs(); err != nil {
 			nt.T.Fatal(err)
 		}
@@ -157,7 +157,7 @@ func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPushBranch("add namespace to acme directory", devBranch))
 
 	// Update RootSync to sync from the dev branch
-	nomostest.SetGitBranch(nt, configsync.RootSyncName, devBranch)
+	nomostest.SetRootSyncGitBranch(nt, configsync.RootSyncName, devBranch)
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
 	}

--- a/e2e/testcases/profiling_test.go
+++ b/e2e/testcases/profiling_test.go
@@ -449,18 +449,18 @@ func watchForSyncedAndReconciled(nt *nomostest.NT, rsRefs []rSyncRef) error {
 			tg.Go(func() error {
 				return nt.WatchForSync(reRefPtr.GroupVersionKind, reRefPtr.Name, reRefPtr.Namespace,
 					reRefPtr.CommitFunc, nomostest.RootSyncHasStatusSyncCommit,
-					&nomostest.SyncDirPredicatePair{
-						Dir:       reRefPtr.SyncPath,
-						Predicate: nomostest.RootSyncHasStatusSyncDirectory,
+					&nomostest.SyncPathPredicatePair{
+						Path:      reRefPtr.SyncPath,
+						Predicate: nomostest.RootSyncHasStatusSyncPath,
 					})
 			})
 		case configsync.RepoSyncKind:
 			tg.Go(func() error {
 				return nt.WatchForSync(reRefPtr.GroupVersionKind, reRefPtr.Name, reRefPtr.Namespace,
 					reRefPtr.CommitFunc, nomostest.RepoSyncHasStatusSyncCommit,
-					&nomostest.SyncDirPredicatePair{
-						Dir:       reRefPtr.SyncPath,
-						Predicate: nomostest.RepoSyncHasStatusSyncDirectory,
+					&nomostest.SyncPathPredicatePair{
+						Path:      reRefPtr.SyncPath,
+						Predicate: nomostest.RepoSyncHasStatusSyncPath,
 					})
 			})
 		default:

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -1261,12 +1261,10 @@ func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 	// Change RepoSync sync dir to trigger reconciler-manager to update the reconciler
 	repoSync := k8sobjects.RepoSyncObjectV1Beta1(repoSyncKey.Namespace, repoSyncKey.Name)
 	nt.MustMergePatch(repoSync, fmt.Sprintf(`{"spec":{"git":{"dir":%q}}}`, repoSyncDir2))
+	nomostest.SetExpectedSyncPath(nt, repoSyncID, repoSyncDir2)
 	nt.Must(nt.WatchForAllSyncs(
 		nomostest.SkipReadyCheck(), // Skip ready check because it requires the RootSync CRD to exist.
-		nomostest.RepoSyncOnly(),
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-			repoSyncKey: repoSyncDir2,
-		})))
+		nomostest.RepoSyncOnly()))
 	nt.Must(nt.Validate(saName2, repoSyncNS, &corev1.ServiceAccount{}))
 
 	nt.Must(nomostest.InstallRootSyncCRD(nt))
@@ -1284,10 +1282,6 @@ func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 	rootSync.Status = v1beta1.RootSyncStatus{}
 	// Re-create RootSync with same spec as before
 	nt.Must(nt.KubeClient.Create(rootSync))
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-			rootSyncKey: rootSyncDir1,
-			repoSyncKey: repoSyncDir2,
-		})))
+	nt.Must(nt.WatchForAllSyncs())
 	nt.Must(nt.Validate(nsName1, "", &corev1.Namespace{}))
 }

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -197,21 +197,21 @@ func TestWorkloadIdentity(t *testing.T) {
 			fleetWITest:  false,
 			crossProject: false,
 			rootSrcCfg: sourceConfig{
-				chart:    privateCoreDNSHelmChart,
-				version:  privateCoreDNSHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateCoreDNSHelmChartVersion)},
+				chart:   privateCoreDNSHelmChart,
+				version: privateCoreDNSHelmChartVersion,
+			},
 			nsSrcCfg: sourceConfig{
-				chart:    privateNSHelmChart,
-				version:  "0.1.0",
-				commitFn: nomostest.HelmChartVersionShaFn("0.1.0")},
+				chart:   privateNSHelmChart,
+				version: "0.1.0",
+			},
 			newRootSrcCfg: sourceConfig{
-				chart:    privateSimpleHelmChart,
-				version:  privateSimpleHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateSimpleHelmChartVersion)},
+				chart:   privateSimpleHelmChart,
+				version: privateSimpleHelmChartVersion,
+			},
 			newNSSrcCfg: sourceConfig{
-				chart:    "simple-ns-chart",
-				version:  "1.0.0",
-				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
+				chart:   "simple-ns-chart",
+				version: "1.0.0",
+			},
 			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
@@ -222,21 +222,21 @@ func TestWorkloadIdentity(t *testing.T) {
 			fleetWITest:  true,
 			crossProject: false,
 			rootSrcCfg: sourceConfig{
-				chart:    privateCoreDNSHelmChart,
-				version:  privateCoreDNSHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateCoreDNSHelmChartVersion)},
+				chart:   privateCoreDNSHelmChart,
+				version: privateCoreDNSHelmChartVersion,
+			},
 			nsSrcCfg: sourceConfig{
-				chart:    privateNSHelmChart,
-				version:  "0.1.0",
-				commitFn: nomostest.HelmChartVersionShaFn("0.1.0")},
+				chart:   privateNSHelmChart,
+				version: "0.1.0",
+			},
 			newRootSrcCfg: sourceConfig{
-				chart:    privateSimpleHelmChart,
-				version:  privateSimpleHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateSimpleHelmChartVersion)},
+				chart:   privateSimpleHelmChart,
+				version: privateSimpleHelmChartVersion,
+			},
 			newNSSrcCfg: sourceConfig{
-				chart:    "simple-ns-chart",
-				version:  "1.0.0",
-				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
+				chart:   "simple-ns-chart",
+				version: "1.0.0",
+			},
 			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
@@ -247,21 +247,21 @@ func TestWorkloadIdentity(t *testing.T) {
 			fleetWITest:  true,
 			crossProject: true,
 			rootSrcCfg: sourceConfig{
-				chart:    privateCoreDNSHelmChart,
-				version:  privateCoreDNSHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateCoreDNSHelmChartVersion)},
+				chart:   privateCoreDNSHelmChart,
+				version: privateCoreDNSHelmChartVersion,
+			},
 			nsSrcCfg: sourceConfig{
-				chart:    privateNSHelmChart,
-				version:  "0.1.0",
-				commitFn: nomostest.HelmChartVersionShaFn("0.1.0")},
+				chart:   privateNSHelmChart,
+				version: "0.1.0",
+			},
 			newRootSrcCfg: sourceConfig{
-				chart:    privateSimpleHelmChart,
-				version:  privateSimpleHelmChartVersion,
-				commitFn: nomostest.HelmChartVersionShaFn(privateSimpleHelmChartVersion)},
+				chart:   privateSimpleHelmChart,
+				version: privateSimpleHelmChartVersion,
+			},
 			newNSSrcCfg: sourceConfig{
-				chart:    "simple-ns-chart",
-				version:  "1.0.0",
-				commitFn: nomostest.HelmChartVersionShaFn("1.0.0")},
+				chart:   "simple-ns-chart",
+				version: "1.0.0",
+			},
 			sourceType:       configsync.HelmSource,
 			gsaEmail:         gsaARReaderEmail(),
 			testKSAMigration: true,
@@ -371,11 +371,11 @@ func TestWorkloadIdentity(t *testing.T) {
 
 			case configsync.OciSource:
 				if tc.requireOCIGAR { // OCI provider is AR
-					rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rootSyncKey, tc.rootSrcCfg)
+					rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rootSyncID, tc.rootSrcCfg)
 					if err != nil {
 						nt.T.Fatal(err)
 					}
-					nsMeta, err = updateRepoSyncWithOCISourceConfig(nt, repoSyncKey, tc.nsSrcCfg)
+					nsMeta, err = updateRepoSyncWithOCISourceConfig(nt, repoSyncID, tc.nsSrcCfg)
 					if err != nil {
 						nt.T.Fatal(err)
 					}
@@ -392,7 +392,7 @@ func TestWorkloadIdentity(t *testing.T) {
 						}
 					}`, configsync.OciSource, tc.rootSrcCfg.repo, tc.rootSrcCfg.dir, tc.gsaEmail))
 					rootMeta = rsyncValidateMeta{
-						rsRef:    rootSyncKey,
+						rsID:     rootSyncID,
 						sha1Func: tc.rootSrcCfg.commitFn,
 						syncDir:  tc.rootSrcCfg.dir,
 					}
@@ -408,7 +408,7 @@ func TestWorkloadIdentity(t *testing.T) {
 						}
 					}`, configsync.OciSource, tc.nsSrcCfg.repo, tc.nsSrcCfg.dir, tc.gsaEmail))
 					nsMeta = rsyncValidateMeta{
-						rsRef:    repoSyncKey,
+						rsID:     repoSyncID,
 						sha1Func: tc.nsSrcCfg.commitFn,
 						syncDir:  tc.nsSrcCfg.dir,
 					}
@@ -457,43 +457,27 @@ func TestWorkloadIdentity(t *testing.T) {
 
 			switch tc.sourceType {
 			case configsync.GitSource, configsync.OciSource:
-				if err = nt.WatchForAllSyncs(
+				nomostest.SetExpectedSyncPath(nt, rootMeta.rsID, rootMeta.syncDir)
+				nomostest.SetExpectedSyncPath(nt, nsMeta.rsID, nsMeta.syncDir)
+				nt.Must(nt.WatchForAllSyncs(
 					nomostest.WithRootSha1Func(rootMeta.sha1Func),
-					nomostest.WithRepoSha1Func(nsMeta.sha1Func),
-					nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-						rootMeta.rsRef: rootMeta.syncDir,
-						nsMeta.rsRef:   nsMeta.syncDir})); err != nil {
-					nt.T.Fatal(err)
-				}
+					nomostest.WithRepoSha1Func(nsMeta.sha1Func)))
 				kustomizecomponents.ValidateAllTenants(nt, string(declared.RootScope), "base", "tenant-a", "tenant-b", "tenant-c")
-				kustomizecomponents.ValidateTenant(nt, nsMeta.rsRef.Namespace, "test-ns", "base")
+				kustomizecomponents.ValidateTenant(nt, nsMeta.rsID.Namespace, "test-ns", "base")
 
 			case configsync.HelmSource:
-				if err = nt.WatchForAllSyncs(
-					nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(rootChart.Version)),
-					nomostest.WithRepoSha1Func(nomostest.HelmChartVersionShaFn(nsChart.Version)),
-					nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-						rootSyncKey: rootChart.Name,
-						repoSyncKey: nsChart.Name})); err != nil {
-					nt.T.Fatal(err)
-				}
-				if err = nt.Validate(truncateStringByLength(fmt.Sprintf("%s-%s", rootChart.Name, rootChart.Name), 63),
+				nt.Must(nt.WatchForAllSyncs())
+				nt.Must(nt.Validate(truncateStringByLength(fmt.Sprintf("%s-%s", rootChart.Name, rootChart.Name), 63),
 					"default", &appsv1.Deployment{},
-					testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rootSyncKey.Name)); err != nil {
-					nt.T.Fatal(err)
-				}
-				if err = nt.Validate(truncateStringByLength(nsChart.Name, 63),
+					testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rootSyncKey.Name)))
+				nt.Must(nt.Validate(truncateStringByLength(nsChart.Name, 63),
 					repoSyncKey.Namespace, &appsv1.Deployment{},
-					testpredicates.IsManagedBy(nt.Scheme, declared.Scope(repoSyncKey.Namespace), repoSyncKey.Name)); err != nil {
-					nt.T.Fatal(err)
-				}
+					testpredicates.IsManagedBy(nt.Scheme, declared.Scope(repoSyncKey.Namespace), repoSyncKey.Name)))
 			}
 
 			// Migrate from gcpserviceaccount to k8sserviceaccount
 			if tc.testKSAMigration {
-				if err := migrateFromGSAtoKSA(nt, tc.fleetWITest, tc.sourceType, rootSyncKey, repoSyncKey, tc.newRootSrcCfg, tc.newNSSrcCfg); err != nil {
-					nt.T.Fatal(err)
-				}
+				nt.Must(migrateFromGSAtoKSA(nt, tc.fleetWITest, tc.sourceType, rootSyncID, repoSyncID, tc.newRootSrcCfg, tc.newNSSrcCfg))
 			}
 		})
 	}
@@ -540,17 +524,16 @@ func updateRepoSyncWithHelmSourceConfig(nt *nomostest.NT, rsRef types.Namespaced
 	return chart, nil
 }
 
-func updateRootSyncWithOCISourceConfig(nt *nomostest.NT, rsRef types.NamespacedName, sc sourceConfig, mutators ...rootSyncMutator) (rsyncValidateMeta, error) {
-	meta := rsyncValidateMeta{rsRef: rsRef, syncDir: sc.dir}
-	image, err := nt.BuildAndPushOCIImage(rsRef,
+func updateRootSyncWithOCISourceConfig(nt *nomostest.NT, rsID core.ID, sc sourceConfig, mutators ...rootSyncMutator) (rsyncValidateMeta, error) {
+	meta := rsyncValidateMeta{rsID: rsID, syncDir: sc.dir}
+	image, err := nt.BuildAndPushOCIImage(rsID.ObjectKey,
 		registryproviders.ImageSourcePackage(sc.pkg),
 		registryproviders.ImageVersion(sc.version))
 	if err != nil {
 		return meta, fmt.Errorf("pushing oci image: %w", err)
 	}
 	nt.T.Log("Update RootSync to sync from an OCI image")
-	rootSyncOCI := nt.RootSyncObjectOCI(configsync.RootSyncName, image)
-	rootSyncOCI.Spec.Oci.Dir = sc.dir
+	rootSyncOCI := nt.RootSyncObjectOCI(configsync.RootSyncName, image.OCIImageID().WithoutDigest(), sc.dir, image.Digest)
 	for _, mutator := range mutators {
 		mutator(rootSyncOCI)
 	}
@@ -561,17 +544,16 @@ func updateRootSyncWithOCISourceConfig(nt *nomostest.NT, rsRef types.NamespacedN
 	return meta, nil
 }
 
-func updateRepoSyncWithOCISourceConfig(nt *nomostest.NT, rsRef types.NamespacedName, sc sourceConfig, mutators ...repoSyncMutator) (rsyncValidateMeta, error) {
-	meta := rsyncValidateMeta{rsRef: rsRef, syncDir: sc.dir}
-	image, err := nt.BuildAndPushOCIImage(rsRef,
+func updateRepoSyncWithOCISourceConfig(nt *nomostest.NT, rsID core.ID, sc sourceConfig, mutators ...repoSyncMutator) (rsyncValidateMeta, error) {
+	meta := rsyncValidateMeta{rsID: rsID, syncDir: sc.dir}
+	image, err := nt.BuildAndPushOCIImage(rsID.ObjectKey,
 		registryproviders.ImageSourcePackage(sc.pkg),
 		registryproviders.ImageVersion(sc.version))
 	if err != nil {
 		return meta, fmt.Errorf("pushing oci image: %w", err)
 	}
 	nt.T.Log("Update RepoSync to sync from an OCI image")
-	repoSyncOCI := nt.RepoSyncObjectOCI(rsRef, image)
-	repoSyncOCI.Spec.Oci.Dir = sc.dir
+	repoSyncOCI := nt.RepoSyncObjectOCI(rsID.ObjectKey, image.OCIImageID().WithoutDigest(), sc.dir, image.Digest)
 	for _, mutator := range mutators {
 		mutator(repoSyncOCI)
 	}
@@ -583,7 +565,7 @@ func updateRepoSyncWithOCISourceConfig(nt *nomostest.NT, rsRef types.NamespacedN
 }
 
 type rsyncValidateMeta struct {
-	rsRef    types.NamespacedName
+	rsID     core.ID
 	sha1Func nomostest.Sha1Func
 	syncDir  string
 }
@@ -598,8 +580,11 @@ func updateRSyncWithGitSourceConfig(nt *nomostest.NT, rs client.Object, repo *gi
 						}
 					}
 				}`, sc.dir))
-	rsRef := client.ObjectKey{Name: rs.GetName(), Namespace: rs.GetNamespace()}
-	return rsyncValidateMeta{rsRef: rsRef, sha1Func: sc.commitFn, syncDir: sc.dir}
+	id, err := kinds.LookupID(rs, nt.Scheme)
+	if err != nil {
+		nt.T.Fatalf("invalid object ID: %v", err)
+	}
+	return rsyncValidateMeta{rsID: id, sha1Func: sc.commitFn, syncDir: sc.dir}
 }
 
 func truncateStringByLength(s string, l int) string {
@@ -611,34 +596,33 @@ func truncateStringByLength(s string, l int) string {
 
 // migrateFromGSAtoKSA tests the scenario of migrating from impersonating a GSA
 // to leveraging KSA+WI (a.k.a, BYOID/Ubermint).
-func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsync.SourceType, rsRef, nsRef types.NamespacedName, rootSC, nsSC sourceConfig) error {
+func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsync.SourceType, rsID, nsID core.ID, rootSC, nsSC sourceConfig) error {
 	nt.T.Log("Update RootSync auth type from gcpserviceaccount to k8sserviceaccount")
 	var err error
 	var rootMeta, nsMeta rsyncValidateMeta
-	var rootChart, nsChart *registryproviders.HelmPackage
 	// Change the source config to guarantee new resources can be reconciled with k8sserviceaccount
 	switch sourceType {
 	case configsync.HelmSource:
-		rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rsRef, rootSC, func(rs *v1beta1.RootSync) {
+		_, err = updateRootSyncWithHelmSourceConfig(nt, rsID.ObjectKey, rootSC, func(rs *v1beta1.RootSync) {
 			rs.Spec.Helm.Auth = configsync.AuthK8sServiceAccount
 		})
 		if err != nil {
 			nt.T.Fatal(err)
 		}
-		nsChart, err = updateRepoSyncWithHelmSourceConfig(nt, nsRef, nsSC, func(rs *v1beta1.RepoSync) {
+		_, err = updateRepoSyncWithHelmSourceConfig(nt, nsID.ObjectKey, nsSC, func(rs *v1beta1.RepoSync) {
 			rs.Spec.Helm.Auth = configsync.AuthK8sServiceAccount
 		})
 		if err != nil {
 			nt.T.Fatal(err)
 		}
 	case configsync.OciSource:
-		rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rsRef, rootSC, func(rs *v1beta1.RootSync) {
+		rootMeta, err = updateRootSyncWithOCISourceConfig(nt, rsID, rootSC, func(rs *v1beta1.RootSync) {
 			rs.Spec.Oci.Auth = configsync.AuthK8sServiceAccount
 		})
 		if err != nil {
 			nt.T.Fatal(err)
 		}
-		nsMeta, err = updateRepoSyncWithOCISourceConfig(nt, nsRef, nsSC, func(rs *v1beta1.RepoSync) {
+		nsMeta, err = updateRepoSyncWithOCISourceConfig(nt, nsID, nsSC, func(rs *v1beta1.RepoSync) {
 			rs.Spec.Oci.Auth = configsync.AuthK8sServiceAccount
 		})
 		if err != nil {
@@ -647,8 +631,8 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsy
 	}
 
 	// Validations
-	rootReconcilerName := core.RootReconcilerName(rsRef.Name)
-	nsReconcilerName := core.NsReconcilerName(nsRef.Namespace, nsRef.Name)
+	rootReconcilerName := core.RootReconcilerName(rsID.Name)
+	nsReconcilerName := core.NsReconcilerName(nsID.Namespace, nsID.Name)
 	nt.T.Log("Validate the GSA annotation is removed from the RSync's service accounts")
 	tg := taskgroup.New()
 	tg.Go(func() error {
@@ -690,14 +674,11 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsy
 
 	switch sourceType {
 	case configsync.GitSource, configsync.OciSource:
-		if err = nt.WatchForAllSyncs(
+		nomostest.SetExpectedSyncPath(nt, rootMeta.rsID, rootMeta.syncDir)
+		nomostest.SetExpectedSyncPath(nt, nsMeta.rsID, nsMeta.syncDir)
+		nt.Must(nt.WatchForAllSyncs(
 			nomostest.WithRootSha1Func(rootMeta.sha1Func),
-			nomostest.WithRepoSha1Func(nsMeta.sha1Func),
-			nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-				rootMeta.rsRef: rootMeta.syncDir,
-				nsMeta.rsRef:   nsMeta.syncDir})); err != nil {
-			nt.T.Fatal(err)
-		}
+			nomostest.WithRepoSha1Func(nsMeta.sha1Func)))
 		kustomizecomponents.ValidateAllTenants(nt, string(declared.RootScope), "../base", "tenant-a")
 		if err := nt.ValidateNotFound("tenant-b", "", &corev1.Namespace{}); err != nil {
 			return err
@@ -705,29 +686,16 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsy
 		if err := nt.ValidateNotFound("tenant-c", "", &corev1.Namespace{}); err != nil {
 			return err
 		}
-		kustomizecomponents.ValidateTenant(nt, nsMeta.rsRef.Namespace, "test-ns", "../base")
+		kustomizecomponents.ValidateTenant(nt, nsMeta.rsID.Namespace, "test-ns", "../base")
 
 	case configsync.HelmSource:
-		if err = nt.WatchForAllSyncs(
-			nomostest.WithRootSha1Func(nomostest.HelmChartVersionShaFn(rootChart.Version)),
-			nomostest.WithRepoSha1Func(nomostest.HelmChartVersionShaFn(nsChart.Version)),
-			nomostest.WithSyncDirectoryMap(map[types.NamespacedName]string{
-				rsRef: rootChart.Name,
-				nsRef: nsChart.Name})); err != nil {
-			nt.T.Fatal(err)
-		}
-		if err = nt.Validate("deploy-ns", "ns", &appsv1.Deployment{},
-			testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rsRef.Name)); err != nil {
-			nt.T.Fatal(err)
-		}
-		if err = nt.Validate("deploy-default", "default", &appsv1.Deployment{},
-			testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rsRef.Name)); err != nil {
-			nt.T.Fatal(err)
-		}
-		if err = nt.Validate("repo-sync-deployment", testNs, &appsv1.Deployment{},
-			testpredicates.IsManagedBy(nt.Scheme, declared.Scope(nsRef.Namespace), nsRef.Name)); err != nil {
-			nt.T.Fatal(err)
-		}
+		nt.Must(nt.WatchForAllSyncs())
+		nt.Must(nt.Validate("deploy-ns", "ns", &appsv1.Deployment{},
+			testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rsID.Name)))
+		nt.Must(nt.Validate("deploy-default", "default", &appsv1.Deployment{},
+			testpredicates.IsManagedBy(nt.Scheme, declared.RootScope, rsID.Name)))
+		nt.Must(nt.Validate("repo-sync-deployment", testNs, &appsv1.Deployment{},
+			testpredicates.IsManagedBy(nt.Scheme, declared.Scope(nsID.Namespace), nsID.Name)))
 	}
 	return nil
 }

--- a/pkg/core/id.go
+++ b/pkg/core/id.go
@@ -32,10 +32,12 @@ type ID struct {
 }
 
 // IDOf converts an Object to its ID.
+//
+// TODO: Replace usage with LookupID, unless explicitly Unstructured.
 func IDOf(o client.Object) ID {
 	return ID{
 		GroupKind: o.GetObjectKind().GroupVersionKind().GroupKind(),
-		ObjectKey: client.ObjectKey{Namespace: o.GetNamespace(), Name: o.GetName()},
+		ObjectKey: client.ObjectKeyFromObject(o),
 	}
 }
 

--- a/pkg/kinds/lookup.go
+++ b/pkg/kinds/lookup.go
@@ -19,6 +19,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kpt.dev/configsync/pkg/core"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -30,4 +32,18 @@ func Lookup(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind
 		return schema.GroupVersionKind{}, fmt.Errorf("failed to lookup object type: %w", err)
 	}
 	return gvk, nil
+}
+
+// LookupID returns the object's ID. If the GK isn't already populated, the
+// Scheme is used to look it up by object type.
+func LookupID(obj client.Object, scheme *runtime.Scheme) (core.ID, error) {
+	id := core.IDOf(obj)
+	if id.GroupKind.Empty() {
+		gvk, err := Lookup(obj, scheme)
+		if err != nil {
+			return id, err
+		}
+		id.GroupKind = gvk.GroupKind()
+	}
+	return id, nil
 }

--- a/pkg/syncer/syncertest/fake/common.go
+++ b/pkg/syncer/syncertest/fake/common.go
@@ -61,20 +61,6 @@ func toTypedClientObject(obj client.Object, scheme *runtime.Scheme) (client.Obje
 	return cObj, nil
 }
 
-// lookupObjectID returns the object's ID.
-// If the GK isn't set, the Scheme is used to look it up by object type.
-func lookupObjectID(obj client.Object, scheme *runtime.Scheme) (core.ID, error) {
-	id := core.IDOf(obj)
-	if id.GroupKind.Empty() {
-		gvk, err := kinds.Lookup(obj, scheme)
-		if err != nil {
-			return id, err
-		}
-		id.GroupKind = gvk.GroupKind()
-	}
-	return id, nil
-}
-
 // matchesListFilters returns true if the object matches the constraints
 // specified by the ListOptions: Namespace, LabelSelector, and FieldSelector.
 func matchesListFilters(obj runtime.Object, opts *client.ListOptions, scheme *runtime.Scheme) (bool, error) {

--- a/pkg/syncer/syncertest/fake/storage.go
+++ b/pkg/syncer/syncertest/fake/storage.go
@@ -154,7 +154,7 @@ func (ms *MemoryStorage) TestPut(obj client.Object) error {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	id, err := lookupObjectID(obj, ms.scheme)
+	id, err := kinds.LookupID(obj, ms.scheme)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (ms *MemoryStorage) TestPutAll(objs ...client.Object) error {
 	defer ms.lock.Unlock()
 
 	for _, obj := range objs {
-		id, err := lookupObjectID(obj, ms.scheme)
+		id, err := kinds.LookupID(obj, ms.scheme)
 		if err != nil {
 			return err
 		}
@@ -470,7 +470,7 @@ func (ms *MemoryStorage) Create(ctx context.Context, obj client.Object, opts *cl
 		return err
 	}
 
-	id, err := lookupObjectID(tObj, ms.scheme)
+	id, err := kinds.LookupID(tObj, ms.scheme)
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func (ms *MemoryStorage) deleteWithoutLock(ctx context.Context, obj client.Objec
 		return err
 	}
 
-	id, err := lookupObjectID(obj, ms.scheme)
+	id, err := kinds.LookupID(obj, ms.scheme)
 	if err != nil {
 		return err
 	}
@@ -717,7 +717,7 @@ func (ms *MemoryStorage) updateWithoutLock(ctx context.Context, obj client.Objec
 		return err
 	}
 
-	id, err := lookupObjectID(obj, ms.scheme)
+	id, err := kinds.LookupID(obj, ms.scheme)
 	if err != nil {
 		return err
 	}
@@ -832,7 +832,7 @@ func (ms *MemoryStorage) Patch(ctx context.Context, obj client.Object, patch cli
 		return fmt.Errorf("failed to build patch: %w", err)
 	}
 
-	id, err := lookupObjectID(obj, ms.scheme)
+	id, err := kinds.LookupID(obj, ms.scheme)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/syncertest/fake/subresource_storage.go
+++ b/pkg/syncer/syncertest/fake/subresource_storage.go
@@ -58,7 +58,7 @@ func (ss *SubresourceStorage) Update(ctx context.Context, obj client.Object, opt
 		return err
 	}
 
-	id, err := lookupObjectID(obj, ss.Storage.scheme)
+	id, err := kinds.LookupID(obj, ss.Storage.scheme)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Add Path method that wraps Git & OCI dir & Helm chart name.
- Add SetExpectedSyncPath to update the directory expectation.
- Add SetExpectedGitSource, SetExpectedHelmSource, &
  SetExpectedOCISource to update source expectations and replace
  WithSyncDirectoryMap.
- Move all Git repo test defaults to setupTestCase
- Remove obsolete HelmChartVersionShaFn
- Add kinds.LookupID to replace usace of core.IDof using the schema.
- Add OCIImageID to simplify address/url generation
- Add RootSyncObjectGit and RepoSyncObjectGit to handle setting
  defaults that were in multiple places before.
- Add RootSyncObjectOCI & RepoSyncObjectOCI for building RSyncs with
  OCI sources.
- Add RootSyncObjectHelm & RepoSyncObjectHelm for building RSyncs
  with Helm sources.