### PR TITLE
chore: bump otelcontribcol to 0.103.0-gke.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 GIT_SYNC_VERSION := v4.2.4-gke.2__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.103.0-gke.3
+OTELCONTRIBCOL_VERSION := v0.103.0-gke.4
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.


### PR DESCRIPTION
This addresses CVEs in the previous image