### PR TITLE
ci: remove GCP_PROJECT arg from test-e2e-kind

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -86,7 +86,6 @@ test-e2e-kind: config-sync-manifest-local build-kind-e2e
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ARTIFACTS):/logs/artifacts \
 		--env ARTIFACTS="/logs/artifacts" \
-		--env GCP_PROJECT=$(GCP_PROJECT) \
 		--network="host" \
 		--rm \
 		$(KIND_IMAGE) \


### PR DESCRIPTION
This argument is already unused when running the tests in kind clusters, but this makes the intent more clear. The e2e tests should/do not require a GCP project to run with kind.