### PR TITLE
e2e: Add watch predicate options

### DIFF
--- a/e2e/nomostest/crds.go
+++ b/e2e/nomostest/crds.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/kinds"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -45,7 +46,7 @@ func WaitForCRDs(nt *NT, crds []string) error {
 		tg.Go(func() error {
 			return nt.Watcher.WatchObject(kinds.CustomResourceDefinitionV1(),
 				nn.Name, nn.Namespace,
-				[]testpredicates.Predicate{IsEstablished})
+				testwatcher.WatchPredicates(IsEstablished))
 		})
 	}
 	return tg.Wait()

--- a/e2e/nomostest/reset.go
+++ b/e2e/nomostest/reset.go
@@ -28,6 +28,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -172,9 +173,9 @@ func ResetRootSyncs(nt *NT, rsList []v1beta1.RootSync) error {
 			if err := nt.KubeClient.MergePatch(rs, patch); err != nil {
 				return err
 			}
-			if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace, []testpredicates.Predicate{
-				testpredicates.HasFinalizer(metadata.ReconcilerFinalizer),
-			}); err != nil {
+			if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rs.Name, rs.Namespace,
+				testwatcher.WatchPredicates(testpredicates.HasFinalizer(metadata.ReconcilerFinalizer)),
+			); err != nil {
 				return err
 			}
 		}
@@ -247,9 +248,9 @@ func ResetRepoSyncs(nt *NT, rsList []v1beta1.RepoSync) error {
 			if err := nt.KubeClient.MergePatch(rs, patch); err != nil {
 				return err
 			}
-			if err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), rs.Name, rs.Namespace, []testpredicates.Predicate{
-				testpredicates.HasFinalizer(metadata.ReconcilerFinalizer),
-			}); err != nil {
+			if err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), rs.Name, rs.Namespace,
+				testwatcher.WatchPredicates(testpredicates.HasFinalizer(metadata.ReconcilerFinalizer)),
+			); err != nil {
 				return err
 			}
 		}

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -26,6 +26,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
@@ -170,18 +171,18 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 
 	tg := taskgroup.New()
 	tg.Go(func() error {
-		predicates := []testpredicates.Predicate{
-			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
-		}
 		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.RootReconcilerName(configsync.RootSyncName), configsync.ControllerNamespace, predicates)
+			core.RootReconcilerName(configsync.RootSyncName), configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+				testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
+			))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Namespace(), "hello", "",
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.MissingAnnotation(metadata.DeclaredFieldsKey),
-			})
+			))
 	})
 	if err := tg.Wait(); err != nil {
 		nt.T.Fatal(err)
@@ -201,18 +202,18 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 	nt.T.Logf("Check declared-fields annotation is re-populated")
 	tg = taskgroup.New()
 	tg.Go(func() error {
-		predicates := []testpredicates.Predicate{
-			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled, "true"),
-		}
 		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.RootReconcilerName(configsync.RootSyncName), configsync.ControllerNamespace, predicates)
+			core.RootReconcilerName(configsync.RootSyncName), configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+				testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled, "true"),
+			))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Namespace(), "hello", "",
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.HasAnnotationKey(metadata.DeclaredFieldsKey),
-			})
+			))
 	})
 	if err := tg.Wait(); err != nil {
 		nt.T.Fatal(err)
@@ -243,18 +244,18 @@ func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
 
 	tg := taskgroup.New()
 	tg.Go(func() error {
-		predicates := []testpredicates.Predicate{
-			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
-		}
 		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.NsReconcilerName(namespaceRepo, configsync.RepoSyncName), configsync.ControllerNamespace, predicates)
+			core.NsReconcilerName(namespaceRepo, configsync.RepoSyncName), configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+				testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
+			))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.ServiceAccount(), "store", namespaceRepo,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.MissingAnnotation(metadata.DeclaredFieldsKey),
-			})
+			))
 	})
 	if err := tg.Wait(); err != nil {
 		nt.T.Fatal(err)
@@ -274,18 +275,18 @@ func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
 	nt.T.Logf("Check declared-fields annotation is re-populated")
 	tg = taskgroup.New()
 	tg.Go(func() error {
-		predicates := []testpredicates.Predicate{
-			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled, "true"),
-		}
 		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.NsReconcilerName(namespaceRepo, configsync.RepoSyncName), configsync.ControllerNamespace, predicates)
+			core.NsReconcilerName(namespaceRepo, configsync.RepoSyncName), configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+				testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled, "true"),
+			))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.ServiceAccount(), "store", namespaceRepo,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.HasAnnotationKey(metadata.DeclaredFieldsKey),
-			})
+			))
 	})
 	if err := tg.Wait(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/cli_test.go
+++ b/e2e/testcases/cli_test.go
@@ -1385,24 +1385,16 @@ func TestNomosMigrate(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	err := nt.Watcher.WatchObject(kinds.Deployment(), "reconciler-manager", configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), "reconciler-manager", configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerImageEquals(
 				"reconciler-manager",
 				"gcr.io/config-management-release/reconciler-manager:v1.18.0-rc.3",
 			),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 
 	nt.T.Log("Running nomos migrate to migrate from ConfigManagement to OSS install")
-	_, err = nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
-	// TODO: this breaks the XML parsing of the junit report
-	//nt.T.Log(string(out))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput())
 
 	nt.T.Log("Wait for legacy resources to be NotFound...")
 	tg = taskgroup.New()
@@ -1555,16 +1547,13 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	err := nt.Watcher.WatchObject(kinds.Deployment(), "reconciler-manager", configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), "reconciler-manager", configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerImageEquals(
 				"reconciler-manager",
 				"gcr.io/config-management-release/reconciler-manager:v1.18.0-rc.3",
 			),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 
 	cmObj = &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1626,12 +1615,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 	}
 
 	nt.T.Log("Running nomos migrate to migrate from ConfigManagement to OSS install")
-	_, err = nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput()
-	// TODO: this breaks the XML parsing of the junit report
-	//nt.T.Log(string(out))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Shell.Command("nomos", "migrate", "--remove-configmanagement").CombinedOutput())
 
 	nt.T.Log("Wait for legacy resources to be NotFound...")
 	tg = taskgroup.New()
@@ -1668,9 +1652,7 @@ func TestNomosMigrateMonoRepo(t *testing.T) {
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 			configsync.RootSyncName, configsync.ControllerNamespace,
-			[]testpredicates.Predicate{
-				testpredicates.RootSyncSpecEquals(expectedRootSyncSpec),
-			})
+			testwatcher.WatchPredicates(testpredicates.RootSyncSpecEquals(expectedRootSyncSpec)))
 	})
 	if err := tg.Wait(); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/cluster_resources_test.go
+++ b/e2e/testcases/cluster_resources_test.go
@@ -26,6 +26,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/metrics"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
@@ -121,11 +122,8 @@ func TestRevertClusterRole(t *testing.T) {
 	}
 
 	// Ensure the conflict is reverted.
