### PR TITLE
Switch to use the OSS git-sync with githubapp support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.2.4-gke.8__linux_amd64
+GIT_SYNC_VERSION := v4.3.0-gke.1__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.103.0-gke.4


### PR DESCRIPTION
We have been using an internal fork for the githubapp feature. Now this feature is officially included in OSS git-sync v4.3.0. This commit switches to the OSS project for continuous update.

b/376738669