### PR TITLE
e2e: Add ReadOnlyRepository

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -784,7 +784,7 @@ func RootSyncObjectV1Alpha1FromRootRepo(nt *NT, name string) *v1alpha1.RootSync 
 	if !ok {
 		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
 	}
-	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
+	repoURL := gitSource.Repository.SyncURL()
 	sourceFormat := gitSource.Repository.Format
 	rs := rootSyncObjectV1Alpha1Git(name, repoURL, sourceFormat)
 	SetRSyncTestDefaults(nt, rs)
@@ -899,7 +899,7 @@ func RepoSyncObjectV1Alpha1FromNonRootRepo(nt *NT, nn types.NamespacedName) *v1a
 	if !ok {
 		nt.T.Fatalf("expected SyncSources for %s to have *GitSyncSource, but got %T", id, source)
 	}
-	repoURL := nt.GitProvider.SyncURL(gitSource.Repository.RemoteRepoName)
+	repoURL := gitSource.Repository.SyncURL()
 	// RepoSync is always Unstructured. So ignore repo.Format.
 	rs := repoSyncObjectV1Alpha1Git(nn, repoURL)
 	SetRSyncTestDefaults(nt, rs)
@@ -944,10 +944,10 @@ func RepoSyncObjectV1Beta1Git(nn types.NamespacedName, repoURL string, sourceFor
 // RootSyncObjectGit creates a new RootSync object with a Git source, using the
 // default test config plus the specified inputs.
 // Creates, updates, or replaces the SyncSource expectation for this RootSync.
-func (nt *NT) RootSyncObjectGit(name string, repo *gitproviders.Repository, syncPath string, sourceFormat configsync.SourceFormat) *v1beta1.RootSync {
+func (nt *NT) RootSyncObjectGit(name string, repo *gitproviders.ReadWriteRepository, syncPath string, sourceFormat configsync.SourceFormat) *v1beta1.RootSync {
 	id := core.RootSyncID(name)
 	SetExpectedGitSource(nt, id, repo, syncPath, sourceFormat)
-	repoURL := nt.GitProvider.SyncURL(repo.RemoteRepoName)
+	repoURL := repo.SyncURL()
 	rs := rootSyncObjectV1Beta1Git(name, repoURL, sourceFormat)
 	SetRSyncTestDefaults(nt, rs)
 	return rs
@@ -956,10 +956,10 @@ func (nt *NT) RootSyncObjectGit(name string, repo *gitproviders.Repository, sync
 // RepoSyncObjectGit creates a new RepoSync object with a Git source, using the
 // default test config plus the specified inputs.
 // Creates, updates, or replaces the SyncSource expectation for this RepoSync.
-func (nt *NT) RepoSyncObjectGit(nn types.NamespacedName, repo *gitproviders.Repository, syncPath string, sourceFormat configsync.SourceFormat) *v1beta1.RepoSync {
+func (nt *NT) RepoSyncObjectGit(nn types.NamespacedName, repo *gitproviders.ReadWriteRepository, syncPath string, sourceFormat configsync.SourceFormat) *v1beta1.RepoSync {
 	id := core.RepoSyncID(nn.Name, nn.Namespace)
 	SetExpectedGitSource(nt, id, repo, syncPath, sourceFormat)
-	repoURL := nt.GitProvider.SyncURL(repo.RemoteRepoName)
+	repoURL := repo.SyncURL()
 	// RepoSync is always Unstructured. So ignore repo.Format.
 	rs := RepoSyncObjectV1Beta1Git(nn, repoURL, sourceFormat)
 	SetRSyncTestDefaults(nt, rs)
@@ -1146,7 +1146,7 @@ func setupCentralizedControl(nt *NT) {
 	nt.T.Log("[SETUP] Centralized control")
 
 	rootSyncID := core.RootSyncID(configsync.RootSyncName)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	// Add any RootSyncs specified by the test options
 	rootSyncSources := nt.SyncSources.RootSyncs()

--- a/e2e/nomostest/config_sync_sources.go
+++ b/e2e/nomostest/config_sync_sources.go
@@ -43,7 +43,7 @@ func SetExpectedSyncPath(nt *NT, syncID core.ID, syncPath string) {
 
 // SetExpectedGitSource creates, updates, or replaces the SyncSource for the
 // specified RootSync or RepoSync with the provided Git repo.
-func SetExpectedGitSource(nt *NT, syncID core.ID, repo *gitproviders.Repository, syncPath string, sourceFormat configsync.SourceFormat) {
+func SetExpectedGitSource(nt *NT, syncID core.ID, repo *gitproviders.ReadWriteRepository, syncPath string, sourceFormat configsync.SourceFormat) {
 	source, exists := nt.SyncSources[syncID]
 	if !exists {
 		nt.T.Logf("Creating expectation for %s %s to sync with Git repo (repository: %q, directory: %q, sourceFormat: %q)",

--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -267,7 +267,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		SyncSources:             make(map[core.ID]syncsource.SyncSource),
 		MetricsExpectations:     testmetrics.NewSyncSetExpectations(t, scheme),
 		Scheme:                  scheme,
-		RemoteRepositories:      make(map[types.NamespacedName]*gitproviders.Repository),
+		RemoteRepositories:      make(map[types.NamespacedName]*gitproviders.ReadWriteRepository),
 		WebhookDisabled:         &webhookDisabled,
 		GitProvider:             gitproviders.NewGitProvider(t, *e2e.GitProvider, opts.ClusterName, logger, shell),
 		OCIProvider:             registryproviders.NewOCIProvider(*e2e.OCIProvider, opts.ClusterName, shell, ociClient),
@@ -480,7 +480,7 @@ func setupTestCase(nt *NT, opts *ntopts.New) {
 
 	if opts.InitialCommit != nil {
 		rootSyncID := DefaultRootSyncID
-		rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+		rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 		for path, obj := range opts.InitialCommit.Files {
 			nt.Must(rootSyncGitRepo.Add(path, obj))
 			// Some source objects are not included in the declared resources.

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -188,7 +188,7 @@ type NT struct {
 	// RemoteRepositories maintains a map between the repo local name and the remote repository.
 	// It includes both root repo and namespace repos and can be shared among test cases.
 	// It is used to reuse existing repositories instead of creating new ones.
-	RemoteRepositories map[types.NamespacedName]*gitproviders.Repository
+	RemoteRepositories map[types.NamespacedName]*gitproviders.ReadWriteRepository
 
 	// WebhookDisabled indicates whether the ValidatingWebhookConfiguration is deleted.
 	WebhookDisabled *bool
@@ -390,9 +390,9 @@ func (nt *NT) NumRepoSyncNamespaces() int {
 	return len(rsNamespaces)
 }
 
-// SyncSourceGitRepository returns the git Repository for the specified RSync,
+// SyncSourceGitReadWriteRepository returns the git Repository for the specified RSync,
 // if it exists in NT.SyncSources.
-func (nt *NT) SyncSourceGitRepository(id core.ID) *gitproviders.Repository {
+func (nt *NT) SyncSourceGitReadWriteRepository(id core.ID) *gitproviders.ReadWriteRepository {
 	source, found := nt.SyncSources[id]
 	if !found {
 		nt.T.Fatalf("Missing %s: %s", id.Kind, id.ObjectKey)
@@ -712,7 +712,7 @@ func (nt *NT) portForwardGitServer() {
 		// allGitRepos specifies the slice all repos for port forwarding.
 		var allGitRepos []types.NamespacedName
 		// allGitRepoMap is a map of repoNN->Repository for port forwarding.
-		allGitRepoMap := make(map[types.NamespacedName]*gitproviders.Repository)
+		allGitRepoMap := make(map[types.NamespacedName]*gitproviders.ReadWriteRepository)
 		for id, source := range nt.SyncSources {
 			if gitSource, ok := source.(*syncsource.GitSyncSource); ok {
 				allGitRepos = append(allGitRepos, id.ObjectKey)

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -418,14 +418,14 @@ func stringSliceContains(list []string, value string) bool {
 }
 
 // ResetRepository creates or re-initializes a remote repository.
-func ResetRepository(nt *NT, syncKind string, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.Repository {
+func ResetRepository(nt *NT, syncKind string, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.ReadWriteRepository {
 	repo := initRepository(nt, syncKind, nn, sourceFormat)
 	initialCommit(nt, syncKind, nn, sourceFormat)
 	return repo
 }
 
 // initRepository inits a local repository and ensures its remote exists
-func initRepository(nt *NT, syncKind string, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.Repository {
+func initRepository(nt *NT, syncKind string, nn types.NamespacedName, sourceFormat configsync.SourceFormat) *gitproviders.ReadWriteRepository {
 	repo, found := nt.RemoteRepositories[nn]
 	if !found {
 		repo = gitproviders.NewRepository(syncKind, nn, sourceFormat, nt.Scheme,

--- a/e2e/nomostest/syncsource/syncsource.go
+++ b/e2e/nomostest/syncsource/syncsource.go
@@ -40,10 +40,11 @@ type SyncSource interface {
 type GitSyncSource struct {
 	// Repository is a local clone of the remote Git repository that contains
 	// the current/latest commit.
-	Repository *gitproviders.Repository
-	// TODO: Add SyncPath and Branch/Revision to uniquely identify part of a repo
+	// TODO: Add support for ReadOnlyRepository too (+ Branch, Revision, & ExpectedCommit)
+	Repository *gitproviders.ReadWriteRepository
+	// SourceFormat of the repository
 	SourceFormat configsync.SourceFormat
-	// Directory is the path within the source to sync to the cluster.
+	// Directory is the path within the repository to sync to the cluster.
 	Directory string
 }
 

--- a/e2e/testcases/acme_test.go
+++ b/e2e/testcases/acme_test.go
@@ -44,7 +44,7 @@ func configSyncManagementLabels(namespace, folder string) map[string]string {
 func TestAcmeCorpRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
 
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nsToFolder := map[string]string{
 		"analytics":                  "eng",
@@ -186,7 +186,7 @@ func TestObjectInCMSNamespace(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Copy("../testdata/object-in-cms-namespace", "acme"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("adding resource to config-management-system namespace"))

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -45,7 +45,7 @@ import (
 func TestAdmission(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
 
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/hello/ns.yaml",
 		k8sobjects.NamespaceObject("hello", core.Annotation("goodbye", "moon"))))
@@ -157,7 +157,7 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 	// Test starts with Admission Webhook already installed
 	nomostest.WaitForWebhookReadiness(nt)
 
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/hello/ns.yaml", k8sobjects.NamespaceObject("hello")))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add test namespace"))
@@ -228,7 +228,7 @@ func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	sa := k8sobjects.ServiceAccountObject("store", core.Namespace(namespaceRepo))
 	nt.Must(repoSyncGitRepo.Add("acme/sa.yaml", sa))

--- a/e2e/testcases/adopt_client_side_applied_test.go
+++ b/e2e/testcases/adopt_client_side_applied_test.go
@@ -29,7 +29,7 @@ import (
 func TestAdoptClientSideAppliedResource(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
 
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Declare a ClusterRole and `kubectl apply -f` it to the cluster.
 	nsViewerName := "ns-viewer"

--- a/e2e/testcases/apiservice_test.go
+++ b/e2e/testcases/apiservice_test.go
@@ -36,7 +36,7 @@ func TestCreateAPIServiceAndEndpointInTheSameCommit(t *testing.T) {
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.
 		ntopts.WithReconcileTimeout(5*time.Minute))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	t.Cleanup(func() {
 		if t.Failed() {
 			nt.PodLogs(adapterNamespace, adapterName, "pod-custom-metrics-stackdriver-adapter", true)
@@ -81,7 +81,7 @@ func TestReconcilerResilientToFlakyAPIService(t *testing.T) {
 		// Increase the timeout from 1m to 5m to avoid reconcile timeout for the
 		// custom-metrics-stackdriver-adapter Deployment on Autopilot cluster.
 		ntopts.WithReconcileTimeout(5*time.Minute))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {
 		nt.MustKubectl("delete", "-f", "../testdata/apiservice/apiservice.yaml", "--ignore-not-found")
 		nt.MustKubectl("delete", "-f", "../testdata/apiservice/namespace-custom-metrics.yaml", "--ignore-not-found")

--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -35,7 +35,7 @@ const (
 
 func TestNamespaceGarbageCollection(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Copy(fmt.Sprintf("%s/accounting-namespace.yaml", yamlDir), "acme/namespaces/accounting/namespace.yaml"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add accounting namespace"))
@@ -60,7 +60,7 @@ func TestNamespaceGarbageCollection(t *testing.T) {
 
 func TestNamespacePolicyspaceConversion(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Copy(fmt.Sprintf("%s/dir-namespace.yaml", yamlDir), "acme/namespaces/dir/namespace.yaml"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add dir namespace"))
@@ -90,7 +90,7 @@ func TestNamespacePolicyspaceConversion(t *testing.T) {
 
 func TestSyncDeploymentAndReplicaSet(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Test the ability to fix a mistake: overlapping replicaset and deployment.
 	// Readiness behavior is undefined for this race condition.
@@ -145,7 +145,7 @@ func TestSyncDeploymentAndReplicaSet(t *testing.T) {
 
 func TestRolebindingsUpdated(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Copy("../../examples/acme/namespaces/eng/backend/namespace.yaml", "acme/namespaces/eng/backend/namespace.yaml"))
 	nt.Must(rootSyncGitRepo.Copy("../../examples/acme/namespaces/eng/backend/bob-rolebinding.yaml", "acme/namespaces/eng/backend/br.yaml"))
@@ -173,7 +173,7 @@ func TestRolebindingsUpdated(t *testing.T) {
 }
 
 func manageNamespace(nt *nomostest.NT, namespace string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Log("Add an unmanaged resource into the namespace as a control")
 	nt.T.Log("We should never modify this resource")
 	_, err := nt.Shell.Kubectl("apply", "-f", fmt.Sprintf("%s/reserved_namespaces/unmanaged-service.%s.yaml", yamlDir, namespace))
@@ -221,7 +221,7 @@ func manageNamespace(nt *nomostest.NT, namespace string) {
 }
 
 func unmanageNamespace(nt *nomostest.NT, namespace string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Log("stop managing the system namespace")
 	nt.Must(rootSyncGitRepo.Copy(fmt.Sprintf("%s/reserved_namespaces/unmanaged-namespace.%s.yaml", yamlDir, namespace), fmt.Sprintf("acme/namespaces/%s/namespace.yaml", namespace)))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Stop managing the namespace"))

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -489,7 +489,7 @@ func testNomosHydrateWithClusterSelectors(t *testing.T, configPath string, sourc
 }
 
 func testSyncFromNomosHydrateOutput(nt *nomostest.NT, config string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.ValidateNotFound("bookstore1", "", &corev1.Namespace{}); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -75,7 +75,7 @@ func managerFieldsNonEmpty() testpredicates.Predicate {
 // changes to cluster-scoped objects.
 func TestRevertClusterRole(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	crName := "e2e-test-clusterrole"
 
@@ -144,7 +144,7 @@ func TestRevertClusterRole(t *testing.T) {
 // resources.
 func TestClusterRoleLifecycle(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	crName := "e2e-test-clusterrole"
 

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -103,7 +103,7 @@ func namespaceObject(name string, annotations map[string]string) *corev1.Namespa
 func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	configMapName := clusterNameConfigMapName(nt)
 
 	nt.T.Log("Add test cluster, and cluster registry data")
@@ -181,7 +181,7 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 func TestClusterSelectorOnObjects(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 
@@ -274,7 +274,7 @@ func TestClusterSelectorOnObjects(t *testing.T) {
 
 func TestClusterSelectorOnNamespaces(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 
@@ -454,7 +454,7 @@ func TestClusterSelectorOnNamespaces(t *testing.T) {
 
 func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, backendNamespace, inlineProdClusterSelectorAnnotation)
@@ -506,7 +506,7 @@ func TestObjectReactsToChangeInInlineClusterSelector(t *testing.T) {
 
 func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add prod cluster, and cluster registry data")
 	prodCluster := clusterObject(prodClusterName, environmentLabelKey, prodEnvironment)
@@ -564,7 +564,7 @@ func TestObjectReactsToChangeInLegacyClusterSelector(t *testing.T) {
 
 func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add test cluster, and cluster registry data")
 	testCluster := clusterObject(testClusterName, environmentLabelKey, testEnvironment)
@@ -609,7 +609,7 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages rolebindings
 	)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	nt.T.Log("Add a valid cluster selector annotation to a role binding")
 	rb := roleBinding(roleBindingName, namespaceRepo, inlineProdClusterSelectorAnnotation)
@@ -684,7 +684,7 @@ func TestClusterSelectorOnNamespaceRepos(t *testing.T) {
 
 func TestInlineClusterSelectorFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	configMapName := clusterNameConfigMapName(nt)
 	renameCluster(nt, configMapName, "")
@@ -849,7 +849,7 @@ func TestInlineClusterSelectorFormat(t *testing.T) {
 
 func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add both cluster selector annotations to a role binding")
 	nt.Must(rootSyncGitRepo.Add(
@@ -881,7 +881,7 @@ func TestClusterSelectorAnnotationConflicts(t *testing.T) {
 
 func TestClusterSelectorForCRD(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Add CRD without ClusterSelectors or cluster-name-selector annotation")
 	crd := anvilV1CRD()

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -90,7 +90,7 @@ func TestComposition(t *testing.T) {
 	lvl3NN := types.NamespacedName{Namespace: testNs, Name: "level-3"}
 	lvl4NN := types.NamespacedName{Namespace: testNs, Name: "level-4"}
 
-	lvl0Repo := nt.SyncSourceGitRepository(lvl0ID)
+	lvl0Repo := nt.SyncSourceGitReadWriteRepository(lvl0ID)
 
 	lvl0Sync := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, lvl0NN.Name)
 	lvl0Sync.Spec.Git.Dir = gitproviders.DefaultSyncDir
@@ -405,7 +405,7 @@ func validateStatusCurrent(nt *nomostest.NT, objs ...client.Object) {
 	}
 }
 
-func commitForRepo(repo *gitproviders.Repository) nomostest.Sha1Func {
+func commitForRepo(repo *gitproviders.ReadWriteRepository) nomostest.Sha1Func {
 	return func(_ *nomostest.NT, _ types.NamespacedName) (string, error) {
 		return repo.Hash()
 	}
@@ -415,7 +415,7 @@ func commitForRepo(repo *gitproviders.Repository) nomostest.Sha1Func {
 // then waits until the specified sync object is synced.
 // This assumes the specified syncObj is configured to watch the specified
 // dirPath in the specified repo.
-func cleanupManagedSync(nt *nomostest.NT, repo *gitproviders.Repository, dirPath string, syncObj client.Object) {
+func cleanupManagedSync(nt *nomostest.NT, repo *gitproviders.ReadWriteRepository, dirPath string, syncObj client.Object) {
 	exists, err := repo.Exists(dirPath)
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/custom_resource_definitions_schema_test.go
+++ b/e2e/testcases/custom_resource_definitions_schema_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestChangeCustomResourceDefinitionSchema(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	oldCRDFile := filepath.Join(".", "..", "testdata", "customresources", "changed_schema_crds", "old_schema_crd.yaml")
 	newCRDFile := filepath.Join(".", "..", "testdata", "customresources", "changed_schema_crds", "new_schema_crd.yaml")

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
 	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
@@ -124,7 +124,7 @@ func TestMustRemoveCustomResourceWithDefinitionV1(t *testing.T) {
 }
 
 func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
 	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
@@ -206,7 +206,7 @@ func TestAddAndRemoveCustomResourceV1(t *testing.T) {
 }
 
 func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
 	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
@@ -273,7 +273,7 @@ func TestMustRemoveUnManagedCustomResourceV1(t *testing.T) {
 }
 
 func addUpdateRemoveClusterScopedCRD(nt *nomostest.NT, dir string, crd string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
 	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
@@ -355,7 +355,7 @@ func TestAddUpdateRemoveClusterScopedCRDV1(t *testing.T) {
 }
 
 func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", dir, crd)
 	crdContent, err := os.ReadFile(crdFile)
 	if err != nil {
@@ -455,7 +455,7 @@ func TestAddUpdateNamespaceScopedCRDV1(t *testing.T) {
 
 func TestLargeCRD(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	for _, file := range []string{"challenges-acme-cert-manager-io.yaml", "solrclouds-solr-apache-org.yaml"} {
 		crdFile := filepath.Join(".", "..", "testdata", "customresources", file)

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", "v1_crds", "anvil-crd.yaml")
 	clusterFile := filepath.Join(".", "..", "testdata", "customresources", "v1_crds", "clusteranvil-crd.yaml")
@@ -162,7 +162,7 @@ func TestCRDDeleteBeforeRemoveCustomResourceV1(t *testing.T) {
 
 func TestSyncUpdateCustomResource(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	crdFile := filepath.Join(".", "..", "testdata", "customresources", "v1_crds", "anvil-crd.yaml")
 	_, err := nt.Shell.Kubectl("apply", "-f", crdFile)

--- a/e2e/testcases/declared_fields_test.go
+++ b/e2e/testcases/declared_fields_test.go
@@ -28,7 +28,7 @@ import (
 func TestDeclaredFieldsPod(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))

--- a/e2e/testcases/gatekeeper_test.go
+++ b/e2e/testcases/gatekeeper_test.go
@@ -52,7 +52,7 @@ func emptyConstraintTemplate() unstructured.Unstructured {
 func TestConstraintTemplateAndConstraintInSameCommit(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	crdName := "k8sallowedrepos.constraints.gatekeeper.sh"
 	nt.T.Logf("Delete the %q CRD if needed", crdName)

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -59,9 +59,9 @@ func TestGCENodeCSR(t *testing.T) {
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.WithDelegatedControl)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	if err := workloadidentity.ValidateDisabled(nt); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	if err := nt.KubeClient.Get(configsync.RootSyncName, configmanagement.ControllerNamespace, rs); err != nil {

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -462,7 +462,7 @@ func TestHelmNamespaceRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AllAdmin()), // NS reconciler manages a bunch of resources.
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Log("Build a Helm chart with cluster-scoped resources")
 	chart, err := nt.BuildAndPushHelmPackage(repoSyncNN,
@@ -506,7 +506,7 @@ func TestHelmConfigMapNamespaceRepo(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireHelmProvider,
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()),
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	cmName := "helm-cm-ns-repo-1"
 
 	chart, err := nt.BuildAndPushHelmPackage(repoSyncNN,

--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -48,7 +48,7 @@ func TestHydrateKustomizeComponents(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	// Dry configs not yet added to repo, assert that hydration is disabled
 	tg := taskgroup.New()
@@ -176,7 +176,7 @@ func TestHydrateExternalFiles(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	nt.T.Log("Add the external files root directory")
 	nt.Must(rootSyncGitRepo.Copy("../testdata/hydration/external-files", "."))
@@ -206,7 +206,7 @@ func TestHydrateHelmComponents(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	nt.T.Log("Add the helm components root directory")
 	nt.Must(rootSyncGitRepo.Copy("../testdata/hydration/helm-components", "."))
@@ -269,7 +269,7 @@ func TestHydrateHelmOverlay(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	nt.T.Log("Add the helm-overlay root directory")
 	nt.Must(rootSyncGitRepo.Copy("../testdata/hydration/helm-overlay", "."))
@@ -329,7 +329,7 @@ func TestHydrateRemoteResources(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	nt.T.Log("Add the remote-base root directory")
 	nt.Must(rootSyncGitRepo.Copy("../testdata/hydration/remote-base", "."))
@@ -406,7 +406,7 @@ func TestHydrateResourcesInRelativePath(t *testing.T) {
 		nomostesting.Hydration,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	nt.T.Log("Add the root directory")
 	nt.Must(rootSyncGitRepo.Copy("../testdata/hydration/relative-path", "."))

--- a/e2e/testcases/invalid_auth_test.go
+++ b/e2e/testcases/invalid_auth_test.go
@@ -56,7 +56,7 @@ func TestInvalidAuth(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 	// TODO: Fix commit to be UNKNOWN (b/361182373)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	commitHash := rootSyncGitRepo.MustHash(nt.T)
 
 	err = nomostest.ValidateMetrics(nt,

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestInvalidRootSyncBranchStatus(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Update RootSync to invalid branch name
 	nomostest.SetRootSyncGitBranch(nt, configsync.RootSyncName, "invalid-branch")
@@ -69,9 +69,9 @@ func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	repoSync := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSyncKey)
 	repoSync.Spec.Branch = "invalid-branch"
@@ -134,7 +134,7 @@ func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 
 func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {
 		nt.T.Log("Resetting all RootSync branches to main")
 		nt.Must(rootSyncGitRepo.CheckoutBranch(gitproviders.MainBranch))

--- a/e2e/testcases/kptfile_test.go
+++ b/e2e/testcases/kptfile_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestIgnoreKptfiles(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Add multiple Kptfiles
 	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/Kptfile", []byte("random content")))

--- a/e2e/testcases/lifecycle_directives_test.go
+++ b/e2e/testcases/lifecycle_directives_test.go
@@ -39,7 +39,7 @@ var preventDeletion = core.Annotation(common.LifecycleDeleteAnnotation, common.P
 func TestPreventDeletionNamespace(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the Namespace doesn't already exist.
 	err := nt.ValidateNotFound("shipping", "", &corev1.Namespace{})
@@ -135,7 +135,7 @@ func TestPreventDeletionNamespace(t *testing.T) {
 func TestPreventDeletionRole(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the Namespace doesn't already exist.
 	err := nt.ValidateNotFound("shipping-admin", "shipping", &rbacv1.Role{})
@@ -238,7 +238,7 @@ func TestPreventDeletionRole(t *testing.T) {
 func TestPreventDeletionClusterRole(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Lifecycle)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Ensure the ClusterRole doesn't already exist.
 	err := nt.ValidateNotFound("test-admin", "", &rbacv1.ClusterRole{})
@@ -317,7 +317,7 @@ func skipAutopilotManagedNamespace(nt *nomostest.NT, ns string) bool {
 func TestPreventDeletionSpecialNamespaces(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Build list of special namespaces to test.
 	// Skip namespaces managed by GKE Autopilot, if on an Autopilot cluster

--- a/e2e/testcases/local_config_test.go
+++ b/e2e/testcases/local_config_test.go
@@ -30,7 +30,7 @@ var LocalConfigValue = "true"
 
 func TestLocalConfig(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	ns := "local-config"
 	nt.Must(rootSyncGitRepo.Add(
@@ -84,7 +84,7 @@ func TestLocalConfig(t *testing.T) {
 
 func TestLocalConfigWithManagementDisabled(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	ns := "local-config"
 	nt.Must(rootSyncGitRepo.Add(

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -59,7 +59,7 @@ import (
 func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
@@ -250,7 +250,7 @@ func TestDriftKubectlApplyClusterScoped(t *testing.T) {
 func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSync2Name := "abcdef"
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
@@ -500,7 +500,7 @@ func TestDriftKubectlApplyNamespaceScoped(t *testing.T) {
 func TestDriftKubectlDelete(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -562,7 +562,7 @@ func TestDriftKubectlDelete(t *testing.T) {
 func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -624,7 +624,7 @@ func TestDriftKubectlDeleteWithIgnoreMutationAnnotation(t *testing.T) {
 func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -686,7 +686,7 @@ func TestDriftKubectlAnnotateUnmanagedField(t *testing.T) {
 func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -717,7 +717,7 @@ func TestDriftKubectlAnnotateUnmanagedFieldWithIgnoreMutationAnnotation(t *testi
 func TestDriftKubectlAnnotateManagedField(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -782,7 +782,7 @@ func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
@@ -850,7 +850,7 @@ func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing
 func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -915,7 +915,7 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"),
@@ -984,7 +984,7 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 func TestDriftRemoveApplySetPartOfLabel(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSync1ApplySetID := applyset.IDFromSync(configsync.RootSyncName, declared.RootScope)
 

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -88,8 +88,8 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.RepoSyncAdmin()),
 		ntopts.SyncWithGitSource(repoSync1ID),
 		ntopts.SyncWithGitSource(repoSync6ID))
-	rootSync0GitRepo := nt.SyncSourceGitRepository(rootSync0ID)
-	rootSync1GitRepo := nt.SyncSourceGitRepository(rootSync1ID)
+	rootSync0GitRepo := nt.SyncSourceGitReadWriteRepository(rootSync0ID)
+	rootSync1GitRepo := nt.SyncSourceGitReadWriteRepository(rootSync1ID)
 
 	// Cleanup all unmanaged RepoSyncs BEFORE the root-sync is deleted!
 	// Otherwise, the test Namespace will be deleted while still containing
@@ -123,8 +123,8 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	resetExpectedGitSync(nt, repoSync4ID)
 	resetExpectedGitSync(nt, repoSync5ID)
 
-	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)
-	repoSync2GitRepo := nt.SyncSourceGitRepository(repoSync2ID)
+	rootSync2GitRepo := nt.SyncSourceGitReadWriteRepository(rootSync2ID)
+	repoSync2GitRepo := nt.SyncSourceGitReadWriteRepository(repoSync2ID)
 
 	nrb2 := nomostest.RepoSyncRoleBinding(repoSync2Key)
 	nrb3 := nomostest.RepoSyncRoleBinding(repoSync3Key)
@@ -282,8 +282,8 @@ func TestConflictingDefinitions_RootToNamespace(t *testing.T) {
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS Reconciler manages Roles
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	podRoleFilePath := fmt.Sprintf("acme/namespaces/%s/pod-role.yaml", testNs)
 	nt.T.Logf("Add a Role to root: %s", rootSyncKey.Name)
@@ -403,8 +403,8 @@ func TestConflictingDefinitions_NamespaceToRoot(t *testing.T) {
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin()), // NS reconciler manages Roles
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	podRoleFilePath := fmt.Sprintf("acme/namespaces/%s/pod-role.yaml", testNs)
 	nt.T.Logf("Add a Role to Namespace repo: %s", rootSyncKey.Name)
@@ -535,8 +535,8 @@ func TestConflictingDefinitions_RootToRoot(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(rootSync2ID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	rootSync2GitRepo := nt.SyncSourceGitReadWriteRepository(rootSync2ID)
 
 	podRoleFilePath := fmt.Sprintf("acme/namespaces/%s/pod-role.yaml", testNs)
 	nt.T.Logf("Add a Role to RootSync: %s", rootSyncID.Name)
@@ -660,8 +660,8 @@ func TestConflictingDefinitions_NamespaceToNamespace(t *testing.T) {
 		ntopts.SyncWithGitSource(repoSync1ID),
 		ntopts.SyncWithGitSource(repoSync2ID))
 
-	repoSync1GitRepo := nt.SyncSourceGitRepository(repoSync1ID)
-	repoSync2GitRepo := nt.SyncSourceGitRepository(repoSync2ID)
+	repoSync1GitRepo := nt.SyncSourceGitReadWriteRepository(repoSync1ID)
+	repoSync2GitRepo := nt.SyncSourceGitReadWriteRepository(repoSync2ID)
 
 	podRoleFilePath := fmt.Sprintf("acme/namespaces/%s/pod-role.yaml", testNs)
 	nt.T.Logf("Add a Role to Namespace: %s", repoSync1Key)

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -36,7 +36,7 @@ import (
 func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Add the Anvil CRD.
 	crdObj := anvilV1CRD()
@@ -186,7 +186,7 @@ func anvilGVK(version string) schema.GroupVersionKind {
 func TestMultipleVersions_RoleBinding(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation1)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rbV1 := k8sobjects.RoleBindingObject(core.Name("v1user"))
 	rbV1.RoleRef = rbacv1.RoleRef{

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -58,7 +58,7 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 		ntopts.WithCentralizedControl,
 	)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	// Validate status condition "Reconciling" and "Stalled "is set to "False"
 	// after the reconciler deployment is successfully created.
@@ -108,7 +108,7 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 	validateRepoSyncRBAC(nt, bsNamespace, repoSyncGitRepo, configureRBACInCentralizedMode)
 }
 
-func validateRepoSyncRBAC(nt *nomostest.NT, ns string, nsRepo *gitproviders.Repository, configureRBAC configureRBACFunc) {
+func validateRepoSyncRBAC(nt *nomostest.NT, ns string, nsRepo *gitproviders.ReadWriteRepository, configureRBAC configureRBACFunc) {
 	nt.T.Cleanup(func() {
 		// Grant full permission to manage the Deployment in case the test fails early
 		configureRBAC(nt, ns, []string{"*"})
@@ -196,7 +196,7 @@ func validateRepoSyncRBAC(nt *nomostest.NT, ns string, nsRepo *gitproviders.Repo
 type configureRBACFunc func(nt *nomostest.NT, ns string, verbs []string)
 
 func configureRBACInCentralizedMode(nt *nomostest.NT, ns string, verbs []string) {
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{appsv1.GroupName},
@@ -330,7 +330,7 @@ func TestNamespaceRepo_Delegated(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 	)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	// Validate service account 'store' not present.
 	err := nt.ValidateNotFound("store", bsNamespaceRepo, &corev1.ServiceAccount{})
@@ -405,7 +405,7 @@ func TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1(t *testing.T) {
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.WithCentralizedControl,
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
 
 	secretNames := getNsReconcilerSecrets(nt, bsNamespace)
@@ -472,7 +472,7 @@ func TestManageSelfRepoSync(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.MultiRepos,
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 		ntopts.SyncWithGitSource(repoSyncID))
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	rs := &v1beta1.RepoSync{}
 	if err := nt.KubeClient.Get(repoSyncID.Name, repoSyncID.Namespace, rs); err != nil {
@@ -545,8 +545,8 @@ func TestDeleteNamespaceReconcilerDeployment(t *testing.T) {
 	)
 	rootSyncKey := rootSyncID.ObjectKey
 	repoSyncKey := repoSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	nsReconciler := core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name)
 

--- a/e2e/testcases/namespace_selectors_test.go
+++ b/e2e/testcases/namespace_selectors_test.go
@@ -77,7 +77,7 @@ var (
 
 func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
 	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),
@@ -125,7 +125,7 @@ func TestNamespaceSelectorHierarchicalFormat(t *testing.T) {
 func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Selector,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	bookstoreNSS := k8sobjects2.NamespaceSelectorObject(core.Name(bookstoreNSSName))
 	bookstoreCM := k8sobjects2.ConfigMapObject(core.Name(bookstoreCMName),

--- a/e2e/testcases/namespace_strategy_test.go
+++ b/e2e/testcases/namespace_strategy_test.go
@@ -49,7 +49,7 @@ import (
 func TestNamespaceStrategy(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)
@@ -179,10 +179,10 @@ func TestNamespaceStrategyMultipleRootSyncs(t *testing.T) {
 		ntopts.SyncWithGitSource(rootSyncXID, ntopts.Unstructured), // will declare resources in namespace-a, but not namespace-a itself
 		ntopts.SyncWithGitSource(rootSyncYID, ntopts.Unstructured), // will declare resources in namespace-a, but not namespace-a itself
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	rootSyncAGitRepo := nt.SyncSourceGitRepository(rootSyncAID)
-	rootSyncXGitRepo := nt.SyncSourceGitRepository(rootSyncXID)
-	rootSyncYGitRepo := nt.SyncSourceGitRepository(rootSyncYID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	rootSyncAGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncAID)
+	rootSyncXGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncXID)
+	rootSyncYGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncYID)
 
 	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncAID.Name)
 	rootSyncX := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncXID.Name)

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -43,7 +43,7 @@ import (
 // TestDeclareNamespace runs a test that ensures ACM syncs Namespaces to clusters.
 func TestDeclareNamespace(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	err := nt.ValidateNotFound("foo", "", &corev1.Namespace{})
 	if err != nil {
@@ -77,7 +77,7 @@ func TestDeclareNamespace(t *testing.T) {
 
 func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Create foo namespace without any labels or annotations.
 	nsObj := k8sobjects.NamespaceObject("foo")
@@ -178,7 +178,7 @@ func TestNamespaceLabelAndAnnotationLifecycle(t *testing.T) {
 
 func TestNamespaceExistsAndDeclared(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Create nsObj using kubectl first then commit.
 	nsObj := k8sobjects.NamespaceObject("decl-namespace-annotation-none")
@@ -209,7 +209,7 @@ func TestNamespaceExistsAndDeclared(t *testing.T) {
 
 func TestNamespaceEnabledAnnotationNotDeclared(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Create nsObj with managed annotation using kubectl.
 	nsObj := k8sobjects.NamespaceObject("undeclared-annotation-enabled")
@@ -240,7 +240,7 @@ func TestNamespaceEnabledAnnotationNotDeclared(t *testing.T) {
 // TestManagementDisabledNamespace tests https://cloud.google.com/anthos-config-management/docs/how-to/managing-objects#unmanaged-namespaces.
 func TestManagementDisabledNamespace(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	checkpointProtectedNamespace(nt, metav1.NamespaceDefault)
 
@@ -361,7 +361,7 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 			"acme/namespaces/foo/cm3.yaml": cm3,
 		},
 	}))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Test that the namespace exists with expected config management labels and annotations.
 	err := nt.Validate(fooNamespace.Name, "", &corev1.Namespace{}, testpredicates.HasAllNomosMetadata())
@@ -475,7 +475,7 @@ func TestManagementDisabledConfigMap(t *testing.T) {
 
 func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2, ntopts.SkipAutopilotCluster)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	checkpointProtectedNamespace(nt, metav1.NamespaceSystem)
 
@@ -559,7 +559,7 @@ func TestSyncLabelsAndAnnotationsOnKubeSystem(t *testing.T) {
 
 func TestDoNotRemoveManagedByLabelExceptForConfigManagement(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Create namespace using kubectl with managed by helm label.
 	helmManagedNamespace := k8sobjects.NamespaceObject("helm-managed-namespace")
@@ -592,7 +592,7 @@ func TestDoNotRemoveManagedByLabelExceptForConfigManagement(t *testing.T) {
 func TestDeclareImplicitNamespace(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	var unixMilliseconds = time.Now().UnixNano() / 1000000
 	var implicitNamespace = "shipping-" + fmt.Sprint(unixMilliseconds)
@@ -668,7 +668,7 @@ func TestDeclareImplicitNamespace(t *testing.T) {
 
 func TestDontDeleteAllNamespaces(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Test Setup + Preconditions.
 	// Declare two Namespaces.

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -36,7 +36,7 @@ func TestNoSSLVerifyV1Alpha1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -117,7 +117,7 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -123,9 +123,9 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 		// bookinfo repo contains ServiceAccount
 		ntopts.RepoSyncPermissions(policy.RBACAdmin(), policy.CoreAdmin()),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	var err error
 	// file path to the RepoSync config in the root repository.
@@ -180,7 +180,7 @@ func TestSwitchFromGitToOciDelegated(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.RBACAdmin(), policy.CoreAdmin()),
 	)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	// Remote git branch will only contain the bookinfo-sa ServiceAccount
 	bookinfoSA := k8sobjects.ServiceAccountObject("bookinfo-sa", core.Namespace(namespace))

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -116,7 +116,7 @@ func TestOtelCollectorDeployment(t *testing.T) {
 		ntopts.RequireGKE(t),
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	nt.T.Cleanup(func() {
 		if t.Failed() {
 			nt.PodLogs("config-management-monitoring", csmetrics.OtelCollectorName, "", false)
@@ -234,7 +234,7 @@ func TestGCMMetrics(t *testing.T) {
 		ntopts.RequireGKE(t),
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {
 		if t.Failed() {
 			nt.PodLogs("config-management-monitoring", csmetrics.OtelCollectorName, "", false)
@@ -318,7 +318,7 @@ func TestGCMMetrics(t *testing.T) {
 //   - roles/iam.workloadIdentityUser on config-management-monitoring/default for e2e-test-metric-writer
 func TestOtelCollectorGCMLabelAggregation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.RequireGKE(t))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	setupMetricsServiceAccount(nt)
 
 	startTime := time.Now().UTC()

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -38,7 +38,7 @@ func TestOverrideGitSyncDepthV1Alpha1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -138,7 +138,7 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -35,7 +35,7 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	rootReconcilerName := core.RootReconcilerObjectKey(rootSyncID.Name)
 	rootSyncV1 := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
@@ -136,9 +136,9 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	frontendReconcilerNN := core.NsReconcilerObjectKey(repoSyncID.Namespace, repoSyncID.Name)
 	repoSyncFrontend := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSyncKey)

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -38,7 +38,7 @@ import (
 func TestOverrideReconcileTimeout(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 
 	// Override reconcileTimeout to a short time 30s, only actuation should succeed, reconcile should time out.

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -42,7 +42,7 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.SyncWithGitSource(repoSync1ID),
 		ntopts.SyncWithGitSource(repoSync2ID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)
@@ -411,7 +411,7 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI, ntopts.SkipAutopilotCluster,
 		ntopts.SyncWithGitSource(repoSync1ID),
 		ntopts.SyncWithGitSource(repoSync2ID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	rootReconcilerNN := core.RootReconcilerObjectKey(rootSyncNN.Name)

--- a/e2e/testcases/override_role_refs_test.go
+++ b/e2e/testcases/override_role_refs_test.go
@@ -39,7 +39,7 @@ func TestRootSyncRoleRefs(t *testing.T) {
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(rootSyncAID, ntopts.Unstructured),
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	rootSyncA := nomostest.RootSyncObjectV1Beta1FromRootRepo(nt, rootSyncAID.Name)
 	syncAReconcilerName := core.RootReconcilerName(rootSyncA.Name)
 	syncANN := rootSyncAID.ObjectKey

--- a/e2e/testcases/policy_dir_test.go
+++ b/e2e/testcases/policy_dir_test.go
@@ -36,7 +36,7 @@ func TestMissingRepoErrorWithHierarchicalFormat(t *testing.T) {
 func TestPolicyDirUnset(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	// There are 6 cluster-scoped objects under `../../examples/acme/cluster`.
 	//
 	// Copying the whole `../../examples/acme/cluster` dir would cause the Config Sync mono-repo mode CI job to fail,

--- a/e2e/testcases/preserve_fields_test.go
+++ b/e2e/testcases/preserve_fields_test.go
@@ -41,7 +41,7 @@ import (
 func TestPreserveGeneratedServiceFields(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Declare the Service's Namespace
 	ns := "autogen-fields"
@@ -158,7 +158,7 @@ func TestPreserveGeneratedServiceFields(t *testing.T) {
 func TestPreserveGeneratedClusterRoleFields(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nsViewerName := "namespace-viewer"
 	nsViewer := k8sobjects.ClusterRoleObject(core.Name(nsViewerName),
@@ -267,7 +267,7 @@ aggregationRule:
 func TestPreserveLastApplied(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Declare a ClusterRole and wait for it to sync.
 	nsViewerName := "namespace-viewer"
@@ -322,7 +322,7 @@ func TestPreserveLastApplied(t *testing.T) {
 func TestAddUpdateDeleteLabels(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	ns := "crud-labels"
 	nsObj := k8sobjects.NamespaceObject(ns)
@@ -392,7 +392,7 @@ func TestAddUpdateDeleteLabels(t *testing.T) {
 func TestAddUpdateDeleteAnnotations(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.Reconciliation2)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	ns := "crud-annotations"
 	nsObj := k8sobjects.NamespaceObject(ns)

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -69,9 +69,9 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
 	repoSyncReconcilerName := core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name)
 
@@ -150,7 +150,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	}
 
 	// Set RootSync to use SSH again
-	rootSyncSSHURL := nt.GitProvider.SyncURL(rootSyncGitRepo.RemoteRepoName)
+	rootSyncSSHURL := rootSyncGitRepo.SyncURL()
 	nt.MustMergePatch(rootSync, syncURLSSHPatch(rootSyncSSHURL))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -172,7 +172,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	}
 
 	// Set RepoSync to use SSH again
-	repoSyncSSHURL := nt.GitProvider.SyncURL(repoSyncGitRepo.RemoteRepoName)
+	repoSyncSSHURL := repoSyncGitRepo.SyncURL()
 	repoSyncBackend.Spec.Git.Repo = repoSyncSSHURL
 	repoSyncBackend.Spec.Git.Auth = "ssh"
 	repoSyncBackend.Spec.Git.SecretRef = &v1alpha1.SecretReference{Name: "ssh-key"}
@@ -191,9 +191,9 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
 
 	key := controllers.GitSSLCAInfo
@@ -277,7 +277,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	}
 
 	// Set RootSync to use SSH again
-	rootSyncSSHURL := nt.GitProvider.SyncURL(rootSyncGitRepo.RemoteRepoName)
+	rootSyncSSHURL := rootSyncGitRepo.SyncURL()
 	nt.MustMergePatch(rootSync, syncURLSSHPatch(rootSyncSSHURL))
 	if err := nt.WatchForAllSyncs(); err != nil {
 		nt.T.Fatal(err)
@@ -299,7 +299,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 	}
 
 	// Set RepoSync to use SSH again
-	repoSyncSSHURL := nt.GitProvider.SyncURL(repoSyncGitRepo.RemoteRepoName)
+	repoSyncSSHURL := repoSyncGitRepo.SyncURL()
 	repoSyncBackend.Spec.Git.Repo = repoSyncSSHURL
 	repoSyncBackend.Spec.Git.Auth = "ssh"
 	repoSyncBackend.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: "ssh-key"}
@@ -318,9 +318,9 @@ func TestCACertSecretWatch(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 	rootSyncReconcilerName := nomostest.DefaultRootReconcilerName
 	repoSyncReconcilerName := core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name)
 
@@ -384,7 +384,7 @@ func TestCACertSecretWatch(t *testing.T) {
 			testpredicates.SecretHasKey("baz", "bat"),
 		}))
 	// Unset caCertSecret for repoSyncBackend and use SSH
-	repoSyncSSHURL := nt.GitProvider.SyncURL(repoSyncGitRepo.RemoteRepoName)
+	repoSyncSSHURL := repoSyncGitRepo.SyncURL()
 	repoSyncBackend.Spec.Git.Repo = repoSyncSSHURL
 	repoSyncBackend.Spec.Git.Auth = "ssh"
 	repoSyncBackend.Spec.Git.SecretRef = &v1beta1.SecretReference{Name: "ssh-key"}
@@ -439,7 +439,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
 	repoSyncReconcilerName := core.NsReconcilerName(repoSyncID.Namespace, repoSyncID.Name)
 
@@ -528,7 +528,7 @@ func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	caCertSecret := nomostest.PublicCertSecretName(nomostest.RegistrySyncSource)
 

--- a/e2e/testcases/profiling_test.go
+++ b/e2e/testcases/profiling_test.go
@@ -44,7 +44,7 @@ func TestProfilingResourcesByObjectCount(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := filepath.Join(gitproviders.DefaultSyncDir, "stress-test")
 	ns := "stress-test-ns"
@@ -110,7 +110,7 @@ func TestProfilingResourcesByObjectCountWithMultiSync(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	steps := 4
 	deploysPerStep := 1000
@@ -238,7 +238,7 @@ func TestProfilingByObjectCountAndSyncCount(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	steps := 5
 	syncsPerStep := 1
@@ -344,7 +344,7 @@ func TestProfilingResourcesByRootSyncCount(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.ProfilingTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Create the namespace using the default root-sync.
 	// Use the same namespace for all other RSyncs to ensure they all show up in watches, whether it's cluster-scope or namespace-scope.

--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -55,7 +55,7 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.MultiRepos)
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: testNs}
 	namespace1NN := types.NamespacedName{Name: testNs}
@@ -145,7 +145,7 @@ func TestReconcilerFinalizer_Foreground(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.MultiRepos)
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: testNs}
 	namespace1NN := types.NamespacedName{Name: testNs}
@@ -237,9 +237,9 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	repoSyncPath := nomostest.StructuredNSPath(repoSyncKey.Namespace, repoSyncKey.Name)
 	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: repoSyncKey.Namespace}
@@ -367,9 +367,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()), // NS Reconciler manages Deployments
 	)
 	rootSyncKey := rootSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	repoSyncPath := nomostest.StructuredNSPath(repoSyncKey.Namespace, repoSyncKey.Name)
 	deployment1NN := types.NamespacedName{Name: "helloworld-1", Namespace: repoSyncKey.Namespace}
@@ -520,8 +520,8 @@ func TestReconcileFinalizerReconcileTimeout(t *testing.T) {
 		ntopts.SyncWithGitSource(rootSync2ID, ntopts.Unstructured), // Create a nested RootSync to delete mid-test
 		ntopts.WithReconcileTimeout(10*time.Second),                // Reconcile expected to fail, so use a short timeout
 	)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
-	rootSync2GitRepo := nt.SyncSourceGitRepository(rootSync2ID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
+	rootSync2GitRepo := nt.SyncSourceGitReadWriteRepository(rootSync2ID)
 
 	// add a Namespace to the nested RootSync
 	namespace := k8sobjects.NamespaceObject(namespaceNN.Name)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -1187,9 +1187,9 @@ func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // NS Reconciler manages ServiceAccounts
 	)
 	rootSyncKey := rootSyncID.ObjectKey
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	reconcilerManagerKey := client.ObjectKey{
 		Name:      reconcilermanager.ManagerName,

--- a/e2e/testcases/remediator_test.go
+++ b/e2e/testcases/remediator_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestSurfaceFightError(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.T.Logf("Stop the admission webhook to generate the fights")
 	nomostest.StopWebhook(nt)

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -39,7 +39,7 @@ import (
 
 func TestResourceGroupController(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	ns := "rg-test"
 	nt.Must(rootSyncGitRepo.Add(

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -89,7 +89,7 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	// Validate RootSync is present.
 	var rs v1beta1.RootSync
@@ -177,7 +177,7 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 func TestUpdateRootSyncGitBranch(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nsA := "ns-a"
 	nsB := "ns-b"
@@ -310,7 +310,7 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 
 func TestForceRevert(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource)
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Remove("acme/system/repo.yaml"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Cause source error"))
@@ -369,7 +369,7 @@ func TestRootSyncReconcilingStatus(t *testing.T) {
 func TestManageSelfRootSync(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.ACMController,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	rs := &v1beta1.RootSync{}
 	if err := nt.KubeClient.Get(configsync.RootSyncName, configsync.ControllerNamespace, rs); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -35,7 +35,7 @@ import (
 func TestRootSyncSSHKnownHost(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	var err error
 	rootSecret := &corev1.Secret{}
@@ -135,7 +135,7 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.AppsAdmin(), policy.CoreAdmin()))
-	repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 
 	var err error
 	repoSecret := &corev1.Secret{}

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -40,7 +40,7 @@ import (
 func TestStatusEnabledAndDisabled(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.OverrideAPI,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	id := applier.InventoryID(configsync.RootSyncName, configsync.ControllerNamespace)
 
 	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -77,7 +77,7 @@ func TestStressCRD(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := gitproviders.DefaultSyncDir
 
@@ -141,7 +141,7 @@ func TestStressLargeNamespace(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := gitproviders.DefaultSyncDir
 	ns := "my-ns-1"
@@ -181,7 +181,7 @@ func TestStressFrequentGitCommits(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := gitproviders.DefaultSyncDir
 	ns := "bookstore"
@@ -296,7 +296,7 @@ func TestStress100CRDs(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := gitproviders.DefaultSyncDir
 	ns := "stress-test-ns"
@@ -351,7 +351,7 @@ func TestStressManyDeployments(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := filepath.Join(gitproviders.DefaultSyncDir, "stress-test")
 	ns := "stress-test-ns"
@@ -399,7 +399,7 @@ func TestStressMemoryUsageGit(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(configsync.DefaultReconcileTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	syncPath := filepath.Join(gitproviders.DefaultSyncDir, "stress-test")
 	ns := "stress-test-ns"

--- a/e2e/testcases/sync_ordering_test.go
+++ b/e2e/testcases/sync_ordering_test.go
@@ -47,7 +47,7 @@ import (
 func TestMultiDependencies(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespaceName := "bookstore"
 	nt.T.Logf("Remove the namespace %q if it already exists", namespaceName)
@@ -341,7 +341,7 @@ func TestMultiDependencies(t *testing.T) {
 func TestExternalDependencyError(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespaceName := "bookstore"
 	nt.T.Logf("Remove the namespace %q if it already exists", namespaceName)
@@ -454,7 +454,7 @@ func TestDependencyWithReconciliation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Lifecycle,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.WithReconcileTimeout(longTimeout))
-	rootSyncGitRepo := nt.SyncSourceGitRepository(nomostest.DefaultRootSyncID)
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	namespaceName := "bookstore"
 	nt.T.Logf("Remove the namespace %q if it already exists", namespaceName)

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -355,9 +355,9 @@ func TestWorkloadIdentity(t *testing.T) {
 			nt.T.Logf("Update RootSync and RepoSync to sync from %s", tc.sourceType)
 			switch tc.sourceType {
 			case configsync.GitSource:
-				rootSyncGitRepo := nt.SyncSourceGitRepository(rootSyncID)
+				rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 				rootMeta = updateRSyncWithGitSourceConfig(nt, rootSync, rootSyncGitRepo, tc.rootSrcCfg)
-				repoSyncGitRepo := nt.SyncSourceGitRepository(repoSyncID)
+				repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)
 				nsMeta = updateRSyncWithGitSourceConfig(nt, repoSync, repoSyncGitRepo, tc.nsSrcCfg)
 			case configsync.HelmSource:
 				rootChart, err = updateRootSyncWithHelmSourceConfig(nt, rootSyncKey, tc.rootSrcCfg)
@@ -570,7 +570,7 @@ type rsyncValidateMeta struct {
 	syncDir  string
 }
 
-func updateRSyncWithGitSourceConfig(nt *nomostest.NT, rs client.Object, repo *gitproviders.Repository, sc sourceConfig) rsyncValidateMeta {
+func updateRSyncWithGitSourceConfig(nt *nomostest.NT, rs client.Object, repo *gitproviders.ReadWriteRepository, sc sourceConfig) rsyncValidateMeta {
 	nt.Must(repo.Copy("../testdata/"+sc.pkg, "."))
 	nt.Must(repo.CommitAndPush("add DRY configs to the repository"))
 	nt.MustMergePatch(rs, fmt.Sprintf(`{


### PR DESCRIPTION
- ReadOnlyRepository can be used as a substitute for
  ReadWriteRepository when using a public repo that we don't need
  to modify.
- Rename Repository to ReadWriteRepository.
- Add a Repository interface with a SyncURL method for use as a
  Git source.
- Rename SyncSourceGitRepository to SyncSourceGitReadWriteRepository

This PR does not yet use ReadOnlyRepository, but does some of the preliminary refactoring to make it easier to review.

Follow Up: https://github.com/GoogleContainerTools/kpt-config-sync/pull/1410