### PR TITLE
Only watch ResourceGroups with the correct owner label

### DIFF
--- a/e2e/nomostest/testresourcegroup/resourcegroup.go
+++ b/e2e/nomostest/testresourcegroup/resourcegroup.go
@@ -25,6 +25,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcegroup"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/status"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -45,6 +46,7 @@ func New(nn types.NamespacedName, id string) *v1alpha1.ResourceGroup {
 	if id != "" {
 		rg.SetLabels(map[string]string{
 			common.InventoryLabel: id,
+			metadata.ManagedByKey: metadata.ManagedByValue,
 		})
 	}
 	return rg

--- a/pkg/resourcegroup/controllers/root/root_controller.go
+++ b/pkg/resourcegroup/controllers/root/root_controller.go
@@ -300,17 +300,25 @@ func isConditionTrue(cType v1alpha1.ConditionType, conditions []v1alpha1.Conditi
 	return false
 }
 
+// OwnedByConfigSyncPredicate filters events for objects that have the label "app.kubernetes.io/managed-by=configmanagement.gke.io"
 type OwnedByConfigSyncPredicate struct{}
 
+// Create implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Create(e event.CreateEvent) bool {
 	return isOwnedByConfigSync(e.Object)
 }
+
+// Delete implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Delete(e event.DeleteEvent) bool {
 	return isOwnedByConfigSync(e.Object)
 }
+
+// Update implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Update(e event.UpdateEvent) bool {
 	return isOwnedByConfigSync(e.ObjectOld) || isOwnedByConfigSync(e.ObjectNew)
 }
+
+// Generic implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Generic(e event.GenericEvent) bool {
 	return isOwnedByConfigSync(e.Object)
 }

--- a/pkg/resourcegroup/controllers/root/root_controller.go
+++ b/pkg/resourcegroup/controllers/root/root_controller.go
@@ -309,7 +309,7 @@ func (OwnedByConfigSyncPredicate) Delete(e event.DeleteEvent) bool {
 	return isOwnedByConfigSync(e.Object)
 }
 func (OwnedByConfigSyncPredicate) Update(e event.UpdateEvent) bool {
-	return isOwnedByConfigSync(e.ObjectOld)
+	return isOwnedByConfigSync(e.ObjectOld) || isOwnedByConfigSync(e.ObjectNew)
 }
 func (OwnedByConfigSyncPredicate) Generic(e event.GenericEvent) bool {
 	return isOwnedByConfigSync(e.Object)

--- a/pkg/resourcegroup/controllers/root/root_controller.go
+++ b/pkg/resourcegroup/controllers/root/root_controller.go
@@ -305,22 +305,27 @@ type OwnedByConfigSyncPredicate struct{}
 
 // Create implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Create(e event.CreateEvent) bool {
-	return isOwnedByConfigSync(e.Object)
+	return !isResourceGroup(e.Object) || isOwnedByConfigSync(e.Object)
 }
 
 // Delete implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Delete(e event.DeleteEvent) bool {
-	return isOwnedByConfigSync(e.Object)
+	return !isResourceGroup(e.Object) || isOwnedByConfigSync(e.Object)
 }
 
 // Update implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Update(e event.UpdateEvent) bool {
-	return isOwnedByConfigSync(e.ObjectOld) || isOwnedByConfigSync(e.ObjectNew)
+	return !isResourceGroup(e.ObjectOld) || !isResourceGroup(e.ObjectNew) || isOwnedByConfigSync(e.ObjectOld) || isOwnedByConfigSync(e.ObjectNew)
 }
 
 // Generic implements predicate.Predicate
 func (OwnedByConfigSyncPredicate) Generic(e event.GenericEvent) bool {
-	return isOwnedByConfigSync(e.Object)
+	return !isResourceGroup(e.Object) || isOwnedByConfigSync(e.Object)
+}
+
+func isResourceGroup(o client.Object) bool {
+	return o.GetObjectKind().GroupVersionKind().Group == v1alpha1.SchemeGroupVersion.Group &&
+		o.GetObjectKind().GroupVersionKind().Kind == v1alpha1.ResourceGroupKind
 }
 
 func isOwnedByConfigSync(o client.Object) bool {

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -197,7 +197,7 @@ func TestRootReconciler(t *testing.T) {
 	assert.Equal(t, "group0", e.Object.GetName())
 }
 
-func TestOnwedByConfigSyncPredicate(t *testing.T) {
+func TestOwnedByConfigSyncPredicate(t *testing.T) {
 	type testCase struct {
 		name string
 		got  bool

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -213,6 +213,8 @@ func TestOwnedByConfigSyncPredicate(t *testing.T) {
 			Name:      "bar",
 		},
 	}
+	ownedByConfigSync.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ResourceGroup"))
+
 	ownedBySomeoneElse := &v1alpha1.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -222,12 +224,15 @@ func TestOwnedByConfigSyncPredicate(t *testing.T) {
 			Name:      "bar",
 		},
 	}
+	ownedBySomeoneElse.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ResourceGroup"))
+
 	notOwned := &v1alpha1.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "bar",
 		},
 	}
