### PR TITLE
chore: Extract Reconciler from Parser

### DIFF
--- a/pkg/parse/opts.go
+++ b/pkg/parse/opts.go
@@ -15,28 +15,28 @@
 package parse
 
 import (
-	"context"
-	"sync"
 	"time"
 
 	"k8s.io/utils/clock"
 	"kpt.dev/configsync/pkg/declared"
-	"kpt.dev/configsync/pkg/importer/analyzer/ast"
 	"kpt.dev/configsync/pkg/importer/filesystem"
-	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Options holds configuration and core functionality required by all parsers.
+// Options holds configuration and dependencies required by all parsers.
 type Options struct {
+	// Files lists Files in the source of truth.
+	// TODO: compose Files without extending.
+	Files
+
 	// Clock is used for time tracking, namely to simplify testing by allowing
 	// a fake clock, instead of a RealClock.
 	Clock clock.Clock
 
-	// Parser defines the minimum interface required for Reconciler to use a
-	// Parser to read configs from a filesystem.
-	Parser filesystem.ConfigParser
+	// ConfigParser defines the minimum interface required for Reconciler to use a
+	// ConfigParser to read configs from a filesystem.
+	ConfigParser filesystem.ConfigParser
 
 	// ClusterName is the name of the cluster we're syncing configuration to.
 	ClusterName string
@@ -52,56 +52,40 @@ type Options struct {
 	// SyncName is the name of the RootSync or RepoSync object.
 	SyncName string
 
-	// StatusUpdatePeriod is how long the Parser waits between updates of the
-	// sync status, to account for management conflict errors from the Remediator.
-	StatusUpdatePeriod time.Duration
+	// Scope defines the scope of the reconciler, either root or namespaced.
+	Scope declared.Scope
 
-	// DiscoveryInterface is how the Parser learns what types are currently
+	// DiscoveryClient is how the Parser learns what types are currently
 	// available on the cluster.
-	DiscoveryInterface discovery.ServerResourcer
+	DiscoveryClient discovery.ServerResourcer
 
 	// Converter uses the DiscoveryInterface to encode the declared fields of
 	// objects in Git.
 	Converter *declared.ValueConverter
 
-	// mux prevents status update conflicts.
-	mux sync.Mutex
+	// WebhookEnabled indicates whether the Webhook is currently enabled
+	WebhookEnabled bool
+
+	// DeclaredResources is the set of valid source objects, managed by the
+	// Updater and shared with the Parser & Remediator.
+	// This is used by the Parser to validate that CRDs can only be removed from
+	// the source when all of its CRs are removed as well.
+	DeclaredResources *declared.Resources
+}
+
+// ReconcilerOptions holds configuration for the reconciler.
+type ReconcilerOptions struct {
+	// Extend parser options to ensure they're using the same dependencies.
+	*Options
+
+	// Updater syncs the source from the parsed cache to the cluster.
+	*Updater
+
+	// StatusUpdatePeriod is how long the Parser waits between updates of the
+	// sync status, to account for management conflict errors from the Remediator.
+	StatusUpdatePeriod time.Duration
 
 	// RenderingEnabled indicates whether the hydration-controller is currently
 	// running for this reconciler.
 	RenderingEnabled bool
-
-	// WebhookEnabled indicates whether the Webhook is currently enabled
-	WebhookEnabled bool
-
-	// Files lists Files in the source of truth.
-	Files
-	// Updater mutates the most-recently-seen versions of objects stored in memory.
-	Updater
-}
-
-// Parser represents a parser that can be pointed at and continuously parse a source.
-type Parser interface {
-	parseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError)
-	ReconcilerStatusFromCluster(ctx context.Context) (*ReconcilerStatus, error)
-	setSourceStatus(ctx context.Context, newStatus *SourceStatus) error
-	setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error
-	SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error
-	options() *Options
-	// SyncErrors returns all the sync errors, including remediator errors,
-	// validation errors, applier errors, and watch update errors.
-	SyncErrors() status.MultiError
-	// K8sClient returns the Kubernetes client that talks to the API server.
-	K8sClient() client.Client
-	// setRequiresRendering sets the requires-rendering annotation on the RSync
-	setRequiresRendering(ctx context.Context, renderingRequired bool) error
-	setSourceAnnotations(ctx context.Context, commit string) error
-}
-
-func (o *Options) k8sClient() client.Client {
-	return o.Client
-}
-
-func (o *Options) discoveryClient() discovery.ServerResourcer {
-	return o.DiscoveryInterface
 }

--- a/pkg/parse/parser.go
+++ b/pkg/parse/parser.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+
+	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/status"
+)
+
+// Parser represents a parser that can be pointed at and continuously parse a source.
+type Parser interface {
+	// ParseSource parses the source manifest files and returns the objects.
+	ParseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError)
+}

--- a/pkg/parse/reconciler.go
+++ b/pkg/parse/reconciler.go
@@ -1,0 +1,117 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+
+	"kpt.dev/configsync/pkg/status"
+)
+
+// Reconciler represents a parser that can be pointed at and continuously parse a source.
+// TODO: Move to reconciler package; requires unwinding dependency cycles
+type Reconciler interface {
+	// Options returns the ReconcilerOptions used by this reconciler.
+	Options() *ReconcilerOptions
+	// SyncStatusClient returns the SyncStatusClient used by this reconciler.
+	SyncStatusClient() SyncStatusClient
+	// Parser returns the Parser used by this reconciler.
+	Parser() Parser
+	// ReconcilerState returns the current state of the parser/reconciler.
+	ReconcilerState() *ReconcilerState
+
+	// Read source manifests from the shared source volume.
+	// Waits for rendering, if enabled.
+	// Updates the RSync status (source, rendering, and syncing condition).
+	//
+	// Read is exposed for use by DefaultRunFunc.
+	Read(ctx context.Context, trigger string, sourceState *sourceState) status.MultiError
+
+	// ParseAndUpdate parses objects from the source manifests, validates them,
+	// and then syncs them to the cluster with the Updater.
+	//
+	// ParseAndUpdate is exposed for use by DefaultRunFunc.
+	ParseAndUpdate(ctx context.Context, trigger string) status.MultiError
+
+	// SetSyncStatus updates `.status.sync` and the Syncing condition, if needed,
+	// as well as `state.syncStatus` and `state.syncingConditionLastUpdate` if
+	// the update is successful.
+	//
+	// SetSyncStatus is exposed for use by the EventHandler, for periodic status
+	// updates.
+	SetSyncStatus(context.Context, *SyncStatus) error
+}
+
+// TODO: Move to reconciler package; requires unwinding dependency cycles
+type reconciler struct {
+	options          *ReconcilerOptions
+	syncStatusClient SyncStatusClient
+	parser           Parser
+	reconcilerState  *ReconcilerState
+}
+
+var _ Reconciler = &reconciler{}
+
+// Options returns the ReconcilerOptions used by this reconciler.
+func (p *reconciler) Options() *ReconcilerOptions {
+	return p.options
+}
+
+// SyncStatusClient returns the SyncStatusClient used by this reconciler.
+func (p *reconciler) SyncStatusClient() SyncStatusClient {
+	return p.syncStatusClient
+}
+
+// ReconcilerState returns the current state of the reconciler.
+func (p *reconciler) Parser() Parser {
+	return p.parser
+}
+
+// ReconcilerState returns the current state of the reconciler.
+func (p *reconciler) ReconcilerState() *ReconcilerState {
+	return p.reconcilerState
+}
+
+// NewRootRunner creates a new runnable parser for parsing a Root repository.
+func NewRootRunner(recOpts *ReconcilerOptions, parseOpts *RootOptions) Reconciler {
+	return &reconciler{
+		options: recOpts,
+		reconcilerState: &ReconcilerState{
+			syncErrorCache: recOpts.SyncErrorCache,
+		},
+		syncStatusClient: &rootSyncStatusClient{
+			options: parseOpts.Options,
+		},
+		parser: &rootSyncParser{
+			options: parseOpts,
+		},
+	}
+}
+
+// NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
+func NewNamespaceRunner(recOpts *ReconcilerOptions, parseOpts *Options) Reconciler {
+	return &reconciler{
+		options: recOpts,
+		reconcilerState: &ReconcilerState{
+			syncErrorCache: recOpts.SyncErrorCache,
+		},
+		syncStatusClient: &repoSyncStatusClient{
+			options: parseOpts,
+		},
+		parser: &repoSyncParser{
+			options: parseOpts,
+		},
+	}
+}