-	err = nt.Watcher.WatchObject(kinds.ClusterRole(), crName, "",
-		[]testpredicates.Predicate{clusterRoleHasRules(declaredRules)})
-	if err != nil {
-		nt.T.Error(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ClusterRole(), crName, "",
+		testwatcher.WatchPredicates(clusterRoleHasRules(declaredRules))))
 
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
 	nt.MetricsExpectations.AddObjectApply(configsync.RootSyncKind, rootSyncNN, declaredCr)

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -30,6 +30,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/policy"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
@@ -141,9 +142,8 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	// 	nt.T.Fatal(err)
 	// }
 	require.NoError(nt.T,
-		nt.Watcher.WatchObject(kinds.ResourceQuota(), rqLegacy.Name, rqLegacy.Namespace, []testpredicates.Predicate{
-			resourceQuotaHasHardPods(nt, testPodsQuota),
-		}))
+		nt.Watcher.WatchObject(kinds.ResourceQuota(), rqLegacy.Name, rqLegacy.Namespace,
+			testwatcher.WatchPredicates(resourceQuotaHasHardPods(nt, testPodsQuota))))
 
 	renameCluster(nt, configMapName, prodClusterName)
 	nt.Must(nt.WatchForAllSyncs())
@@ -156,9 +156,8 @@ func TestTargetingDifferentResourceQuotasToDifferentClusters(t *testing.T) {
 	// 	nt.T.Fatal(err)
 	// }
 	require.NoError(nt.T,
-		nt.Watcher.WatchObject(kinds.ResourceQuota(), rqInline.Name, rqInline.Namespace, []testpredicates.Predicate{
-			resourceQuotaHasHardPods(nt, prodPodsQuota),
-		}))
+		nt.Watcher.WatchObject(kinds.ResourceQuota(), rqInline.Name, rqInline.Namespace,
+			testwatcher.WatchPredicates(resourceQuotaHasHardPods(nt, prodPodsQuota))))
 
 	nt.MetricsExpectations.AddObjectApply(configsync.RootSyncKind, rootSyncNN, nsObj)
 	nt.MetricsExpectations.AddObjectApply(configsync.RootSyncKind, rootSyncNN, rqInline)

--- a/e2e/testcases/custom_resources_test.go
+++ b/e2e/testcases/custom_resources_test.go
@@ -183,12 +183,9 @@ func TestSyncUpdateCustomResource(t *testing.T) {
 		}
 	})
 
-	err = nt.Watcher.WatchObject(kinds.CustomResourceDefinitionV1(), "anvils.acme.com", "",
-		[]testpredicates.Predicate{nomostest.IsEstablished},
-		testwatcher.WatchTimeout(30*time.Second))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.CustomResourceDefinitionV1(), "anvils.acme.com", "",
+		testwatcher.WatchPredicates(nomostest.IsEstablished),
+		testwatcher.WatchTimeout(30*time.Second)))
 
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", k8sobjects.NamespaceObject("foo")))
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvil-v1.yaml", anvilCR("v1", "heavy", 10)))

--- a/e2e/testcases/github_test.go
+++ b/e2e/testcases/github_test.go
@@ -113,8 +113,8 @@ func TestGithubAppRootSync(t *testing.T) {
 		},
 	}
 	nt.Must(nt.KubeClient.Apply(rs))
-	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), githubAppRepoNamespace, "", nil))
-	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace, nil))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), githubAppRepoNamespace, ""))
+	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace))
 	// This hack exists because we don't have a way to authenticate to the repo from
 	// the test framework. The branch is not expected to change, so just trust the
 	// SHA reported on the RootSync.
@@ -218,7 +218,7 @@ func TestGithubAppRepoSync(t *testing.T) {
 		},
 	}
 	nt.Must(nt.KubeClient.Apply(rs))
-	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace, nil))
+	nt.Must(nt.Watcher.WatchObject(kinds.ConfigMap(), githubAppRepoConfigMap, githubAppRepoNamespace))
 	// This hack exists because we don't have a way to authenticate to the repo from
 	// the test framework. The branch is not expected to change, so just trust the
 	// SHA reported on the RepoSync.

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -208,10 +208,8 @@ func TestKCCResourceGroup(t *testing.T) {
 			Status: v1alpha1.InProgress,
 		},
 	}
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 }

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -67,10 +67,10 @@ func TestNamespaceRepo_Centralized(t *testing.T) {
 	// Log error if the Reconciling condition does not progress to False before
 	// the timeout expires.
 	err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), "repo-sync", bsNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			hasReconcilingStatus(metav1.ConditionFalse),
 			hasStalledStatus(metav1.ConditionFalse),
-		},
+		),
 		testwatcher.WatchTimeout(30*time.Second))
 	if err != nil {
 		nt.T.Errorf("RepoSync did not finish reconciling: %v", err)
@@ -546,10 +546,10 @@ func TestDeleteNamespaceReconcilerDeployment(t *testing.T) {
 	// Here we are checking for false condition which requires atleast 2 reconcile
 	// request to be processed by the controller.
 	err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSyncID.Name, repoSyncID.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			hasReconcilingStatus(metav1.ConditionFalse),
 			hasStalledStatus(metav1.ConditionFalse),
-		})
+		))
 	if err != nil {
 		nt.T.Errorf("RepoSync did not finish reconciling: %v", err)
 	}
@@ -563,10 +563,10 @@ func TestDeleteNamespaceReconcilerDeployment(t *testing.T) {
 	// Verify that the deployment is re-created after deletion by checking the
 	// Reconciling and Stalled condition in RepoSync resource.
 	err = nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSyncID.Name, repoSyncID.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			hasReconcilingStatus(metav1.ConditionFalse),
 			hasStalledStatus(metav1.ConditionFalse),
-		})
+		))
 	if err != nil {
 		nt.T.Errorf("RepoSync did not finish reconciling: %v", err)
 	}

--- a/e2e/testcases/namespace_selectors_test.go
+++ b/e2e/testcases/namespace_selectors_test.go
@@ -27,6 +27,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	v1 "kpt.dev/configsync/pkg/api/configmanagement/v1"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -177,25 +178,18 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	bookstoreNSS.Spec.Mode = v1.NSSelectorDynamicMode
 	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use dynamic mode"))
-	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
-			testpredicates.HasAnnotation(
-				metadata.DynamicNSSelectorEnabledAnnotationKey, "true"),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.Watcher.WatchObject(kinds.Deployment(),
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.DynamicNSSelectorEnabledAnnotationKey, "true"),
+		)))
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerName(configsync.RootSyncName),
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
-			testpredicates.DeploymentHasEnvVar(
-				reconcilermanager.Reconciler,
-				reconcilermanager.DynamicNSSelectorEnabled, "true"),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		testwatcher.WatchPredicates(
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.DynamicNSSelectorEnabled, "true"),
+		)))
 
 	nt.Must(nt.WatchForAllSyncs())
 	validateSelectedAndUnselectedResources(nt,
@@ -219,15 +213,13 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	})
 
 	nt.Logger.Info("Watching the ResourceGroup object until new selected resources are added to the inventory")