+	notOwned.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ResourceGroup"))
 
 	create := func(o client.Object) bool {
 		return OwnedByConfigSyncPredicate{}.Create(

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -240,7 +240,8 @@ func TestOnwedByConfigSyncPredicate(t *testing.T) {
 		)
 	}
 
-	delete := func(o client.Object) bool {
+	// not allowed to redefine delete, so we use a different name
+	yeet := func(o client.Object) bool {
 		return OwnedByConfigSyncPredicate{}.Delete(
 			event.TypedDeleteEvent[client.Object]{Object: o},
 		)
@@ -267,9 +268,9 @@ func TestOnwedByConfigSyncPredicate(t *testing.T) {
 		{name: "update old not owned, new owned by someone else", got: update(notOwned, ownedBySomeoneElse), want: false},
 		{name: "update old owned by someone else, new not owned", got: update(ownedBySomeoneElse, notOwned), want: false},
 
-		{name: "delete owned by configsync", got: delete(ownedByConfigSync), want: true},
-		{name: "delete owned by someone else", got: delete(ownedBySomeoneElse), want: false},
-		{name: "delete not owned", got: delete(notOwned), want: false},
+		{name: "delete owned by configsync", got: yeet(ownedByConfigSync), want: true},
+		{name: "delete owned by someone else", got: yeet(ownedBySomeoneElse), want: false},
+		{name: "delete not owned", got: yeet(notOwned), want: false},
 
 		{name: "generic owned by configsync", got: generic(ownedByConfigSync), want: true},
 		{name: "generic owned by someone else", got: generic(ownedBySomeoneElse), want: false},

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -234,6 +235,9 @@ func TestOwnedByConfigSyncPredicate(t *testing.T) {
 	}
 	notOwned.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ResourceGroup"))
 
+	notResourceGroup := &v1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	notResourceGroup.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+
 	create := func(o client.Object) bool {
 		return OwnedByConfigSyncPredicate{}.Create(
 			event.TypedCreateEvent[client.Object]{Object: o},
@@ -262,6 +266,7 @@ func TestOwnedByConfigSyncPredicate(t *testing.T) {
 		{name: "create owned by configsync", got: create(ownedByConfigSync), want: true},
 		{name: "create owned by someone else", got: create(ownedBySomeoneElse), want: false},
 		{name: "create not owned", got: create(notOwned), want: false},
+		{name: "create non-resourcegroup owned by configsync", got: create(notResourceGroup), want: true},
 
 		{name: "update both owned by configsync", got: update(ownedByConfigSync, ownedByConfigSync), want: true},
 		{name: "update old owned by configsync, new owned by someone else", got: update(ownedByConfigSync, ownedBySomeoneElse), want: true},
@@ -272,14 +277,17 @@ func TestOwnedByConfigSyncPredicate(t *testing.T) {
 		{name: "update both not owned", got: update(notOwned, notOwned), want: false},
 		{name: "update old not owned, new owned by someone else", got: update(notOwned, ownedBySomeoneElse), want: false},
 		{name: "update old owned by someone else, new not owned", got: update(ownedBySomeoneElse, notOwned), want: false},
+		{name: "update non-resourcegroup owned by configsync", got: update(notResourceGroup, notResourceGroup), want: true},
 
 		{name: "delete owned by configsync", got: yeet(ownedByConfigSync), want: true},
 		{name: "delete owned by someone else", got: yeet(ownedBySomeoneElse), want: false},
 		{name: "delete not owned", got: yeet(notOwned), want: false},
+		{name: "delete non-resourcegroup owned by configsync", got: yeet(notResourceGroup), want: true},
 
 		{name: "generic owned by configsync", got: generic(ownedByConfigSync), want: true},
 		{name: "generic owned by someone else", got: generic(ownedBySomeoneElse), want: false},
 		{name: "generic not owned", got: generic(notOwned), want: false},
+		{name: "generic non-resourcegroup owned by configsync", got: generic(notResourceGroup), want: true},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This fixes #1297.

I didn't see any tests for the full NewController function, and decided setting one up was overkill for this change; we should be able to trust here that controller-runtime can properly add and apply a provided predicate, so as long as that predicate works as expected, so whould the watch configuration.

The new tests exhaustively specify the behavior of the new predicate, so that for every type of event, it matches if (and only if) the label `app.kubernetes.io/managed-by` is set to `configmanagement.gke.io`; this is what Config Sync already does to all objects it creates.
