### PR TITLE
test: Fix RootSync spec in TestStressLargeRequest

### DIFF
--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -232,8 +232,9 @@ func TestStressLargeRequest(t *testing.T) {
 	repo := gitproviders.ReadOnlyRepository{
 		URL: "https://github.com/config-sync-examples/crontab-crs",
 	}
-	rootSync := nt.RootSyncObjectGit(rootSyncID.Name, repo, gitproviders.MainBranch, "configs", "", configsync.SourceFormatUnstructured)
+	rootSync := nt.RootSyncObjectGit(rootSyncID.Name, repo, gitproviders.MainBranch, "", "configs", configsync.SourceFormatUnstructured)
 	rootSync.Spec.Git.Auth = configsync.AuthNone
+	rootSync.Spec.SecretRef = nil
 	rootSync.Spec.SafeOverride().OverrideSpec.StatusMode = applier.StatusDisabled
 	rootSync.Spec.SafeOverride().OverrideSpec.Resources = []v1beta1.ContainerResourcesSpec{reconcilerOverride}
 	nt.T.Logf("Apply the RootSync object to sync to %s", rootSync.Spec.Git.Repo)


### PR DESCRIPTION
Sets the `Directory` instead of the `Revision` to "configs" and removes `SecretRef` from the RootSync spec in TestStressLargeRequest

This fixes a breaking change introduced by https://github.com/GoogleContainerTools/kpt-config-sync/pull/1410

Example failure: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-rapid-latest-stress/1831422149634560000