### PR TITLE
chore: cleanup some logs

### DIFF
--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -209,23 +209,20 @@ func (u *Updater) apply(ctx context.Context, objs []client.Object, commit string
 			}
 		}
 	}
-	klog.V(1).Info("Applier starting...")
+	klog.Info("Applier starting...")
 	start := time.Now()
 	u.SyncErrorCache.ResetApplyErrors()
 	objStatusMap, syncStats := u.Applier.Apply(ctx, eventHandler, objs)
-	if syncStats.Empty() {
-		klog.V(4).Info("Applier made no new progress")
-	} else {
+	if !syncStats.Empty() {
 		klog.Infof("Applier made new progress: %s", syncStats.String())
 		objStatusMap.Log(klog.V(0))
 	}
 	metrics.RecordApplyDuration(ctx, metrics.StatusTagKey(err), commit, start)
 	if err != nil {
-		klog.Warningf("Failed to apply declared resources: %v", err)
+		klog.Warningf("Applier failed: %v", err)
 		return err
 	}
-	klog.V(4).Info("Apply completed without error: all resources are up to date.")
-	klog.V(3).Info("Applier stopped")
+	klog.Info("Applier succeeded")
 	return nil
 }
 

--- a/pkg/reconciler/finalizer/base_finalizer.go
+++ b/pkg/reconciler/finalizer/base_finalizer.go
@@ -39,12 +39,10 @@ func (bf *baseFinalizer) destroy(ctx context.Context) status.MultiError {
 			}
 		}
 	}
-	klog.V(1).Info("Destroyer starting...")
+	klog.Info("Destroyer starting...")
 	// start := time.Now()
 	objStatusMap, syncStats := bf.Destroyer.Destroy(ctx, eventHandler)
-	if syncStats.Empty() {
-		klog.V(4).Info("Destroyer made no new progress")
-	} else {
+	if !syncStats.Empty() {
 		klog.Infof("Destroyer made new progress: %s", syncStats.String())
 		objStatusMap.Log(klog.V(0))
 	}
@@ -52,10 +50,9 @@ func (bf *baseFinalizer) destroy(ctx context.Context) status.MultiError {
 	// We don't have the commit here, so we can't send the apply metric.
 	// metrics.RecordApplyDuration(ctx, metrics.StatusTagKey(errs), commit, start)
 	if err != nil {
-		klog.Warningf("Failed to destroy declared resources: %v", err)
+		klog.Warningf("Destroyer failed: %v", err)
 		return err
 	}
-	klog.V(4).Info("Destroyer completed without error: all resources are deleted.")
-	klog.V(3).Info("Applier stopped")
+	klog.Info("Destroyer succeeded")
 	return nil
 }

--- a/pkg/remediator/conflict/handler.go
+++ b/pkg/remediator/conflict/handler.go
@@ -45,8 +45,10 @@ type Handler interface {
 
 // Record a management conflict error, including log and metric.
 func Record(ctx context.Context, handler Handler, err status.ManagementConflictError, commit string) {
-	klog.Errorf("Management conflict detected. "+
-		"Reconciler %q received a watch event for object %q, which is manage by namespace reconciler %q. ",
+	klog.Errorf("Remediator detected a management conflict: "+
+		"reconciler %q received a watch event for object %q, which is managed by namespace reconciler %q. "+
+		"To resolve the conflict, remove the object from one of the sources of truth "+
+		"so that the object is only managed by one reconciler.",
 		err.DesiredManager(), err.ObjectID(), err.CurrentManager())
 	handler.AddConflictError(err.ObjectID(), err)
 	// TODO: Use separate metrics for management conflicts vs resource conflicts

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -98,6 +98,9 @@ func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Objec
 		switch err.Code() {
 		case syncerclient.ResourceConflictCode:
 			// Record cache conflict (create/delete/update failure due to found/not-found/resource-version)
+			klog.Warningf("Remediator encountered a resource conflict: "+
+				"%v. To resolve the conflict, the remediator will fetch the latest object from the cluster "+
+				"and requeue it for remediation", err)
 			metrics.RecordResourceConflict(ctx, commit)
 		case status.ManagementConflictErrorCode:
 			if mce, ok := err.(status.ManagementConflictError); ok {


### PR DESCRIPTION
- Simplify & fix applier/destroyer logs on success & failure
- Add the component in front of a few logs to make it clear where in the code the log came from, to simplify debugging.
- Log resource conflicts as warnings with explainations of how remediation will retry.
- Only log the keys from the GVK maps in the remediator manager.
- Fix remediator shutdown log to go to info instead of warning.