--- a/pkg/parse/repo_sync_client.go
+++ b/pkg/parse/repo_sync_client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,109 +30,43 @@ import (
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/core"
-	"kpt.dev/configsync/pkg/importer/analyzer/ast"
-	"kpt.dev/configsync/pkg/importer/reader"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/util/compare"
-	utildiscovery "kpt.dev/configsync/pkg/util/discovery"
-	"kpt.dev/configsync/pkg/validate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
-func NewNamespaceRunner(opts *Options) Parser {
-	return &namespace{
-		Options: opts,
-	}
+type repoSyncStatusClient struct {
+	options *Options
+	// mux prevents status update conflicts.
+	mux sync.Mutex
 }
 
-type namespace struct {
-	*Options
-}
-
-var _ Parser = &namespace{}
-
-func (p *namespace) options() *Options {
-	return p.Options
-}
-
-// parseSource implements the Parser interface
-func (p *namespace) parseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError) {
-	p.mux.Lock()
-	defer p.mux.Unlock()
-
-	filePaths := reader.FilePaths{
-		RootDir:   state.syncDir,
-		PolicyDir: p.SyncDir,
-		Files:     state.files,
-	}
-	crds, err := p.declaredCRDs()
-	if err != nil {
-		return nil, err
-	}
-	builder := utildiscovery.ScoperBuilder(p.DiscoveryInterface)
-
-	klog.Infof("Parsing files from source dir: %s", state.syncDir.OSPath())
-	objs, err := p.Parser.Parse(filePaths)
-	if err != nil {
-		return nil, err
-	}
-
-	options := validate.Options{
-		ClusterName:  p.ClusterName,
-		SyncName:     p.SyncName,
-		PolicyDir:    p.SyncDir,
-		PreviousCRDs: crds,
-		BuildScoper:  builder,
-		Converter:    p.Converter,
-		// Namespaces and NamespaceSelectors should not be declared in a namespace repo.
-		// So disable the API call and dynamic mode of NamespaceSelector.
-		AllowAPICall:             false,
-		DynamicNSSelectorEnabled: false,
-		WebhookEnabled:           p.WebhookEnabled,
-		FieldManager:             configsync.FieldManager,
-	}
-	options = OptionsForScope(options, p.Scope)
-
-	objs, err = validate.Unstructured(ctx, p.Client, objs, options)
-
-	if status.HasBlockingErrors(err) {
-		return nil, err
-	}
-
-	// Duplicated with root.go.
-	e := addAnnotationsAndLabels(objs, p.Scope, p.SyncName, p.sourceContext(), state.commit)
-	if e != nil {
-		err = status.Append(err, status.InternalErrorf("unable to add annotations and labels: %v", e))
-		return nil, err
-	}
-	return objs, err
-}
-
-// setSourceStatus implements the Parser interface
+// SetSourceStatus implements the Parser interface
 //
-// setSourceStatus sets the source status with a given source state and set of errors.  If errs is empty, all errors
+// SetSourceStatus sets the source status with a given source state and set of errors.  If errs is empty, all errors
 // will be removed from the status.
-func (p *namespace) setSourceStatus(ctx context.Context, newStatus *SourceStatus) error {
+func (p *repoSyncStatusClient) SetSourceStatus(ctx context.Context, newStatus *SourceStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSourceStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus *SourceStatus, denominator int) error {
+func (p *repoSyncStatusClient) setSourceStatusWithRetries(ctx context.Context, newStatus *SourceStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
+	opts := p.options
+
 	// The main idea here is an error-robust way of surfacing to the user that
 	// we're having problems reading from our local clone of their source repository.
 	// This can happen when Kubernetes does weird things with mounted filesystems,
 	// or if an attacker tried to maliciously change the cluster's record of the
 	// source of truth.
 	var rs v1beta1.RepoSync
-	if err := p.Client.Get(ctx, reposync.ObjectKey(p.Scope, p.SyncName), &rs); err != nil {
+	if err := opts.Client.Get(ctx, reposync.ObjectKey(opts.Scope, opts.SyncName), &rs); err != nil {
 		return status.APIServerError(err, "failed to get RepoSync for parser")
 	}
 
@@ -165,7 +100,7 @@ func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus *S
 			cmp.Diff(currentRS.Status, rs.Status))
 	}
 
-	if err := p.Client.Status().Update(ctx, &rs, client.FieldOwner(configsync.FieldManager)); err != nil {
+	if err := opts.Client.Status().Update(ctx, &rs, client.FieldOwner(configsync.FieldManager)); err != nil {
 		// If the update failure was caused by the size of the RepoSync object, we would truncate the errors and retry.
 		if isRequestTooLargeError(err) {
 			klog.Infof("Failed to update RepoSync source status (total error count: %d, denominator: %d): %s.", rs.Status.Source.ErrorSummary.TotalCount, denominator, err)
@@ -176,24 +111,25 @@ func (p *namespace) setSourceStatusWithRetries(ctx context.Context, newStatus *S
 	return nil
 }
 
-func (p *namespace) setSourceAnnotations(ctx context.Context, commit string) error {
+func (p *repoSyncStatusClient) SetSourceAnnotations(ctx context.Context, commit string) error {
+	opts := p.options
 	rs := &v1beta1.RepoSync{}
-	rs.Namespace = string(p.Scope)
-	rs.Name = p.SyncName
+	rs.Namespace = string(opts.Scope)
+	rs.Name = opts.SyncName
 
 	var patch string
-	if p.Options.SourceType == configsync.OciSource ||
-		(p.Options.SourceType == configsync.HelmSource && strings.HasPrefix(p.Options.SourceRepo, "oci://")) {
+	if opts.SourceType == configsync.OciSource ||
+		(opts.SourceType == configsync.HelmSource && strings.HasPrefix(opts.SourceRepo, "oci://")) {
 		patch = fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`,
 			metadata.ImageToSyncAnnotationKey,
-			fmt.Sprintf("%s@sha256:%s", p.Options.SourceRepo, commit),
+			fmt.Sprintf("%s@sha256:%s", opts.SourceRepo, commit),
 		)
 	} else {
 		patch = fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}}`,
 			metadata.ImageToSyncAnnotationKey)
 	}
 
-	err := p.Client.Patch(ctx, rs,
+	err := opts.Client.Patch(ctx, rs,
 		client.RawPatch(types.MergePatchType, []byte(patch)),
 		client.FieldOwner(configsync.FieldManager))
 
@@ -204,9 +140,10 @@ func (p *namespace) setSourceAnnotations(ctx context.Context, commit string) err
 	return nil
 }
 
-func (p *namespace) setRequiresRendering(ctx context.Context, renderingRequired bool) error {
+func (p *repoSyncStatusClient) SetRequiresRendering(ctx context.Context, renderingRequired bool) error {
+	opts := p.options
 	rs := &v1beta1.RepoSync{}
-	if err := p.Client.Get(ctx, reposync.ObjectKey(p.Scope, p.SyncName), rs); err != nil {
+	if err := opts.Client.Get(ctx, reposync.ObjectKey(opts.Scope, opts.SyncName), rs); err != nil {
 		return status.APIServerError(err, "failed to get RepoSync for Parser")
 	}
 	newVal := strconv.FormatBool(renderingRequired)
@@ -216,11 +153,11 @@ func (p *namespace) setRequiresRendering(ctx context.Context, renderingRequired 
 	}
 	existing := rs.DeepCopy()
 	core.SetAnnotation(rs, metadata.RequiresRenderingAnnotationKey, newVal)
-	return p.Client.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(configsync.FieldManager))
+	return opts.Client.Patch(ctx, rs, client.MergeFrom(existing), client.FieldOwner(configsync.FieldManager))
 }
 
-// setRenderingStatus implements the Parser interface
-func (p *namespace) setRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error {
+// SetRenderingStatus implements the Parser interface
+func (p *repoSyncStatusClient) SetRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error {
 	if oldStatus.Equals(newStatus) {
 		return nil
 	}
@@ -230,13 +167,14 @@ func (p *namespace) setRenderingStatus(ctx context.Context, oldStatus, newStatus
 	return p.setRenderingStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setRenderingStatusWithRetries(ctx context.Context, newStatus *RenderingStatus, denominator int) error {
+func (p *repoSyncStatusClient) setRenderingStatusWithRetries(ctx context.Context, newStatus *RenderingStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
+	opts := p.options
 
 	var rs v1beta1.RepoSync
-	if err := p.Client.Get(ctx, reposync.ObjectKey(p.Scope, p.SyncName), &rs); err != nil {
+	if err := opts.Client.Get(ctx, reposync.ObjectKey(opts.Scope, opts.SyncName), &rs); err != nil {
 		return status.APIServerError(err, "failed to get RepoSync for parser")
 	}
 
@@ -270,7 +208,7 @@ func (p *namespace) setRenderingStatusWithRetries(ctx context.Context, newStatus
 			cmp.Diff(currentRS.Status, rs.Status))
 	}
 
-	if err := p.Client.Status().Update(ctx, &rs, client.FieldOwner(configsync.FieldManager)); err != nil {
+	if err := opts.Client.Status().Update(ctx, &rs, client.FieldOwner(configsync.FieldManager)); err != nil {
 		// If the update failure was caused by the size of the RepoSync object, we would truncate the errors and retry.
 		if isRequestTooLargeError(err) {
 			klog.Infof("Failed to update RepoSync rendering status (total error count: %d, denominator: %d): %s.", rs.Status.Rendering.ErrorSummary.TotalCount, denominator, err)
@@ -282,13 +220,14 @@ func (p *namespace) setRenderingStatusWithRetries(ctx context.Context, newStatus
 }
 
 // ReconcilerStatusFromCluster gets the RepoSync sync status from the cluster.
-func (p *namespace) ReconcilerStatusFromCluster(ctx context.Context) (*ReconcilerStatus, error) {
+func (p *repoSyncStatusClient) ReconcilerStatusFromCluster(ctx context.Context) (*ReconcilerStatus, error) {
+	opts := p.options
 	rs := &v1beta1.RepoSync{}
-	if err := p.Client.Get(ctx, reposync.ObjectKey(p.Scope, p.SyncName), rs); err != nil {
+	if err := opts.Client.Get(ctx, reposync.ObjectKey(opts.Scope, opts.SyncName), rs); err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return nil, nil
 		}
-		return nil, status.APIServerError(err, fmt.Sprintf("failed to get the RepoSync object for the %v namespace", p.Scope))
+		return nil, status.APIServerError(err, fmt.Sprintf("failed to get the RepoSync object for the %v namespace", opts.Scope))
 	}
 
 	// Read Syncing condition
@@ -304,26 +243,27 @@ func (p *namespace) ReconcilerStatusFromCluster(ctx context.Context) (*Reconcile
 		}
 	}
 
-	return reconcilerStatusFromRSyncStatus(rs.Status.Status, p.options().SourceType, syncing, syncingConditionLastUpdate), nil
+	return reconcilerStatusFromRSyncStatus(rs.Status.Status, opts.SourceType, syncing, syncingConditionLastUpdate), nil
 }
 
 // SetSyncStatus implements the Parser interface
 // SetSyncStatus sets the RepoSync sync status.
 // `errs` includes the errors encountered during the apply step;
-func (p *namespace) SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error {
+func (p *repoSyncStatusClient) SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.setSyncStatusWithRetries(ctx, newStatus, defaultDenominator)
 }
 
-func (p *namespace) setSyncStatusWithRetries(ctx context.Context, newStatus *SyncStatus, denominator int) error {
+func (p *repoSyncStatusClient) setSyncStatusWithRetries(ctx context.Context, newStatus *SyncStatus, denominator int) error {
 	if denominator <= 0 {
 		return fmt.Errorf("The denominator must be a positive number")
 	}
+	opts := p.options
 
 	rs := &v1beta1.RepoSync{}
-	if err := p.Client.Get(ctx, reposync.ObjectKey(p.Scope, p.SyncName), rs); err != nil {
-		return status.APIServerError(err, fmt.Sprintf("failed to get the RepoSync object for the %v namespace", p.Scope))
+	if err := opts.Client.Get(ctx, reposync.ObjectKey(opts.Scope, opts.SyncName), rs); err != nil {
+		return status.APIServerError(err, fmt.Sprintf("failed to get the RepoSync object for the %v namespace", opts.Scope))
 	}
 
 	currentRS := rs.DeepCopy()
@@ -371,25 +311,13 @@ func (p *namespace) setSyncStatusWithRetries(ctx context.Context, newStatus *Syn
 			cmp.Diff(currentRS.Status, rs.Status))
 	}
 
-	if err := p.Client.Status().Update(ctx, rs, client.FieldOwner(configsync.FieldManager)); err != nil {
+	if err := opts.Client.Status().Update(ctx, rs, client.FieldOwner(configsync.FieldManager)); err != nil {
 		// If the update failure was caused by the size of the RepoSync object, we would truncate the errors and retry.
 		if isRequestTooLargeError(err) {
 			klog.Infof("Failed to update RepoSync sync status (total error count: %d, denominator: %d): %s.", rs.Status.Sync.ErrorSummary.TotalCount, denominator, err)
 			return p.setSyncStatusWithRetries(ctx, newStatus, denominator*2)
 		}
-		return status.APIServerError(err, fmt.Sprintf("failed to update the RepoSync sync status for the %v namespace", p.Scope))
+		return status.APIServerError(err, fmt.Sprintf("failed to update the RepoSync sync status for the %v namespace", opts.Scope))
 	}
 	return nil
-}
-
-// SyncErrors returns all the sync errors, including remediator errors,
-// validation errors, applier errors, and watch update errors.
-// SyncErrors implements the Parser interface
-func (p *namespace) SyncErrors() status.MultiError {
-	return p.SyncErrorCache.Errors()
-}
-
-// K8sClient implements the Parser interface
-func (p *namespace) K8sClient() client.Client {
-	return p.Client
 }

--- a/pkg/parse/repo_sync_parser.go
+++ b/pkg/parse/repo_sync_parser.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/importer/reader"
+	"kpt.dev/configsync/pkg/status"
+	utildiscovery "kpt.dev/configsync/pkg/util/discovery"
+	"kpt.dev/configsync/pkg/validate"
+)
+
+type repoSyncParser struct {
+	options *Options
+}
+
+// ParseSource implements the Parser interface
+func (p *repoSyncParser) ParseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError) {
+	opts := p.options
+	filePaths := reader.FilePaths{
+		RootDir:   state.syncDir,
+		PolicyDir: opts.SyncDir,
+		Files:     state.files,
+	}
+	crds, err := opts.DeclaredResources.DeclaredCRDs()
+	if err != nil {
+		return nil, err
+	}
+	builder := utildiscovery.ScoperBuilder(opts.DiscoveryClient)
+
+	klog.Infof("Parsing files from source dir: %s", state.syncDir.OSPath())
+	objs, err := opts.ConfigParser.Parse(filePaths)
+	if err != nil {
+		return nil, err
+	}
+
+	options := validate.Options{
+		ClusterName:  opts.ClusterName,
+		SyncName:     opts.SyncName,
+		PolicyDir:    opts.SyncDir,
+		PreviousCRDs: crds,
+		BuildScoper:  builder,
+		Converter:    opts.Converter,
+		// Namespaces and NamespaceSelectors should not be declared in a namespace repo.
+		// So disable the API call and dynamic mode of NamespaceSelector.
+		AllowAPICall:             false,
+		DynamicNSSelectorEnabled: false,
+		WebhookEnabled:           opts.WebhookEnabled,
+		FieldManager:             configsync.FieldManager,
+	}
+	options = OptionsForScope(options, opts.Scope)
+
+	objs, err = validate.Unstructured(ctx, opts.Client, objs, options)
+
+	if status.HasBlockingErrors(err) {
+		return nil, err
+	}
+
+	// Duplicated with root.go.
+	e := addAnnotationsAndLabels(objs, opts.Scope, opts.SyncName, opts.Files.sourceContext(), state.commit)
+	if e != nil {
+		err = status.Append(err, status.InternalErrorf("unable to add annotations and labels: %v", e))
+		return nil, err
+	}
+	return objs, err
+}

--- a/pkg/parse/root_reconciler_test.go
+++ b/pkg/parse/root_reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -84,7 +83,7 @@ func gitSpec(repo string, auth configsync.AuthType) core.MetaMutator {
 	}
 }
 
-func TestRoot_Parse(t *testing.T) {
+func TestRootReconciler_ParseAndUpdate(t *testing.T) {
 	fakeMetaTime := metav1.Now().Rfc3339Copy() // truncate to second precision
 	fakeTime := fakeMetaTime.Time
 	fakeClock := fakeclock.NewFakeClock(fakeTime)
@@ -677,33 +676,10 @@ func TestRoot_Parse(t *testing.T) {
 				},
 			}
 			tc.existingObjects = append(tc.existingObjects, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
-			parser := &root{
-				Options: &Options{
-					Clock:              fakeClock,
-					Parser:             fakeConfigParser,
-					SyncName:           rootSyncName,
-					ReconcilerName:     rootReconcilerName,
-					Client:             fakeClient,
-					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-					Converter:          converter,
-					Files:              Files{FileSource: fileSource},
-					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
-					},
-				},
-				RootOptions: &RootOptions{
-					SourceFormat:      tc.format,
-					NamespaceStrategy: tc.namespaceStrategy,
-				},
-			}
 			files := []cmpath.Absolute{
 				"example.yaml",
 			}
-			state := &reconcilerState{
+			state := &ReconcilerState{
 				status: reconcilerStatus.DeepCopy(),
 				cache: cacheForCommit{
 					source: &sourceState{
@@ -718,8 +694,48 @@ func TestRoot_Parse(t *testing.T) {
 						files:   files,
 					},
 				},
+				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 			}
-			if err := parseAndUpdate(context.Background(), parser, triggerReimport, state); err != nil {
+			opts := &Options{
+				Clock:             fakeClock,
+				ConfigParser:      fakeConfigParser,
+				SyncName:          rootSyncName,
+				Scope:             declared.RootScope,
+				ReconcilerName:    rootReconcilerName,
+				Client:            fakeClient,
+				DiscoveryClient:   syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
+				Converter:         converter,
+				Files:             Files{FileSource: fileSource},
+				DeclaredResources: &declared.Resources{},
+			}
+			rootOpts := &RootOptions{
+				Options:           opts,
+				SourceFormat:      tc.format,
+				NamespaceStrategy: tc.namespaceStrategy,
+			}
+			recOpts := &ReconcilerOptions{
+				Options: opts,
+				Updater: &Updater{
+					Scope:          opts.Scope,
+					Resources:      opts.DeclaredResources,
+					Remediator:     &remediatorfake.Remediator{},
+					Applier:        fakeApplier,
+					SyncErrorCache: state.syncErrorCache,
+				},
+				StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+				RenderingEnabled:   false,
+			}
+			reconciler := &reconciler{
+				options: recOpts,
+				syncStatusClient: &rootSyncStatusClient{
+					options: opts,
+				},
+				parser: &rootSyncParser{
+					options: rootOpts,
+				},
+				reconcilerState: state,
+			}
+			if err := reconciler.ParseAndUpdate(context.Background(), triggerReimport); err != nil {
 				t.Fatal(err)
 			}
 
@@ -754,7 +770,7 @@ func TestRoot_Parse(t *testing.T) {
 	}
 }
 
-func TestRoot_DeclaredFields(t *testing.T) {
+func TestRootReconciler_DeclaredFields(t *testing.T) {
 	applySetID := applyset.IDFromSync(rootSyncName, declared.RootScope)
 
 	testCases := []struct {
@@ -915,36 +931,53 @@ func TestRoot_DeclaredFields(t *testing.T) {
 				},
 			}
 			tc.existingObjects = append(tc.existingObjects, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
-			parser := &root{
-				Options: &Options{
-					Clock:              clock.RealClock{}, // TODO: Test with fake clock
-					Parser:             fakeConfigParser,
-					SyncName:           rootSyncName,
-					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, tc.existingObjects...),
-					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-					Converter:          converter,
-					WebhookEnabled:     tc.webhookEnabled,
-					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
-					},
-				},
-				RootOptions: &RootOptions{
-					SourceFormat:      configsync.SourceFormatUnstructured,
-					NamespaceStrategy: configsync.NamespaceStrategyExplicit,
-				},
-			}
-			state := &reconcilerState{
+			state := &ReconcilerState{
 				status: &ReconcilerStatus{},
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
+				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 			}
-			if err := parseAndUpdate(context.Background(), parser, triggerReimport, state); err != nil {
+			opts := &Options{
+				Clock:             clock.RealClock{}, // TODO: Test with fake clock
+				ConfigParser:      fakeConfigParser,
+				SyncName:          rootSyncName,
+				Scope:             declared.RootScope,
+				ReconcilerName:    rootReconcilerName,
+				Client:            syncertest.NewClient(t, core.Scheme, tc.existingObjects...),
+				DiscoveryClient:   syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
+				Converter:         converter,
+				WebhookEnabled:    tc.webhookEnabled,
+				DeclaredResources: &declared.Resources{},
+			}
+			rootOpts := &RootOptions{
+				Options:           opts,
+				SourceFormat:      configsync.SourceFormatUnstructured,
+				NamespaceStrategy: configsync.NamespaceStrategyExplicit,
+			}
+			recOpts := &ReconcilerOptions{
+				Options: opts,
+				Updater: &Updater{
+					Scope:          opts.Scope,
+					Resources:      opts.DeclaredResources,
+					Remediator:     &remediatorfake.Remediator{},
+					Applier:        fakeApplier,
+					SyncErrorCache: state.syncErrorCache,
+				},
+				StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+				RenderingEnabled:   false,
+			}
+			reconciler := &reconciler{
+				options: recOpts,
+				syncStatusClient: &rootSyncStatusClient{
+					options: opts,
+				},
+				parser: &rootSyncParser{
+					options: rootOpts,
+				},
+				reconcilerState: state,
+			}
+			if err := reconciler.ParseAndUpdate(context.Background(), triggerReimport); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1017,7 +1050,7 @@ func fakeParseError(err error, gvks ...schema.GroupVersionKind) status.MultiErro
 	return status.APIServerError(&discovery.ErrGroupDiscoveryFailed{Groups: groups}, "API discovery failed")
 }
 
-func TestRoot_Parse_Discovery(t *testing.T) {
+func TestRootReconciler_Parse_Discovery(t *testing.T) {
 	applySetID := applyset.IDFromSync(rootSyncName, declared.RootScope)
 
 	testCases := []struct {
@@ -1183,35 +1216,52 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
-			parser := &root{
-				Options: &Options{
-					Clock:              clock.RealClock{}, // TODO: Test with fake clock
-					Parser:             fakeConfigParser,
-					SyncName:           rootSyncName,
-					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
-					DiscoveryInterface: tc.discoveryClient,
-					Converter:          converter,
-					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
-					},
-				},
-				RootOptions: &RootOptions{
-					SourceFormat:      configsync.SourceFormatUnstructured,
-					NamespaceStrategy: configsync.NamespaceStrategyImplicit,
-				},
-			}
-			state := &reconcilerState{
+			state := &ReconcilerState{
 				status: &ReconcilerStatus{},
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
+				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 			}
-			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
+			opts := &Options{
+				Clock:             clock.RealClock{}, // TODO: Test with fake clock
+				ConfigParser:      fakeConfigParser,
+				SyncName:          rootSyncName,
+				Scope:             declared.RootScope,
+				ReconcilerName:    rootReconcilerName,
+				Client:            syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
+				DiscoveryClient:   tc.discoveryClient,
+				Converter:         converter,
+				DeclaredResources: &declared.Resources{},
+			}
+			rootOpts := &RootOptions{
+				Options:           opts,
+				SourceFormat:      configsync.SourceFormatUnstructured,
+				NamespaceStrategy: configsync.NamespaceStrategyImplicit,
+			}
+			recOpts := &ReconcilerOptions{
+				Options: opts,
+				Updater: &Updater{
+					Scope:          opts.Scope,
+					Resources:      opts.DeclaredResources,
+					Remediator:     &remediatorfake.Remediator{},
+					Applier:        fakeApplier,
+					SyncErrorCache: state.syncErrorCache,
+				},
+				StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+				RenderingEnabled:   false,
+			}
+			reconciler := &reconciler{
+				options: recOpts,
+				syncStatusClient: &rootSyncStatusClient{
+					options: opts,
+				},
+				parser: &rootSyncParser{
+					options: rootOpts,
+				},
+				reconcilerState: state,
+			}
+			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			// After parsing, the objects set is processed and modified.
@@ -1221,7 +1271,7 @@ func TestRoot_Parse_Discovery(t *testing.T) {
 	}
 }
 
-func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
+func TestRootReconciler_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 	testCases := []struct {
 		name            string
 		parseErrors     status.MultiError
@@ -1275,33 +1325,50 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 					{}, // One Apply call
 				},
 			}
-			parser := &root{
-				Options: &Options{
-					Clock:              clock.RealClock{}, // TODO: Test with fake clock
-					Parser:             fakeConfigParser,
-					SyncName:           rootSyncName,
-					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
-					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
-					},
-				},
-				RootOptions: &RootOptions{
-					SourceFormat: configsync.SourceFormatUnstructured,
-				},
-			}
-			state := &reconcilerState{
+			state := &ReconcilerState{
 				status: &ReconcilerStatus{},
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
+				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 			}
-			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
+			opts := &Options{
+				Clock:             clock.RealClock{}, // TODO: Test with fake clock
+				ConfigParser:      fakeConfigParser,
+				SyncName:          rootSyncName,
+				Scope:             declared.RootScope,
+				ReconcilerName:    rootReconcilerName,
+				Client:            syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
+				DiscoveryClient:   syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
+				DeclaredResources: &declared.Resources{},
+			}
+			rootOpts := &RootOptions{
+				Options:      opts,
+				SourceFormat: configsync.SourceFormatUnstructured,
+			}
+			recOpts := &ReconcilerOptions{
+				Options: opts,
+				Updater: &Updater{
+					Scope:          opts.Scope,
+					Resources:      opts.DeclaredResources,
+					Remediator:     &remediatorfake.Remediator{},
+					Applier:        fakeApplier,
+					SyncErrorCache: state.syncErrorCache,
+				},
+				StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+				RenderingEnabled:   false,
+			}
+			reconciler := &reconciler{
+				options: recOpts,
+				syncStatusClient: &rootSyncStatusClient{
+					options: opts,
+				},
+				parser: &rootSyncParser{
+					options: rootOpts,
+				},
+				reconcilerState: state,
+			}
+			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {
@@ -1311,7 +1378,7 @@ func TestRoot_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 	}
 }
 
-func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
+func TestRootReconciler_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 	testCases := []struct {
 		name            string
 		applyErrors     []status.Error
@@ -1367,583 +1434,55 @@ func TestRoot_SourceAndSyncReconcilerErrorsMetricValidation(t *testing.T) {
 					{Errors: tc.applyErrors}, // One Apply call, optional errors
 				},
 			}
-			parser := &root{
-				Options: &Options{
-					Clock:  clock.RealClock{}, // TODO: Test with fake clock
-					Parser: fakeConfigParser,
-					Updater: Updater{
-						Scope:          declared.RootScope,
-						Resources:      &declared.Resources{},
-						Remediator:     &remediatorfake.Remediator{},
-						Applier:        fakeApplier,
-						SyncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
-					},
-					SyncName:           rootSyncName,
-					ReconcilerName:     rootReconcilerName,
-					Client:             syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
-					DiscoveryInterface: syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
-				},
-				RootOptions: &RootOptions{
-					SourceFormat: configsync.SourceFormatUnstructured,
-				},
-			}
-			state := &reconcilerState{
+			state := &ReconcilerState{
 				status: &ReconcilerStatus{},
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
+				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
 			}
-			err := parseAndUpdate(context.Background(), parser, triggerReimport, state)
+			opts := &Options{
+				Clock:             clock.RealClock{}, // TODO: Test with fake clock
+				ConfigParser:      fakeConfigParser,
+				SyncName:          rootSyncName,
+				Scope:             declared.RootScope,
+				ReconcilerName:    rootReconcilerName,
+				Client:            syncertest.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName)),
+				DiscoveryClient:   syncertest.NewDiscoveryClient(kinds.Namespace(), kinds.Role()),
+				DeclaredResources: &declared.Resources{},
+			}
+			rootOpts := &RootOptions{
+				Options:      opts,
+				SourceFormat: configsync.SourceFormatUnstructured,
+			}
+			recOpts := &ReconcilerOptions{
+				Options: opts,
+				Updater: &Updater{
+					Scope:          opts.Scope,
+					Resources:      opts.DeclaredResources,
+					Remediator:     &remediatorfake.Remediator{},
+					Applier:        fakeApplier,
+					SyncErrorCache: state.syncErrorCache,
+				},
+				StatusUpdatePeriod: configsync.DefaultReconcilerSyncStatusUpdatePeriod,
+				RenderingEnabled:   false,
+			}
+			reconciler := &reconciler{
+				options: recOpts,
+				syncStatusClient: &rootSyncStatusClient{
+					options: opts,
+				},
+				parser: &rootSyncParser{
+					options: rootOpts,
+				},
+				reconcilerState: state,
+			}
+			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {
 				t.Error(diff)
 			}
-		})
-	}
-}
-
-func TestSummarizeErrors(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		sourceStatus         v1beta1.SourceStatus
-		renderingStatus      v1beta1.RenderingStatus
-		syncStatus           v1beta1.SyncStatus
-		expectedErrorSources []v1beta1.ErrorSource
-		expectedErrorSummary *v1beta1.ErrorSummary
-	}{
-		{
-			name:                 "both sourceStatus and syncStatus are empty",
-			sourceStatus:         v1beta1.SourceStatus{},
-			renderingStatus:      v1beta1.RenderingStatus{},
-			syncStatus:           v1beta1.SyncStatus{},
-			expectedErrorSources: nil,
-			expectedErrorSummary: &v1beta1.ErrorSummary{},
-		},
-		{
-			name: "sourceStatus is not empty (no trucation), syncStatus is empty",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus:      v1beta1.RenderingStatus{},
-			syncStatus:           v1beta1.SyncStatus{},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                2,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 2,
-			},
-		},
-		{
-			name: "sourceStatus is not empty and trucates errors, syncStatus is empty",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus:      v1beta1.RenderingStatus{},
-			syncStatus:           v1beta1.SyncStatus{},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                100,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 2,
-			},
-		},
-		{
-			name:            "sourceStatus is empty, syncStatus is not empty (no trucation)",
-			sourceStatus:    v1beta1.SourceStatus{},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                2,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 2,
-			},
-		},
-		{
-			name:            "sourceStatus is empty, syncStatus is not empty and trucates errors",
-			sourceStatus:    v1beta1.SourceStatus{},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                100,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 2,
-			},
-		},
-		{
-			name: "neither sourceStatus nor syncStatus is empty or trucates errors",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                4,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 4,
-			},
-		},
-		{
-			name: "neither sourceStatus nor syncStatus is empty, sourceStatus trucates errors",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                102,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 4,
-			},
-		},
-		{
-			name: "neither sourceStatus nor syncStatus is empty, syncStatus trucates errors",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                102,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 4,
-			},
-		},
-		{
-			name: "neither sourceStatus nor syncStatus is empty, both trucates errors",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                200,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 4,
-			},
-		},
-		{
-			name: "source, rendering, and sync errors",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1068", ErrorMessage: "1068-error-message"},
-					{Code: "2015", ErrorMessage: "2015-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.RenderingError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                6,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 6,
-			},
-		},
-		{
-			name: "source, rendering, and sync errors, all truncated",
-			sourceStatus: v1beta1.SourceStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-					{Code: "1022", ErrorMessage: "1022-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1068", ErrorMessage: "1068-error-message"},
-					{Code: "2015", ErrorMessage: "2015-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			syncStatus: v1beta1.SyncStatus{
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                100,
-					Truncated:                 true,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.RenderingError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                300,
-				Truncated:                 true,
-				ErrorCountAfterTruncation: 6,
-			},
-		},
-		{
-			name: "source errors from newer commit",
-			sourceStatus: v1beta1.SourceStatus{
-				Commit: "newer-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                1,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 1,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{
-				Commit: "older-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1068", ErrorMessage: "1068-error-message"},
-					{Code: "2015", ErrorMessage: "2015-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			syncStatus: v1beta1.SyncStatus{
-				Commit: "older-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-					{Code: "2009", ErrorMessage: "another error"},
-					{Code: "2009", ErrorMessage: "yet-another error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                4,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 4,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                6,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 6,
-			},
-		},
-		{
-			name: "rendering errors from newer commit",
-			sourceStatus: v1beta1.SourceStatus{
-				Commit: "newer-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1021", ErrorMessage: "1021-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                1,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 1,
-				},
-			},
-			renderingStatus: v1beta1.RenderingStatus{
-				Commit: "newer-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "1068", ErrorMessage: "1068-error-message"},
-					{Code: "2015", ErrorMessage: "2015-error-message"},
-				},
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                2,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 2,
-				},
-			},
-			syncStatus: v1beta1.SyncStatus{
-				Commit: "older-commit",
-				Errors: []v1beta1.ConfigSyncError{
-					{Code: "2009", ErrorMessage: "apiserver error"},
-					{Code: "2009", ErrorMessage: "webhook error"},
-					{Code: "2009", ErrorMessage: "another error"},
-					{Code: "2009", ErrorMessage: "yet-another error"},
-				},
-
-				ErrorSummary: &v1beta1.ErrorSummary{
-					TotalCount:                4,
-					Truncated:                 false,
-					ErrorCountAfterTruncation: 4,
-				},
-			},
-			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
-			expectedErrorSummary: &v1beta1.ErrorSummary{
-				TotalCount:                4,
-				Truncated:                 false,
-				ErrorCountAfterTruncation: 4,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotErrorSources, gotErrorSummary := summarizeErrorsForCommit(tc.sourceStatus, tc.renderingStatus, tc.syncStatus, tc.syncStatus.Commit)
-			if diff := cmp.Diff(tc.expectedErrorSources, gotErrorSources); diff != "" {
-				t.Errorf("summarizeErrors() got %v, expected %v", gotErrorSources, tc.expectedErrorSources)
-			}
-			if diff := cmp.Diff(tc.expectedErrorSummary, gotErrorSummary); diff != "" {
-				t.Errorf("summarizeErrors() got %v, expected %v", gotErrorSummary, tc.expectedErrorSummary)
-			}
-		})
-	}
-}
-
-func TestPrependRootSyncRemediatorStatus(t *testing.T) {
-	const rootSyncName = "my-root-sync"
-	const thisManager = "this-manager"
-	const otherManager = "other-manager"
-	conflictingObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, otherManager))
-	conflictAB := status.ManagementConflictErrorWrap(conflictingObject, thisManager)
-	invertedObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, thisManager))
-	conflictBA := status.ManagementConflictErrorWrap(invertedObject, otherManager)
-	conflictABInverted := conflictAB.Invert()
-	// KptManagementConflictError is created with the desired object, not the current live object.
-	// So its manager annotation matches the reconciler doing the applying.
-	// This is the opposite of the objects passed to ManagementConflictErrorWrap.
-	kptConflictError := applier.KptManagementConflictError(invertedObject)
-	// Assert the value of each error message to make each value clear
-	const conflictABMessage = `KNV1060: The "this-manager" reconciler detected a management conflict with the "other-manager" reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
-
-metadata.name: foo-ns
-group:
-version: v1
-kind: Namespace
-
-For more information, see https://g.co/cloud/acm-errors#knv1060`
-	const conflictBAMessage = `KNV1060: The "other-manager" reconciler detected a management conflict with the "this-manager" reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
-
-metadata.name: foo-ns
-group:
-version: v1
-kind: Namespace
-
-For more information, see https://g.co/cloud/acm-errors#knv1060`
-	const kptConflictMessage = `KNV1060: The "this-manager" reconciler detected a management conflict with another reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
-
-metadata.name: foo-ns
-group:
-version: v1
-kind: Namespace
-
-For more information, see https://g.co/cloud/acm-errors#knv1060`
-	testutil.AssertEqual(t, conflictABMessage, conflictAB.ToCSE().ErrorMessage)
-	testutil.AssertEqual(t, conflictBAMessage, conflictBA.ToCSE().ErrorMessage)
-	testutil.AssertEqual(t, kptConflictMessage, kptConflictError.ToCSE().ErrorMessage)
-	testutil.AssertEqual(t, conflictBA, conflictABInverted)
-	testCases := map[string]struct {
-		thisSyncErrors []v1beta1.ConfigSyncError
-		expectedErrors []v1beta1.ConfigSyncError
-	}{
-		"empty errors": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictAB.ToCSE(),
-			},
-		},
-		"unchanged conflict error": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{
-				conflictAB.ToCSE(),
-			},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictAB.ToCSE(),
-			},
-		},
-		"prepend conflict error": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{
-				{ErrorMessage: "foo"},
-			},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictAB.ToCSE(),
-				{ErrorMessage: "foo"},
-			},
-		},
-		"dedupe AB and BA errors": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{
-				conflictBA.ToCSE(),
-			},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictBA.ToCSE(),
-			},
-		},
-		"dedupe AB and AB inverted errors": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{
-				conflictABInverted.ToCSE(),
-			},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictABInverted.ToCSE(),
-			},
-		},
-		// TODO: De-dupe ManagementConflictErrorWrap & KptManagementConflictError
-		// These are currently de-duped locally by the conflict handler,
-		// but not remotely by prependRootSyncRemediatorStatus.
-		"prepend KptManagementConflictError": {
-			thisSyncErrors: []v1beta1.ConfigSyncError{
-				kptConflictError.ToCSE(),
-			},
-			expectedErrors: []v1beta1.ConfigSyncError{
-				conflictAB.ToCSE(),
-				kptConflictError.ToCSE(),
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncName)
-			rootSync.Status.Sync.Errors = tc.thisSyncErrors
-			fakeClient := syncertest.NewClient(t, core.Scheme, rootSync)
-			ctx := context.Background()
-			err := prependRootSyncRemediatorStatus(ctx, fakeClient, rootSyncName,
-				[]status.ManagementConflictError{conflictAB}, defaultDenominator)
-			require.NoError(t, err)
-			var updatedRootSync v1beta1.RootSync
-			err = fakeClient.Get(ctx, rootsync.ObjectKey(rootSyncName), &updatedRootSync)
-			require.NoError(t, err)
-			testutil.AssertEqual(t, tc.expectedErrors, updatedRootSync.Status.Sync.Errors)
 		})
 	}
 }

