### PR TITLE
[WIP] fix: retry event delay

### DIFF
--- a/pkg/parse/event_handler.go
+++ b/pkg/parse/event_handler.go
@@ -136,7 +136,7 @@ func (s *EventHandler) Handle(event events.Event) events.Result {
 		} else if opts.needToUpdateWatch() {
 			trigger = triggerWatchUpdate
 		} else {
-			// No RunFunc call
+			klog.Info("Skipping retry attempt: not needed")
 			break
 		}
 

--- a/pkg/parse/event_handler.go
+++ b/pkg/parse/event_handler.go
@@ -67,22 +67,21 @@ func (s *EventHandler) Handle(event events.Event) events.Result {
 	var runResult RunResult
 	switch event.Type {
 	case events.SyncWithReimportEventType:
-		// Re-apply even if no changes have been detected.
-		// This case should be checked first since it resets the cache.
-		// If the reconciler is in the process of reconciling a given commit, the resync won't
-		// happen until the ongoing reconciliation is done.
-		klog.Infof("It is time for a force-resync")
-		// Reset the cache partially to make sure all the steps of a parse-apply-watch loop will run.
-		// The cached sourceState will not be reset to avoid reading all the source files unnecessarily.
-		// The cached needToRetry will not be reset to avoid resetting the backoff retries.
-		state.resetPartialCache()
-		runResult = runFn(s.Context, s.Reconciler, triggerResync)
+		// Reimport = Read* + Render* + Parse + Update
+		//
+		// * Read & Render will only happen if there's a new commit, new source
+		//   spec change, or a previous error invalidated the cache.
+		//   Otherwise re-import starts from re-parsing the objects from disk.
+		runResult = runFn(s.Context, s.Reconciler, triggerReimport)
 
 	case events.SyncEventType:
-		// Re-import declared resources from the filesystem (from *-sync).
-		// If the reconciler is in the process of reconciling a given commit, the re-import won't
-		// happen until the ongoing reconciliation is done.
-		runResult = runFn(s.Context, s.Reconciler, triggerReimport)
+		// Resync = Read* + Render* + Parse* + Update
+		//
+		// * Read, Render, and Parse will only happen if there's a new commit,
+		//   new source spec change, or a previous error invalidated the cache.
+		//   Otherwise re-sync skips directly to the Update stage, using the
+		//   previously parsed in-memory object cache.
+		runResult = runFn(s.Context, s.Reconciler, triggerResync)
 
 	case events.StatusEventType:
 		// Publish the sync status periodically to update remediator errors.
@@ -108,43 +107,20 @@ func (s *EventHandler) Handle(event events.Event) events.Result {
 		}
 
 	case events.NamespaceResyncEventType:
-		// If the namespace controller indicates that an update is needed,
-		// attempt to re-sync.
+		// Reimport & Resync if the namespace controller detected a change.
 		if !s.NSControllerState.ScheduleSync() {
 			// No RunFunc call
 			break
 		}
-
-		klog.Infof("A new sync is triggered by a Namespace event")
-		// Reset the cache partially to make sure all the steps of a parse-apply-watch loop will run.
-		// The cached sourceState will not be reset to avoid reading all the source files unnecessarily.
-		// The cached needToRetry will not be reset to avoid resetting the backoff retries.
-		state.resetPartialCache()
 		runResult = runFn(s.Context, s.Reconciler, namespaceEvent)
 
 	case events.RetrySyncEventType:
-		// Retry if there was an error, conflict, or any watches need to be updated.
-		var trigger string
-		if opts.HasManagementConflict() {
-			// Reset the cache partially to make sure all the steps of a parse-apply-watch loop will run.
-			// The cached sourceState will not be reset to avoid reading all the source files unnecessarily.
-			// The cached needToRetry will not be reset to avoid resetting the backoff retries.
-			state.resetPartialCache()
-			trigger = triggerManagementConflict
-		} else if state.cache.needToRetry {
-			trigger = triggerRetry
-		} else if opts.needToUpdateWatch() {
-			trigger = triggerWatchUpdate
-		} else {
+		// Resync if there was an error.
+		if !state.cache.needToRetry {
 			klog.Info("Skipping retry attempt: not needed")
 			break
 		}
-
-		// During the execution of `run`, if a new commit is detected,
-		// retryTimer will be reset to `Options.RetryPeriod`, and state.backoff is reset to `defaultBackoff()`.
-		// In this case, `run` will try to sync the configs from the new commit instead of the old commit
-		// being retried.
-		runResult = runFn(s.Context, s.Reconciler, trigger)
+		runResult = runFn(s.Context, s.Reconciler, triggerRetry)
 
 	default:
 		klog.Fatalf("Invalid event received: %#v", event)

--- a/pkg/parse/events/funnel_test.go
+++ b/pkg/parse/events/funnel_test.go
@@ -128,12 +128,16 @@ func TestFunnel_Start(t *testing.T) {
 			stepSize: time.Second,
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: RetrySyncEventType},
-					Result: Result{},
+					Event: Event{Type: RetrySyncEventType},
+					Result: Result{
+						RunAttempted: true,
+					},
 				},
 				{
-					Event:  Event{Type: RetrySyncEventType},
-					Result: Result{},
+					Event: Event{Type: RetrySyncEventType},
+					Result: Result{
+						RunAttempted: true,
+					},
 				},
 				{
 					Event:  Event{Type: RetrySyncEventType},
@@ -158,16 +162,22 @@ func TestFunnel_Start(t *testing.T) {
 			},
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: RetrySyncEventType}, // 1s
-					Result: Result{},
+					Event: Event{Type: RetrySyncEventType}, // 1s
+					Result: Result{
+						RunAttempted: true,
+					},
 				},
 				{
-					Event:  Event{Type: RetrySyncEventType}, // 3s
-					Result: Result{},
+					Event: Event{Type: RetrySyncEventType}, // 3s
+					Result: Result{
+						RunAttempted: true,
+					},
 				},
 				{
-					Event:  Event{Type: RetrySyncEventType}, // 7s
-					Result: Result{},
+					Event: Event{Type: RetrySyncEventType}, // 7s
+					Result: Result{
+						RunAttempted: true,
+					},
 				},
 				// No more retry events until another event sets ResetRetryBackoff=true
 			},