-	if err := nt.Watcher.WatchObject(kinds.ResourceGroup(),
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupHasObjects(selectedResourcesWithBookstoreNSSAndShoestoreNSS),
 			testpredicates.ResourceGroupMissingObjects(unselectedResourcesWithBookstoreNSSAndShoestoreNSS),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	nt.Must(nt.WatchForAllSyncs())
 	validateSelectedAndUnselectedResources(nt,
 		selectedResourcesWithBookstoreNSSAndShoestoreNSS,
@@ -239,23 +231,18 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use static mode"))
 
-	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
-			testpredicates.HasAnnotation(
-				metadata.DynamicNSSelectorEnabledAnnotationKey, "false"),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.Watcher.WatchObject(kinds.Deployment(),
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.DynamicNSSelectorEnabledAnnotationKey, "false"),
+		)))
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerName(configsync.RootSyncName),
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.DynamicNSSelectorEnabled),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 
 	nt.Logger.Info("Only resources in shoestore are created because bookstore Namespace is not selected")
 	nt.Must(nt.WatchForAllSyncs())
@@ -268,25 +255,18 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	bookstoreNSS.Spec.Mode = v1.NSSelectorDynamicMode
 	nt.Must(rootSyncGitRepo.Add("acme/namespace-selector-bookstore.yaml", bookstoreNSS))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update NamespaceSelector to use dynamic mode again"))
-	if err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
-			testpredicates.HasAnnotation(
-				metadata.DynamicNSSelectorEnabledAnnotationKey, "true"),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.Watcher.WatchObject(kinds.Deployment(),
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.DynamicNSSelectorEnabledAnnotationKey, "true"),
+		)))
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerName(configsync.RootSyncName),
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
-			testpredicates.DeploymentHasEnvVar(
-				reconcilermanager.Reconciler,
-				reconcilermanager.DynamicNSSelectorEnabled, "true"),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		testwatcher.WatchPredicates(
+			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.DynamicNSSelectorEnabled, "true"),
+		)))
 
 	nt.Must(nt.WatchForAllSyncs())
 	validateSelectedAndUnselectedResources(nt,
@@ -298,15 +278,13 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt.MustMergePatch(bookstoreNamespace, `{"metadata":{"labels":{"app":"other"}}}`)
 
 	nt.Logger.Info("Watching the ResourceGroup object until unselected resources are removed from the inventory")
-	if err := nt.Watcher.WatchObject(kinds.ResourceGroup(),
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupHasObjects(selectedResourcesWithShoestoreNSSOnly),
 			testpredicates.ResourceGroupMissingObjects(unselectedResourcesWithShoestoreNSSOnly),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	nt.Must(nt.WatchForAllSyncs())
 	validateSelectedAndUnselectedResources(nt,
 		selectedResourcesWithShoestoreNSSOnly,
@@ -316,15 +294,13 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	nt.Logger.Info("Update Namespace's label to make it selected again, resources should be selected")
 	nt.MustMergePatch(bookstoreNamespace, fmt.Sprintf(`{"metadata":{"labels":{"app":"%s"}}}`, bookstoreNS))
 
-	if err := nt.Watcher.WatchObject(kinds.ResourceGroup(),
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupHasObjects(selectedResourcesWithBookstoreNSSAndShoestoreNSS),
 			testpredicates.ResourceGroupMissingObjects(unselectedResourcesWithBookstoreNSSAndShoestoreNSS),
-		}); err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	nt.Must(nt.WatchForAllSyncs())
 	validateSelectedAndUnselectedResources(nt,
 		selectedResourcesWithBookstoreNSSAndShoestoreNSS,
@@ -345,10 +321,10 @@ func TestNamespaceSelectorUnstructuredFormat(t *testing.T) {
 	if err := nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName,
 		configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupHasObjects(selectedResourcesWithShoestoreNSSOnly),
 			testpredicates.ResourceGroupMissingObjects(unselectedResourcesWithShoestoreNSSOnly),
-		}); err != nil {
+		)); err != nil {
 		nt.T.Fatal(err)
 	}
 	nt.Must(nt.WatchForAllSyncs())

--- a/e2e/testcases/namespaces_test.go
+++ b/e2e/testcases/namespaces_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +29,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
@@ -670,10 +670,10 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 	nt.Must(rootSyncGitRepo.RemoveSafetyNamespace())
 	nt.Must(rootSyncGitRepo.CommitAndPush("undeclare all Namespaces"))
 
-	require.NoError(nt.T,
-		nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.RootSyncHasSyncError(status.EmptySourceErrorCode, ""),
-		}))
+		)))
 
 	// Wait 10 seconds before checking the namespaces.
 	// Checking the namespaces immediately may not catch the case where

--- a/e2e/testcases/no_ssl_verify_test.go
+++ b/e2e/testcases/no_ssl_verify_test.go
@@ -185,8 +185,8 @@ func TestNoSSLVerifyV1Beta1(t *testing.T) {
 
 func validateDeploymentContainerMissingEnvVar(nt *nomostest.NT, nn types.NamespacedName, container, key string) error {
 	return nt.Watcher.WatchObject(kinds.Deployment(), nn.Name, nn.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentMissingEnvVar(container, key),
-		},
+		),
 		testwatcher.WatchTimeout(30*time.Second))
 }

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -270,7 +270,7 @@ func TestOciSyncWithDigest(t *testing.T) {
 	// RootSync should fail because image can no longer be pulled
 	nt.T.Log("Wait for RootSync to have source error")
 	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSyncID.Name, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "failed to pull image")}))
+		testwatcher.WatchPredicates(testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "failed to pull image"))))
 	nt.WaitForRootSyncSourceError(rootSyncID.Name, status.SourceErrorCode, "failed to pull image")
 	// Specify image with digest
 	image, err = nt.BuildAndPushOCIImage(rootSyncKey, registryproviders.ImageInputObjects(nt.Scheme, bookinfoRole))
@@ -298,7 +298,7 @@ func TestOciSyncWithDigest(t *testing.T) {
 	nt.T.Log("Make sure RootSync remains healthy for 30 seconds")
 	// RootSync should remain healthy as long as the Pod isn't restarted (could be flaky)
 	err = nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSyncID.Name, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "failed to pull image")},
+		testwatcher.WatchPredicates(testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "failed to pull image")),
 		testwatcher.WatchTimeout(30*time.Second)) // wait for source error to occur (it shouldn't)
 	if err == nil {
 		nt.T.Fatal("expected no source error code but found one")

--- a/e2e/testcases/override_git_sync_depth_test.go
+++ b/e2e/testcases/override_git_sync_depth_test.go
@@ -219,8 +219,8 @@ func TestOverrideGitSyncDepthV1Beta1(t *testing.T) {
 
 func validateDeploymentContainerHasEnvVar(nt *nomostest.NT, nn types.NamespacedName, container, key, value string) error {
 	return nt.Watcher.WatchObject(kinds.Deployment(), nn.Name, nn.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(container, key, value),
-		},
+		),
 		testwatcher.WatchTimeout(30*time.Second))
 }

