### PR TITLE
chore: clean up unused e2e-kind make targets

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -110,17 +110,3 @@ test-e2e-kind-test-group2:
 .PHONY: test-e2e-kind-test-group3
 test-e2e-kind-test-group3:
 	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=reconciliation-2,multi-repos,override-api,hydration" test-e2e-kind
-
-# Legacy aliases to support backwards compatibility for CI
-# These can be removed once CI uses the newly named targets
-.PHONY: test-e2e-kind-multi-repo
-test-e2e-kind-multi-repo: test-e2e-kind
-
-.PHONY: test-e2e-kind-multi-repo-test-group1
-test-e2e-kind-multi-repo-test-group1: test-e2e-kind-test-group1
-
-.PHONY: test-e2e-kind-multi-repo-test-group2
-test-e2e-kind-multi-repo-test-group2: test-e2e-kind-test-group2
-
-.PHONY: test-e2e-kind-multi-repo-test-group3
-test-e2e-kind-multi-repo-test-group3: test-e2e-kind-test-group3


### PR DESCRIPTION
These legacy aliases are no longer in use and can be removed