### PR TITLE
e2e: refactor sync expectations

### DIFF
--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -143,9 +143,7 @@ func TestGCENodeOCI(t *testing.T) {
 	repoSyncOCI := nt.RepoSyncObjectOCI(repoSyncRef, nsImage.OCIImageID().WithoutDigest(), "", nsImage.Digest)
 	nt.Must(nt.KubeClient.Apply(repoSyncOCI))
 
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRootSha1Func(imageDigestFuncByDigest(rootImage.Digest)),
-		nomostest.WithRepoSha1Func(imageDigestFuncByDigest(nsImage.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 	kustomizecomponents.ValidateAllTenants(nt, string(declared.RootScope), "base", "tenant-a", "tenant-b", "tenant-c")
 	kustomizecomponents.ValidateTenant(nt, repoSyncRef.Namespace, repoSyncRef.Namespace, "base")
 
@@ -153,9 +151,7 @@ func TestGCENodeOCI(t *testing.T) {
 	nt.T.Log("Update RootSync to sync from an OCI image in a private Google Container Registry")
 	nt.MustMergePatch(rootSyncOCI, fmt.Sprintf(`{"spec": {"oci": {"image": "%s", "dir": "%s"}}}`, privateGCRImage("kustomize-components"), tenant))
 	nomostest.SetExpectedSyncPath(nt, rootSyncID, tenant)
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRootSha1Func(imageDigestFuncByName(privateGCRImage("kustomize-components"))),
-		nomostest.WithRepoSha1Func(imageDigestFuncByDigest(nsImage.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 	kustomizecomponents.ValidateAllTenants(nt, string(declared.RootScope), "../base", tenant)
 }
 

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -38,6 +38,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/policy"
 	"kpt.dev/configsync/e2e/nomostest/registryproviders"
+	"kpt.dev/configsync/e2e/nomostest/syncsource"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -399,7 +400,9 @@ func TestHelmLatestVersion(t *testing.T) {
 	}
 
 	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chart.HelmChartID)
-	nomostest.SetExpectedHelmSource(nt, rootSyncID, chart.HelmChartID)
+	nomostest.SetExpectedSyncSource(nt, rootSyncID, &syncsource.HelmSyncSource{
+		ChartID: chart.HelmChartID,
+	})
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate version label of a deployment from the helm chart")
@@ -415,7 +418,9 @@ func TestHelmLatestVersion(t *testing.T) {
 	}
 
 	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chart.HelmChartID)
-	nomostest.SetExpectedHelmSource(nt, rootSyncID, chart.HelmChartID)
+	nomostest.SetExpectedSyncSource(nt, rootSyncID, &syncsource.HelmSyncSource{
+		ChartID: chart.HelmChartID,
+	})
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate version label of a deployment from the helm chart")
@@ -440,12 +445,14 @@ func TestHelmVersionRange(t *testing.T) {
 		GroupKind: nomostest.DefaultRootSyncID.GroupKind,
 		ObjectKey: client.ObjectKeyFromObject(rs),
 	}
-	chartID := registryproviders.HelmChartID{
-		Name:    rs.Spec.Helm.Chart,
-		Version: "15.4.1", // latest minor+patch with the same major version
-	}
-	nt.T.Logf("Wait for RootSync to sync from helm chart: %s", chartID)
-	nomostest.SetExpectedHelmSource(nt, rootSyncID, chartID)
+	nt.T.Log("Wait for RootSync to sync from helm chart")
+	nomostest.SetExpectedSyncSource(nt, rootSyncID, &syncsource.HelmSyncSource{
+		ChartID: registryproviders.HelmChartID{
+			Name:    rs.Spec.Helm.Chart,
+			Version: "^15.0.0",
+		},
+		ExpectedChartVersion: "15.4.1", // latest minor+patch with the same major version
+	})
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Validate Deployment from chart exists")

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -32,6 +32,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/metrics"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	"kpt.dev/configsync/e2e/nomostest/policy"
+	"kpt.dev/configsync/e2e/nomostest/syncsource"
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
@@ -237,10 +238,13 @@ func resetExpectedGitSync(nt *nomostest.NT, syncID core.ID) {
 	if nt.GitProvider.Type() == e2e.Local {
 		nomostest.InitGitRepos(nt, syncID.ObjectKey)
 	}
-	syncPath := gitproviders.DefaultSyncDir
 	sourceFormat := configsync.SourceFormatUnstructured
-	repo := nomostest.ResetRepository(nt, syncID.Kind, syncID.ObjectKey, sourceFormat)
-	nomostest.SetExpectedGitSource(nt, syncID, repo, syncPath, sourceFormat)
+	nomostest.SetExpectedSyncSource(nt, syncID, &syncsource.GitSyncSource{
+		Repository:   nomostest.ResetRepository(nt, syncID.Kind, syncID.ObjectKey, sourceFormat),
+		Branch:       gitproviders.MainBranch,
+		SourceFormat: sourceFormat,
+		Directory:    gitproviders.DefaultSyncDir,
+	})
 }
 
 func validateReconcilerResource(nt *nomostest.NT, gvk schema.GroupVersionKind, labels map[string]string, expectedCount int) {

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -158,8 +158,7 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 	nt.Must(rootSyncGitRepo.Add(repoSyncPath, repoSyncOCI))
 	nt.Must(rootSyncGitRepo.CommitAndPush("configure RepoSync to sync from OCI in the root repository"))
 
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRepoSha1Func(imageDigestFuncByDigest(image.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 	nt.Must(nt.Validate(configsync.RepoSyncName, namespace, &v1beta1.RepoSync{}, isSourceType(configsync.OciSource)))
 	nt.Must(nt.Validate(bookinfoRole.Name, namespace, &rbacv1.Role{},
 		testpredicates.HasAnnotation(metadata.ResourceManagerKey, namespace)))
@@ -263,8 +262,7 @@ func TestOciSyncWithDigest(t *testing.T) {
 	rootSyncOCI := nt.RootSyncObjectOCI(rootSyncKey.Name, image.OCIImageID().WithoutDigest(), "", image.Digest)
 	rootSyncOCI.Spec.Oci.Period = metav1.Duration{Duration: 5 * time.Second}
 	nt.Must(nt.KubeClient.Apply(rootSyncOCI))
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRootSha1Func(imageDigestFuncByDigest(image.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 
 	// Delete the remote image
 	nt.T.Log("Delete image from remote registry")
@@ -284,8 +282,7 @@ func TestOciSyncWithDigest(t *testing.T) {
 	rootSyncOCI = nt.RootSyncObjectOCI(rootSyncKey.Name, image.OCIImageID().WithoutTag(), "", image.Digest)
 	rootSyncOCI.Spec.Oci.Period = metav1.Duration{Duration: 5 * time.Second}
 	nt.Must(nt.KubeClient.Apply(rootSyncOCI))
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRootSha1Func(imageDigestFuncByDigest(image.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 	nt.T.Log("Check for log message in oci-sync container")
 	out, err := nt.Shell.Kubectl("logs", fmt.Sprintf("deployment/%s", core.RootReconcilerName(rootSyncKey.Name)),
 		"-n", configsync.ControllerNamespace, "-c", reconcilermanager.OciSync)

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
@@ -169,8 +170,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	}
 
 	// Override the git sync depth setting for ns-reconciler-backend
-	var depth int64 = 33
-	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
+	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = ptr.To[int64](33)
 	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 33"))
 	nt.Must(nt.WatchForAllSyncs())
@@ -193,8 +193,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	nt.MustMergePatch(rootSync, `{"spec": {"override": null}}`)
 
 	// Override the git sync depth setting for ns-reconciler-backend to 0
-	depth = 0
-	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = &depth
+	repoSyncBackend.Spec.SafeOverride().GitSyncDepth = ptr.To[int64](0)
 	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), repoSyncBackend))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update backend RepoSync git sync depth to 0"))
 	nt.Must(nt.WatchForAllSyncs())

--- a/e2e/testcases/policy_dir_test.go
+++ b/e2e/testcases/policy_dir_test.go
@@ -21,7 +21,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
-	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/status"
 )
 
@@ -54,7 +53,7 @@ func TestPolicyDirUnset(t *testing.T) {
 	nt.Must(nt.WatchForAllSyncs())
 
 	nomostest.SetRootSyncGitDir(nt, rootSyncID.Name, "")
-	nomostest.SetExpectedSyncPath(nt, rootSyncID, controllers.DefaultSyncDir)
+	nomostest.SetExpectedSyncPath(nt, rootSyncID, "")
 	nt.Must(nt.WatchForAllSyncs())
 }
 

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -406,8 +406,7 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 
 	nt.T.Log("Add caCertSecretRef to RootSync")
 	nt.MustMergePatch(rs, caCertSecretPatch(configsync.OciSource, caCertSecret))
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRootSha1Func(imageDigestFuncByDigest(image.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 }
 
 // TestOCICACertSecretRefNamespaceRepo can run only run on KinD clusters.
@@ -447,8 +446,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	rs.Spec.Oci.CACertSecretRef = &v1beta1.SecretReference{Name: caCertSecret}
 	nt.Must(rootSyncGitRepo.Add(nomostest.StructuredNSPath(repoSyncID.Namespace, repoSyncID.Name), rs))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Set the CA cert for the RepoSync"))
-	nt.Must(nt.WatchForAllSyncs(
-		nomostest.WithRepoSha1Func(imageDigestFuncByDigest(image.Digest))))
+	nt.Must(nt.WatchForAllSyncs())
 	nt.T.Log("Verify the ConfigMap was created")
 	nt.Must(nt.Validate(cm.Name, cm.Namespace, &corev1.ConfigMap{}))
 	nt.T.Log("Verify the upserted Secret was created")


### PR DESCRIPTION
- Add Branch & Revision to GitSyncSource to configure root-sync
  and other test setup RSyncs.
- Add SetExpectedSyncSource & UpdateExpectedSyncSource
- Add ExpectedCommit, ExpectedChartVersion, & ExpectedImageDigest
- Add ExpectedDirectory for OCI and Git
- Remove WithRootSha1Func & WithRepoSha1Func.
  Use one of the Expected- fields in the SyncSource instead.
- Update test setup to provision RSyncs without overwriting any
  existing SyncSource expectations.

Dependencies: 
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1413
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1414
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1416