### PR TITLE
e2e: Update WatchForSync to take a SyncSource

### DIFF
--- a/e2e/nomostest/config_sync_sources.go
+++ b/e2e/nomostest/config_sync_sources.go
@@ -41,9 +41,10 @@ func SetExpectedSyncSource(nt *NT, syncID core.ID, source syncsource.SyncSource)
 // UpdateExpectedSyncSource executes the provided function on an existing
 // SyncSource in the SyncSources, allowing updating multiple fields.
 func UpdateExpectedSyncSource[T syncsource.SyncSource](nt *NT, syncID core.ID, mutateFn func(T)) {
+	nt.T.Helper()
 	source, exists := nt.SyncSources[syncID]
 	if !exists {
-		nt.T.Fatalf("Failed to update expectation for %s %s: nt.SyncSources not registered", syncID.Kind, syncID.ObjectKey)
+		nt.T.Fatalf("Failed to update expectation for %s %s: not registered in nt.SyncSources", syncID.Kind, syncID.ObjectKey)
 	}
 	switch tSource := source.(type) {
 	case T:
@@ -59,9 +60,10 @@ func UpdateExpectedSyncSource[T syncsource.SyncSource](nt *NT, syncID core.ID, m
 // RepoSync with the provided Git dir, OCI dir.
 // Updates both the Directory & ExpectedDirectory.
 func SetExpectedSyncPath(nt *NT, syncID core.ID, syncPath string) {
+	nt.T.Helper()
 	source, exists := nt.SyncSources[syncID]
 	if !exists {
-		nt.T.Fatalf("Failed to update expectation for %s %s: nt.SyncSources not registered", syncID.Kind, syncID.ObjectKey)
+		nt.T.Fatalf("Failed to update expectation for %s %s: not registered in nt.SyncSources", syncID.Kind, syncID.ObjectKey)
 	}
 	switch tSource := source.(type) {
 	case *syncsource.GitSyncSource:
@@ -81,6 +83,7 @@ func SetExpectedSyncPath(nt *NT, syncID core.ID, syncPath string) {
 // RepoSync with the provided Git commit, without changing the git reference of
 // the source being pulled.
 func SetExpectedGitCommit(nt *NT, syncID core.ID, expectedCommit string) {
+	nt.T.Helper()
 	UpdateExpectedSyncSource(nt, syncID, func(source *syncsource.GitSyncSource) {
 		source.ExpectedCommit = expectedCommit
 	})
@@ -90,6 +93,7 @@ func SetExpectedGitCommit(nt *NT, syncID core.ID, expectedCommit string) {
 // or RepoSync with the provided OCI image digest, without changing the ID of
 // the image being pulled.
 func SetExpectedOCIImageDigest(nt *NT, syncID core.ID, expectedImageDigest string) {
+	nt.T.Helper()
 	UpdateExpectedSyncSource(nt, syncID, func(source *syncsource.OCISyncSource) {
 		source.ExpectedImageDigest = expectedImageDigest
 	})

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -195,13 +195,9 @@ func TestSwitchFromGitToOciDelegated(t *testing.T) {
 
 	// Verify the manual configuration: switch from Git to OCI
 	// Verify the default sourceType is set when not specified.
-	if err := nt.Validate(bookinfoSA.Name, namespace, &corev1.ServiceAccount{},
-		testpredicates.HasAnnotation(metadata.ResourceManagerKey, namespace)); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.ValidateNotFound(bookinfoRole.Name, namespace, &rbacv1.Role{}); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Validate(bookinfoSA.Name, namespace, &corev1.ServiceAccount{},
+		testpredicates.HasAnnotation(metadata.ResourceManagerKey, namespace)))
+	nt.Must(nt.ValidateNotFound(bookinfoRole.Name, namespace, &rbacv1.Role{}))
 
 	// Switch from Git to OCI
 	repoSyncOCI := nt.RepoSyncObjectOCI(repoSyncKey, image.OCIImageID().WithoutDigest(), "", image.Digest)
@@ -210,8 +206,8 @@ func TestSwitchFromGitToOciDelegated(t *testing.T) {
 
 	nt.Must(nt.Validate(configsync.RepoSyncName, namespace, &v1beta1.RepoSync{}, isSourceType(configsync.OciSource)))
 	nt.T.Log("Verify the namespace objects are synced")
-	nt.Must(nt.WatchForSync(kinds.RepoSyncV1Beta1(), configsync.RepoSyncName, namespace,
-		imageDigestFuncByDigest(image.Digest), nomostest.RepoSyncHasStatusSyncCommit, nil))
+	nt.Must(nt.WatchForSync(kinds.RepoSyncV1Beta1(), repoSyncID.Name, repoSyncID.Namespace,
+		nt.SyncSources[repoSyncID]))
 	nt.Must(nt.Validate(bookinfoRole.Name, namespace, &rbacv1.Role{},
 		testpredicates.HasAnnotation(metadata.ResourceManagerKey, namespace)))
 	nt.Must(nt.ValidateNotFound(bookinfoSA.Name, namespace, &corev1.ServiceAccount{}))


### PR DESCRIPTION
- Update WatchForSync to take a SyncSource, instead of Sha1Func,
  sha1 Predicate, and SyncPathPredicatePair. These are replaced by
  SyncSource.Path() and SyncSource.Commit() which handle defaulting
  and using the spec value if an expectation was not explicitly set.
- Update SyncSource expectation functions to be test helpers
- Refactor TestComposition to update expecations and use
  WatchForAllSyncs instead of a custom watch wrapper.
- Refactor a few tests that were using WatchForSync directly to
  pass in a SyncSource with expectations updated.

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1430
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1435