### PR TITLE
test: fix git dir for kcc test RootSync

### DIFF
--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -49,7 +49,7 @@ func TestKCCResourcesOnCSR(t *testing.T) {
 	repo := gitproviders.ReadOnlyRepository{
 		URL: fmt.Sprintf("%s/p/%s/r/configsync-kcc", nomostesting.CSRHost, *e2e.GCPProject),
 	}
-	rs := nt.RootSyncObjectGit(rootSyncID.Name, repo, gitproviders.MainBranch, "kcc", "", configsync.SourceFormatUnstructured)
+	rs := nt.RootSyncObjectGit(rootSyncID.Name, repo, gitproviders.MainBranch, "", "kcc", configsync.SourceFormatUnstructured)
 	rs.Spec.Git.Auth = "gcpserviceaccount"
 	rs.Spec.Git.GCPServiceAccountEmail = fmt.Sprintf("e2e-test-csr-reader@%s.iam.gserviceaccount.com", *e2e.GCPProject)
 	rs.Spec.Git.SecretRef = nil


### PR DESCRIPTION
The arguments are in the wrong order, causing the directory argument to be used as the revision instead. This was introduced by a previous refactor.

This fixes a breaking change introduced by https://github.com/GoogleContainerTools/kpt-config-sync/pull/1410

Example failure: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-regular-kcc/1831814738229596160