### PR TITLE
fix: ignored conflicts and watch updates

### DIFF
--- a/pkg/parse/events/publisher.go
+++ b/pkg/parse/events/publisher.go
@@ -161,7 +161,7 @@ func (s *RetrySyncPublisher) Publish(subscriber Subscriber) Result {
 
 	retryDuration := s.currentBackoff.Step()
 	retries := s.retryLimit - s.currentBackoff.Steps
-	klog.Infof("a retry is triggered (retries: %v/%v)", retries, s.retryLimit)
+	klog.V(3).Infof("Sending retry event (step: %v/%v)", retries, s.retryLimit)
 
 	result := subscriber.Handle(Event{Type: s.EventType})
 


### PR DESCRIPTION
- Reset the retry backoff when syncing is skipped due to
  prior successful sync and there are no conflicts or watch updates.
  This ensures the retry event will still fire to check for new
  conflicts and watch update requests from the remediator.
- Add logging with more details for debugging, but at level 3, to
  avoid spamming customer logs.