### PR TITLE
set the registry for image URL replacement

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -212,6 +212,9 @@ package-kustomize-bundle:
 		-e "s|CONFIG_SYNC_MANIFEST|./manifests/config-sync-manifest.yaml|g" \
 		-e "s|ADMISSION_WEBHOOK_MANIFEST|./manifests/admission-webhook.yaml|g" \
 		$(OUTPUT_DIR)/tmp/kustomization/kustomization.yaml
+	sed -i \
+		-e "s|CONFIG_SYNC_REGISTRY|$(REGISTRY)|g" \
+		$(OUTPUT_DIR)/tmp/kustomization/README.md
 	cd $(OUTPUT_DIR)/tmp/kustomization && tar -czvf $(OSS_MANIFEST_STAGING_DIR)/kustomization.tar.gz .
 	rm -rf $(OUTPUT_DIR)/tmp/kustomization
 

--- a/installation/README.md
+++ b/installation/README.md
@@ -33,7 +33,7 @@ rather than the default registry, the following command can be used to replace
 the image URLs for all deployments:
 
 ```shell
-kustomize build . | sed -e "s|gcr.io/config-management-release/|[*REGISTRY*]/|g" > config-sync-install.yaml
+kustomize build . | sed -e "s|CONFIG_SYNC_REGISTRY/|[*REGISTRY*]/|g" > config-sync-install.yaml
 ```
 
 ### Apply the manifest to the cluster


### PR DESCRIPTION
Previously the README always assumed gcr.io/config-management-release. With this change, the source registry is updated dynamically based on where the images were actually published.