### PR TITLE
[cherry-pick] test: fix logic to create ca certs when git=csr (#1412)

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -687,7 +687,7 @@ func setupDelegatedControl(nt *NT) {
 			nt.T.Fatal(err)
 		}
 
-		nt.Must(CreateNamespaceSecretForNonCSR(nt, id.Namespace))
+		nt.Must(CreateNamespaceSecrets(nt, id.Namespace))
 
 		if err := setupRepoSyncRoleBinding(nt, id.ObjectKey); err != nil {
 			nt.T.Fatal(err)
@@ -1285,7 +1285,7 @@ func setupCentralizedControl(nt *NT) {
 	// Now that the Namespaces exist, create the Secrets,
 	// which are required for the RepoSyncs to reconcile.
 	for nn := range repoSyncs {
-		nt.Must(CreateNamespaceSecretForNonCSR(nt, nn.Namespace))
+		nt.Must(CreateNamespaceSecrets(nt, nn.Namespace))
 	}
 }
 

--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -161,7 +161,7 @@ func TestComposition(t *testing.T) {
 	nt.T.Log("Validating synced objects are reconciled...")
 	validateStatusCurrent(nt, lvl0Repo.MustGetAll(nt.T, lvl0SubDir, true)...)
 
-	nt.Must(nomostest.CreateNamespaceSecretForNonCSR(nt, lvl2NN.Namespace))
+	nt.Must(nomostest.CreateNamespaceSecrets(nt, lvl2NN.Namespace))
 
 	// lvl1 RootSync
 	lvl1Path := filepath.Join(lvl0SubDir, fmt.Sprintf("rootsync-%s.yaml", lvl1NN.Name))

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -424,7 +424,7 @@ func validateRepoSyncDependencies(nt *nomostest.NT, ns, rsName string) []client.
 	setNN(repoSyncSA, client.ObjectKeyFromObject(repoSyncReconciler))
 	repoSyncDependencies = append(repoSyncDependencies, repoSyncSA)
 
-	// See nomostest.CreateNamespaceSecretForNonCSR for creation of user secrets.
+	// See nomostest.CreateNamespaceSecrets for creation of user secrets.
 	// The Secret is neither needed nor created when using CSR as the Git provider.
 	if nt.GitProvider.Type() != e2e.CSR {
 		repoSyncAuthSecret := &corev1.Secret{}
@@ -434,7 +434,7 @@ func validateRepoSyncDependencies(nt *nomostest.NT, ns, rsName string) []client.
 		})
 		repoSyncDependencies = append(repoSyncDependencies, repoSyncAuthSecret)
 	}
-	// See nomostest.CreateNamespaceSecretForNonCSR for creation of user secrets.
+	// See nomostest.CreateNamespaceSecrets for creation of user secrets.
 	// This is a managed secret with a derivative name.
 	// For local kind clusters, the CA Certs are provided to authenticate the git server.
 	if nt.GitProvider.Type() == e2e.Local {


### PR DESCRIPTION
It is possible to run the tests as a combination of git-provider=csr and oci-provider=local. In this case the CA certs for the registry server need to be created in the RepoSync namespace.