@@ -184,32 +194,39 @@ func TestFunnel_Start(t *testing.T) {
 			},
 			steps: []time.Duration{
 				time.Second,
-				3 * time.Second, //+2
-				7 * time.Second, //+4
-				10 * time.Second,
-				11 * time.Second, //+1
+				3 * time.Second,  //+2
+				7 * time.Second,  //+4
+				17 * time.Second, //+10
+				18 * time.Second, //+1
 			},
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: RetrySyncEventType}, // 1s
-					Result: Result{},
-				},
-				{
-					Event:  Event{Type: RetrySyncEventType}, // 3s
-					Result: Result{},
-				},
-				{
-					Event:  Event{Type: RetrySyncEventType}, // 7s
-					Result: Result{},
-				},
-				{
-					Event: Event{Type: SyncEventType}, // 10s
+					Event: Event{Type: RetrySyncEventType}, // 1s
 					Result: Result{
+						RunAttempted: true,
+					},
+				},
+				{
+					Event: Event{Type: RetrySyncEventType}, // 3s
+					Result: Result{
+						RunAttempted: true,
+					},
+				},
+				{
+					Event: Event{Type: RetrySyncEventType}, // 7s
+					Result: Result{
+						RunAttempted: true,
+					},
+				},
+				{
+					Event: Event{Type: SyncEventType}, // 17s
+					Result: Result{
+						RunAttempted:      true,
 						ResetRetryBackoff: true,
 					},
 				},
 				{
-					Event:  Event{Type: RetrySyncEventType}, // 11s
+					Event:  Event{Type: RetrySyncEventType}, // 18s
 					Result: Result{},
 				},
 			},

--- a/pkg/parse/root_reconciler_test.go
+++ b/pkg/parse/root_reconciler_test.go
@@ -48,11 +48,11 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/metrics"
-	"kpt.dev/configsync/pkg/remediator/conflict"
 	remediatorfake "kpt.dev/configsync/pkg/remediator/fake"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/status"
 	"kpt.dev/configsync/pkg/syncer/reconcile/fight"
+	"kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	syncertest "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"kpt.dev/configsync/pkg/testing/openapitest"
 	"kpt.dev/configsync/pkg/testing/testerrors"
@@ -694,7 +694,7 @@ func TestRootReconciler_ParseAndUpdate(t *testing.T) {
 						files:   files,
 					},
 				},
