### PR TITLE
feat: add kustomize tooling for custom CS install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ OTELCONTRIBCOL_VERSION := v0.103.0-gke.4
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.
-STAGING_DIR := $(OUTPUT_DIR)/staging
+STAGING_DIR ?= $(OUTPUT_DIR)/staging
 
 # Directory used for staging the manifest primitives.
 NOMOS_MANIFEST_STAGING_DIR := $(STAGING_DIR)/operator
@@ -311,9 +311,15 @@ build-status:
 test-unit: buildenv-dirs "$(KUSTOMIZE)"
 	@./scripts/test-unit.sh $(NOMOS_GO_PKG)
 
+# small unit test to verify the behavior of an example kustomization for manual install
+.PHONY: test-kustomization
+test-kustomization:
+	$(MAKE) build-manifests STAGING_DIR=$(OUTPUT_DIR)/testing REGISTRY=gcr.io/cs-test IMAGE_TAG=placeholder
+	@./scripts/test-kustomization.sh
+
 # Runs unit tests and linter.
 .PHONY: test
-test: test-unit lint
+test: test-unit test-kustomization lint
 
 # The presubmits have made side-effects in the past, which makes their
 # validation suspect (as the repository they are validating is different

--- a/installation/README.md
+++ b/installation/README.md
@@ -1,0 +1,93 @@
+# Installing Config Sync manually
+
+This document is a guide on how to manually install Config Sync on a Kubernetes
+cluster without Fleet Management.
+
+The recommended approach is to [install Config Sync managed by fleet](https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/installing-config-sync).
+
+This document includes configurations for some common user journeys, but is not
+an exhaustive list of how a Config Sync installation can be customized.
+
+## Pre-requisites
+
+This guide requires the following command line tools:
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [kustomize](https://github.com/kubernetes-sigs/kustomize)
+
+## Uninstall Config Management
+
+**Prerequisites**:
+- Set the kubectl context in your shell to the desired cluster before proceeding.
+- Ensure [hierarchy controller is disabled](https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/migrate-hierarchy-controller#kubectl) before proceeding.
+
+
+If you have previously installed Config Management on your cluster, Config Management
+must first be uninstalled before following this guide to install/upgrade Config Sync.
+
+You can check if Config Management is installed on your cluster with the following command:
+
+```shell
+kubectl get configmanagement
+```
+
+If the output is not empty, Config Management is currently installed on the cluster
+and must be uninstalled before proceeding. To uninstall Config Management, there are
+two options:
+- Use `nomos migrate --remove-configmanagement`
+- Use the [uninstall script](uninstall_configmanagement.sh) provided in this directory.
+
+### Using `nomos migrate`
+
+Install the [nomos CLI](https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/nomos-command)
+of version 1.20.0 or greater. Then run the following command to update the cluster
+in your current kubectl context:
+
+```shell
+nomos migrate --remove-configmanagement
+```
+
+### Using the uninstall shell script
+
+The `nomos` approach is recommended, however a simple shell script is also provided
+as an alternative approach that does not require installing the `nomos` binary.
+The script can be run directly to update the cluster in your current kubectl context:
+
+```shell
+./uninstall_configmanagement.sh
+```
+
+## Install Config Sync
+
+### Rendering the installation manifest
+
+A [kustomization file](kustomization.yaml) is provided in this directory with
+some common use cases commented out. Edit the kustomization file accordingly for
+any desired customizations before installing.
+
+Once the kustomization file is ready, the manifests can be rendered using `kustomize`:
+
+```shell
+kustomize build . > config-sync-install.yaml
+```
+
+The rendered manifests are now written to the `config-sync-install.yaml` file. This
+file may be inspected/reviewed before applying to the cluster.
+
+Optional: If you want Config Sync deployments to use a private registry
+rather than the default registry, the following command can be used to replace
+the image URLs for all deployments:
+
+```shell
+kustomize build . | sed -e "s|gcr.io/config-management-release/|[*REGISTRY*]/|g" > config-sync-install.yaml
+```
+
+### Apply the manifest to the cluster
+
+Once you are ready to apply the manifests to the cluster and install Config Sync,
+the manifests can be applied directly with `kubectl`:
+
+```shell
+kubectl apply -f config-sync-install.yaml
+```
+

--- a/installation/kustomization.yaml
+++ b/installation/kustomization.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- CONFIG_SYNC_MANIFEST
+# [WEBHOOK] - To install admission-webhook, uncomment the following line
+#- ADMISSION_WEBHOOK_MANIFEST
+
+patches:
+# [RESOURCES] - To adjust resource requests/limits, uncomment the following section and set the desired resources
+#- patch: |-
+#    - op: add
+#      path: "/spec/template/spec/containers/0/resources"
+#      value:
+#        requests:
+#          cpu: [*CPU_REQUEST*]
+#          memory: [*MEMORY_REQUEST*]
+#        limits:
+#          cpu: [*CPU_LIMIT*]
+#          memory: [*MEMORY_LIMIT*]
+#  target:
+#    kind: Deployment
+#    name: reconciler-manager
+#    namespace: config-management-system
+#
+# [CLUSTER_NAME] - To set cluster name, uncomment the following section and set the desired cluster name
+#- patch: |-
+#    - op: add
+#      path: /spec/template/spec/containers/0/args/-
+#      value: --cluster-name=[*CLUSTER_NAME*]
+#  target:
+#    kind: Deployment
+#    name: reconciler-manager
+#    namespace: config-management-system
+#
+# [LOG_LEVEL] - To set log level, uncomment the following section and set the desired log level
+#- patch: |-
+#    - op: add
+#      path: /spec/template/spec/containers/0/args/-
+#      value: --v=[*VERBOSITY*]
+#  target:
+#    kind: Deployment
+#    name: reconciler-manager
+#    namespace: config-management-system

--- a/scripts/test-kustomization.sh
+++ b/scripts/test-kustomization.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,35 +15,8 @@
 
 set -euo pipefail
 
-if [[ -z "$(which addlicense)" ]]; then
-  echo "addlicense not in PATH"
-  exit 1
-fi
-
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-cd "${REPO_ROOT}"
 
-ignores=(
-  "-ignore=vendor/**"
-  "-ignore=e2e/testdata/helm-charts/**"
-  "-ignore=test/kustomization/expected.yaml"
-  "-ignore=.output/**"
-  "-ignore=e2e/testdata/*.xml"
-  "-ignore=.idea/**"
-  "-ignore=.vscode/**"
-)
+out=$(kustomize build --load-restrictor=LoadRestrictionsNone "${REPO_ROOT}/test/kustomization" | sed -e "s|gcr.io/cs-test/|example.com/|g")
 
-case "$1" in
-  lint)
-    "addlicense" -check "${ignores[@]}" . 2>&1 | sed '/ skipping: / d'
-    ;;
-  add)
-    "addlicense" -v -c "Google LLC" -f LICENSE_TEMPLATE \
-      "${ignores[@]}" \
-      . 2>&1 | sed '/ skipping: / d'
-    ;;
-  *)
-    echo "Usage: $0 (lint|add)"
-    exit 1
-    ;;
-esac
+diff "${REPO_ROOT}/test/kustomization/expected.yaml" <( echo "${out}" )