--- a/pkg/parse/root_sync_client_test.go
+++ b/pkg/parse/root_sync_client_test.go
@@ -1,0 +1,577 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/rootsync"
+	"kpt.dev/configsync/pkg/status"
+	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestSummarizeErrors(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		sourceStatus         v1beta1.SourceStatus
+		renderingStatus      v1beta1.RenderingStatus
+		syncStatus           v1beta1.SyncStatus
+		expectedErrorSources []v1beta1.ErrorSource
+		expectedErrorSummary *v1beta1.ErrorSummary
+	}{
+		{
+			name:                 "both sourceStatus and syncStatus are empty",
+			sourceStatus:         v1beta1.SourceStatus{},
+			renderingStatus:      v1beta1.RenderingStatus{},
+			syncStatus:           v1beta1.SyncStatus{},
+			expectedErrorSources: nil,
+			expectedErrorSummary: &v1beta1.ErrorSummary{},
+		},
+		{
+			name: "sourceStatus is not empty (no trucation), syncStatus is empty",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus:      v1beta1.RenderingStatus{},
+			syncStatus:           v1beta1.SyncStatus{},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                2,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 2,
+			},
+		},
+		{
+			name: "sourceStatus is not empty and trucates errors, syncStatus is empty",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus:      v1beta1.RenderingStatus{},
+			syncStatus:           v1beta1.SyncStatus{},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                100,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 2,
+			},
+		},
+		{
+			name:            "sourceStatus is empty, syncStatus is not empty (no trucation)",
+			sourceStatus:    v1beta1.SourceStatus{},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                2,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 2,
+			},
+		},
+		{
+			name:            "sourceStatus is empty, syncStatus is not empty and trucates errors",
+			sourceStatus:    v1beta1.SourceStatus{},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                100,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 2,
+			},
+		},
+		{
+			name: "neither sourceStatus nor syncStatus is empty or trucates errors",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                4,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 4,
+			},
+		},
+		{
+			name: "neither sourceStatus nor syncStatus is empty, sourceStatus trucates errors",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                102,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 4,
+			},
+		},
+		{
+			name: "neither sourceStatus nor syncStatus is empty, syncStatus trucates errors",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                102,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 4,
+			},
+		},
+		{
+			name: "neither sourceStatus nor syncStatus is empty, both trucates errors",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                200,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 4,
+			},
+		},
+		{
+			name: "source, rendering, and sync errors",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1068", ErrorMessage: "1068-error-message"},
+					{Code: "2015", ErrorMessage: "2015-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.RenderingError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                6,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 6,
+			},
+		},
+		{
+			name: "source, rendering, and sync errors, all truncated",
+			sourceStatus: v1beta1.SourceStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+					{Code: "1022", ErrorMessage: "1022-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1068", ErrorMessage: "1068-error-message"},
+					{Code: "2015", ErrorMessage: "2015-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			syncStatus: v1beta1.SyncStatus{
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                100,
+					Truncated:                 true,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SourceError, v1beta1.RenderingError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                300,
+				Truncated:                 true,
+				ErrorCountAfterTruncation: 6,
+			},
+		},
+		{
+			name: "source errors from newer commit",
+			sourceStatus: v1beta1.SourceStatus{
+				Commit: "newer-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                1,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 1,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{
+				Commit: "older-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1068", ErrorMessage: "1068-error-message"},
+					{Code: "2015", ErrorMessage: "2015-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			syncStatus: v1beta1.SyncStatus{
+				Commit: "older-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+					{Code: "2009", ErrorMessage: "another error"},
+					{Code: "2009", ErrorMessage: "yet-another error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                4,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 4,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.RenderingError, v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                6,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 6,
+			},
+		},
+		{
+			name: "rendering errors from newer commit",
+			sourceStatus: v1beta1.SourceStatus{
+				Commit: "newer-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1021", ErrorMessage: "1021-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                1,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 1,
+				},
+			},
+			renderingStatus: v1beta1.RenderingStatus{
+				Commit: "newer-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "1068", ErrorMessage: "1068-error-message"},
+					{Code: "2015", ErrorMessage: "2015-error-message"},
+				},
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                2,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 2,
+				},
+			},
+			syncStatus: v1beta1.SyncStatus{
+				Commit: "older-commit",
+				Errors: []v1beta1.ConfigSyncError{
+					{Code: "2009", ErrorMessage: "apiserver error"},
+					{Code: "2009", ErrorMessage: "webhook error"},
+					{Code: "2009", ErrorMessage: "another error"},
+					{Code: "2009", ErrorMessage: "yet-another error"},
+				},
+
+				ErrorSummary: &v1beta1.ErrorSummary{
+					TotalCount:                4,
+					Truncated:                 false,
+					ErrorCountAfterTruncation: 4,
+				},
+			},
+			expectedErrorSources: []v1beta1.ErrorSource{v1beta1.SyncError},
+			expectedErrorSummary: &v1beta1.ErrorSummary{
+				TotalCount:                4,
+				Truncated:                 false,
+				ErrorCountAfterTruncation: 4,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErrorSources, gotErrorSummary := summarizeErrorsForCommit(tc.sourceStatus, tc.renderingStatus, tc.syncStatus, tc.syncStatus.Commit)
+			if diff := cmp.Diff(tc.expectedErrorSources, gotErrorSources); diff != "" {
+				t.Errorf("summarizeErrors() got %v, expected %v", gotErrorSources, tc.expectedErrorSources)
+			}
+			if diff := cmp.Diff(tc.expectedErrorSummary, gotErrorSummary); diff != "" {
+				t.Errorf("summarizeErrors() got %v, expected %v", gotErrorSummary, tc.expectedErrorSummary)
+			}
+		})
+	}
+}
+
+func TestPrependRootSyncRemediatorStatus(t *testing.T) {
+	const rootSyncName = "my-root-sync"
+	const thisManager = "this-manager"
+	const otherManager = "other-manager"
+	conflictingObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, otherManager))
+	conflictAB := status.ManagementConflictErrorWrap(conflictingObject, thisManager)
+	invertedObject := k8sobjects.NamespaceObject("foo-ns", core.Annotation(metadata.ResourceManagerKey, thisManager))
+	conflictBA := status.ManagementConflictErrorWrap(invertedObject, otherManager)
+	conflictABInverted := conflictAB.Invert()
+	// KptManagementConflictError is created with the desired object, not the current live object.
+	// So its manager annotation matches the reconciler doing the applying.
+	// This is the opposite of the objects passed to ManagementConflictErrorWrap.
+	kptConflictError := applier.KptManagementConflictError(invertedObject)
+	// Assert the value of each error message to make each value clear
+	const conflictABMessage = `KNV1060: The "this-manager" reconciler detected a management conflict with the "other-manager" reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
+
+metadata.name: foo-ns
+group:
+version: v1
+kind: Namespace
+
+For more information, see https://g.co/cloud/acm-errors#knv1060`
+	const conflictBAMessage = `KNV1060: The "other-manager" reconciler detected a management conflict with the "this-manager" reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
+
+metadata.name: foo-ns
+group:
+version: v1
+kind: Namespace
+
+For more information, see https://g.co/cloud/acm-errors#knv1060`
+	const kptConflictMessage = `KNV1060: The "this-manager" reconciler detected a management conflict with another reconciler. Remove the object from one of the sources of truth so that the object is only managed by one reconciler.
+
+metadata.name: foo-ns
+group:
+version: v1
+kind: Namespace
+
+For more information, see https://g.co/cloud/acm-errors#knv1060`
+	testutil.AssertEqual(t, conflictABMessage, conflictAB.ToCSE().ErrorMessage)
+	testutil.AssertEqual(t, conflictBAMessage, conflictBA.ToCSE().ErrorMessage)
+	testutil.AssertEqual(t, kptConflictMessage, kptConflictError.ToCSE().ErrorMessage)
+	testutil.AssertEqual(t, conflictBA, conflictABInverted)
+	testCases := map[string]struct {
+		thisSyncErrors []v1beta1.ConfigSyncError
+		expectedErrors []v1beta1.ConfigSyncError
+	}{
+		"empty errors": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictAB.ToCSE(),
+			},
+		},
+		"unchanged conflict error": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{
+				conflictAB.ToCSE(),
+			},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictAB.ToCSE(),
+			},
+		},
+		"prepend conflict error": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{
+				{ErrorMessage: "foo"},
+			},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictAB.ToCSE(),
+				{ErrorMessage: "foo"},
+			},
+		},
+		"dedupe AB and BA errors": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{
+				conflictBA.ToCSE(),
+			},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictBA.ToCSE(),
+			},
+		},
+		"dedupe AB and AB inverted errors": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{
+				conflictABInverted.ToCSE(),
+			},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictABInverted.ToCSE(),
+			},
+		},
+		// TODO: De-dupe ManagementConflictErrorWrap & KptManagementConflictError
+		// These are currently de-duped locally by the conflict handler,
+		// but not remotely by prependRootSyncRemediatorStatus.
+		"prepend KptManagementConflictError": {
+			thisSyncErrors: []v1beta1.ConfigSyncError{
+				kptConflictError.ToCSE(),
+			},
+			expectedErrors: []v1beta1.ConfigSyncError{
+				conflictAB.ToCSE(),
+				kptConflictError.ToCSE(),
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			rootSync := k8sobjects.RootSyncObjectV1Beta1(rootSyncName)
+			rootSync.Status.Sync.Errors = tc.thisSyncErrors
+			fakeClient := syncertest.NewClient(t, core.Scheme, rootSync)
+			ctx := context.Background()
+			err := prependRootSyncRemediatorStatus(ctx, fakeClient, rootSyncName,
+				[]status.ManagementConflictError{conflictAB}, defaultDenominator)
+			require.NoError(t, err)
+			var updatedRootSync v1beta1.RootSync
+			err = fakeClient.Get(ctx, rootsync.ObjectKey(rootSyncName), &updatedRootSync)
+			require.NoError(t, err)
+			testutil.AssertEqual(t, tc.expectedErrors, updatedRootSync.Status.Sync.Errors)
+		})
+	}
+}

