### PR TITLE
fix: remediator missing custom resource events

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 # Applying hierarchyconfig-crd.yaml allows client-side validation of the HierarchyConfig resources.
 - ../hierarchyconfig-crd.yaml
 - ../namespace-selector-crd.yaml
+- ../ns-reconciler-cluster-scope-cluster-role.yaml
 - ../ns-reconciler-base-cluster-role.yaml
 - ../root-reconciler-base-cluster-role.yaml
 - ../otel-agent-cm.yaml

--- a/manifests/ns-reconciler-cluster-scope-cluster-role.yaml
+++ b/manifests/ns-reconciler-cluster-scope-cluster-role.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This ClusterRole is used by both root-reconcilers and ns-reconcilers.
+# It includes read access for cluster-scope resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: configsync.gke.io:root-reconciler
+  name: configsync.gke.io:ns-reconciler:cluster-scope
   labels:
     configmanagement.gke.io/system: "true"
     configmanagement.gke.io/arch: "csmr"
 rules:
-- apiGroups: ["configsync.gke.io"]
-  resources: ["rootsyncs"]
-  verbs: ["get","list","watch","update","patch"]
-- apiGroups: ["configsync.gke.io"]
-  resources: ["rootsyncs/status"]
-  verbs: ["get","list","watch","update","patch"]
-- apiGroups: ["kpt.dev"]
-  resources: ["resourcegroups"]
-  verbs: ["*"]
-- apiGroups: ["kpt.dev"]
-  resources: ["resourcegroups/status"]
-  verbs: ["*"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get","list","watch"]

--- a/pkg/reconcilermanager/controllers/build_names.go
+++ b/pkg/reconcilermanager/controllers/build_names.go
@@ -22,15 +22,25 @@ import (
 )
 
 const (
+	// RepoSyncClusterScopeClusterRoleName is the name of the ClusterRole with
+	// cluster-scoped read permissions for the namespace reconciler.
+	// e.g. configsync.gke.io:ns-reconciler:cluster-scope
+	RepoSyncClusterScopeClusterRoleName = configsync.GroupName + ":" + core.NsReconcilerPrefix + ":cluster-scope"
 	// RepoSyncBaseClusterRoleName is the namespace reconciler permissions name.
 	// e.g. configsync.gke.io:ns-reconciler
 	RepoSyncBaseClusterRoleName = configsync.GroupName + ":" + core.NsReconcilerPrefix
 	// RootSyncBaseClusterRoleName is the root reconciler base ClusterRole name.
 	// e.g. configsync.gke.io:root-reconciler
 	RootSyncBaseClusterRoleName = configsync.GroupName + ":" + core.RootReconcilerPrefix
+	// RepoSyncClusterScopeClusterRoleBindingName is the name of the default
+	// ClusterRoleBinding created for RepoSync objects. This contains basic
+	// cluster-scoped permissions for RepoSync reconcilers
+	// (e.g. CustomResourceDefinition watch).
+	RepoSyncClusterScopeClusterRoleBindingName = RepoSyncClusterScopeClusterRoleName
 	// RepoSyncBaseRoleBindingName is the name of the default RoleBinding created
-	// for RepoSync objects. This contains basic permissions for RepoSync reconcilers
-	//(e.g. RepoSync status update).
+	// for RepoSync objects. This contains basic namespace-scoped permissions
+	// for RepoSync reconcilers
+	// (e.g. RepoSync status update).
 	RepoSyncBaseRoleBindingName = RepoSyncBaseClusterRoleName
 	// RootSyncLegacyClusterRoleBindingName is the name of the legacy ClusterRoleBinding created
 	// for RootSync objects. It is always bound to cluster-admin.

--- a/pkg/reconcilermanager/controllers/crd_controller.go
+++ b/pkg/reconcilermanager/controllers/crd_controller.go
@@ -21,125 +21,154 @@ import (
 
 	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// CRDHandler is called by the CRDReconciler to handle establishment of a CRD.
-type CRDHandler func() error
+// CRDReconcileFunc is called by the CRDMetaController to handle CRD updates.
+type CRDReconcileFunc func(context.Context, *apiextensionsv1.CustomResourceDefinition) error
 
-var _ reconcile.Reconciler = &CRDReconciler{}
-
-// CRDReconciler watches CRDs and calls handlers once they are established.
-type CRDReconciler struct {
-	loggingController
-
-	registerLock sync.Mutex
-	handlers     map[string]CRDHandler
-	handledCRDs  map[string]struct{}
+// CRDController keeps track of CRDReconcileFuncs and calls them when the
+// CRD changes. Only one reconciler is allowed per GroupKind.
+type CRDController struct {
+	lock        sync.RWMutex
+	reconcilers map[schema.GroupKind]CRDReconcileFunc
 }
 
-// NewCRDReconciler constructs a new CRDReconciler.
-func NewCRDReconciler(log logr.Logger) *CRDReconciler {
-	return &CRDReconciler{
+// SetReconciler sets the reconciler for the specified CRD.
+// The reconciler will be called when the CRD becomes established.
+// If the reconciler errors, it will be retried with backoff until success.
+// A new reconciler will replace any old reconciler set with the same GroupKind.
+func (s *CRDController) SetReconciler(gk schema.GroupKind, crdHandler CRDReconcileFunc) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.reconcilers == nil {
+		s.reconcilers = make(map[schema.GroupKind]CRDReconcileFunc)
+	}
+	s.reconcilers[gk] = crdHandler
+}
+
+// DeleteReconciler removes the reconciler for the specified CRD.
+func (s *CRDController) DeleteReconciler(gk schema.GroupKind) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.reconcilers != nil {
+		delete(s.reconcilers, gk)
+	}
+}
+
+// Reconcile calls the CRDReconcileFunc registered for this CRD by GroupKind.
+func (s *CRDController) Reconcile(ctx context.Context, gk schema.GroupKind, crd *apiextensionsv1.CustomResourceDefinition) error {
+	// Let getReconciler handle locking to prevent deadlock in case the
+	// reconciler calls SetReconciler/DeleteReconciler.
+	reconciler := s.getReconciler(gk)
+	if reconciler == nil {
+		// No reconciler for this CRD
+		return nil
+	}
+	if err := reconciler(ctx, crd); err != nil {
+		return fmt.Errorf("reconciling CRD: %s: %w", gk, err)
+	}
+	return nil
+}
+
+func (s *CRDController) getReconciler(gk schema.GroupKind) CRDReconcileFunc {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	reconciler, found := s.reconcilers[gk]
+	if !found {
+		return nil
+	}
+	return reconciler
+}
+
+// CRDMetaController watches CRDs and delegates reconciliation to a CRDControllerManager.
+type CRDMetaController struct {
+	loggingController
+	cache             cache.Cache
+	delegate          *CRDController
+	observedResources map[schema.GroupResource]schema.GroupKind
+}
+
+var _ reconcile.Reconciler = &CRDMetaController{}
+
+// NewCRDMetaController constructs a new CRDMetaController.
+func NewCRDMetaController(delegate *CRDController, cache cache.Cache, log logr.Logger) *CRDMetaController {
+	return &CRDMetaController{
 		loggingController: loggingController{
 			log: log,
 		},
-		handlers:    make(map[string]CRDHandler),
-		handledCRDs: make(map[string]struct{}),
+		cache:             cache,
+		delegate:          delegate,
+		observedResources: make(map[schema.GroupResource]schema.GroupKind),
 	}
 }
 
-// SetCRDHandler adds an handler for the specified CRD.
-// The handler will be called when the CRD becomes established.
-// If the handler errors, it will be retried with backoff until success.
-// One the handler succeeds, it will not be called again, unless SetCRDHandler
-// is called again.
-func (r *CRDReconciler) SetCRDHandler(crdName string, crdHandler CRDHandler) {
-	r.registerLock.Lock()
-	defer r.registerLock.Unlock()
-
-	r.handlers[crdName] = crdHandler
-	delete(r.handledCRDs, crdName)
-}
-
-// Reconcile the otel ConfigMap and update the Deployment annotation.
-func (r *CRDReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+// Reconcile checks is the CRD exists and delegates to the CRDController to
+// reconcile the update.
+func (r *CRDMetaController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	crdName := req.Name
 	ctx = r.setLoggerValues(ctx, "crd", crdName)
 
-	r.registerLock.Lock()
-	defer r.registerLock.Unlock()
-
-	handler, found := r.handlers[crdName]
-	if !found {
-		// No handler for this CRD
-		return reconcile.Result{}, nil
+	// Established if CRD exists and .status.conditions[type="Established"].status = "True"
+	var kind schema.GroupKind
+	crdObj := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.cache.Get(ctx, req.NamespacedName, crdObj); err != nil {
+		switch {
+		// Should never run into NoMatchFound, since CRD is a built-in resource.
+		case apierrors.IsNotFound(err):
+			// Lookup last known GroupKind for the CRD name
+			resource := schema.ParseGroupResource(crdName)
+			var found bool
+			kind, found = r.observedResources[resource]
+			if !found {
+				// No retry possible
+				return reconcile.Result{}, reconcile.TerminalError(
+					fmt.Errorf("failed to handle CRD update for deleted resource: %w",
+						&meta.NoResourceMatchError{PartialResource: resource.WithVersion("")}))
+			}
+			crdObj = nil
+		default:
+			// Retry with backoff
+			return reconcile.Result{},
+				fmt.Errorf("getting CRD from cache: %s: %w", crdName, err)
+		}
+	} else {
+		kind = schema.GroupKind{
+			Group: crdObj.Spec.Group,
+			Kind:  crdObj.Spec.Names.Kind,
+		}
+		resource := schema.GroupResource{
+			Group:    crdObj.Spec.Group,
+			Resource: crdObj.Spec.Names.Plural,
+		}
+		// Cache last known mapping from GroupResource to GroupKind.
+		// This lets us lookup the GroupKind using the CRD name.
+		r.observedResources[resource] = kind
 	}
-	if _, handled := r.handledCRDs[crdName]; handled {
-		// Already handled
-		return reconcile.Result{}, nil
-	}
 
-	r.logger(ctx).V(3).Info("reconciling CRD", "crd", crdName)
+	r.logger(ctx).Info("CRDMetaController handling CRD status update", "name", crdName)
 
-	if err := handler(); err != nil {
+	if err := r.delegate.Reconcile(ctx, kind, crdObj); err != nil {
 		// Retry with backoff
-		return reconcile.Result{},
-			fmt.Errorf("reconciling CRD %s: %w", crdName, err)
+		return reconcile.Result{}, err
 	}
-	// Mark CRD as handled
-	r.handledCRDs[crdName] = struct{}{}
 
-	r.logger(ctx).V(3).Info("reconciling CRD successful", "crd", crdName)
+	r.logger(ctx).V(3).Info("CRDMetaController handled CRD status update", "name", crdName)
 
-	return controllerruntime.Result{}, nil
+	return reconcile.Result{}, nil
 }
 
-// Register the CRD controller with reconciler-manager.
-func (r *CRDReconciler) Register(mgr controllerruntime.Manager) error {
+// Register the CRDMetaController with the ReconcilerManager.
+func (r *CRDMetaController) Register(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
-		For(&apiextensionsv1.CustomResourceDefinition{},
-			builder.WithPredicates(
-				ignoreDeletesPredicate(),
-				crdIsEstablishedPredicate())).
+		For(&apiextensionsv1.CustomResourceDefinition{}).
 		Complete(r)
-}
-
-// ignoreDeletesPredicate returns a predicate that handles CREATE, UPDATE, and
-// GENERIC events, but not DELETE events.
-func ignoreDeletesPredicate() predicate.Predicate {
-	return predicate.Funcs{
-		DeleteFunc: func(_ event.DeleteEvent) bool {
-			return false
-		},
-	}
-}
-
-// crdIsEstablishedPredicate returns a predicate that only processes events for
-// established CRDs.
-func crdIsEstablishedPredicate() predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		if crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition); ok {
-			return crdIsEstablished(crd)
-		}
-		return false
-	})
-}
-
-// crdIsEstablished returns true if the given CRD is established on the cluster,
-// which indicates if discovery knows about it yet. For more info see
-// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
-func crdIsEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
-	for _, condition := range crd.Status.Conditions {
-		if condition.Type == v1.Established && condition.Status == v1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -237,9 +237,9 @@ func (r *reconcilerBase) deleteDeployment(ctx context.Context, reconcilerRef typ
 	return r.cleanup(ctx, d)
 }
 
-func (r *RootSyncReconciler) deleteSharedClusterRoleBinding(ctx context.Context, name string, reconcilerRef types.NamespacedName) error {
+func (r *reconcilerBase) deleteSharedClusterRoleBinding(ctx context.Context, name string, reconcilerRef types.NamespacedName) error {
 	crbKey := client.ObjectKey{Name: name}
-	// Update the CRB to delete the subject for the deleted RootSync's reconciler
+	// Update the CRB to delete the subject for the deleted reconciler
 	crb := &rbacv1.ClusterRoleBinding{}
 	if err := r.client.Get(ctx, crbKey, crb); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/remediator/remediator.go
+++ b/pkg/remediator/remediator.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/declared"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/remediator/conflict"
 	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/remediator/reconcile"
@@ -101,6 +102,7 @@ func New(
 	applier syncerreconcile.Applier,
 	conflictHandler conflict.Handler,
 	fightHandler fight.Handler,
+	crdController *controllers.CRDController,
 	decls *declared.Resources,
 	numWorkers int,
 ) (*Remediator, error) {
@@ -117,7 +119,7 @@ func New(
 		conflictHandler: conflictHandler,
 	}
 
-	watchMgr, err := watch.NewManager(scope, syncName, cfg, q, decls, nil, conflictHandler)
+	watchMgr, err := watch.NewManager(scope, syncName, cfg, q, decls, nil, conflictHandler, crdController)
 	if err != nil {
 		return nil, fmt.Errorf("creating watch manager: %w", err)
 	}

--- a/pkg/remediator/watch/mapper_wrapper.go
+++ b/pkg/remediator/watch/mapper_wrapper.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ResettableRESTMapper is a RESTMapper which is capable of resetting itself
+// from discovery.
+//
+// This interface replaces meta.ResettableRESTMapper so that Reset can return an
+// error. If Reset errors, it may be retried.
+// This interface does NOT work with meta.MaybeResetRESTMapper.
+//
+// TODO: Only reset one resource at a time, for efficiency.
+type ResettableRESTMapper interface {
+	meta.RESTMapper
+	Reset() error
+}
+
+// MapperFunc returns a RESTMapper with an empty/reset cache or an error.
+type MapperFunc func() (meta.RESTMapper, error)
+
+type mapper struct {
+	mux        sync.RWMutex
+	mapper     meta.RESTMapper
+	mapperFunc MapperFunc
+}
+
+var _ ResettableRESTMapper = &mapper{}
+
+// NewReplaceOnResetRESTMapper wraps the provided RESTMapper and replaces it
+// using the MapperFunc when the Reset method is called.
+func NewReplaceOnResetRESTMapper(m meta.RESTMapper, newMapperFunc MapperFunc) ResettableRESTMapper {
+	return &mapper{
+		mapper:     m,
+		mapperFunc: newMapperFunc,
+	}
+}
+
+// KindFor delegates to mapper.KindFor.
+func (m *mapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return m.getMapper().KindFor(resource)
+}
+
+// KindsFor delegates to mapper.KindsFor.
+func (m *mapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return m.getMapper().KindsFor(resource)
+}
+
+// RESTMapping delegates to mapper.RESTMapping.
+func (m *mapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return m.getMapper().RESTMapping(gk, versions...)
+}
+
+// RESTMappings delegates to mapper.RESTMappings.
+func (m *mapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return m.getMapper().RESTMappings(gk, versions...)
+}
+
+// ResourceFor delegates to mapper.ResourcesFor.
+func (m *mapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return m.getMapper().ResourceFor(input)
+}
+
+// ResourcesFor delegates to mapper.ResourcesFor.
+func (m *mapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return m.getMapper().ResourcesFor(input)
+}
+
+// ResourceSingularizer delegates to mapper.ResourceSingularizer.
+func (m *mapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return m.getMapper().ResourceSingularizer(resource)
+}
+
+// Reset replaces the old mapper with a new one.
+func (m *mapper) Reset() error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	mapper, err := m.mapperFunc()
+	if err != nil {
+		return err
+	}
+	m.mapper = mapper
+	return nil
+}
+
+func (m *mapper) getMapper() meta.RESTMapper {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+	return m.mapper
+}

--- a/pkg/util/customresource/customresource.go
+++ b/pkg/util/customresource/customresource.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customresource
+
+import apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+// IsEstablished returns true if the given CRD is established on the cluster,
+// which indicates if discovery knows about it yet. For more info see
+// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
+func IsEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	if crd == nil {
+		return false
+	}
+	for _, condition := range crd.Status.Conditions {
+		if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/customresource/customresource_test.go
+++ b/pkg/util/customresource/customresource_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package customresource
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestIsEstablished(t *testing.T) {
+	tests := []struct {
+		name        string
+		crd         *apiextensionsv1.CustomResourceDefinition
+		established bool
+	}{
+		{
+			name:        "not found",
+			crd:         nil,
+			established: false,
+		},
+		{
+			name: "established",
+			crd: &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+						{
+							Type:   apiextensionsv1.Established,
+							Status: apiextensionsv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			established: true,
+		},
+		{
+			name: "not established",
+			crd: &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+						{
+							Type:   apiextensionsv1.Established,
+							Status: apiextensionsv1.ConditionFalse,
+						},
+					},
+				},
+			},
+			established: false,
+		},
+		{
+			name:        "not observed",
+			crd:         &apiextensionsv1.CustomResourceDefinition{},
+			established: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEstablished(tc.crd); got != tc.established {
+				t.Errorf("IsEstablished() = %v, want %v", got, tc.established)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prior to this change, the remediator watches were only being started
for new custom resources after the apply attempt had fully completed.
This left some time after the object was applied that the remediator
could miss events made by third-parties. Normally, this would be fine,
because the remediator would revert any change after the watch was
started. But if a DELETE event was missed, the object wouldn't be
recreated until the next apply attempt.

This change adds a CRD Controller to the remediator that watches CRDs
and executes any registered handlers when the CRD is established,
unestablished, or deleted. The remediator now registers CRD handlers
for each resource type it watches, starting watchers as soon as
possible, without waiting for the next apply attempt.

This change also adds a ClusterRole and ClusterRoleBinding specifically
for RepoSync reconcilers, to allow watching of CRDs. RootSync
reconcilers now also watch CRDs, but they already have a CR & CRD.

Fixes: b/355532135

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1445
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1446
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1447