--- a/test/kustomization/expected.yaml
+++ b/test/kustomization/expected.yaml
@@ -1,0 +1,6486 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: config-management-monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: config-management-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+    control-plane: controller-manager
+  name: resource-group-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-retired/cluster-registry/pull/269
+  labels:
+    api: ""
+    configmanagement.gke.io/system: "true"
+    kubebuilder.k8s.io: 1.0.3
+  name: clusters.clusterregistry.k8s.io
+spec:
+  group: clusterregistry.k8s.io
+  names:
+    kind: Cluster
+    plural: clusters
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              authInfo:
+                properties:
+                  controller:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  user:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              kubernetesApiEndpoints:
+                properties:
+                  caBundle:
+                    format: byte
+                    type: string
+                  serverEndpoints:
+                    items:
+                      properties:
+                        clientCIDR:
+                          type: string
+                        serverAddress:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: clusterselectors.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: ClusterSelector
+    listKind: ClusterSelectorList
+    plural: clusterselectors
+    singular: clusterselector
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterSelector specifies a LabelSelector applied to clusters that exist within a
+          cluster registry.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The actual object definition, per K8S object definition style.
+            properties:
+              selector:
+                description: |-
+                  Selects clusters.
+                  This field is NOT optional and follows standard label selector semantics. An empty selector
+                  matches all clusters.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - selector
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: hierarchyconfigs.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: HierarchyConfig
+    listKind: HierarchyConfigList
+    plural: hierarchyconfigs
+    singular: hierarchyconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: HierarchyConfig is used for configuring the HierarchyModeType
+          for managed resources.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the standard spec field.
+            properties:
+              resources:
+                items:
+                  description: HierarchyConfigResource specifies the HierarchyModeType
+                    based on the matching Groups and Kinds enabled.
+                  properties:
+                    group:
+                      description: Group is the name of the APIGroup that contains
+                        the resources.
+                      type: string
+                    hierarchyMode:
+                      description: |-
+                        HierarchyMode specifies how the object is treated when it appears in an abstract namespace.
+                        The default is "inherit", meaning objects are inherited from parent abstract namespaces.
+                        If set to "none", the type is not allowed in Abstract Namespaces.
+                      type: string
+                    kinds:
+                      description: Kinds is a list of kinds this rule applies to.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+            required:
+            - resources
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: namespaceselectors.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: NamespaceSelector
+    listKind: NamespaceSelectorList
+    plural: namespaceselectors
+    singular: namespaceselector
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespaceSelector specifies a LabelSelector applied to namespaces that exist within a
+          NamespaceConfig hierarchy.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The actual object definition, per K8S object definition style.
+            properties:
+              mode:
+                default: static
+                description: |-
+                  mode specifies the selection mode of the NamespaceSelector.
+                  It must be set to either "static" or "dynamic" and is optional. If not specified, it defaults to "static."
+                  In static mode, only resources with labels matching Namespaces statically declared in the source of truth are selected.
+                  In dynamic mode, selection includes both statically declared Namespaces and Namespaces present on the cluster.
+                pattern: ^(static|dynamic)$
+                type: string
+              selector:
+                description: |-
+                  Selects namespaces.
+                  This field is NOT optional and follows standard label selector semantics. An empty selector
+                  matches all namespaces.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - selector
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: reposyncs.configsync.gke.io
+spec:
+  group: configsync.gke.io
+  names:
+    kind: RepoSync
+    listKind: RepoSyncList
+    plural: reposyncs
+    singular: reposync
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RepoSync is the Schema for the reposyncs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepoSyncSpec defines the desired state of a RepoSync.
+            properties:
+              git:
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - githubapp
+                    - token
+                    - none
+                    type: string
+                  branch:
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.git.auth: gcpserviceaccount.
+                    type: string
+                  noSSLVerify:
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                  proxy:
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - token
+                    - gcenode
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
+                    type: string
+                  includeCRDs:
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    items:
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
+                    type: array
+                  version:
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - none
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  image:
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a reconciler.
+                nullable: true
+                properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
+                  enableShellInRendering:
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
+                    type: boolean
+                  gitSyncDepth:
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
+                    items:
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory
+                            request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  statusMode:
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be one of hierarchy, unstructured. Optional. Set to
+                  hierarchy if not specified.
+
+
+                  The validation of this is case-sensitive.
+                pattern: ^(unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RepoSyncStatus defines the observed state of a RepoSync.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the latest available observations of the RepoSync's
+                  current state.
+                items:
+                  description: RepoSyncCondition describes the state of a RepoSync
+                    at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
+                        properties:
+                          code:
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated
+                              with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RepoSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
+                type: string
+              rendering:
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the
+                      rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RepoSync is the Schema for the reposyncs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepoSyncSpec defines the desired state of a RepoSync.
+            properties:
+              git:
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - token
+                    - githubapp
+                    - none
+                    type: string
+                  branch:
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  noSSLVerify:
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                  proxy:
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - token
+                    - gcenode
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
+                    type: string
+                  includeCRDs:
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    items:
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
+                    type: array
+                  version:
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - none
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  image:
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a namespace
+                  reconciler.
+                nullable: true
+                properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
+                  enableShellInRendering:
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
+                    type: boolean
+                  gitSyncDepth:
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
+                    items:
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory
+                            request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  statusMode:
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be unstructured. Optional. Set to
+                  unstructured if not specified.
+
+
+                  The validation of this is case-sensitive.
+                pattern: ^(unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RepoSyncStatus defines the observed state of a RepoSync.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the latest available observations of the RepoSync's
+                  current state.
+                items:
+                  description: RepoSyncCondition describes the state of a RepoSync
+                    at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
+                        properties:
+                          code:
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated
+                              with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RepoSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
+                type: string
+              rendering:
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the
+                      rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resourcegroups.kpt.dev
+spec:
+  group: kpt.dev
+  names:
+    kind: ResourceGroup
+    listKind: ResourceGroupList
+    plural: resourcegroups
+    singular: resourcegroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].status
+      name: Reconciling
+      type: string
+    - jsonPath: .status.conditions[1].status
+      name: Stalled
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceGroup is the Schema for the resourcegroups API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of ResourceGroup
+            properties:
+              descriptor:
+                description: descriptor regroups the information and metadata about
+                  a resource group
+                properties:
+                  description:
+                    description: description is a brief description of a group of
+                      resources
+                    type: string
+                  links:
+                    description: |-
+                      links are a list of descriptive URLs intended to be used to surface
+                      additional information
+                    items:
+                      properties:
+                        description:
+                          description: description explains the purpose of the link
+                          type: string
+                        url:
+                          description: url is the URL of the link
+                          type: string
+                      required:
+                      - description
+                      - url
+                      type: object
+                    type: array
+                  revision:
+                    description: revision is an optional revision for a group of resources
+                    type: string
+                  type:
+                    description: type can contain prefix, such as Application/WordPress
+                      or Service/Spanner
+                    type: string
+                type: object
+              resources:
+                description: resources contains a list of resources that form the
+                  resource group
+                items:
+                  description: |-
+                    each item organizes and stores the identifying information
+                    for an object. This struct (as a string) is stored in a
+                    grouping object to keep track of sets of applied objects.
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - namespace
+                  type: object
+                type: array
+              subgroups:
+                description: subgroups contains a list of sub groups that the current
+                  group includes.
+                items:
+                  description: |-
+                    Each item organizes and stores the identifying information
+                    for a ResourceGroup object. It includes name and namespace.
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status defines the observed state of ResourceGroup
+            properties:
+              conditions:
+                description: conditions lists the conditions of the current status
+                  for the group
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: last time the condition transit from one status
+                        to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: one-word CamelCase reason for the condition’s last
+                        transition
+                      type: string
+                    status:
+                      description: status of the condition
+                      type: string
+                    type:
+                      description: type of the condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed.
+                  It corresponds to the Object's generation, which is updated on
+                  mutation by the API Server.
+                  Everytime the controller does a successful reconcile, it sets
+                  observedGeneration to match ResourceGroup.metadata.generation.
+                format: int64
+                type: integer
+              resourceStatuses:
+                description: resourceStatuses lists the status for each resource in
+                  the group
+                items:
+                  description: |-
+                    each item contains the status of a given resource uniquely identified by
+                    its group, kind, name and namespace.
+                  properties:
+                    actuation:
+                      description: actuation indicates whether actuation has been
+                        performed yet and how it went.
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: last time the condition transit from one
+                              status to another
+                            format: date-time
+                            type: string
+                          message:
+                            description: human-readable message indicating details
+                              about last transition
+                            type: string
+                          reason:
+                            description: one-word CamelCase reason for the condition’s
+                              last transition
+                            type: string
+                          status:
+                            description: status of the condition
+                            type: string
+                          type:
+                            description: type of the condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    reconcile:
+                      description: reconcile indicates whether reconciliation has
+                        been performed yet and how it went.
+                      type: string
+                    sourceHash:
+                      type: string
+                    status:
+                      description: status describes the status of a resource.
+                      type: string
+                    strategy:
+                      description: strategy indicates the method of actuation (apply
+                        or delete) used or planned to be used.
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - namespace
+                  - status
+                  type: object
+                type: array
+              subgroupStatuses:
+                description: subgroupStatuses lists the status for each subgroup.
+                items:
+                  description: |-
+                    Each item contains the status of a given group uniquely identified by
+                    its name and namespace.
+                  properties:
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: last time the condition transit from one
+                              status to another
+                            format: date-time
+                            type: string
+                          message:
+                            description: human-readable message indicating details
+                              about last transition
+                            type: string
+                          reason:
+                            description: one-word CamelCase reason for the condition’s
+                              last transition
+                            type: string
+                          status:
+                            description: status of the condition
+                            type: string
+                          type:
+                            description: type of the condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    status:
+                      description: status describes the status of a resource.
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - status
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: rootsyncs.configsync.gke.io
+spec:
+  group: configsync.gke.io
+  names:
+    kind: RootSync
+    listKind: RootSyncList
+    plural: rootsyncs
+    singular: rootsync
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RootSync is the Schema for the rootsyncs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RootSyncSpec defines the desired state of RootSync
+            properties:
+              git:
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - githubapp
+                    - token
+                    - none
+                    type: string
+                  branch:
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.git.auth: gcpserviceaccount.
+                    type: string
+                  noSSLVerify:
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                  proxy:
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - token
+                    - gcenode
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  deployNamespace:
+                    description: |-
+                      deployNamespace specifies the namespace in which to deploy the chart.
+                      This is a mutually exclusive setting with "namespace".
+                      If neither namespace nor deployNamespace are set, the chart will be
+                      deployed into the default namespace.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
+                    type: string
+                  includeCRDs:
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
+                    type: boolean
+                  namespace:
+                    description: |-
+                      namespace sets the target namespace for a release.
+                      Default: "default".
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    items:
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
+                    type: array
+                  version:
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - none
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  image:
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a reconciler.
+                nullable: true
+                properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
+                  enableShellInRendering:
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
+                    type: boolean
+                  gitSyncDepth:
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
+                    items:
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  namespaceStrategy:
+                    description: |-
+                      namespaceStrategy controls how the reconciler handles Namespaces
+                      which are used by resources in the source but not declared. Only applies
+                      when using the unstructured sourceFormat.
+                      Must be "implicit" or "explicit". Default: "implicit".
+                      "implicit" means that the reconciler will implicitly create Namespaces
+                      if they do not exist, even if they are not declared in the source.
+                      "explicit" means that the reconciler will not create Namespaces which
+                      are not declared in the source.
+                    enum:
+                    - implicit
+                    - explicit
+                    type: string
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory
+                            request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  roleRefs:
+                    description: |-
+                      roleRefs is a list of Roles or ClusterRoles to create bindings.
+                      If unset, a binding to cluster-admin will be created.
+                    items:
+                      description: |-
+                        each item references a Role or ClusterRole to create
+                        a binding to for this reconciler. It supports a namespace field that can be used
+                        to create RoleBindings rather than ClusterRoleBindings.
+                      properties:
+                        kind:
+                          description: |-
+                            kind refers to the Kind of the RBAC resource.
+                            Accepted values are Role and ClusterRole. Required.
+                          enum:
+                          - Role
+                          - ClusterRole
+                          type: string
+                        name:
+                          description: name is the name of the Role or ClusterRole
+                            resource. Required.
+                          type: string
+                        namespace:
+                          description: |-
+                            namespace indicates the Namespace in which a RoleBinding should be created.
+                            For ClusterRole objects, will determine whether a RoleBinding or ClusterRoleBinding
+                            is created.
+                            For Role objects, must be set to the same namespace as the Role.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  statusMode:
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be one of hierarchy, unstructured. Optional. Set to
+                  hierarchy if not specified.
+
+
+                  The validation of this is case-sensitive.
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RootSyncStatus defines the observed state of RootSync
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the latest available observations of the RootSync's
+                  current state.
+                items:
+                  description: RootSyncCondition describes the state of a RootSync
+                    at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
+                        properties:
+                          code:
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated
+                              with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RootSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
+                type: string
+              rendering:
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the
+                      rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RootSync is the Schema for the rootsyncs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RootSyncSpec defines the desired state of RootSync
+            properties:
+              git:
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - token
+                    - githubapp
+                    - none
+                    type: string
+                  branch:
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  noSSLVerify:
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
+                    type: boolean
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                  proxy:
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
+                properties:
+                  auth:
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - token
+                    - gcenode
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  deployNamespace:
+                    description: |-
+                      deployNamespace specifies the namespace in which to deploy the chart.
+                      This is a mutually exclusive setting with "namespace".
+                      If neither namespace nor deployNamespace are set, the chart will be
+                      deployed into the default namespace.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
+                    type: string
+                  includeCRDs:
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
+                    type: boolean
+                  namespace:
+                    description: |-
+                      namespace sets the value of {{Release.Namespace}} defined in the chart templates.
+                      This is a mutually exclusive setting with "deployNamespace".
+                      Default: default.
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    items:
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
+                    type: array
+                  version:
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
+                properties:
+                  auth:
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - k8sserviceaccount
+                    - none
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  dir:
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
+                    type: string
+                  image:
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
+                    type: string
+                  period:
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a root reconciler.
+                nullable: true
+                properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
+                  enableShellInRendering:
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
+                    type: boolean
+                  gitSyncDepth:
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
+                    items:
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  namespaceStrategy:
+                    description: |-
+                      namespaceStrategy controls how the reconciler handles Namespaces
+                      which are used by resources in the source but not declared. Only applies
+                      when using the unstructured sourceFormat.
+                      Must be "implicit" or "explicit". Default: "implicit".
+                      "implicit" means that the reconciler will implicitly create Namespaces
+                      if they do not exist, even if they are not declared in the source.
+                      "explicit" means that the reconciler will not create Namespaces which
+                      are not declared in the source.
+                    enum:
+                    - implicit
+                    - explicit
+                    type: string
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory
+                            request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  roleRefs:
+                    description: |-
+                      roleRefs is a list of Roles or ClusterRoles to create bindings.
+                      If unset, a binding to cluster-admin will be created.
+                    items:
+                      description: |-
+                        each item references a Role or ClusterRole to create
+                        a binding to for this reconciler. It supports a namespace field that can be used
+                        to create RoleBindings rather than ClusterRoleBindings.
+                      properties:
+                        kind:
+                          description: |-
+                            kind refers to the Kind of the RBAC resource.
+                            Accepted values are Role and ClusterRole. Required.
+                          enum:
+                          - Role
+                          - ClusterRole
+                          type: string
+                        name:
+                          description: name is the name of the Role or ClusterRole
+                            resource. Required.
+                          type: string
+                        namespace:
+                          description: |-
+                            namespace indicates the Namespace in which a RoleBinding should be created.
+                            For ClusterRole objects, will determine whether a RoleBinding or ClusterRoleBinding
+                            is created.
+                            For Role objects, must be set to the same namespace as the Role.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  statusMode:
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be one of hierarchy, unstructured. Optional. Set to
+                  hierarchy if not specified.
+
+
+                  The validation of this is case-sensitive.
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RootSyncStatus defines the observed state of RootSync
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the latest available observations of the RootSync's
+                  current state.
+                items:
+                  description: RootSyncCondition describes the state of a RootSync
+                    at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
+                        properties:
+                          code:
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated
+                              with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RootSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
+                type: string
+              rendering:
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the
+                      rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
+                properties:
+                  commit:
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
+                    items:
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
+                      properties:
+                        code:
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated
+                            with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
+                            properties:
+                              gvk:
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
+                  lastUpdate:
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
+                    properties:
+                      dir:
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: admission-webhook
+  namespace: config-management-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: reconciler-manager
+  namespace: config-management-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-sa
+  namespace: resource-group-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-leader-election-role
+  namespace: resource-group-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: configsync.gke.io:ns-reconciler
+rules:
+- apiGroups:
+  - configsync.gke.io
+  resources:
+  - reposyncs
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - configsync.gke.io
+  resources:
+  - reposyncs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups
+  verbs:
+  - '*'
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups/status
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: configsync.gke.io:ns-reconciler:cluster-scope
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: configsync.gke.io:root-reconciler
+rules:
+- apiGroups:
+  - configsync.gke.io
+  resources:
+  - rootsyncs
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - configsync.gke.io
+  resources:
+  - rootsyncs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups
+  verbs:
+  - '*'
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups/status
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-manager-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kpt.dev
+  resources:
+  - resourcegroups/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-leader-election-rolebinding
+  namespace: resource-group-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: resource-group-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: resource-group-sa
+  namespace: resource-group-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: configsync.gke.io:admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admission-webhook
+  namespace: config-management-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: configsync.gke.io:reconciler-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: reconciler-manager
+  namespace: config-management-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: resource-group-manager-role
+subjects:
+- kind: ServiceAccount
+  name: resource-group-sa
+  namespace: resource-group-system
+---
+apiVersion: v1
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      opencensus:
+    exporters:
+      prometheus:
+        endpoint: :8675
+        namespace: config_sync
+        resource_to_telemetry_conversion:
+          enabled: true
+    processors:
+      batch:
+    extensions:
+      health_check:
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [opencensus]
+          processors: [batch]
+          exporters: [prometheus]
+kind: ConfigMap
+metadata:
+  labels:
+    app: opentelemetry
+    component: otel-collector
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: otel-collector
+  namespace: config-management-monitoring
+---
+apiVersion: v1
+data:
+  otel-agent-config.yaml: |
+    receivers:
+      opencensus:
+    exporters:
+      opencensus:
+        endpoint: otel-collector.config-management-monitoring:55678
+        tls:
+          insecure: true
+    processors:
+      # Attributes processor adds custom configsync metric labels to applicable
+      # metrics to identify the sync object used to configure this deployment.
+      #
+      # Note: configsync.sync.generation is explicitly excluded here, because it
+      # is high cardinality. So we don't want to send it as a label, only as a
+      # resource attribute. That way it's only propagated to Prometheus, and not
+      # Monarch or Cloud Monitoring, which ignore custom resource attributes.
+      attributes:
+        actions:
+          - key: configsync.sync.kind
+            action: upsert
+            value: $CONFIGSYNC_SYNC_KIND
+          - key: configsync.sync.name
+            action: upsert
+            value: $CONFIGSYNC_SYNC_NAME
+          - key: configsync.sync.namespace
+            action: upsert
+            value: $CONFIGSYNC_SYNC_NAMESPACE
+      batch:
+      # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
+      # the GCE metadata service, if available.
+      resourcedetection:
+        detectors: [env, gcp]
+    extensions:
+      health_check:
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [opencensus]
+          processors: [batch, resourcedetection, attributes]
+          exporters: [opencensus]
+      telemetry:
+        logs:
+          level: "INFO"
+kind: ConfigMap
+metadata:
+  labels:
+    app: opentelemetry
+    component: otel-agent
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: otel-agent
+  namespace: config-management-system
+---
+apiVersion: v1
+data:
+  deployment.yaml: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: # this field will be assigned dynamically by the reconciler-manager
+      namespace: config-management-system
+      labels:
+        app: reconciler
+        configmanagement.gke.io/system: "true"
+        configmanagement.gke.io/arch: "csmr"
+    spec:
+      minReadySeconds: 10
+      replicas: 1
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app: reconciler
+          configsync.gke.io/deployment-name: "" # this field will be assigned dynamically by the reconciler-manager
+      template:
+        metadata:
+          labels:
+            app: reconciler
+            configsync.gke.io/deployment-name: "" # this field will be assigned dynamically by the reconciler-manager
+            configsync.gke.io/sync-kind: "" # this field will be assigned dynamically by the reconciler-manager
+            configsync.gke.io/sync-name: "" # this field will be assigned dynamically by the reconciler-manager
+            configsync.gke.io/sync-namespace: "" # this field will be assigned dynamically by the reconciler-manager
+            configsync.gke.io/sync-generation: "" # this field will be assigned dynamically by the reconciler-manager
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true" # this annotation is needed so that pods doesn't block scale down
+        spec:
+          serviceAccountName: # this field will be assigned dynamically by the reconciler-manager
+          containers:
+          - name: hydration-controller
+            image: example.com/hydration-controller:placeholder
+            command:
+            - /hydration-controller
+            args:
+            - "--repo-root=/repo"
+            - "--source-root=source"
+            - "--hydrated-root=hydrated"
+            - "--source-link=rev"
+            - "--hydrated-link=rev"
+            volumeMounts:
+            - name: repo
+              mountPath: /repo
+            - name: service-account # This is needed to prevent any credentials from being exposed to malicious users.
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                - ALL
+              runAsUser: 65533
+          - name: reconciler
+            image: example.com/reconciler:placeholder
+            command:
+            - /reconciler
+            args:
+            - "--repo-root=/repo"
+            - "--source-dir=/repo/source/rev"
+            - "--hydrated-root=/repo/hydrated"
+            - "--hydrated-link=rev"
+            env:
+            - name: KUBECACHEDIR
+              value: "/.kube/cache"
+            volumeMounts:
+            - name: repo
+              mountPath: /repo
+              readOnly: true
+            - name: kube
+              mountPath: /.kube
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                - ALL
+            imagePullPolicy: IfNotPresent
+          - name: git-sync
+            image: gcr.io/config-management-release/git-sync:v4.2.4-gke.8__linux_amd64
+            args: ["--root=/repo/source", "--link=rev", "--max-failures=30", "--error-file=error.json"]
+            volumeMounts:
+            - name: repo
+              mountPath: /repo
+            - name: git-creds
+              mountPath: /etc/git-secret
+              readOnly: true
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                - ALL
+              runAsUser: 65533
+          - name: gcenode-askpass-sidecar
+            image: example.com/gcenode-askpass-sidecar:placeholder
+            args: ["--port=9102", "--logtostderr"]
+            imagePullPolicy: IfNotPresent
+            terminationMessagePolicy: File
+            terminationMessagePath: /dev/termination-log
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                - ALL
+          - name: oci-sync
+            image: example.com/oci-sync:placeholder
+            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
+            volumeMounts:
+            - name: repo
+              mountPath: /repo
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                - ALL
+              runAsUser: 65533
+          - name: helm-sync
+            image: example.com/helm-sync:placeholder
+            args: ["--root=/repo/source", "--dest=rev", "--max-sync-failures=30", "--error-file=error.json"]
+            volumeMounts:
+            - name: repo
+              mountPath: /repo
+            - name: helm-creds
+              mountPath: /etc/helm-secret
+              readOnly: true
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                - ALL
+              runAsUser: 65533
+          - name: otel-agent
+            image: gcr.io/config-management-release/otelcontribcol:v0.103.0-gke.4
+            command:
+            - /otelcontribcol
+            args:
+            - "--config=/conf/otel-agent-config.yaml"
+            # The prometheus transformer appends `_ratio` to gauge metrics: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.86.0/pkg/translator/prometheus/normalize_name.go#L149
+            # Add the feature gate to enable metric suffix trimming.
+            - "--feature-gates=-pkg.translator.prometheus.NormalizeName"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                - ALL
+            ports:
+            - containerPort: 55678 # Default OpenCensus receiver port.
+              protocol: TCP
+            - containerPort: 8888  # Metrics.
+              protocol: TCP
+            volumeMounts:
+            - name: otel-agent-config-vol
+              mountPath: /conf
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 13133 # Health Check extension default port.
+                scheme: HTTP
+            imagePullPolicy: IfNotPresent
+            # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
+            # is used by the otel-agent to populate resource attributes when
+            # emitting metrics to the otel-collector. This is more efficient than
+            # having the otel-collector look them up from the apiserver.
+            #
+            # Unlike the other configsync metric labels,
+            # "configsync.sync.generation" is specified here as a resource
+            # attribute so that it is sent to Prometheus, but not Monarch or
+            # Cloud Monitoring.
+            env:
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: KUBE_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: KUBE_POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: KUBE_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: KUBE_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+            - name: CONFIGSYNC_SYNC_KIND
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['configsync.gke.io/sync-kind']
+            - name: CONFIGSYNC_SYNC_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['configsync.gke.io/sync-name']
+            - name: CONFIGSYNC_SYNC_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['configsync.gke.io/sync-namespace']
+            - name: CONFIGSYNC_SYNC_GENERATION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['configsync.gke.io/sync-generation']
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(KUBE_POD_NAME),\
+                k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
+                k8s.pod.uid=$(KUBE_POD_UID),\
+                k8s.pod.ip=$(KUBE_POD_IP),\
+                k8s.node.name=$(KUBE_NODE_NAME),\
+                k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME),\
+                configsync.sync.generation=$(CONFIGSYNC_SYNC_GENERATION)"
+          volumes:
+          - name: repo
+            emptyDir: {}
+          - name: kube
+            emptyDir: {}
+          - name: helm-creds
+            secret:
+              secretName: helm-creds
+              defaultMode: 288
+          - name: git-creds
+            secret:
+              secretName: git-creds
+              defaultMode: 288
+          - name: otel-agent-config-vol
+            configMap:
+              name: otel-agent
+              defaultMode: 420
+          - name: service-account
+            emptyDir: {}
+          securityContext:
+            fsGroup: 65533
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+kind: ConfigMap
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: reconciler-manager-cm
+  namespace: config-management-system
+---
+apiVersion: v1
+data:
+  otel-agent-config.yaml: |
+    receivers:
+      opencensus:
+    exporters:
+      opencensus:
+        endpoint: otel-collector.config-management-monitoring:55678
+        tls:
+          insecure: true
+    processors:
+      batch:
+      # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
+      # the GCE metadata service, if available.
+      resourcedetection:
+        detectors: [env, gcp]
+    extensions:
+      health_check:
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [opencensus]
+          processors: [batch, resourcedetection]
+          exporters: [opencensus]
+kind: ConfigMap
+metadata:
+  labels:
+    app: opentelemetry
+    component: otel-agent
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: resource-group-otel-agent
+  namespace: resource-group-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: admission-webhook-cert
+  namespace: config-management-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+    monitored: "true"
+  name: otel-collector
+  namespace: config-management-monitoring
+spec:
+  ports:
+  - name: opencensus
+    port: 55678
+    protocol: TCP
+    targetPort: 55678
+  - name: metrics-default
+    port: 8888
+  - name: metrics
+    port: 8675
+  selector:
+    app: opentelemetry
+    component: otel-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+    monitored: "true"
+  name: admission-webhook
+  namespace: config-management-system
+spec:
+  ports:
+  - name: admission
+    port: 443
+    targetPort: admission
+  selector:
+    app: admission-webhook
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  labels:
+    configmanagement.gke.io/system: "true"
+  name: container-limits
+  namespace: config-management-system
+spec:
+  limits:
+  - defaultRequest:
+      cpu: 10m
+      memory: 10Mi
+    type: Container
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: opentelemetry
+    component: otel-collector
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: otel-collector
+  namespace: config-management-monitoring
+spec:
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-collector
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+      - args:
+        - --config=/conf/otel-collector-config.yaml
+        - --feature-gates=-pkg.translator.prometheus.NormalizeName
+        command:
+        - /otelcontribcol
+        image: gcr.io/config-management-release/otelcontribcol:v0.103.0-gke.4
+        name: otel-collector
+        ports:
+        - containerPort: 55678
+        - containerPort: 8888
+        - containerPort: 8675
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-collector-config-vol
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - name: otel-collector-config-vol
+        projected:
+          sources:
+          - configMap:
+              name: otel-collector
+          - configMap:
+              name: otel-collector-googlecloud
+              optional: true
+          - configMap:
+              name: otel-collector-custom
+              optional: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: admission-webhook
+  namespace: config-management-system
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  selector:
+    matchLabels:
+      app: admission-webhook
+  template:
+    metadata:
+      labels:
+        app: admission-webhook
+    spec:
+      containers:
+      - command:
+        - /admission-webhook
+        - --graceful-shutdown-timeout=10s
+        - --health-probe-bind-addr=:10258
+        image: example.com/admission-webhook:placeholder
+        name: admission-webhook
+        ports:
+        - containerPort: 10250
+          name: admission
+          protocol: TCP
+        - containerPort: 10258
+          name: readyz
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: readyz
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: admission-webhook
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: admission-webhook-cert
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reconciler-manager
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: reconciler-manager
+  namespace: config-management-system
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reconciler-manager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: reconciler-manager
+        configsync.gke.io/deployment-name: reconciler-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        - -v=1
+        - --cluster-name=test-cluster
+        - --v=5
+        command:
+        - /reconciler-manager
+        envFrom:
+        - configMapRef:
+            name: reconciler-manager
+            optional: true
+        image: example.com/reconciler-manager:placeholder
+        name: reconciler-manager
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /deployment.yaml
+          name: configs
+          subPath: deployment.yaml
+      - args:
+        - --config=/conf/otel-agent-config.yaml
+        - --feature-gates=-pkg.translator.prometheus.NormalizeName
+        command:
+        - /otelcontribcol
+        env:
+        - name: KUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: KUBE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBE_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: KUBE_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: KUBE_DEPLOYMENT_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
+        image: gcr.io/config-management-release/otelcontribcol:v0.103.0-gke.4
+        name: otel-agent
+        ports:
+        - containerPort: 55678
+        - containerPort: 8888
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-agent-config-vol
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: reconciler-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: reconciler-manager-cm
+        name: configs
+      - configMap:
+          name: otel-agent
+        name: otel-agent-config-vol
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+    control-plane: controller-manager
+  name: resource-group-controller-manager
+  namespace: resource-group-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      configmanagement.gke.io/arch: csmr
+      configsync.gke.io/deployment-name: resource-group-controller-manager
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        configmanagement.gke.io/arch: csmr
+        configsync.gke.io/deployment-name: resource-group-controller-manager
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /resource-group
+        env:
+        - name: OC_RESOURCE_LABELS
+          value: k8s.container.name="manager"
+        image: example.com/resource-group-controller:placeholder
+        name: manager
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      - args:
+        - --config=/conf/otel-agent-config.yaml
+        - --feature-gates=-pkg.translator.prometheus.NormalizeName
+        command:
+        - /otelcontribcol
+        env:
+        - name: KUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: KUBE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBE_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: KUBE_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: KUBE_DEPLOYMENT_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.pod.name=$(KUBE_POD_NAME),k8s.pod.namespace=$(KUBE_POD_NAMESPACE),k8s.pod.uid=$(KUBE_POD_UID),k8s.pod.ip=$(KUBE_POD_IP),k8s.node.name=$(KUBE_NODE_NAME),k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)
+        image: gcr.io/config-management-release/otelcontribcol:v0.103.0-gke.4
+        name: otel-agent
+        ports:
+        - containerPort: 55678
+        - containerPort: 8888
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-agent-config-vol
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: resource-group-sa
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: resource-group-otel-agent
+        name: otel-agent-config-vol
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app: admission-webhook
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: admission-webhook.configsync.gke.io