--- a/pkg/parse/root_sync_parser.go
+++ b/pkg/parse/root_sync_parser.go
@@ -1,0 +1,177 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elliotchance/orderedmap/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/declared"
+	"kpt.dev/configsync/pkg/diff"
+	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/importer/filesystem"
+	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
+	"kpt.dev/configsync/pkg/importer/reader"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/util/discovery"
+	"kpt.dev/configsync/pkg/validate"
+	"sigs.k8s.io/cli-utils/pkg/common"
+)
+
+type rootSyncParser struct {
+	options *RootOptions
+}
+
+// ParseSource implements the Parser interface
+func (p *rootSyncParser) ParseSource(ctx context.Context, state *sourceState) ([]ast.FileObject, status.MultiError) {
+	opts := p.options
+
+	wantFiles := state.files
+	if opts.SourceFormat == configsync.SourceFormatHierarchy {
+		// We're using hierarchical mode for the root repository, so ignore files
+		// outside of the allowed directories.
+		wantFiles = filesystem.FilterHierarchyFiles(state.syncDir, wantFiles)
+	}
+
+	filePaths := reader.FilePaths{
+		RootDir:   state.syncDir,
+		PolicyDir: p.options.SyncDir,
+		Files:     wantFiles,
+	}
+
+	crds, err := opts.DeclaredResources.DeclaredCRDs()
+	if err != nil {
+		return nil, err
+	}
+	builder := discovery.ScoperBuilder(opts.DiscoveryClient)
+
+	klog.Infof("Parsing files from source dir: %s", state.syncDir.OSPath())
+	objs, err := opts.ConfigParser.Parse(filePaths)
+	if err != nil {
+		return nil, err
+	}
+
+	options := validate.Options{
+		ClusterName:  opts.ClusterName,
+		SyncName:     opts.SyncName,
+		PolicyDir:    opts.SyncDir,
+		PreviousCRDs: crds,
+		BuildScoper:  builder,
+		Converter:    opts.Converter,
+		// Enable API call so NamespaceSelector can talk to k8s-api-server.
+		AllowAPICall:             true,
+		DynamicNSSelectorEnabled: opts.DynamicNSSelectorEnabled,
+		NSControllerState:        opts.NSControllerState,
+		WebhookEnabled:           opts.WebhookEnabled,
+		FieldManager:             configsync.FieldManager,
+	}
+	options = OptionsForScope(options, opts.Scope)
+
+	if opts.SourceFormat == configsync.SourceFormatUnstructured {
+		if opts.NamespaceStrategy == configsync.NamespaceStrategyImplicit {
+			options.Visitors = append(options.Visitors, p.addImplicitNamespaces)
+		}
+		objs, err = validate.Unstructured(ctx, opts.Client, objs, options)
+	} else {
+		objs, err = validate.Hierarchical(objs, options)
+	}
+
+	if status.HasBlockingErrors(err) {
+		return nil, err
+	}
+
+	// Duplicated with namespace.go.
+	e := addAnnotationsAndLabels(objs, declared.RootScope, opts.SyncName, opts.Files.sourceContext(), state.commit)
+	if e != nil {
+		err = status.Append(err, status.InternalErrorf("unable to add annotations and labels: %v", e))
+		return nil, err
+	}
+	return objs, err
+}
+
+// addImplicitNamespaces hydrates the given FileObjects by injecting implicit
+// namespaces into the list before returning it. Implicit namespaces are those
+// that are declared by an object's metadata namespace field but are not present
+// in the list. The implicit namespace is only added if it doesn't exist.
+func (p *rootSyncParser) addImplicitNamespaces(objs []ast.FileObject) ([]ast.FileObject, status.MultiError) {
+	opts := p.options
+	var errs status.MultiError
+	// namespaces will track the set of Namespaces we expect to exist, and those
+	// which actually do.
+	namespaces := orderedmap.NewOrderedMap[string, bool]()
+
+	for _, o := range objs {
+		if o.GetObjectKind().GroupVersionKind().GroupKind() == kinds.Namespace().GroupKind() {
+			namespaces.Set(o.GetName(), true)
+		} else if o.GetNamespace() != "" {
+			if _, found := namespaces.Get(o.GetNamespace()); !found {
+				// If unset, this ensures the key exists and is false.
+				// Otherwise it has no impact.
+				namespaces.Set(o.GetNamespace(), false)
+			}
+		}
+	}
+
+	for e := namespaces.Front(); e != nil; e = e.Next() {
+		ns, isDeclared := e.Key, e.Value
+		// Do not treat config-management-system as an implicit namespace for multi-sync support.
+		// Otherwise, the namespace will become a managed resource, and will cause conflict among multiple RootSyncs.
+		if isDeclared || ns == configsync.ControllerNamespace {
+			continue
+		}
+		existingNs := &corev1.Namespace{}
+		err := opts.Client.Get(context.Background(), types.NamespacedName{Name: ns}, existingNs)
+		if err != nil && !apierrors.IsNotFound(err) {
+			errs = status.Append(errs, fmt.Errorf("unable to check the existence of the implicit namespace %q: %w", ns, err))
+			continue
+		}
+
+		existingNs.SetGroupVersionKind(kinds.Namespace())
+		// If the namespace already exists and not self-managed, do not add it as an implicit namespace.
+		// This is to avoid conflicts caused by multiple Root reconcilers managing the same implicit namespace.
+		if err == nil && !diff.IsManager(opts.Scope, opts.SyncName, existingNs) {
+			continue
+		}
+
+		// Add the implicit namespace if it doesn't exist, or if it is managed by itself.
+		// If it is a self-managed namespace, still add it to the object list. Otherwise,
+		// it will be pruned because it is no longer in the inventory list.
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(kinds.Namespace())
+		u.SetName(ns)
+		// We do NOT want to delete theses implicit Namespaces when the resources
+		// inside them are removed from the repo. We don't know when it is safe to remove
+		// the implicit namespaces. An implicit namespace may already exist in the
+		// cluster. Deleting it will cause other unmanaged resources in that namespace
+		// being deleted.
+		//
+		// Adding the LifecycleDeleteAnnotation is to prevent the applier from deleting
+		// the implicit namespace when the namespaced config is removed from the repo.
+		// Note that if the user later declares the
+		// Namespace without this annotation, the annotation is removed as expected.
+		u.SetAnnotations(map[string]string{common.LifecycleDeleteAnnotation: common.PreventDeletion})
+		objs = append(objs, ast.NewFileObject(u, cmpath.RelativeOS("")))
+	}
+
+	return objs, errs
+}

