### PR TITLE
fix: Remove ApplySet part-of label on abandon

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -829,8 +829,9 @@ func (s *supervisor) abandonObject(ctx context.Context, obj client.Object) error
 		fromObj.SetLabels(uObj.GetLabels())
 
 		toObj := fromObj.DeepCopy()
-		updated := metadata.RemoveConfigSyncMetadata(toObj)
-		if !updated {
+		updated1 := metadata.RemoveConfigSyncMetadata(toObj)
+		updated2 := metadata.RemoveApplySetPartOfLabel(toObj, s.clientSet.ApplySetID)
+		if !updated1 && !updated2 {
 			return nil
 		}
 		// Use merge-patch instead of server-side-apply, because we don't have

--- a/pkg/applier/clientset.go
+++ b/pkg/applier/clientset.go
@@ -53,6 +53,7 @@ type ClientSet struct {
 	Client       client.Client
 	Mapper       meta.RESTMapper
 	StatusMode   string
+	ApplySetID   string
 }
 
 // NewClientSet constructs a new ClientSet.
@@ -113,5 +114,6 @@ func NewClientSet(c client.Client, configFlags *genericclioptions.ConfigFlags, s
 		Client:       c,
 		Mapper:       mapper,
 		StatusMode:   statusMode,
+		ApplySetID:   applySetID,
 	}, nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -137,3 +137,20 @@ func RemoveConfigSyncMetadata(obj client.Object) bool {
 	after := len(obj.GetAnnotations()) + len(obj.GetLabels())
 	return before != after
 }
+
+// RemoveApplySetPartOfLabel removes the ApplySet part-of label IFF the value
+// matches the specified applySetID.
+// The resource is modified in place. Returns true if the object was modified.
+func RemoveApplySetPartOfLabel(obj client.Object, applySetID string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	v, found := labels[ApplySetPartOfLabel]
+	if !found || v != applySetID {
+		return false
+	}
+	delete(labels, ApplySetPartOfLabel)
+	obj.SetLabels(labels)
+	return true
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -185,8 +185,9 @@ func Run(opts Options) {
 	}
 
 	// Configure the Applier.
+	applySetID := applyset.IDFromSync(opts.SyncName, opts.ReconcilerScope)
 	genericClient := syncerclient.New(cl, metrics.APICallDuration)
-	baseApplier, err := reconcile.NewApplierForMultiRepo(cfg, genericClient)
+	baseApplier, err := reconcile.NewApplierForMultiRepo(cfg, genericClient, applySetID)
 	if err != nil {
 		klog.Fatalf("Instantiating Applier: %v", err)
 	}
@@ -198,7 +199,6 @@ func Run(opts Options) {
 	if reconcileTimeout < 0 {
 		klog.Fatalf("Invalid reconcileTimeout: %v, timeout should not be negative", reconcileTimeout)
 	}
-	applySetID := applyset.IDFromSync(opts.SyncName, opts.ReconcilerScope)
 	clientSet, err := applier.NewClientSet(cl, configFlags, opts.StatusMode, applySetID)
 	if err != nil {
 		klog.Fatalf("Error creating clients: %v", err)

--- a/pkg/syncer/syncertest/fake/applier.go
+++ b/pkg/syncer/syncertest/fake/applier.go
@@ -33,6 +33,7 @@ type Applier struct {
 	CreateError  status.Error
 	UpdateError  status.Error
 	DeleteError  status.Error
+	ApplySetID   string
 }
 
 var _ reconcile.Applier = &Applier{}
@@ -63,8 +64,10 @@ func (a *Applier) Update(ctx context.Context, intendedState, _ *unstructured.Uns
 
 // RemoveNomosMeta implements reconcile.Applier.
 func (a *Applier) RemoveNomosMeta(ctx context.Context, intent *unstructured.Unstructured, _ string) status.Error {
-	updated := metadata.RemoveConfigSyncMetadata(intent)
-	if !updated {
+	changed1 := metadata.RemoveConfigSyncMetadata(intent)
+	changed2 := metadata.RemoveApplySetPartOfLabel(intent, a.ApplySetID)
+	changed := changed1 || changed2
+	if !changed {
 		return nil
 	}
 


### PR DESCRIPTION
This change removes the `applyset.kubernetes.io/part-of` label from managed objects when they are abandoned.

Supported Use Cases:
- Unmanage object
  - `configmanagement.gke.io/managed: disabled`
  - `client.lifecycle.config.k8s.io/deletion: detach`
  - `cli-utils.sigs.k8s.io/on-remove: keep`
  - The Config Sync Applier/Destroyer calls RemoveConfigSyncMetadata if object HasConfigSyncMetadata when a Delete Skipped event is received (deletion detach or keep on remove).
  - The Config Sync Remediator calls RemoveConfigSyncMetadata when an Abandon operation is requested (managed disabled or deletion detach).
- Uninstall package
  - `configsync.gke.io/deletion-propagation-policy: Foreground`
  - This use case invokes the Destroyer, which handles the unmanage annotations the same way the Applier does.

Unsupported use cases:
- Orphan Package
  - `configsync.gke.io/deletion-propagation-policy: Orphan`
  - Unsupported because we don't have a finalizer handling this case today. Maybe in the future.

Fixes: b/355534413

This change also fixes (b/256043590) the expectations in `TestReconcilerFinalizer_MultiLevelMixed` to expect removal of metadata on abandoned objects, which was fixed in an applier refactor a few months ago. 