--- a/e2e/testcases/override_log_level_test.go
+++ b/e2e/testcases/override_log_level_test.go
@@ -22,6 +22,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -52,75 +53,63 @@ func TestOverrideRootSyncLogLevel(t *testing.T) {
 	nt.Must(nt.WatchForAllSyncs())
 
 	// validate initial container log level value
-	err := nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerName.Name, rootReconcilerName.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=0"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
 			testpredicates.DeploymentHasContainer(reconcilermanager.HydrationController),
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.RenderingEnabled, "true"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 	nt.Must(nt.WatchForAllSyncs())
 
 	// apply override to one container and validate the others are unaffected
 	nt.MustMergePatch(rootSyncV1, `{"spec": {"override": {"logLevels": [{"containerName": "reconciler", "logLevel": 3}]}}}`)
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerName.Name, rootReconcilerName.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=3"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 	nt.Must(nt.WatchForAllSyncs())
 
 	// apply override to all containers and validate
 	nt.MustMergePatch(rootSyncV1, `{"spec": {"override": {"logLevels": [{"containerName": "reconciler", "logLevel": 5}, {"containerName": "git-sync", "logLevel": 7}, {"containerName": "otel-agent", "logLevel": 0}, {"containerName": "hydration-controller", "logLevel": 9}]}}}`)
 
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerName.Name, rootReconcilerName.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=7"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=fatal"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=9"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// remove override and validate values are back to initial
 	nt.MustMergePatch(rootSyncV1, `{"spec": {"override": null}}`)
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerName.Name, rootReconcilerName.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=0"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 	nt.Must(nt.WatchForAllSyncs())
 
 	// try invalid log level value
 	maxError := "logLevel in body should be less than or equal to 10"
 	minError := "logLevel in body should be greater than or equal to 0"
 
-	err = nt.KubeClient.MergePatch(rootSyncV1, `{"spec": {"override": {"logLevels": [{"containerName": "reconciler", "logLevel": 13}]}}}`)
+	err := nt.KubeClient.MergePatch(rootSyncV1, `{"spec": {"override": {"logLevels": [{"containerName": "reconciler", "logLevel": 13}]}}}`)
 	if !strings.Contains(err.Error(), maxError) {
 		nt.T.Fatalf("Expecting invalid value error: %q, got %s", maxError, err.Error())
 	}
@@ -154,20 +143,17 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update RepoSync to sync from the kustomize directory"))
 
 	// Verify ns-reconciler-frontend uses the default log level
-	err := nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		frontendReconcilerNN.Name, frontendReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=0"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
 			testpredicates.DeploymentHasContainer(reconcilermanager.HydrationController),
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.Reconciler, reconcilermanager.RenderingEnabled, "true"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// Override the log level of the reconciler container of ns-reconciler-frontend
 	repoSyncFrontend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{
@@ -184,18 +170,15 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update log level of frontend Reposync"))
 
 	// validate override and make sure other containers are unaffected
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		frontendReconcilerNN.Name, frontendReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=3"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// Override the log level of the all containers in ns-reconciler-frontend
 	repoSyncFrontend.Spec.Override = &v1beta1.RepoSyncOverrideSpec{
@@ -224,18 +207,15 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update log level of frontend Reposync"))
 
 	// validate override for all containers
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		frontendReconcilerNN.Name, frontendReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=7"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=9"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=debug"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// Clear override from repoSync Frontend
 	repoSyncFrontend.Spec.Override = nil
@@ -243,16 +223,13 @@ func TestOverrideRepoSyncLogLevel(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Clear override from repoSync Frontend"))
 
 	// validate log level value are back to default for all containers
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		frontendReconcilerNN.Name, frontendReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.Reconciler, "-v=0"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.GitSync, "-v=5"),
 			testpredicates.DeploymentContainerArgsContains(reconcilermanager.HydrationController, "-v=0"),
 			testpredicates.DeploymentContainerArgsContains(metrics.OtelAgentName, "--set=service.telemetry.logs.level=info"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 }

--- a/e2e/testcases/override_resource_limits_test.go
+++ b/e2e/testcases/override_resource_limits_test.go
@@ -117,17 +117,14 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	// Verify the reconciler container of root-reconciler uses the new resource request and limits, and the git-sync container uses the default resource requests and limits.
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(updatedRootReconcilerResources),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.GitSync]),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
@@ -251,18 +248,15 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	}
 
 	// Verify the reconciler container root-reconciler uses the default resource requests and limits, and the git-sync container uses the new resource limits.
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.Reconciler]),
 			testpredicates.DeploymentContainerResourcesEqual(updatedRootReconcilerGitSyncResources),
-		},
+		),
 		testwatcher.WatchTimeout(30*time.Second),
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	))
 
 	// Verify the resource limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
@@ -289,17 +283,14 @@ func TestOverrideReconcilerResourcesV1Alpha1(t *testing.T) {
 	rootReconcilerDeploymentGeneration++
 
 	// Verify root-reconciler uses the default resource requests and limits
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.Reconciler]),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.GitSync]),
-		},
-		testwatcher.WatchTimeout(30*time.Second))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+		testwatcher.WatchTimeout(30*time.Second)))
 
 	// Verify the resource requests and limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
@@ -480,17 +471,14 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	// Verify the reconciler container of root-reconciler uses the new resource request and limits, and the git-sync container uses the default resource requests and limits.
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(updatedRootReconcilerResources),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.GitSync]),
-		},
-		testwatcher.WatchTimeout(30*time.Second))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+		testwatcher.WatchTimeout(30*time.Second)))
 
 	// Verify ns-reconciler-backend uses the default resource requests and limits
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
@@ -612,18 +600,15 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	}
 
 	// Verify the reconciler container root-reconciler uses the default resource requests and limits, and the git-sync container uses the new resource limits.
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.Reconciler]),
 			testpredicates.DeploymentContainerResourcesEqual(updatedRootReconcilerGitSyncResources),
-		},
+		),
 		testwatcher.WatchTimeout(30*time.Second),
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	))
 
 	// Verify the resource limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},
@@ -650,17 +635,14 @@ func TestOverrideReconcilerResourcesV1Beta1(t *testing.T) {
 	rootReconcilerDeploymentGeneration++
 
 	// Verify root-reconciler uses the default resource requests and limits
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		rootReconcilerNN.Name, rootReconcilerNN.Namespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.GenerationEquals(rootReconcilerDeploymentGeneration),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.Reconciler]),
 			testpredicates.DeploymentContainerResourcesEqual(defaultResources[reconcilermanager.GitSync]),
