### PR TITLE
test: fix sha1Func for oci workload identity test

### DIFF
--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -539,6 +539,7 @@ func updateRootSyncWithOCISourceConfig(nt *nomostest.NT, rsID core.ID, sc source
 	if err = nt.KubeClient.Apply(rootSyncOCI); err != nil {
 		return meta, err
 	}
+	meta.sha1Func = imageDigestFuncByDigest(image.Digest)
 	return meta, nil
 }
 
@@ -558,6 +559,7 @@ func updateRepoSyncWithOCISourceConfig(nt *nomostest.NT, rsID core.ID, sc source
 	if err = nt.KubeClient.Apply(repoSyncOCI); err != nil {
 		return meta, err
 	}
+	meta.sha1Func = imageDigestFuncByDigest(image.Digest)
 	return meta, nil
 }
 


### PR DESCRIPTION
This line was removed in a previous change, which leads to a segfault because the sha1Func is nil when accessed.

Fixes breaking change from https://github.com/GoogleContainerTools/kpt-config-sync/pull/1410

For example: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-rapid/1831339095763193856