### PR TITLE
chore: remove ClearManagementConflictsWithKind

### DIFF
--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -73,7 +73,6 @@ const maxWatchRetryFactor = 18
 type Runnable interface {
 	Stop()
 	Run(ctx context.Context) status.Error
-	ClearManagementConflictsWithKind(gk schema.GroupKind)
 	SetLatestCommit(string)
 }
 
@@ -155,10 +154,6 @@ func (w *filteredWatcher) addError(errorID string) bool {
 		return true
 	}
 	return false
-}
-
-func (w *filteredWatcher) ClearManagementConflictsWithKind(gk schema.GroupKind) {
-	w.conflictHandler.ClearConflictErrorsWithKind(gk)
 }
 
 // SetLatestCommit sets the latest observed commit which references the GVK

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -212,6 +212,9 @@ func (m *Manager) UpdateWatches(ctx context.Context, gvkMap map[schema.GroupVers
 			// It is safe to stop the watcher.
 			m.stopWatcher(gvk)
 			stoppedWatches++
+			// Remove all conflict errors for objects with the same GK because
+			// the objects are no longer managed by the reconciler.
+			m.conflictHandler.ClearConflictErrorsWithKind(gvk.GroupKind())
 		}
 	}
 
@@ -307,8 +310,5 @@ func (m *Manager) stopWatcher(gvk schema.GroupVersionKind) {
 
 	// Stop the watcher.
 	w.Stop()
-	// Remove all conflict errors for objects with the same GK because the
-	// objects are no longer managed by the reconciler.
-	w.ClearManagementConflictsWithKind(gvk.GroupKind())
 	delete(m.watcherMap, gvk)
 }


### PR DESCRIPTION
The watch.Runnable interface doesn't need to know how to clear management conflicts, because the watch.Manager already has access to the conflict.Handler. So just clear the conflicts in AddWatches, where it also deals with other conflicts. AddWatches also knows that the watch is no longer needed, whereas stopWatch only knows that it needs to be stopped.