-		},
-		testwatcher.WatchTimeout(30*time.Second))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+		testwatcher.WatchTimeout(30*time.Second)))
 
 	// Verify the resource requests and limits of ns-reconciler-backend are not affected by the resource limit change of root-reconciler
 	err = nt.Validate(backendReconcilerNN.Name, backendReconcilerNN.Namespace, &appsv1.Deployment{},

--- a/e2e/testcases/profiling_test.go
+++ b/e2e/testcases/profiling_test.go
@@ -27,6 +27,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
@@ -476,9 +477,10 @@ func watchForSyncedAndReconciled(nt *nomostest.NT, rsRefs []rSyncRef) error {
 	for _, rsRef := range rsRefs {
 		reRefPtr := rsRef
 		tg.Go(func() error {
-			return nt.Watcher.WatchObject(kinds.ResourceGroup(), reRefPtr.Name, reRefPtr.Namespace, []testpredicates.Predicate{
-				testpredicates.AllResourcesReconciled(nt.Scheme),
-			})
+			return nt.Watcher.WatchObject(kinds.ResourceGroup(), reRefPtr.Name, reRefPtr.Namespace,
+				testwatcher.WatchPredicates(
+					testpredicates.AllResourcesReconciled(nt.Scheme),
+				))
 		})
 	}
 	return tg.Wait()

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/syncsource"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
@@ -42,7 +43,7 @@ func TestSyncingThroughAProxy(t *testing.T) {
 		nt.Must(nt.Watcher.WatchForNotFound(kinds.Deployment(), "tinyproxy-deployment", "proxy-test"))
 	})
 	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), "tinyproxy-deployment", "proxy-test",
-		[]testpredicates.Predicate{hasReadyReplicas(1)}))
+		testwatcher.WatchPredicates(hasReadyReplicas(1))))
 	nt.T.Log("Verify the NoOpProxyError")
 	rs := k8sobjects.RootSyncObjectV1Beta1(rootSyncID.Name)
 	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -42,6 +42,7 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testutils"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
@@ -77,11 +78,11 @@ func TestReconcilerManagerNormalTeardown(t *testing.T) {
 	t.Log("Validate the RootSync")
 	rootSync := &v1beta1.RootSync{}
 	setNN(rootSync, rootSyncID.ObjectKey)
-	err = nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace, []testpredicates.Predicate{
-		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-		testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
-	})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+			testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
+		)))
 
 	t.Log("Validate the RootSync reconciler and its dependencies")
 	rootSyncDependencies := validateRootSyncDependencies(nt, rootSync.Name)
@@ -89,11 +90,11 @@ func TestReconcilerManagerNormalTeardown(t *testing.T) {
 	t.Log("Validate the RepoSync")
 	repoSync := &v1beta1.RepoSync{}
 	setNN(repoSync, repoSyncID.ObjectKey)
-	err = nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace, []testpredicates.Predicate{
-		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-		testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
-	})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+			testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
+		)))
 
 	t.Log("Validate the RepoSync reconciler and its dependencies")
 	repoSyncDependencies := validateRepoSyncDependencies(nt, repoSync.Namespace, repoSync.Name)
@@ -137,11 +138,11 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 
 	t.Log("Validate the RootSync")
 	rootSync := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
-	err = nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace, []testpredicates.Predicate{
-		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-		testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
-	})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+			testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
+		)))
 
 	t.Log("Validate the RootSync reconciler and its dependencies")
 	rootSyncDependencies := validateRootSyncDependencies(nt, rootSync.Name)
@@ -165,11 +166,11 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 
 	t.Log("Validate the RepoSync")
 	repoSync := k8sobjects.RepoSyncObjectV1Beta1(repoSyncID.Namespace, repoSyncID.Name)
-	err = nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace, []testpredicates.Predicate{
-		testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-		testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
-	})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+			testpredicates.HasFinalizer(metadata.ReconcilerManagerFinalizer),
+		)))
 
 	t.Log("Validate the RepoSync reconciler and its dependencies")
 	repoSyncDependencies := validateRepoSyncDependencies(nt, repoSync.Namespace, repoSync.Name)
@@ -268,9 +269,8 @@ func TestReconcilerManagerTeardownRootSyncWithReconcileTimeout(t *testing.T) {
 		Status:  metav1.ConditionTrue,
 		Type:    v1beta1.RootSyncReconciling,
 	}
-	err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace,
-		[]testpredicates.Predicate{testpredicates.RootSyncHasCondition(&expectedCondition)})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace,
+		testwatcher.WatchPredicates(testpredicates.RootSyncHasCondition(&expectedCondition))))
 	nt.T.Log("Validate that all of the managed resources still exist")
 	validateRootSyncDependencies(nt, rootSync.Name)
 
@@ -353,9 +353,8 @@ func TestReconcilerManagerTeardownRepoSyncWithReconcileTimeout(t *testing.T) {
 		Status:  metav1.ConditionTrue,
 		Type:    v1beta1.RepoSyncReconciling,
 	}
-	err := nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace,
-		[]testpredicates.Predicate{testpredicates.RepoSyncHasCondition(&expectedCondition)})
-	require.NoError(t, err)
+	nt.Must(nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), repoSync.Name, repoSync.Namespace,
+		testwatcher.WatchPredicates(testpredicates.RepoSyncHasCondition(&expectedCondition))))
 	nt.T.Log("Validate that all of the managed resources still exist")
 	validateRepoSyncDependencies(nt, repoSync.Namespace, repoSync.Name)
 
@@ -496,14 +495,11 @@ func TestManagingReconciler(t *testing.T) {
 	})
 	nt.T.Log("Verify the ImagePullPolicy should be reverted by the reconciler-manager")
 	generation += 2 // generation bumped by 2 because the change will be first applied then reverted by the reconciler-manager
-	err := nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.HasGenerationAtLeast(generation),
 			testpredicates.DeploymentContainerPullPolicyEquals(reconcilermanager.Reconciler, originalImagePullPolicy),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 
 	// test case 2: the reconciler-manager should manage the replicas field, so that the reconciler can be resumed after pause.
 	nt.T.Log("Manually update the replicas")
@@ -511,11 +507,8 @@ func TestManagingReconciler(t *testing.T) {
 	nt.MustMergePatch(reconcilerDeployment, fmt.Sprintf(`{"spec": {"replicas": %d}}`, newReplicas))
 	nt.T.Log("Verify the reconciler-manager should revert the replicas change")
 	generation += 2 // generation bumped by 2 because the change will be first applied then reverted by the reconciler-manager
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.HasGenerationAtLeast(generation), hasReplicas(managedReplicas)})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(testpredicates.HasGenerationAtLeast(generation), hasReplicas(managedReplicas))))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 
 	// test case 3:  the reconciler-manager should not revert the change to the fields that are not owned by reconciler-manager
@@ -531,17 +524,14 @@ func TestManagingReconciler(t *testing.T) {
 
 	nt.T.Log("Verify the reconciler-manager does not revert the change")
 	generation++ // generation bumped by 1 because reconicler-manager should not revert this change
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.HasGenerationAtLeast(generation),
 			firstContainerTerminationMessagePathEquals("dev/termination-message"),
 			firstContainerStdinEquals(true),
 			hasTolerations(modifiedTolerations),
 			hasPriorityClassName("system-node-critical"),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 	// change the fields back to default values
 	mustUpdateRootReconciler(nt, func(d *appsv1.Deployment) {
@@ -551,17 +541,14 @@ func TestManagingReconciler(t *testing.T) {
 		d.Spec.Template.Spec.PriorityClassName = ""
 	})
 	generation++ // generation bumped by 1 because reconciler-manager should not revert this change
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.HasGenerationAtLeast(generation),
 			firstContainerTerminationMessagePathEquals("dev/termination-log"),
 			firstContainerStdinEquals(false),
 			hasTolerations(originalTolerations),
 			hasPriorityClassName(""),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 
 	// test case 4: the reconciler-manager should update the reconciler Deployment if the manifest in the ConfigMap has been changed.
@@ -580,14 +567,11 @@ func TestManagingReconciler(t *testing.T) {
 	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true)
 	nt.T.Log("Verify the reconciler Deployment has been updated to the new manifest")
 	generation++ // generation bumped by 1 to apply the new change in the default manifests declared in the Config Map
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			testpredicates.HasGenerationAtLeast(generation),
 			testpredicates.DeploymentContainerPullPolicyEquals(reconcilermanager.Reconciler, updatedImagePullPolicy),
-		})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		)))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 
 	// test case 5: the reconciler-manager should add the gcenode-askpass-sidecar container when needed
