### PR TITLE
refactor: clean up unused clusterName in otelreconciler

### DIFF
--- a/cmd/reconciler-manager/main.go
+++ b/cmd/reconciler-manager/main.go
@@ -131,7 +131,7 @@ func main() {
 	})
 	setupLog.Info("RootSync controller registration scheduled")
 
-	otel := controllers.NewOtelReconciler(*clusterName, mgr.GetClient(),
+	otel := controllers.NewOtelReconciler(mgr.GetClient(),
 		textlogger.NewLogger(textlogger.NewConfig()).WithName("controllers").WithName("Otel"),
 		mgr.GetScheme())
 	if err := otel.Register(mgr); err != nil {

--- a/pkg/reconcilermanager/controllers/otel_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_controller.go
@@ -47,23 +47,18 @@ var _ reconcile.Reconciler = &OtelReconciler{}
 type OtelReconciler struct {
 	loggingController
 
-	clusterName string
-	client      client.Client
-	scheme      *runtime.Scheme
+	client client.Client
+	scheme *runtime.Scheme
 }
 
 // NewOtelReconciler returns a new OtelReconciler.
-func NewOtelReconciler(clusterName string, client client.Client, log logr.Logger, scheme *runtime.Scheme) *OtelReconciler {
-	if clusterName == "" {
-		clusterName = "unknown_cluster"
-	}
+func NewOtelReconciler(client client.Client, log logr.Logger, scheme *runtime.Scheme) *OtelReconciler {
 	return &OtelReconciler{
 		loggingController: loggingController{
 			log: log,
 		},
-		clusterName: clusterName,
-		client:      client,
-		scheme:      scheme,
+		client: client,
+		scheme: scheme,
 	}
 }
 

--- a/pkg/reconcilermanager/controllers/otel_controller_test.go
+++ b/pkg/reconcilermanager/controllers/otel_controller_test.go
@@ -63,7 +63,7 @@ func setupOtelReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 	t.Helper()
 
 	fakeClient := syncerFake.NewClient(t, core.Scheme, objs...)
-	testReconciler := NewOtelReconciler("",
+	testReconciler := NewOtelReconciler(
 		fakeClient,
 		controllerruntime.Log.WithName("controllers").WithName("Otel"),
 		fakeClient.Scheme(),


### PR DESCRIPTION
This argument has been long unused by the OtelReconciler, and can be removed without any functional changes.