### PR TITLE
chore: share mapper between controllers

### DIFF
--- a/pkg/remediator/watch/watcher.go
+++ b/pkg/remediator/watch/watcher.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/remediator/conflict"
 	"kpt.dev/configsync/pkg/remediator/queue"
@@ -32,7 +31,6 @@ import (
 // to create a watcher.
 type watcherConfig struct {
 	gvk             schema.GroupVersionKind
-	config          *rest.Config
 	resources       *declared.Resources
 	queue           *queue.ObjectQueue
 	scope           declared.Scope
@@ -43,12 +41,12 @@ type watcherConfig struct {
 	commit          string
 }
 
-// watcherFactory knows how to build watch.Runnables.
-type watcherFactory func(cfg watcherConfig) (Runnable, status.Error)
+// WatcherFactory knows how to build watch.Runnables.
+type WatcherFactory func(cfg watcherConfig) (Runnable, status.Error)
 
-// watcherFactoryFromListerWatcherFactory returns a new watcherFactory that uses
+// WatcherFactoryFromListerWatcherFactory returns a new watcherFactory that uses
 // the specified ListerWatcherFactory.
-func watcherFactoryFromListerWatcherFactory(factory ListerWatcherFactory) watcherFactory {
+func WatcherFactoryFromListerWatcherFactory(factory ListerWatcherFactory) WatcherFactory {
 	factoryPtr := factory
 	return func(cfg watcherConfig) (Runnable, status.Error) {
 		if cfg.startWatch == nil {


### PR DESCRIPTION
Use a common ResettableRESTMapper, shared between controllers and reset automatically by the CRDMetaController when a CRD is updated and the new state is different than what known by the RESTMapper.

Followup after https://github.com/GoogleContainerTools/kpt-config-sync/pull/1441