@@ -599,11 +583,8 @@ func TestManagingReconciler(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec":{"git":{"auth":"gcpserviceaccount","secretRef":{"name":""},"gcpServiceAccountEmail":"test-gcp-sa-email@test-project.iam.gserviceaccount.com"}}}`)
 	nt.T.Log("Verify the gcenode-askpass-sidecar container should exist")
 	generation++ // generation bumped by 1 to apply the new sidecar container and/or the GSA email address.
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.HasGenerationAtLeast(generation), templateForGcpServiceAccountAuthType()})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(testpredicates.HasGenerationAtLeast(generation), templateForGcpServiceAccountAuthType())))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 
 	// test case 6: the reconciler-manager should mount the git-creds volumes again if the auth type requires a git secret
@@ -611,14 +592,9 @@ func TestManagingReconciler(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec":{"git":{"auth":"ssh","secretRef":{"name":"git-creds"}}}}`)
 	nt.T.Log("Verify the git-creds volume exists and the gcenode-askpass-sidecar container is gone")
 	generation++ // generation bumped by 1 to add the git-cred volume again
-	if err = nomostest.SetupFakeSSHCreds(nt, rs.Kind, nomostest.RootSyncNN(rs.Name), configsync.AuthSSH, controllers.GitCredentialVolume); err != nil {
-		nt.T.Fatal(err)
-	}
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.HasGenerationAtLeast(generation), templateForSSHAuthType()})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nomostest.SetupFakeSSHCreds(nt, rs.Kind, nomostest.RootSyncNN(rs.Name), configsync.AuthSSH, controllers.GitCredentialVolume))
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(testpredicates.HasGenerationAtLeast(generation), templateForSSHAuthType())))
 	generation = getDeploymentGeneration(nt, nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace)
 
 	// test case 7: the reconciler-manager should delete the git-creds volume if not needed
