### PR TITLE
chore: Clean up sync event naming & cache resets

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -72,7 +72,7 @@ var (
 	fightDetectionThreshold = flag.Float64(
 		"fight-detection-threshold", 5.0,
 		"The rate of updates per minute to an API Resource at which the Syncer logs warnings about too many updates to the resource.")
-	resyncPeriod = flag.Duration("resync-period", configsync.DefaultReconcilerResyncPeriod,
+	fullSyncPeriod = flag.Duration("full-sync-period", configsync.DefaultReconcilerFullSyncPeriod,
 		"Period of time between forced re-syncs from source (even without a new commit).")
 	workers = flag.Int("workers", 1,
 		"Number of concurrent remediator workers to run at once.")
@@ -178,7 +178,7 @@ func main() {
 		FightDetectionThreshold:  *fightDetectionThreshold,
 		NumWorkers:               *workers,
 		ReconcilerScope:          scope,
-		ResyncPeriod:             *resyncPeriod,
+		FullSyncPeriod:           *fullSyncPeriod,
 		PollingPeriod:            *pollingPeriod,
 		RetryPeriod:              configsync.DefaultReconcilerRetryPeriod,
 		StatusUpdatePeriod:       configsync.DefaultReconcilerSyncStatusUpdatePeriod,

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -67,9 +67,9 @@ const (
 	// filesystem for source updates to sync.
 	DefaultReconcilerPollingPeriod = 15 * time.Second
 
-	// DefaultReconcilerResyncPeriod is the time delay between forced re-syncs
+	// DefaultReconcilerFullSyncPeriod is the time delay between forced re-syncs
 	// from source (even without a new commit).
-	DefaultReconcilerResyncPeriod = time.Hour
+	DefaultReconcilerFullSyncPeriod = time.Hour
 
 	// DefaultReconcilerRetryPeriod is the time delay between polling the
 	// filesystem for source updates to sync, when the previous attempt errored.

--- a/pkg/parse/events/builder.go
+++ b/pkg/parse/events/builder.go
@@ -31,9 +31,9 @@ type PublishingGroupBuilder struct {
 	// SyncPeriod is the period of time between checking the filesystem
 	// for publisher updates to sync.
 	SyncPeriod time.Duration
-	// SyncWithReimportPeriod is the period of time between forced re-sync from
-	// publisher (even without a new commit).
-	SyncWithReimportPeriod time.Duration
+	// FullSyncPeriod is the period of time between full syncs from disk
+	// (even without a new commit).
+	FullSyncPeriod time.Duration
 	// StatusUpdatePeriod is how long the Parser waits between updates of the
 	// sync status, to account for management conflict errors from the Remediator.
 	StatusUpdatePeriod time.Duration
@@ -51,17 +51,17 @@ func (t *PublishingGroupBuilder) Build() []Publisher {
 	if t.SyncPeriod > 0 {
 		publishers = append(publishers, NewResetOnRunAttemptPublisher(SyncEventType, t.Clock, t.SyncPeriod))
 	}
-	if t.SyncWithReimportPeriod > 0 {
-		publishers = append(publishers, NewTimeDelayPublisher(SyncWithReimportEventType, t.Clock, t.SyncWithReimportPeriod))
+	if t.FullSyncPeriod > 0 {
+		publishers = append(publishers, NewTimeDelayPublisher(FullSyncEventType, t.Clock, t.FullSyncPeriod))
 	}
 	if t.NamespaceControllerPeriod > 0 {
-		publishers = append(publishers, NewTimeDelayPublisher(NamespaceResyncEventType, t.Clock, t.NamespaceControllerPeriod))
+		publishers = append(publishers, NewTimeDelayPublisher(NamespaceSyncEventType, t.Clock, t.NamespaceControllerPeriod))
 	}
 	if t.RetryBackoff.Duration > 0 {
 		publishers = append(publishers, NewRetrySyncPublisher(t.Clock, t.RetryBackoff))
 	}
 	if t.StatusUpdatePeriod > 0 {
-		publishers = append(publishers, NewResetOnRunAttemptPublisher(StatusEventType, t.Clock, t.StatusUpdatePeriod))
+		publishers = append(publishers, NewResetOnRunAttemptPublisher(StatusUpdateEventType, t.Clock, t.StatusUpdatePeriod))
 	}
 	return publishers
 }

--- a/pkg/parse/events/events.go
+++ b/pkg/parse/events/events.go
@@ -25,17 +25,17 @@ type Event struct {
 type EventType string
 
 const (
-	// SyncWithReimportEventType is the EventType for a sync from disk,
+	// FullSyncEventType is the EventType for a sync from disk,
 	// including reading and parsing resource objects from the shared volume.
-	SyncWithReimportEventType EventType = "SyncWithReimportEvent"
+	FullSyncEventType EventType = "FullSyncEvent"
 	// SyncEventType is the EventType for a sync from the source cache,
 	// only parsing objects from the shared volume if there's a new commit.
 	SyncEventType EventType = "SyncEvent"
-	// StatusEventType is the EventType for a periodic RSync status update.
-	StatusEventType EventType = "StatusEvent"
-	// NamespaceResyncEventType is the EventType for a sync triggered by an
+	// StatusUpdateEventType is the EventType for a periodic RSync status update.
+	StatusUpdateEventType EventType = "StatusUpdateEvent"
+	// NamespaceSyncEventType is the EventType for a sync triggered by an
 	// update to a selected namespace.
-	NamespaceResyncEventType EventType = "NamespaceResyncEvent"
+	NamespaceSyncEventType EventType = "NamespaceSyncEvent"
 	// RetrySyncEventType is the EventType for a sync triggered by an error
 	// during a previous sync attempt.
 	RetrySyncEventType EventType = "RetrySyncEvent"

--- a/pkg/parse/events/funnel_test.go
+++ b/pkg/parse/events/funnel_test.go
@@ -56,20 +56,20 @@ func TestFunnel_Start(t *testing.T) {
 		{
 			name: "ResyncEvents From SyncWithReimportPeriod",
 			builder: &PublishingGroupBuilder{
-				SyncWithReimportPeriod: time.Second,
+				FullSyncPeriod: time.Second,
 			},
 			stepSize: time.Second,
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: SyncWithReimportEventType},
+					Event:  Event{Type: FullSyncEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: SyncWithReimportEventType},
+					Event:  Event{Type: FullSyncEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: SyncWithReimportEventType},
+					Event:  Event{Type: FullSyncEventType},
 					Result: Result{},
 				},
 			},
@@ -82,15 +82,15 @@ func TestFunnel_Start(t *testing.T) {
 			stepSize: time.Second,
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: StatusEventType},
+					Event:  Event{Type: StatusUpdateEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType},
+					Event:  Event{Type: StatusUpdateEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType},
+					Event:  Event{Type: StatusUpdateEventType},
 					Result: Result{},
 				},
 			},
@@ -103,15 +103,15 @@ func TestFunnel_Start(t *testing.T) {
 			stepSize: time.Second,
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: NamespaceResyncEventType},
+					Event:  Event{Type: NamespaceSyncEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: NamespaceResyncEventType},
+					Event:  Event{Type: NamespaceSyncEventType},
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: NamespaceResyncEventType},
+					Event:  Event{Type: NamespaceSyncEventType},
 					Result: Result{},
 				},
 			},
@@ -215,11 +215,11 @@ func TestFunnel_Start(t *testing.T) {
 			},
 		},
 		{
-			name: "SyncEvents, StatusEventType, ResyncEvents",
+			name: "SyncEvents, StatusUpdateEventType, FullSyncEvents",
 			builder: &PublishingGroupBuilder{
-				SyncPeriod:             700 * time.Millisecond,
-				SyncWithReimportPeriod: 4000 * time.Millisecond,
-				StatusUpdatePeriod:     300 * time.Millisecond,
+				SyncPeriod:         700 * time.Millisecond,
+				FullSyncPeriod:     4000 * time.Millisecond,
+				StatusUpdatePeriod: 300 * time.Millisecond,
 			},
 			// Explicit steps to avoid race conditions that make validation difficult.
 			steps: []time.Duration{
@@ -263,11 +263,11 @@ func TestFunnel_Start(t *testing.T) {
 			},
 			expectedEvents: []eventResult{
 				{
-					Event:  Event{Type: StatusEventType}, // 300ms
+					Event:  Event{Type: StatusUpdateEventType}, // 300ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 600ms
+					Event:  Event{Type: StatusUpdateEventType}, // 600ms
 					Result: Result{},
 				},
 				{
@@ -277,11 +277,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 1000ms
+					Event:  Event{Type: StatusUpdateEventType}, // 1000ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 1300ms
+					Event:  Event{Type: StatusUpdateEventType}, // 1300ms
 					Result: Result{},
 				},
 				{
@@ -291,11 +291,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 1700ms
+					Event:  Event{Type: StatusUpdateEventType}, // 1700ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 2000ms
+					Event:  Event{Type: StatusUpdateEventType}, // 2000ms
 					Result: Result{},
 				},
 				{
@@ -305,11 +305,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 2400ms
+					Event:  Event{Type: StatusUpdateEventType}, // 2400ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 2700ms
+					Event:  Event{Type: StatusUpdateEventType}, // 2700ms
 					Result: Result{},
 				},
 				{
@@ -319,11 +319,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 3100ms
+					Event:  Event{Type: StatusUpdateEventType}, // 3100ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 3400ms
+					Event:  Event{Type: StatusUpdateEventType}, // 3400ms
 					Result: Result{},
 				},
 				{
@@ -333,21 +333,21 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 3800ms
+					Event:  Event{Type: StatusUpdateEventType}, // 3800ms
 					Result: Result{},
 				},
 				{
-					Event: Event{Type: SyncWithReimportEventType}, // 4000ms
+					Event: Event{Type: FullSyncEventType}, // 4000ms
 					Result: Result{
 						RunAttempted: true,
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 4300ms
+					Event:  Event{Type: StatusUpdateEventType}, // 4300ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 4600ms
+					Event:  Event{Type: StatusUpdateEventType}, // 4600ms
 					Result: Result{},
 				},
 				{
@@ -357,11 +357,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 5000ms
+					Event:  Event{Type: StatusUpdateEventType}, // 5000ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 5300ms
+					Event:  Event{Type: StatusUpdateEventType}, // 5300ms
 					Result: Result{},
 				},
 				{
@@ -371,11 +371,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 5700ms
+					Event:  Event{Type: StatusUpdateEventType}, // 5700ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 6000ms
+					Event:  Event{Type: StatusUpdateEventType}, // 6000ms
 					Result: Result{},
 				},
 				{
@@ -385,11 +385,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 6400ms
+					Event:  Event{Type: StatusUpdateEventType}, // 6400ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 6700ms
+					Event:  Event{Type: StatusUpdateEventType}, // 6700ms
 					Result: Result{},
 				},
 				{
@@ -399,11 +399,11 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 7100ms
+					Event:  Event{Type: StatusUpdateEventType}, // 7100ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 7400ms
+					Event:  Event{Type: StatusUpdateEventType}, // 7400ms
 					Result: Result{},
 				},
 				{
@@ -413,21 +413,21 @@ func TestFunnel_Start(t *testing.T) {
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 7800ms
+					Event:  Event{Type: StatusUpdateEventType}, // 7800ms
 					Result: Result{},
 				},
 				{
-					Event: Event{Type: SyncWithReimportEventType}, // 8000ms
+					Event: Event{Type: FullSyncEventType}, // 8000ms
 					Result: Result{
 						RunAttempted: true,
 					},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 8300ms
+					Event:  Event{Type: StatusUpdateEventType}, // 8300ms
 					Result: Result{},
 				},
 				{
-					Event:  Event{Type: StatusEventType}, // 8600ms
+					Event:  Event{Type: StatusUpdateEventType}, // 8600ms
 					Result: Result{},
 				},
 				{

--- a/pkg/parse/root_reconciler_test.go
+++ b/pkg/parse/root_reconciler_test.go
@@ -735,7 +735,7 @@ func TestRootReconciler_ParseAndUpdate(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			if err := reconciler.ParseAndUpdate(context.Background(), triggerReimport); err != nil {
+			if err := reconciler.ParseAndUpdate(context.Background(), triggerSync); err != nil {
 				t.Fatal(err)
 			}
 
@@ -977,7 +977,7 @@ func TestRootReconciler_DeclaredFields(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			if err := reconciler.ParseAndUpdate(context.Background(), triggerReimport); err != nil {
+			if err := reconciler.ParseAndUpdate(context.Background(), triggerSync); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1261,7 +1261,7 @@ func TestRootReconciler_Parse_Discovery(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
+			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			// After parsing, the objects set is processed and modified.
@@ -1368,7 +1368,7 @@ func TestRootReconciler_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
+			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {
@@ -1477,7 +1477,7 @@ func TestRootReconciler_SourceAndSyncReconcilerErrorsMetricValidation(t *testing
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerReimport)
+			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -769,7 +769,7 @@ func TestRun(t *testing.T) {
 			fakeClient := syncerFake.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			reconciler := newRootReconciler(t, fakeClock, fakeClient, fs, tc.renderingEnabled)
 			t.Logf("start running test at %v", time.Now())
-			result := DefaultRunFunc(context.Background(), reconciler, triggerReimport)
+			result := DefaultRunFunc(context.Background(), reconciler, triggerSync)
 
 			assert.Equal(t, tc.expectedSourceChanged, result.SourceChanged)
 			assert.Equal(t, tc.needRetry, reconciler.ReconcilerState().cache.needToRetry)


### PR DESCRIPTION
- Consolidate resetPartialCache calls into the DefaultRunFunc.
  This makes the run func act more like a controller.
- Align the event names, trigger names, and period names.
  FullSync means parse from the filesystem and update the cluster,
  even if nothing changed.
  Sync means only parse from filesystem and update the cluster if
  there was a source change, like repo, commit, or syncDir change.