### PR TITLE
feat: stall nomos migrate if HNC is enabled

### DIFF
--- a/cmd/nomos/migrate/configmanagement.go
+++ b/cmd/nomos/migrate/configmanagement.go
@@ -40,6 +40,11 @@ func migrateConfigManagement(ctx context.Context, cc *status.ClusterClient, kube
 		printNotice("The cluster is already running as an OSS installation.")
 		return nil
 	}
+	if isHNCEnabled, err := cc.ConfigManagement.IsHNCEnabled(ctx); err != nil {
+		return err
+	} else if isHNCEnabled {
+		return fmt.Errorf("Hierarchy Controller is enabled on the ConfigManagement object. It must be disabled before migrating.")
+	}
 
 	fmt.Printf("Removing ConfigManagement on cluster %q ...\n", kubeCtx)
 	cmYamlFile, err := saveConfigManagementOperatorYaml(ctx, cc, kubeCtx)

--- a/cmd/nomos/util/configmanagement.go
+++ b/cmd/nomos/util/configmanagement.go
@@ -202,6 +202,15 @@ func (c *ConfigManagementClient) RemoveFinalizers(ctx context.Context) error {
 	return err
 }
 
+// IsHNCEnabled returns if the ConfigManagement object has HNC enabled.
+func (c *ConfigManagementClient) IsHNCEnabled(ctx context.Context) (bool, error) {
+	isHNCEnabled, err := c.NestedBool(ctx, "spec", "hierarchyController", "enabled")
+	if err != nil {
+		return false, err
+	}
+	return isHNCEnabled, nil
+}
+
 // IsOssInstallation will check for the existence of ConfigManagement object, Operator deployment, and RootSync CRD
 // If RootSync CRD exist but ConfigManagement and Operator doesn't, it indicates an OSS installation
 func IsOssInstallation(ctx context.Context, c *ConfigManagementClient, cl client.Client, ck *kubernetes.Clientset) (bool, error) {


### PR DESCRIPTION
This requires for the user to disable HNC before removing Config Management, so that ACM helps with the uninstallation of HNC before it is absent from the cluster. This is intended to streamline the experience of migrating to OSS HNC.