--- a/pkg/parse/sync_status_client.go
+++ b/pkg/parse/sync_status_client.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"context"
+)
+
+// SyncStatusClient provides methods to read and write RSync object status.
+type SyncStatusClient interface {
+	// ReconcilerStatusFromCluster reads the status of the reconciler from the RSync status.
+	ReconcilerStatusFromCluster(ctx context.Context) (*ReconcilerStatus, error)
+	// SetSourceStatus sets the source status and syncing condition on the RSync.
+	SetSourceStatus(ctx context.Context, newStatus *SourceStatus) error
+	// SetRenderingStatus sets the rendering status and syncing condition on the RSync.
+	SetRenderingStatus(ctx context.Context, oldStatus, newStatus *RenderingStatus) error
+	// SetSyncStatus sets the sync status and syncing condition on the RSync.
+	SetSyncStatus(ctx context.Context, newStatus *SyncStatus) error
+	// SetRequiresRendering sets the requires-rendering annotation on the RSync.
+	SetRequiresRendering(ctx context.Context, renderingRequired bool) error
+	// SetSourceAnnotations sets the source annotations on the RSync.
+	SetSourceAnnotations(ctx context.Context, commit string) error
+}


### PR DESCRIPTION
- Split the Parser interface into Parser & SyncStatusClient.
- Replace the root & namespace structs with seperate implementations of the Parser & SyncStatusClient interfaces.
- Create a new common reconciler struct which composes the Parser & SyncStatusClient interfaces. The reconciler struct can now hold common methods, and the current ReconcilerState, which encompases spec, status, and cache for all reconciler phases, not just the parser.
- Add a new Reconciler interface, for use by the EventHandler and DefaultRunFunc. We may want to move DefaultRunFunc to be a reconciler method in the future, but this would relocate all the run code, so we can do it in a seperate change.
- Move the Mutex out of the Options and into the Reconciler. Options should generally not be mutated after construction.
- Change interface methods to public. There's no reason to have private interface methods, even if the interface itself is private.
- Add ReconcilerOptions, to contain options that the Parser doesn't use itself. ReconcilerOptions extends parse.Options to ensure the injected values are consistent and simplify usage.
- Move SyncErrorCache into the ReconcilerState, since it's not just Parser or Updater errors.
- Move DeclaredCRDs method from the Updater into declared.Resources. Then inject the resources into the Parser, so it doesn't need to depend on the whole Updater just to get the list of valid CRDs. The naming here is still confusing, since it's not just the resource/objects declared in the source, but actually the set of valid & unskipped/known-scoped source objects, after being parsed. Managing the declared.Resources should probably be moved from the Updater to the Reconciler in the future.