@@ -626,11 +602,8 @@ func TestManagingReconciler(t *testing.T) {
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "none", "secretRef": {"name":""}}}}`)
 	nt.T.Log("Verify the git-creds volume is gone")
 	generation++ // generation bumped by 1 to delete the git-creds volume
-	err = nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{testpredicates.HasGenerationAtLeast(generation), noGitCredsVolume()})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(testpredicates.HasGenerationAtLeast(generation), noGitCredsVolume())))
 }
 
 type updateFunc func(deployment *appsv1.Deployment)
@@ -696,9 +669,9 @@ func resetReconcilerDeploymentManifests(nt *nomostest.NT, containerName string, 
 	nt.T.Log("Verify the reconciler Deployment has been reverted to the original manifest")
 	err := nt.Watcher.WatchObject(kinds.Deployment(),
 		nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentContainerPullPolicyEquals(containerName, pullPolicy),
-		},
+		),
 	)
 	if err != nil {
 		nt.T.Fatal(err)
@@ -972,12 +945,10 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 
 	nt.T.Log("Wait for the reconciler deployment to be updated once")
 	generation++ // patched by reconciler-manager
-	err = nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace, []testpredicates.Predicate{
-		testpredicates.HasGenerationAtLeast(generation),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.HasGenerationAtLeast(generation),
+		)))
 
 	nt.T.Log("Verify the reconciler-manager applied the override memory/CPU request change")
 	reconcilerDeployment = &appsv1.Deployment{}
@@ -1007,12 +978,10 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 
 	nt.T.Log("Wait for the reconciler deployment to be updated twice")
 	generation += 2 // manual update + reconciler-manager revert
-	err = nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace, []testpredicates.Predicate{
-		testpredicates.HasGenerationAtLeast(generation),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.HasGenerationAtLeast(generation),
+		)))
 
 	nt.T.Log("Verify the reconciler-manager reverted the manual memory/CPU request change")
 	reconcilerDeployment = &appsv1.Deployment{}
@@ -1048,12 +1017,10 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Log("Wait for the reconciler-manager to update the reconciler deployment CPU request, only on non-autopilot cluster")
-	err = nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace, []testpredicates.Predicate{
-		testpredicates.HasGenerationAtLeast(generation),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), reconcilerNN.Name, reconcilerNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.HasGenerationAtLeast(generation),
+		)))
 
 	nt.T.Log("Verify the reconciler-manager changed the reconciler CPU request, only on non-autopilot cluster")
 	reconcilerDeployment = &appsv1.Deployment{}
@@ -1201,9 +1168,10 @@ func TestReconcilerManagerRootSyncCRDMissing(t *testing.T) {
 	nt.Must(nt.KubeClient.Get(rootSyncKey.Name, rootSyncKey.Namespace, rootSync))
 	if nomostest.EnableDeletionPropagation(rootSync) {
 		nt.Must(nt.KubeClient.Update(rootSync))
-		nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace, []testpredicates.Predicate{
-			testpredicates.HasFinalizer(metadata.ReconcilerFinalizer),
-		}))
+		nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), rootSync.Name, rootSync.Namespace,
+			testwatcher.WatchPredicates(
+				testpredicates.HasFinalizer(metadata.ReconcilerFinalizer),
+			)))
 	}
 
 	t.Log("Validate RootSync syncing works")

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -95,12 +95,10 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
-	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 
 	resources := []v1alpha1.ObjMetadata{
 		{
@@ -112,12 +110,9 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			},
 		},
 	}
-	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
 		rg.Spec.Resources = resources
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	}))
 
 	subRGNN := types.NamespacedName{
 		Name:      "group-b",
@@ -128,17 +123,14 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
 		rg.Spec.Subgroups = []v1alpha1.GroupMetadata{
 			{
 				Name:      subRGNN.Name,
 				Namespace: subRGNN.Namespace,
 			},
 		}
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	}))
 
 	expectedStatus.ObservedGeneration = 3
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
@@ -165,12 +157,10 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 		},
 	}
 
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	}, testwatcher.WatchTimeout(time.Minute))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		), testwatcher.WatchTimeout(time.Minute)))
 
 	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, resourceID); err != nil {
 		nt.T.Fatal(err)
@@ -185,12 +175,10 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 		},
 	}
 
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	}, testwatcher.WatchTimeout(time.Minute))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		), testwatcher.WatchTimeout(time.Minute)))
 
 	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, "another"); err != nil {
 		nt.T.Fatal(err)
@@ -211,12 +199,10 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 		},
 	}
 
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	}, testwatcher.WatchTimeout(time.Minute))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		), testwatcher.WatchTimeout(time.Minute)))
 
 	if err := nt.KubeClient.Delete(rg); err != nil {
 		nt.T.Fatal(err)
@@ -255,12 +241,10 @@ func TestResourceGroupCustomResource(t *testing.T) {
 
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
-	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 	crdObj := anvilV1CRD()
 	crdGVK := anvilGVK("v1")
 	resources := []v1alpha1.ObjMetadata{
@@ -273,12 +257,9 @@ func TestResourceGroupCustomResource(t *testing.T) {
 			},
 		},
 	}
-	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
 		rg.Spec.Resources = resources
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	}))
 	expectedStatus.ObservedGeneration = 2
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
@@ -286,12 +267,10 @@ func TestResourceGroupCustomResource(t *testing.T) {
 			Status:      v1alpha1.NotFound,
 		},
 	}
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 	// Create CRD and CR
 	nt.T.Cleanup(func() {
 		crdObj := anvilV1CRD()
@@ -332,12 +311,10 @@ func TestResourceGroupCustomResource(t *testing.T) {
 			},
 		},
 	}
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 	if err := nt.KubeClient.Delete(crdObj); err != nil {
 		nt.T.Fatal(err)
 	}
@@ -347,12 +324,10 @@ func TestResourceGroupCustomResource(t *testing.T) {
 			Status:      v1alpha1.NotFound,
 		},
 	}
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 }
 
 func TestResourceGroupApplyStatus(t *testing.T) {
@@ -380,12 +355,10 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
-	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 
 	nt.T.Log("Create and apply ConfigMaps")
 	resources := []v1alpha1.ObjMetadata{
@@ -447,15 +420,10 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 		},
 	}
 	nt.T.Log("Apply all but the last ConfigMap to test NotFound error")
-	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources[:len(resources)-1], resourceID); err != nil {
-		nt.T.Fatal(err)
-	}
-	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+	nt.Must(testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources[:len(resources)-1], resourceID))
+	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
 		rg.Spec.Resources = resources
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	}))
 	expectedStatus.ObservedGeneration = 2
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
@@ -493,36 +461,30 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 			Status:      v1alpha1.NotFound,
 		},
 	}
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 
 	nt.T.Log("inject resource status to verify reconcile behavior")
-	err = testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
+	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
 		rg.Status.ResourceStatuses = nil
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	}))
 	nt.T.Log("verify that the controller reconciles to the original status")
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceGroupStatusEquals(expectedStatus),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
 	actualRG := &v1alpha1.ResourceGroup{}
 	if err := nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, actualRG); err != nil {
 		nt.T.Fatal(err)
 	}
 	resourceVersion := actualRG.ResourceVersion
 	nt.T.Log("Wait and check to see we don't cause an infinite/recursive reconcile loop by ensuring the resourceVersion doesn't change.")
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace, []testpredicates.Predicate{
-		testpredicates.ResourceVersionNotEquals(nt.Scheme, resourceVersion),
-	}, testwatcher.WatchTimeout(60*time.Second))
+	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceVersionNotEquals(nt.Scheme, resourceVersion),
+		), testwatcher.WatchTimeout(60*time.Second))
 	if err == nil {
 		nt.T.Fatal("expected ResourceGroup ResourceVersion to not change")
 	}

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -337,15 +337,12 @@ func TestRootSyncReconcilingStatus(t *testing.T) {
 	// Deployment is successfully created.
 	// Log error if the Reconciling condition does not progress to False before the timeout
 	// expires.
-	err := nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
 			hasRootSyncReconcilingStatus(metav1.ConditionFalse),
 			hasRootSyncStalledStatus(metav1.ConditionFalse),
-		},
-		testwatcher.WatchTimeout(15*time.Second))
-	if err != nil {
-		nt.T.Errorf("RootSync did not finish reconciling: %v", err)
-	}
+		),
+		testwatcher.WatchTimeout(15*time.Second)))
 
 	if err := nomostest.ValidateStandardMetrics(nt); err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -23,6 +23,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/policy"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
@@ -43,9 +44,9 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 		nt.MustMergePatch(rootSecret, secretDataDeletePatch(controllers.KnownHostsKey))
 		err = nt.Watcher.WatchObject(kinds.Deployment(),
 			core.RootReconcilerPrefix, configsync.ControllerNamespace,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
-			},
+			),
 		)
 		if err != nil {
 			nt.T.Error(err)
@@ -57,15 +58,12 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerPrefix, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// get known host key value
 	knownHostValue, err := nomostest.GetKnownHosts(nt)
@@ -75,15 +73,12 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 
 	// apply known host key and validate
 	nt.MustMergePatch(rootSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerPrefix, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// try syncing resource and validate
 	cmName := "configmap-test"
@@ -106,21 +101,16 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 	// validate root sync error using invalid known host value
 	knownHostValue = "invalid value"
 	nt.MustMergePatch(rootSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		core.RootReconcilerPrefix, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-	err = nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace, []testpredicates.Predicate{
-		testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
+	nt.Must(nt.Watcher.WatchObject(kinds.RootSyncV1Beta1(), configsync.RootSyncName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
+			testpredicates.RootSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
+		)))
 }
 
 func TestRepoSyncSSHKnownHost(t *testing.T) {
@@ -140,9 +130,9 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 		nt.MustMergePatch(repoSecret, secretDataDeletePatch(controllers.KnownHostsKey))
 		err = nt.Watcher.WatchObject(kinds.Deployment(),
 			repoReconcilerName, configsync.ControllerNamespace,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
-			},
+			),
 		)
 		if err != nil {
 			nt.T.Error(err)
@@ -154,15 +144,12 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		repoReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "false"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// get known host key value
 	knownHostValue, err := nomostest.GetKnownHosts(nt)
@@ -172,15 +159,12 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 
 	// apply known host key and validate
 	nt.MustMergePatch(repoSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		repoReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
 
 	// try syncing resource and validate
 	cmName := "configmap-test"
@@ -203,19 +187,14 @@ func TestRepoSyncSSHKnownHost(t *testing.T) {
 	// validate repo sync error using invalid known host value
 	knownHostValue = "invalid value"
 	nt.MustMergePatch(repoSecret, secretDataPatch(controllers.KnownHostsKey, knownHostValue))
-	err = nt.Watcher.WatchObject(kinds.Deployment(),
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
 		repoReconcilerName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			testpredicates.DeploymentHasEnvVar(reconcilermanager.GitSync, controllers.GitSyncKnownHosts, "true"),
-		},
-	)
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-	err = nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), configsync.RepoSyncName, backendNamespace, []testpredicates.Predicate{
-		testpredicates.RepoSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+	))
+	nt.Must(nt.Watcher.WatchObject(kinds.RepoSyncV1Beta1(), configsync.RepoSyncName, backendNamespace,
+		testwatcher.WatchPredicates(
+			testpredicates.RepoSyncHasSourceError(status.SourceErrorCode, "No ED25519 host key is known"),
+		)))
 }

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -54,31 +54,25 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add a namespace and a configmap"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	err := nt.Watcher.WatchObject(kinds.ResourceGroup(),
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			resourceGroupHasNoStatus,
 			testpredicates.HasLabel(common.InventoryLabel, id),
-		},
-		testwatcher.WatchTimeout(nt.DefaultWaitTimeout))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+		testwatcher.WatchTimeout(nt.DefaultWaitTimeout)))
 
 	// Override the statusMode for root-reconciler to re-enable the status
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"statusMode": "enabled"}}}`)
 	nt.Must(nt.WatchForAllSyncs())
 