-				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+				syncErrorCache: NewSyncErrorCache(fake.NewConflictHandler(), fight.NewHandler()),
 			}
 			opts := &Options{
 				Clock:             fakeClock,
@@ -936,7 +936,7 @@ func TestRootReconciler_DeclaredFields(t *testing.T) {
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
-				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+				syncErrorCache: NewSyncErrorCache(fake.NewConflictHandler(), fight.NewHandler()),
 			}
 			opts := &Options{
 				Clock:             clock.RealClock{}, // TODO: Test with fake clock
@@ -1221,7 +1221,7 @@ func TestRootReconciler_Parse_Discovery(t *testing.T) {
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
-				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+				syncErrorCache: NewSyncErrorCache(fake.NewConflictHandler(), fight.NewHandler()),
 			}
 			opts := &Options{
 				Clock:             clock.RealClock{}, // TODO: Test with fake clock
@@ -1330,7 +1330,7 @@ func TestRootReconciler_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
-				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+				syncErrorCache: NewSyncErrorCache(fake.NewConflictHandler(), fight.NewHandler()),
 			}
 			opts := &Options{
 				Clock:             clock.RealClock{}, // TODO: Test with fake clock
@@ -1439,7 +1439,7 @@ func TestRootReconciler_SourceAndSyncReconcilerErrorsMetricValidation(t *testing
 				cache: cacheForCommit{
 					source: &sourceState{},
 				},
-				syncErrorCache: NewSyncErrorCache(conflict.NewHandler(), fight.NewHandler()),
+				syncErrorCache: NewSyncErrorCache(fake.NewConflictHandler(), fight.NewHandler()),
 			}
 			opts := &Options{
 				Clock:             clock.RealClock{}, // TODO: Test with fake clock

--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -78,6 +78,7 @@ type RunFunc func(ctx context.Context, r Reconciler, trigger string) RunResult
 
 // DefaultRunFunc is the default implementation for RunOpts.RunFunc.
 func DefaultRunFunc(ctx context.Context, r Reconciler, trigger string) RunResult {
+	klog.Infof("Starting sync attempt (trigger: %s)", trigger)
 	opts := r.Options()
 	result := RunResult{}
 	state := r.ReconcilerState()

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -51,10 +51,6 @@ type Updater struct {
 	updateMux sync.RWMutex
 }
 
-func (u *Updater) needToUpdateWatch() bool {
-	return u.Remediator.NeedsUpdate()
-}
-
 // HasManagementConflict returns true when conflict errors have been encountered
 // by the Applier or Remediator for at least one currently managed object.
 func (u *Updater) HasManagementConflict() bool {

--- a/pkg/remediator/watch/manager_test.go
+++ b/pkg/remediator/watch/manager_test.go
@@ -245,9 +245,16 @@ func TestManager_AddWatches(t *testing.T) {
 				return fakeMapper, nil
 			}
 			mapper := utilwatch.NewReplaceOnResetRESTMapper(fakeMapper, newMapperFn)
+			watchUpdateCh := make(chan bool)
+			defer close(watchUpdateCh)
+			go func() {
+				//nolint:revive // empty-block: consume until closed
+				for range watchUpdateCh {
+				}
+			}()
 			m, err := NewManager(":test", "rs", nil, &declared.Resources{},
 				watcherFactory, mapper, fake.NewConflictHandler(),
-				&controllers.CRDController{})
+				&controllers.CRDController{}, watchUpdateCh)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -426,9 +433,16 @@ func TestManager_UpdateWatches(t *testing.T) {
 				return fakeMapper, nil
 			}
 			mapper := utilwatch.NewReplaceOnResetRESTMapper(fakeMapper, newMapperFn)
+			watchUpdateCh := make(chan bool)
+			defer close(watchUpdateCh)
+			go func() {
+				//nolint:revive // empty-block: consume until closed
+				for range watchUpdateCh {
+				}
+			}()
 			m, err := NewManager(":test", "rs", nil, &declared.Resources{},
 				watcherFactory, mapper, fake.NewConflictHandler(),
-				&controllers.CRDController{})
+				&controllers.CRDController{}, watchUpdateCh)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
- Delay retry events after a run was attempted due to a different type of event.
- Change most event logs to level 3, to reduce spam for customers.
- Add a log at the beginning of each sync attempt, to explain the trigger.