--- a/test/kustomization/kustomization.yaml
+++ b/test/kustomization/kustomization.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../.output/testing/oss/config-sync-manifest.yaml
+# [WEBHOOK] - To install admission-webhook, uncomment the following line
+- ../../.output/testing/oss/admission-webhook.yaml
+
+patches:
+# [RESOURCES] - To adjust resource requests/limits, uncomment the following section and set the desired resources
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/resources"
+      value:
+        requests:
+          cpu: 1
+          memory: 2Gi
+        limits:
+          cpu: 1
+          memory: 2Gi
+  target:
+    kind: Deployment
+    name: reconciler-manager
+    namespace: config-management-system
+
+# [CLUSTER_NAME] - To set cluster name, uncomment the following section and set the desired cluster name
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --cluster-name=test-cluster
+  target:
+    kind: Deployment
+    name: reconciler-manager
+    namespace: config-management-system
+
+# [LOG_LEVEL] - To set log level, uncomment the following section and set the desired log level
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --v=5
+  target:
+    kind: Deployment
+    name: reconciler-manager
+    namespace: config-management-system


### PR DESCRIPTION
This provides a new approach for customizing and installing Config Sync with many of the same features that ConfigManagement provides without the need to install another operator layer. A subsequent change will add tooling to package the kustomization file as a release artifact.