-	err = nt.Watcher.WatchObject(kinds.ResourceGroup(),
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName, configsync.ControllerNamespace,
-		[]testpredicates.Predicate{
+		testwatcher.WatchPredicates(
 			resourceGroupHasStatus,
 			testpredicates.HasLabel(common.InventoryLabel, id),
-		},
-		testwatcher.WatchTimeout(nt.DefaultWaitTimeout))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+		),
+		testwatcher.WatchTimeout(nt.DefaultWaitTimeout)))
 }
 
 func resourceGroupHasNoStatus(obj client.Object) error {

--- a/e2e/testcases/sync_ordering_test.go
+++ b/e2e/testcases/sync_ordering_test.go
@@ -466,20 +466,20 @@ func TestDependencyWithReconciliation(t *testing.T) {
 	tg := taskgroup.New()
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Pod(), pod1Name, namespaceName,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				pod1SyncPredicate,
 				podCachePredicate(pod1),
 				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			},
+			),
 			testwatcher.WatchTimeout(nt.DefaultWaitTimeout*2))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Pod(), pod2Name, namespaceName,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				pod2SyncPredicate,
 				podCachePredicate(pod2),
 				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-			},
+			),
 			testwatcher.WatchTimeout(nt.DefaultWaitTimeout*2))
 	})
 	// Watch in the background
@@ -547,22 +547,22 @@ func TestDependencyWithReconciliation(t *testing.T) {
 	tg = taskgroup.New()
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Pod(), pod1Name, namespaceName,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				pod1SyncPredicate,
 				podCachePredicate(pod1),
 				pod1DeletionPredicate,
 				testpredicates.ObjectNotFoundPredicate(nt.Scheme),
-			},
+			),
 			testwatcher.WatchTimeout(nt.DefaultWaitTimeout*2))
 	})
 	tg.Go(func() error {
 		return nt.Watcher.WatchObject(kinds.Pod(), pod2Name, namespaceName,
-			[]testpredicates.Predicate{
+			testwatcher.WatchPredicates(
 				pod2SyncPredicate,
 				podCachePredicate(pod2),
 				pod2LastUpdatedPredicate,
 				testpredicates.ObjectNotFoundPredicate(nt.Scheme),
-			},
+			),
 			testwatcher.WatchTimeout(nt.DefaultWaitTimeout*2))
 	})
 
@@ -615,7 +615,7 @@ func TestDependencyWithReconciliation(t *testing.T) {
 	// pod3 will never reconcile (image pull failure)
 	// TODO: kstatus should probably detect image pull failure and time out to Failure status, like it does for scheduling failure.
 	err = multierr.Append(err, nt.Watcher.WatchObject(kinds.Pod(), "pod3", namespaceName,
-		[]testpredicates.Predicate{testpredicates.StatusEquals(nt.Scheme, kstatus.InProgressStatus)}))
+		testwatcher.WatchPredicates(testpredicates.StatusEquals(nt.Scheme, kstatus.InProgressStatus))))
 	err = multierr.Append(err, nt.ValidateNotFound("pod4", namespaceName, &corev1.Pod{}))
 	if err != nil {
 		nt.T.Fatal(err)

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -35,6 +35,7 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testutils"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/e2e/nomostest/workloadidentity"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
@@ -421,14 +422,16 @@ func TestWorkloadIdentity(t *testing.T) {
 			nt.T.Log("Validate the GSA annotation is added to the RSync's service accounts")
 			tg := taskgroup.New()
 			tg.Go(func() error {
-				return nt.Watcher.WatchObject(kinds.ServiceAccount(), rootReconcilerName, configsync.ControllerNamespace, []testpredicates.Predicate{
-					testpredicates.HasAnnotation(controllers.GCPSAAnnotationKey, tc.gsaEmail),
-				})
+				return nt.Watcher.WatchObject(kinds.ServiceAccount(), rootReconcilerName, configsync.ControllerNamespace,
+					testwatcher.WatchPredicates(
+						testpredicates.HasAnnotation(controllers.GCPSAAnnotationKey, tc.gsaEmail),
+					))
 			})
 			tg.Go(func() error {
-				return nt.Watcher.WatchObject(kinds.ServiceAccount(), nsReconcilerName, configsync.ControllerNamespace, []testpredicates.Predicate{
-					testpredicates.HasAnnotation(controllers.GCPSAAnnotationKey, tc.gsaEmail),
-				})
+				return nt.Watcher.WatchObject(kinds.ServiceAccount(), nsReconcilerName, configsync.ControllerNamespace,
+					testwatcher.WatchPredicates(
+						testpredicates.HasAnnotation(controllers.GCPSAAnnotationKey, tc.gsaEmail),
+					))
 			})
 			if tc.fleetWITest {
 				tg.Go(func() error {
@@ -635,14 +638,16 @@ func migrateFromGSAtoKSA(nt *nomostest.NT, fleetWITest bool, sourceType configsy
 	nt.T.Log("Validate the GSA annotation is removed from the RSync's service accounts")
 	tg := taskgroup.New()
 	tg.Go(func() error {
-		return nt.Watcher.WatchObject(kinds.ServiceAccount(), rootReconcilerName, configsync.ControllerNamespace, []testpredicates.Predicate{
-			testpredicates.MissingAnnotation(controllers.GCPSAAnnotationKey),
-		})
+		return nt.Watcher.WatchObject(kinds.ServiceAccount(), rootReconcilerName, configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.MissingAnnotation(controllers.GCPSAAnnotationKey),
+			))
 	})
 	tg.Go(func() error {
-		return nt.Watcher.WatchObject(kinds.ServiceAccount(), nsReconcilerName, configsync.ControllerNamespace, []testpredicates.Predicate{
-			testpredicates.MissingAnnotation(controllers.GCPSAAnnotationKey),
-		})
+		return nt.Watcher.WatchObject(kinds.ServiceAccount(), nsReconcilerName, configsync.ControllerNamespace,
+			testwatcher.WatchPredicates(
+				testpredicates.MissingAnnotation(controllers.GCPSAAnnotationKey),
+			))
 	})
 	if fleetWITest {
 		nt.T.Log("Validate the serviceaccount_impersonation_url is absent from the injected FWI credentials")


### PR DESCRIPTION
- Replace predicate argument in Watcher.WatchObject with a new WatchPredicates option. This reduces the number of arguments and avoids callers needing to build an array. They can use varargs.
- Add WithPredicates option for WatchForAllSyncs. This allows customizing the predicates used, instead of needing to skip certain rsyncs with different expectations and validate them manually.