### PR TITLE
 fix: the ignore mutation annotation in the applier

### DIFF
--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -224,6 +224,7 @@ func TestAnnotationDrift(t *testing.T) {
 		core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	firstCommitHash := rootSyncGitRepo.MustHash(nt.T)
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
 		testwatcher.WatchPredicates(
@@ -237,6 +238,7 @@ func TestAnnotationDrift(t *testing.T) {
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
 		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.SyncTokenAnnotationKey, firstCommitHash),
 			testpredicates.HasAnnotation("season", "winter"),
 		)))
 
@@ -245,9 +247,12 @@ func TestAnnotationDrift(t *testing.T) {
 	nsObj2 := k8sobjects.NamespaceObject("new-ns")
 	nt.Must(rootSyncGitRepo.Add("acme/ns2.yaml", nsObj2))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add another namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+	secondCommitHash := rootSyncGitRepo.MustHash(nt.T)
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
 		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.SyncTokenAnnotationKey, secondCommitHash),
 			testpredicates.HasAnnotation("season", "winter"),
 		)))
 

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -298,13 +298,9 @@ func TestDriftKubectlAnnotateConfigSyncAnnotation(t *testing.T) {
 		nt.T.Fatalf("got `kubectl annotate namespace bookstore --overwrite %s=fall` error %v %s, want return nil", metadata.ResourceManagementKey, err, out)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotation(metadata.ResourceManagementKey, "fall"))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(testpredicates.HasAnnotation(metadata.ResourceManagementKey, "fall"))))
 }
 
 // TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation
@@ -331,13 +327,9 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 		nt.T.Fatalf("got `kubectl annotate namespace bookstore season-` error %v %s, want return nil", err, out)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.MissingAnnotation("season"))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(testpredicates.MissingAnnotation("season"))))
 
 	// The reason we need to stop the webhook here is that the webhook denies a request to modify Config Sync metadata
 	// even if the resource has the `client.lifecycle.config.k8s.io/mutation` annotation.
@@ -369,10 +361,8 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 	time.Sleep(10 * time.Second)
 
 	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.MissingAnnotation(metadata.ResourceManagementKey))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(testpredicates.MissingAnnotation(metadata.ResourceManagementKey))))
 }
 
 // TestAddIgnoreMutationAnnotationDirectly verifies the behavior of the applier when the

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -46,11 +46,9 @@ func TestDeclareIgnoreMutationForUnmanagedObject(t *testing.T) {
 
 	nt.T.Log("Add an unmanaged namespace using kubectl")
 	nsObj := k8sobjects.NamespaceObject("bookstore")
-	nt.Must(rootSyncGitRepo.Add("ns.yaml", nsObj))
-	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "ns.yaml"))
+	nt.Must(nt.KubeClient.Apply(nsObj))
 
-	err := nt.Validate(nsObj.Name, "", &corev1.Namespace{})
-	if err != nil {
+	if err := nt.Validate(nsObj.Name, "", &corev1.Namespace{}); err != nil {
 		nt.T.Error(err)
 	}
 

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -1,0 +1,264 @@
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"kpt.dev/configsync/e2e/nomostest"
+	"kpt.dev/configsync/e2e/nomostest/ntopts"
+	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testpredicates"
+	"kpt.dev/configsync/e2e/nomostest/testwatcher"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/core/k8sobjects"
+	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+func TestAddIgnoreMutationObject(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Adding a new namespace")
+	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.T.Log("Add the ignore mutation to the namespace")
+	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "summer"),
+			testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))))
+}
+
+func TestDeclareIgnoreMutationForUnmanagedObject(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Add an unmanaged namespace using kubectl")
+	nsObj := k8sobjects.NamespaceObject("bookstore")
+	nt.Must(rootSyncGitRepo.Add("ns.yaml", nsObj))
+	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "ns.yaml"))
+
+	err := nt.Validate(nsObj.Name, "", &corev1.Namespace{})
+	if err != nil {
+		nt.T.Error(err)
+	}
+
+	nt.T.Log("Declare the unmanaged namespace with the ignore mutation annotation and other spec changes")
+	namespace := k8sobjects.NamespaceObject(
+		nsObj.Name,
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		core.Annotation("season", "summer"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
+		testwatcher.WatchPredicates(testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation), testpredicates.MissingAnnotation("season"))))
+}
+
+func TestDeclareExistingObjectWithAnnotation(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	// Create nsObj with managed annotation using kubectl.
+	nt.T.Log("Declare namespace with ignore annotation using kubectl ")
+	nsObj := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+	)
+	nt.Must(rootSyncGitRepo.Add("ns.yaml", nsObj))
+	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "ns.yaml"))
+
+	err := nt.Validate(nsObj.Name, "", &corev1.Namespace{})
+	if err != nil {
+		nt.T.Error(err)
+	}
+
+	nt.T.Log("Declare the namespace without the ignore mutation annotation")
+	namespace := k8sobjects.NamespaceObject(
+		nsObj.Name,
+		core.Annotation("season", "summer"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "summer"),
+			testpredicates.MissingAnnotation(metadata.LifecycleMutationAnnotation),
+		)))
+}
+
+// TODO: Is this test necessary?
+func TestIgnoreObjectIsDeleted(t *testing.T) {
+	//TODO: Add, update, then delete
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Adding namespace to Git")
+	namespace := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		core.Annotation("foo", "bar"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", ""), testpredicates.HasAnnotation("foo", "bar"))
+
+	nt.T.Log("Remove foo=bar annotation from the declared namespace")
+	updatedNamespace := k8sobjects.NamespaceObject(namespace.Name,
+		core.Annotation("season", "summer"),
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("foo", "bar"),
+			testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))))
+
+	// Modify a managed field
+	out, err := nt.Shell.Kubectl("annotate", "namespace", "bookstore", "--overwrite", "foo=baz")
+	if err != nil {
+		nt.T.Fatalf("got `kubectl annotate namespace bookstore --overwrite foo=baz` error %v %s, want return nil", err, out)
+	}
+
+	time.Sleep(10 * time.Second)
+
+	// Remediator SHOULD NOT correct it
+	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotation("foo", "baz"))
+	if err != nil {
+		nt.T.Fatal(err)
+	}
+
+	// The reason we need to stop the webhook here is that the webhook denies a request to delete the namespace
+	nomostest.StopWebhook(nt)
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(),
+		core.RootReconcilerName(nomostest.DefaultRootSyncID.Name), configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
+			testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
+			testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
+		)))
+
+	nt.MustKubectl("delete", "ns", namespace.Name)
+	time.Sleep(10 * time.Second)
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), namespace.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "summer"),
+			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		)))
+}
+
+func TestPruningIgnoredObject(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Adding namespace to Git")
+	namespace := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	// prune the namespace
+	nt.Must(rootSyncGitRepo.Remove("acme/ns.yaml"))
+	nt.Must(rootSyncGitRepo.CommitAndPush("Prune namespace-bookstore"))
+	// check for error
+	nt.Must(nt.WatchForAllSyncs())
+
+	// Should have been pruned
+	nt.Must(nt.Watcher.WatchForNotFound(kinds.Namespace(), namespace.Name, ""))
+
+	namespace = k8sobjects.NamespaceObject("bookstore",
+		core.Annotation("season", "winter"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), namespace.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "winter"),
+			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		)))
+}
+
+func TestDeclare(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Adding namespace to Git")
+	namespace := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.T.Log("Remove label for declared namespace")
+	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), namespace.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "summer"),
+			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		)))
+
+}
+
+//TODO: Something that tests both applier and remediator?
+// Can force resync on new commit
+
+// Add, Update, Add (force resync), Delete, Prune
+
+func TestAddUpdateAdd(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Adding namespace to Git")
+	namespace := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.T.Log("Add annotation")
+	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation), core.Annotation("season", "summer"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(
+			testpredicates.MissingAnnotation("season"),
+			testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))))
+
+	nt.T.Log("Modify using kubectl")
+	nsObj := namespace.DeepCopy()
+	nsObj.Annotations["season"] = "winter"
+	nt.Must(rootSyncGitRepo.Add("unmanaged-ns.yaml", nsObj))
+	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "unmanaged-ns.yaml"))
+	nt.Must(rootSyncGitRepo.Remove("unmanaged-ns.yaml"))
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "winter"),
+		)))
+
+	nsObj2 := k8sobjects.NamespaceObject("new-ns")
+	nt.Must(rootSyncGitRepo.Add("acme/ns2.yaml", nsObj2))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add another namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "winter"),
+		)))
+
+	// Manually modify
+	//Force reapply
+}

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -1,11 +1,11 @@
 package e2e
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
@@ -20,18 +20,21 @@ import (
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
-func TestAddIgnoreMutationObject(t *testing.T) {
+func TestAddIgnoreMutationToManagedObject(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
-	nt.T.Log("Adding a new namespace")
+	nt.T.Log("Add a new namespace")
 	namespace := k8sobjects.NamespaceObject("bookstore", core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	nt.T.Log("Add the ignore mutation to the namespace")
-	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
+	nt.T.Log("Add the ignore mutation annotation and other spec changes to the namespace")
+	updatedNamespace := k8sobjects.NamespaceObject(
+		namespace.Name,
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		core.Annotation("season", "winter"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
@@ -47,6 +50,14 @@ func TestDeclareIgnoreMutationForUnmanagedObject(t *testing.T) {
 	nt.T.Log("Add an unmanaged namespace using kubectl")
 	nsObj := k8sobjects.NamespaceObject("bookstore")
 	nt.Must(nt.KubeClient.Apply(nsObj))
+
+	nt.T.Cleanup(func() {
+		if err := nt.KubeClient.Delete(nsObj); err != nil {
+			if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) {
+				nt.T.Log(err)
+			}
+		}
+	})
 
 	if err := nt.Validate(nsObj.Name, "", &corev1.Namespace{}); err != nil {
 		nt.T.Error(err)
@@ -65,36 +76,7 @@ func TestDeclareIgnoreMutationForUnmanagedObject(t *testing.T) {
 			testpredicates.MissingAnnotation("season"))))
 }
 
-func TestDeclareExistingObjectWithIgnoreAnnotation(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
-
-	nt.T.Log("Add an umanaged namespace with the ignore-mutation annotation using kubectl ")
-	nsObj := k8sobjects.NamespaceObject("bookstore",
-		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
-	)
-
-	nt.Must(nt.KubeClient.Apply(nsObj))
-	if err := nt.Validate(nsObj.Name, "", &corev1.Namespace{}); err != nil {
-		nt.T.Error(err)
-	}
-
-	nt.T.Log("Declare the namespace without the ignore mutation annotation")
-	namespace := k8sobjects.NamespaceObject(
-		nsObj.Name,
-		core.Annotation("season", "summer"))
-	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
-	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
-	nt.Must(nt.WatchForAllSyncs())
-
-	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
-		testwatcher.WatchPredicates(
-			testpredicates.HasAnnotation("season", "summer"),
-			testpredicates.MissingAnnotation(metadata.LifecycleMutationAnnotation),
-		)))
-}
-
-func TestIgnoreObjectIsDeleted(t *testing.T) {
+func TestMutationIgnoredObjectIsDeleted(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
@@ -152,11 +134,11 @@ func TestIgnoreObjectIsDeleted(t *testing.T) {
 		)))
 }
 
-func TestPruningIgnoredObject(t *testing.T) {
+func TestMutationIgnoredObjectPruned(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
-	nt.T.Log("Adding namespace to Git")
+	nt.T.Log("Add  namespace to Git")
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -164,14 +146,15 @@ func TestPruningIgnoredObject(t *testing.T) {
 	nt.Must(nt.WatchForAllSyncs())
 
 	// prune the namespace
+	nt.T.Log("Prune the namespace")
 	nt.Must(rootSyncGitRepo.Remove("acme/ns.yaml"))
-	nt.Must(rootSyncGitRepo.CommitAndPush("Prune namespace-bookstore"))
-	// check for error
+	nt.Must(rootSyncGitRepo.CommitAndPush("prune namespace-bookstore"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	// Should have been pruned
+	// Namespace should have been pruned
 	nt.Must(nt.Watcher.WatchForNotFound(kinds.Namespace(), namespace.Name, ""))
 
+	nt.T.Log("Add back namespace to Git")
 	namespace = k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "winter"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
@@ -184,36 +167,6 @@ func TestPruningIgnoredObject(t *testing.T) {
 		)))
 }
 
-func TestDeclare(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
-
-	nt.T.Log("Adding namespace to Git")
-	namespace := k8sobjects.NamespaceObject("bookstore",
-		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
-	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
-	nt.Must(nt.WatchForAllSyncs())
-
-	nt.T.Log("Remove label for declared namespace")
-	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
-	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
-	nt.Must(nt.WatchForAllSyncs())
-
-	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), namespace.Name, "",
-		testwatcher.WatchPredicates(
-			testpredicates.HasAnnotation("season", "summer"),
-			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
-		)))
-
-}
-
-//TODO: Something that tests both applier and remediator?
-// Can force resync on new commit
-
-// Add, Update, Add (force resync), Delete, Prune
-
 func TestAddUpdateAdd(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
@@ -225,37 +178,63 @@ func TestAddUpdateAdd(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	nt.T.Log("Add annotation")
-	updatedNamespace := k8sobjects.NamespaceObject("bookstore", core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation), core.Annotation("season", "summer"))
+	nt.T.Log("Add annotation to the declared namespace")
+	updatedNamespace := k8sobjects.NamespaceObject("bookstore",
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
 		testwatcher.WatchPredicates(
 			testpredicates.MissingAnnotation("season"),
 			testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))))
 
-	nt.T.Log("Modify using kubectl")
+	nt.T.Log("Add the 'season=winter' annotation to the namespace using kubectl")
 	nsObj := namespace.DeepCopy()
 	nsObj.Annotations["season"] = "winter"
-	nt.Must(rootSyncGitRepo.Add("unmanaged-ns.yaml", nsObj))
-	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "unmanaged-ns.yaml"))
-	nt.Must(rootSyncGitRepo.Remove("unmanaged-ns.yaml"))
+	nt.Must(nt.KubeClient.Apply(nsObj))
+
+	// Wait so the remediator can process the event
+	time.Sleep(10 * time.Second)
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
 		testwatcher.WatchPredicates(
 			testpredicates.HasAnnotation("season", "winter"),
 		)))
 
+	nt.T.Log("Add another namespace to Git to run the applier")
 	nsObj2 := k8sobjects.NamespaceObject("new-ns")
 	nt.Must(rootSyncGitRepo.Add("acme/ns2.yaml", nsObj2))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add another namespace"))
-	nt.Must(nt.WatchForAllSyncs())
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
 		testwatcher.WatchPredicates(
 			testpredicates.HasAnnotation("season", "winter"),
 		)))
+}
 
-	// Manually modify
-	//Force reapply
+func TestDeclareObjectWithoutIgnoreMutationAnnotation(t *testing.T) {
+	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
+	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
+
+	nt.T.Log("Add a new namespace with the ignore mutation annotation")
+	namespace := k8sobjects.NamespaceObject(
+		"bookstore",
+		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+		core.Annotation("season", "summer"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
+
+	nt.T.Log("Remove the ignore mutation annotation from the namespace")
+	updatedNamespace := k8sobjects.NamespaceObject(
+		namespace.Name,
+		core.Annotation("season", "winter"))
+	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", updatedNamespace))
+	nt.Must(rootSyncGitRepo.CommitAndPush("update namespace"))
+	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation("season", "winter"),
+			testpredicates.MissingAnnotation(metadata.LifecycleMutationAnnotation))))
 }

--- a/e2e/testcases/ignore_mutation_test.go
+++ b/e2e/testcases/ignore_mutation_test.go
@@ -60,23 +60,22 @@ func TestDeclareIgnoreMutationForUnmanagedObject(t *testing.T) {
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
-		testwatcher.WatchPredicates(testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation), testpredicates.MissingAnnotation("season"))))
+		testwatcher.WatchPredicates(
+			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+			testpredicates.MissingAnnotation("season"))))
 }
 
-func TestDeclareExistingObjectWithAnnotation(t *testing.T) {
+func TestDeclareExistingObjectWithIgnoreAnnotation(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
-	// Create nsObj with managed annotation using kubectl.
-	nt.T.Log("Declare namespace with ignore annotation using kubectl ")
+	nt.T.Log("Add an umanaged namespace with the ignore-mutation annotation using kubectl ")
 	nsObj := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
 	)
-	nt.Must(rootSyncGitRepo.Add("ns.yaml", nsObj))
-	nt.MustKubectl("apply", "-f", filepath.Join(rootSyncGitRepo.Root, "ns.yaml"))
 
-	err := nt.Validate(nsObj.Name, "", &corev1.Namespace{})
-	if err != nil {
+	nt.Must(nt.KubeClient.Apply(nsObj))
+	if err := nt.Validate(nsObj.Name, "", &corev1.Namespace{}); err != nil {
 		nt.T.Error(err)
 	}
 
@@ -86,6 +85,7 @@ func TestDeclareExistingObjectWithAnnotation(t *testing.T) {
 		core.Annotation("season", "summer"))
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
 	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
+	nt.Must(nt.WatchForAllSyncs())
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), nsObj.Name, "",
 		testwatcher.WatchPredicates(
@@ -94,13 +94,11 @@ func TestDeclareExistingObjectWithAnnotation(t *testing.T) {
 		)))
 }
 
-// TODO: Is this test necessary?
 func TestIgnoreObjectIsDeleted(t *testing.T) {
-	//TODO: Add, update, then delete
 	nt := nomostest.New(t, nomostesting.DriftControl, ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
-	nt.T.Log("Adding namespace to Git")
+	nt.T.Log("Add namespace with the ignore-mutation annotation to Git")
 	namespace := k8sobjects.NamespaceObject("bookstore",
 		core.Annotation("season", "summer"), core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
 		core.Annotation("foo", "bar"))
@@ -119,7 +117,7 @@ func TestIgnoreObjectIsDeleted(t *testing.T) {
 			testpredicates.HasAnnotation("foo", "bar"),
 			testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))))
 
-	// Modify a managed field
+	nt.T.Log("Modify managed field foo of the declared namespace using kubectl")
 	out, err := nt.Shell.Kubectl("annotate", "namespace", "bookstore", "--overwrite", "foo=baz")
 	if err != nil {
 		nt.T.Fatalf("got `kubectl annotate namespace bookstore --overwrite foo=baz` error %v %s, want return nil", err, out)
@@ -143,13 +141,14 @@ func TestIgnoreObjectIsDeleted(t *testing.T) {
 			testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
 		)))
 
+	nt.T.Log("Delete declared namespace using kubectl")
 	nt.MustKubectl("delete", "ns", namespace.Name)
-	time.Sleep(10 * time.Second)
 
 	nt.Must(nt.Watcher.WatchObject(kinds.Namespace(), namespace.Name, "",
 		testwatcher.WatchPredicates(
 			testpredicates.HasAnnotation("season", "summer"),
 			testpredicates.HasAnnotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation),
+			testpredicates.MissingAnnotation("foo"),
 		)))
 }
 

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"kpt.dev/configsync/e2e/nomostest"
 	"kpt.dev/configsync/e2e/nomostest/ntopts"
-	"kpt.dev/configsync/e2e/nomostest/taskgroup"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testkubeclient"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
@@ -37,8 +36,6 @@ import (
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/reconcilermanager"
-	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -735,73 +732,6 @@ func TestDriftKubectlAnnotateManagedField(t *testing.T) {
 		)))
 }
 
-// TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation modifies a
-// managed field of a resource having the
-// `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
-// Config Sync does not correct it.
-func TestDriftKubectlAnnotateManagedFieldWithIgnoreMutationAnnotation(t *testing.T) {
-	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.DriftControl,
-		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
-
-	namespace := k8sobjects.NamespaceObject("bookstore",
-		core.Annotation("season", "summer"),
-		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
-	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
-	nt.Must(nt.WatchForAllSyncs())
-
-	// Modify a managed field
-	out, err := nt.Shell.Kubectl("annotate", "namespace", "bookstore", "--overwrite", "season=winter")
-	if err != nil {
-		nt.T.Fatalf("got `kubectl annotate namespace bookstore --overwrite season=winter` error %v %s, want return nil", err, out)
-	}
-
-	time.Sleep(10 * time.Second)
-
-	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotation("season", "winter"))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-
-	// The reason we need to stop the webhook here is that the webhook denies a request to modify Config Sync metadata
-	// even if the resource has the `client.lifecycle.config.k8s.io/mutation` annotation.
-	nomostest.StopWebhook(nt)
-	// Stopping the webhook causes the reconciler to restart. Wait so that we aren't
-	// racing with the applier and are actually testing the remediator.
-	tg := taskgroup.New()
-	tg.Go(func() error {
-		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.RootReconcilerName(rootSyncID.Name), configsync.ControllerNamespace,
-			testwatcher.WatchPredicates(
-				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-				testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
-			))
-	})
-	tg.Go(func() error {
-		// Note: this proves that the applier DOES honor the ignore-mutation annotation.
-		return nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
-			testwatcher.WatchPredicates(testpredicates.HasAnnotation("season", "winter")))
-	})
-	nt.Must(tg.Wait())
-
-	// Modify a Config Sync annotation
-	out, err = nt.Shell.Kubectl("annotate", "namespace", "bookstore", "--overwrite", fmt.Sprintf("%s=winter", metadata.ResourceManagementKey))
-	if err != nil {
-		nt.T.Fatalf("got `kubectl annotate namespace bookstore --overwrite %s=winter` error %v %s, want return nil", metadata.ResourceManagementKey, err, out)
-	}
-
-	time.Sleep(10 * time.Second)
-
-	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotation(metadata.ResourceManagementKey, "winter"))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-}
-
 // TestDriftKubectlAnnotateDeleteManagedFields deletes a managed field, and
 // verifies that Config Sync corrects it.
 func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
@@ -852,73 +782,6 @@ func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 		testwatcher.WatchPredicates(
 			testpredicates.HasAnnotation(metadata.ResourceManagementKey, metadata.ResourceManagementEnabled),
 		)))
-}
-
-// TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation
-// deletes a managed field of a resource having the
-// `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
-// Config Sync does not correct it.
-func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
-	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.DriftControl,
-		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
-	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
-
-	namespace := k8sobjects.NamespaceObject("bookstore",
-		core.Annotation("season", "summer"),
-		core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation))
-	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespace))
-	nt.Must(rootSyncGitRepo.CommitAndPush("add a namespace"))
-	nt.Must(nt.WatchForAllSyncs())
-
-	// Delete a managed field
-	out, err := nt.Shell.Kubectl("annotate", "namespace", "bookstore", "season-")
-	if err != nil {
-		nt.T.Fatalf("got `kubectl annotate namespace bookstore season-` error %v %s, want return nil", err, out)
-	}
-
-	time.Sleep(10 * time.Second)
-
-	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.MissingAnnotation("season"))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-
-	// The reason we need to stop the webhook here is that the webhook denies a request to modify Config Sync metadata
-	// even if the resource has the `client.lifecycle.config.k8s.io/mutation` annotation.
-	nomostest.StopWebhook(nt)
-	// Stopping the webhook causes the reconciler to restart. Wait so that we aren't
-	// racing with the applier and are actually testing the remediator.
-	tg := taskgroup.New()
-	tg.Go(func() error {
-		return nt.Watcher.WatchObject(kinds.Deployment(),
-			core.RootReconcilerName(rootSyncID.Name), configsync.ControllerNamespace,
-			testwatcher.WatchPredicates(
-				testpredicates.StatusEquals(nt.Scheme, kstatus.CurrentStatus),
-				testpredicates.DeploymentMissingEnvVar(reconcilermanager.Reconciler, reconcilermanager.WebhookEnabled),
-			))
-	})
-	tg.Go(func() error {
-		// Note: this proves that the applier DOES currently honor the ignore-mutation annotation.
-		return nt.Watcher.WatchObject(kinds.Namespace(), "bookstore", "",
-			testwatcher.WatchPredicates(testpredicates.MissingAnnotation("season")))
-	})
-	nt.Must(tg.Wait())
-
-	// Delete a Config Sync annotation
-	out, err = nt.Shell.Kubectl("annotate", "namespace", "bookstore", fmt.Sprintf("%s-", metadata.ResourceManagementKey))
-	if err != nil {
-		nt.T.Fatalf("got `kubectl annotate namespace bookstore %s-` error %v %s, want return nil", metadata.ResourceManagementKey, err, out)
-	}
-
-	time.Sleep(10 * time.Second)
-
-	// Remediator SHOULD NOT correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.MissingAnnotation(metadata.ResourceManagementKey))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
 }
 
 // TestDriftRemoveApplySetPartOfLabel deletes the

--- a/e2e/testcases/managed_resources_test.go
+++ b/e2e/testcases/managed_resources_test.go
@@ -857,7 +857,7 @@ func TestDriftKubectlAnnotateDeleteManagedFields(t *testing.T) {
 // TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation
 // deletes a managed field of a resource having the
 // `client.lifecycle.config.k8s.io/mutation` annotation, and verifies that
-// Config Sync does correct it.
+// Config Sync does not correct it.
 func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t, nomostesting.DriftControl,
@@ -914,22 +914,8 @@ func TestDriftKubectlAnnotateDeleteManagedFieldsWithIgnoreMutationAnnotation(t *
 
 	time.Sleep(10 * time.Second)
 
-	// Remediator SHOULD correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotationKey(metadata.ResourceManagementKey))
-	if err != nil {
-		nt.T.Fatal(err)
-	}
-
-	// Delete Config Sync annotation lifecycle mutation
-	out, err = nt.Shell.Kubectl("annotate", "namespace", "bookstore", fmt.Sprintf("%s-", metadata.LifecycleMutationAnnotation))
-	if err != nil {
-		nt.T.Fatalf("got `kubectl annotate namespace bookstore %s-` error %v %s, want return nil", metadata.LifecycleMutationAnnotation, err, out)
-	}
-
-	time.Sleep(10 * time.Second)
-
-	// Remediator SHOULD correct it
-	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.HasAnnotationKey(metadata.LifecycleMutationAnnotation))
+	// Remediator SHOULD NOT correct it
+	err = nt.Validate("bookstore", "", &corev1.Namespace{}, testpredicates.MissingAnnotation(metadata.ResourceManagementKey))
 	if err != nil {
 		nt.T.Fatal(err)
 	}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -352,7 +352,7 @@ func (s *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, 
 
 		iObj, found := declaredResources.GetIgnored(id)
 		if found {
-			klog.Infof("Deleting object '%v' from the ignore cache", core.GKNN(iObj))
+			klog.V(3).Infof("Deleting object '%v' from the ignore cache", core.GKNN(iObj))
 			declaredResources.DeleteIgnored(id)
 		}
 

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -544,7 +544,7 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), d
 		}
 	}
 
-	objsToApply := handleIgnoredObjects(enabledObjs, declaredResources.GetIgnoredObjsCache())
+	objsToApply := handleIgnoredObjects(enabledObjs, declaredResources)
 
 	klog.Infof("%v objects to be applied: %v", len(objsToApply), core.GKNNs(objsToApply))
 	resources, err := toUnstructured(objsToApply)

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -864,6 +864,7 @@ func (s *supervisor) abandonObject(ctx context.Context, obj client.Object) error
 // cacheIgnoreMutationObjects gets the current cluster state of any declared objects with the ignore mutation annotation and puts it in the Resources ignore objects cache
 // Returns any errors that occur
 func (s *supervisor) cacheIgnoreMutationObjects(ctx context.Context, declaredResources *declared.Resources) error {
+	var objsToUpdate []client.Object
 	declaredObjs := declaredResources.DeclaredObjects()
 
 	for _, obj := range declaredObjs {
@@ -884,10 +885,12 @@ func (s *supervisor) cacheIgnoreMutationObjects(ctx context.Context, declaredRes
 					return err
 				}
 
-				declaredResources.UpdateIgnored(uObj)
+				objsToUpdate = append(objsToUpdate, uObj)
 			}
 		}
 	}
+
+	declaredResources.UpdateIgnored(objsToUpdate...)
 
 	if len(declaredResources.IgnoredObjects()) > 0 {
 		klog.Infof("%v mutation-ignored objects: %v", len(declaredResources.IgnoredObjects()), core.GKNNs(declaredResources.IgnoredObjects()))

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -524,6 +524,10 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), d
 		return objStatusMap, syncStats
 	}
 
+	if len(declaredResources.IgnoredObjects()) > 0 {
+		klog.Infof("%v mutation-ignored objects: %v", len(declaredResources.IgnoredObjects()), core.GKNNs(declaredResources.IgnoredObjects()))
+	}
+
 	// disabledObjs are objects for which the management are disabled
 	// through annotation.
 	enabledObjs, disabledObjs := partitionObjs(objs)
@@ -891,10 +895,6 @@ func (s *supervisor) cacheIgnoreMutationObjects(ctx context.Context, declaredRes
 	}
 
 	declaredResources.UpdateIgnored(objsToUpdate...)
-
-	if len(declaredResources.IgnoredObjects()) > 0 {
-		klog.Infof("%v mutation-ignored objects: %v", len(declaredResources.IgnoredObjects()), core.GKNNs(declaredResources.IgnoredObjects()))
-	}
 
 	return nil
 }

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -72,7 +72,7 @@ type Applier interface {
 	// Returns the status of the applied objects and statistics of the sync.
 	// This is called by the reconciler when changes are detected in the
 	// source of truth (git, OCI, helm) and periodically.
-	Apply(ctx context.Context, eventHandler func(Event), desiredResources []client.Object) (ObjectStatusMap, *stats.SyncStats)
+	Apply(ctx context.Context, eventHandler func(Event), resources *declared.Resources) (ObjectStatusMap, *stats.SyncStats)
 }
 
 // Destroyer is a bulk client for deleting all the managed resource objects
@@ -330,7 +330,7 @@ func (s *supervisor) handleApplySkippedEvent(obj *unstructured.Unstructured, id 
 }
 
 // processPruneEvent handles PruneEvents from the Applier
-func (s *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, syncStats *stats.PruneEventStats, objectStatusMap ObjectStatusMap) status.Error {
+func (s *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, syncStats *stats.PruneEventStats, objectStatusMap ObjectStatusMap, declaredResources *declared.Resources) status.Error {
 	id := idFrom(e.Identifier)
 	syncStats.Add(e.Status)
 
@@ -349,6 +349,13 @@ func (s *supervisor) processPruneEvent(ctx context.Context, e event.PruneEvent, 
 	case event.PruneSuccessful:
 		objectStatus.Actuation = actuation.ActuationSucceeded
 		handleMetrics(ctx, "delete", e.Error)
+
+		iObj, found := declaredResources.GetIgnored(id)
+		if found {
+			klog.Infof("Deleting object '%v' from the ignore cache", core.GKNN(iObj))
+			declaredResources.DeleteIgnored(id)
+		}
+
 		return nil
 
 	case event.PruneFailed:
@@ -504,12 +511,19 @@ func (s *supervisor) checkInventoryObjectSize(ctx context.Context, c client.Clie
 }
 
 // applyInner triggers a kpt live apply library call to apply a set of resources.
-func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), objs []client.Object) (ObjectStatusMap, *stats.SyncStats) {
+func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), declaredResources *declared.Resources) (ObjectStatusMap, *stats.SyncStats) {
 	s.checkInventoryObjectSize(ctx, s.clientSet.Client)
 	isDestroy := false
 
 	syncStats := stats.NewSyncStats()
 	objStatusMap := make(ObjectStatusMap)
+	objs, _ := declaredResources.DeclaredObjects()
+
+	if err := s.cacheIgnoreMutationObjects(ctx, declaredResources); err != nil {
+		sendErrorEvent(err, eventHandler)
+		return objStatusMap, syncStats
+	}
+
 	// disabledObjs are objects for which the management are disabled
 	// through annotation.
 	enabledObjs, disabledObjs := partitionObjs(objs)
@@ -525,8 +539,11 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), o
 			Succeeded: disabledCount,
 		}
 	}
-	klog.Infof("%v objects to be applied: %v", len(enabledObjs), core.GKNNs(enabledObjs))
-	resources, err := toUnstructured(enabledObjs)
+
+	objsToApply := handleIgnoredObjects(enabledObjs, declaredResources.GetIgnoredObjsCache())
+
+	klog.Infof("%v objects to be applied: %v", len(objsToApply), core.GKNNs(objsToApply))
+	resources, err := toUnstructured(objsToApply)
 	if err != nil {
 		sendErrorEvent(err, eventHandler)
 		return objStatusMap, syncStats
@@ -610,7 +627,7 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), o
 			} else {
 				klog.V(1).Info(e.PruneEvent)
 			}
-			if err := s.processPruneEvent(ctx, e.PruneEvent, syncStats.PruneEvent, objStatusMap); err != nil {
+			if err := s.processPruneEvent(ctx, e.PruneEvent, syncStats.PruneEvent, objStatusMap, declaredResources); err != nil {
 				sendErrorEvent(err, eventHandler)
 			}
 		default:
@@ -704,11 +721,11 @@ func (s *supervisor) destroyInner(ctx context.Context, eventHandler func(Event))
 
 // Apply all managed resource objects and return their status.
 // Apply implements the Applier interface.
-func (s *supervisor) Apply(ctx context.Context, eventHandler func(Event), desiredResource []client.Object) (ObjectStatusMap, *stats.SyncStats) {
+func (s *supervisor) Apply(ctx context.Context, eventHandler func(Event), resources *declared.Resources) (ObjectStatusMap, *stats.SyncStats) {
 	s.execMux.Lock()
 	defer s.execMux.Unlock()
 
-	return s.applyInner(ctx, eventHandler, desiredResource)
+	return s.applyInner(ctx, eventHandler, resources)
 }
 
 // Destroy all managed resource objects and return their status.
@@ -809,6 +826,7 @@ func (s *supervisor) abandonObject(ctx context.Context, obj client.Object) error
 	}
 	uObj := &unstructured.Unstructured{}
 	uObj.SetGroupVersionKind(gvk)
+
 	err = s.clientSet.Client.Get(ctx, client.ObjectKeyFromObject(obj), uObj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -840,5 +858,40 @@ func (s *supervisor) abandonObject(ctx context.Context, obj client.Object) error
 		return s.clientSet.Client.Patch(ctx, toObj, client.MergeFrom(fromObj),
 			client.FieldOwner(configsync.FieldManager))
 	}
+	return nil
+}
+
+// cacheIgnoreMutationObjects gets the current cluster state of any declared objects with the ignore mutation annotation and puts it in the Resources ignore objects cache
+// Returns any errors that occur
+func (s *supervisor) cacheIgnoreMutationObjects(ctx context.Context, declaredResources *declared.Resources) error {
+	declaredObjs, _ := declaredResources.DeclaredObjects()
+
+	for _, obj := range declaredObjs {
+		if obj.GetAnnotations()[metadata.LifecycleMutationAnnotation] == metadata.IgnoreMutation {
+
+			if _, found := declaredResources.GetIgnored(core.IDOf(obj)); !found {
+				// Fetch the cluster state of the object if not already in the cache
+				uObj := &unstructured.Unstructured{}
+				uObj.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+				err := s.clientSet.Client.Get(ctx, client.ObjectKeyFromObject(obj), uObj)
+
+				// Object doesn't exist on the cluster
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+
+				if err != nil {
+					return err
+				}
+
+				declaredResources.UpdateIgnored(uObj)
+			}
+		}
+	}
+
+	if len(declaredResources.IgnoredObjects()) > 0 {
+		klog.Infof("%v mutation-ignored objects: %v", len(declaredResources.IgnoredObjects()), core.GKNNs(declaredResources.IgnoredObjects()))
+	}
+
 	return nil
 }

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -517,7 +517,7 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), d
 
 	syncStats := stats.NewSyncStats()
 	objStatusMap := make(ObjectStatusMap)
-	objs, _ := declaredResources.DeclaredObjects()
+	objs := declaredResources.DeclaredObjects()
 
 	if err := s.cacheIgnoreMutationObjects(ctx, declaredResources); err != nil {
 		sendErrorEvent(err, eventHandler)
@@ -864,7 +864,7 @@ func (s *supervisor) abandonObject(ctx context.Context, obj client.Object) error
 // cacheIgnoreMutationObjects gets the current cluster state of any declared objects with the ignore mutation annotation and puts it in the Resources ignore objects cache
 // Returns any errors that occur
 func (s *supervisor) cacheIgnoreMutationObjects(ctx context.Context, declaredResources *declared.Resources) error {
-	declaredObjs, _ := declaredResources.DeclaredObjects()
+	declaredObjs := declaredResources.DeclaredObjects()
 
 	for _, obj := range declaredObjs {
 		if obj.GetAnnotations()[metadata.LifecycleMutationAnnotation] == metadata.IgnoreMutation {

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -431,7 +431,7 @@ func TestApplyMutationIgnoredObjects(t *testing.T) {
 					)),
 			},
 			declaredObjs: []client.Object{
-				newNamespaceObj(
+				k8sobjects.Unstructured(kinds.Namespace(),
 					core.Name("umanaged-ns"),
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label(metadata.ApplySetPartOfLabel, applySetID),
@@ -463,12 +463,13 @@ func TestApplyMutationIgnoredObjects(t *testing.T) {
 					core.Label("foo", "bar"))),
 			},
 			expectedItemsInIgnoreCache: []client.Object{
-				createServerObject(k8sobjects.NamespaceObject("umanaged-ns",
-					syncertest.ManagementDisabled,
-					core.Label("foo", "bar"),
-					core.Generation(1),
-					core.UID("1"),
-					core.ResourceVersion("1"))),
+				asUnstructuredSanitizedObj(
+					createServerObject(k8sobjects.NamespaceObject("umanaged-ns",
+						syncertest.ManagementDisabled,
+						core.Label("foo", "bar"),
+						core.Generation(1),
+						core.UID("1"),
+						core.ResourceVersion("1")))),
 			},
 		},
 		{
@@ -479,8 +480,7 @@ func TestApplyMutationIgnoredObjects(t *testing.T) {
 					core.Label("foo", "bar"))),
 			},
 			declaredObjs: []client.Object{
-				k8sobjects.NamespaceObject("managed-ns",
-					syncertest.ManagementEnabled,
+				newNamespaceObj(core.Name("managed-ns"), syncertest.ManagementEnabled,
 					syncertest.IgnoreMutationAnnotation),
 			},
 			expectedObjsToApply: object.UnstructuredSet{
@@ -493,7 +493,7 @@ func TestApplyMutationIgnoredObjects(t *testing.T) {
 					core.Label("foo", "bar"))),
 			},
 			expectedItemsInIgnoreCache: []client.Object{
-				createServerObject(k8sobjects.NamespaceObject("managed-ns",
+				asUnstructuredSanitizedObj(createServerObject((k8sobjects.NamespaceObject("managed-ns",
 					syncertest.ManagementDisabled,
 					core.Label(metadata.ManagedByKey, metadata.ManagedByValue),
 					core.Label("foo", "bar"),
@@ -501,7 +501,7 @@ func TestApplyMutationIgnoredObjects(t *testing.T) {
 					core.Annotation(metadata.ResourceIDKey, "_namespace_managed-ns"),
 					core.Generation(1),
 					core.UID("1"),
-					core.ResourceVersion("1")))},
+					core.ResourceVersion("1")))))},
 		},
 		{
 			name: "managed and mutation-ignored object was previously deleted",
@@ -964,6 +964,13 @@ func asUnstructuredSanitizedObj(o client.Object) *unstructured.Unstructured {
 	uObj, _ := reconcile.AsUnstructuredSanitized(o)
 
 	return uObj
+}
+
+func asUnstructured(o client.Object) *unstructured.Unstructured {
+	uObj, _ := reconcile.AsUnstructuredSanitized(o)
+
+	return uObj
+
 }
 
 // createServerObject produces the expected output of the object stored on the (fake) server

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -852,12 +852,8 @@ func TestProcessPruneEvent(t *testing.T) {
 		clientSet: cs,
 	}
 
-	//TODO: Refactor
-	testObj2 := k8sobjects.UnstructuredObject(schema.GroupVersionKind{
-		Group:   "configsync.test",
-		Version: "v1",
-		Kind:    "Test",
-	}, core.Namespace("test-namespace"), core.Name("test-1"), core.Annotation(metadata.SourcePathAnnotationKey, "foo/test.yaml"), syncertest.IgnoreMutationAnnotation)
+	testObj2 := testObj.DeepCopy()
+	core.SetAnnotation(testObj2, metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation)
 
 	resources := &declared.Resources{}
 	resources.UpdateIgnored(testObj2)

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -834,7 +834,7 @@ func TestProcessPruneEvent(t *testing.T) {
 	}
 	testutil.AssertEqual(t, expectedObjStatusMap, objStatusMap, "expected object status to match")
 
-	testutil.AssertEqual(t, 0, resources.GetIgnoredObjsCache().Len())
+	testutil.AssertEqual(t, 0, len(resources.IgnoredObjects()))
 
 	// TODO: test handleMetrics on success
 	// TODO: test PruneErrorForResource on failed

--- a/pkg/applier/fake/applier.go
+++ b/pkg/applier/fake/applier.go
@@ -20,6 +20,7 @@ import (
 
 	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/applier/stats"
+	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,6 +33,7 @@ type Applier struct {
 	ApplyCalls   int
 	ApplyInputs  []ApplierInputs
 	ApplyOutputs []ApplierOutputs
+	ApplyClient  client.Client
 }
 
 // ApplierInputs stores inputs for fake.Applier.Apply()
@@ -47,7 +49,9 @@ type ApplierOutputs struct {
 }
 
 // Apply fakes applier.Applier.Apply()
-func (a *Applier) Apply(_ context.Context, eventHandler func(applier.Event), objects []client.Object) (applier.ObjectStatusMap, *stats.SyncStats) {
+func (a *Applier) Apply(_ context.Context, eventHandler func(applier.Event), resources *declared.Resources) (applier.ObjectStatusMap, *stats.SyncStats) {
+	objects, _ := resources.DeclaredObjects()
+
 	a.ApplyInputs = append(a.ApplyInputs, ApplierInputs{
 		Objects: objects,
 	})

--- a/pkg/applier/fake/applier.go
+++ b/pkg/applier/fake/applier.go
@@ -50,7 +50,7 @@ type ApplierOutputs struct {
 
 // Apply fakes applier.Applier.Apply()
 func (a *Applier) Apply(_ context.Context, eventHandler func(applier.Event), resources *declared.Resources) (applier.ObjectStatusMap, *stats.SyncStats) {
-	objects, _ := resources.DeclaredObjects()
+	objects := resources.DeclaredObjects()
 
 	a.ApplyInputs = append(a.ApplyInputs, ApplierInputs{
 		Objects: objects,

--- a/pkg/applier/utils.go
+++ b/pkg/applier/utils.go
@@ -60,11 +60,7 @@ func handleIgnoredObjects(enabled []client.Object, resources *declared.Resources
 		_, deleted := cachedObj.(*queue.Deleted)
 
 		if found && !deleted {
-			// Applies declared Config Sync metadata on top of stored config
-			csAnnotations, csLabels := metadata.GetConfigSyncMetadata(dObj)
-			core.AddAnnotations(cachedObj, csAnnotations)
-			core.AddLabels(cachedObj, csLabels)
-
+			metadata.UpdateConfigSyncMetadata(dObj, cachedObj)
 			allObjs = append(allObjs, cachedObj)
 		} else {
 			allObjs = append(allObjs, dObj)

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -292,7 +293,8 @@ func TestHandleIgnoredObjects(t *testing.T) {
 			expectedObjs: []client.Object{
 				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
 					syncertest.ManagementEnabled,
-					core.Annotation("foo", "bar")),
+					core.Annotation("foo", "bar"),
+					core.Annotation(metadata.LifecycleMutationAnnotation, "")),
 			},
 		},
 	}

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -25,7 +25,6 @@ import (
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/kinds"
-	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -293,8 +292,8 @@ func TestHandleIgnoredObjects(t *testing.T) {
 			expectedObjs: []client.Object{
 				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
 					syncertest.ManagementEnabled,
-					core.Annotation("foo", "bar"),
-					core.Annotation(metadata.LifecycleMutationAnnotation, "")),
+					syncertest.IgnoreMutationAnnotation,
+					core.Annotation("foo", "bar")),
 			},
 		},
 	}

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -206,23 +206,31 @@ func TestHandleIgnoredObjects(t *testing.T) {
 		{
 			name: "an existing but unmanaged object is declared with the ignore mutation annotation",
 			declaredObjs: []client.Object{
-				k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation),
+				k8sobjects.NamespaceObject("test-ns",
+					syncertest.IgnoreMutationAnnotation,
+					syncertest.ManagementEnabled),
 			},
 			ignoredObjs: []client.Object{
-				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns")),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					core.Annotation("foo", "bar")),
 			},
 			expectedObjs: []client.Object{
-				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"), syncertest.IgnoreMutationAnnotation),
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					core.Annotation("foo", "bar"),
+					syncertest.IgnoreMutationAnnotation,
+					syncertest.ManagementEnabled),
 			},
 		},
 		{
 			name: "a managed object is now declared with the ignore mutation annotation",
 			declaredObjs: []client.Object{
-				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+				k8sobjects.NamespaceObject("test-ns",
 					syncertest.ManagementEnabled,
 					syncertest.IgnoreMutationAnnotation),
 			},
-			ignoredObjs: []client.Object{k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"))},
+			ignoredObjs: []client.Object{
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					syncertest.ManagementEnabled)},
 			expectedObjs: []client.Object{
 				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
 					syncertest.ManagementEnabled,
@@ -232,12 +240,15 @@ func TestHandleIgnoredObjects(t *testing.T) {
 		{
 			name: "a managed object is now declared with the ignore mutation annotation and other spec changes",
 			declaredObjs: []client.Object{
-				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+				k8sobjects.NamespaceObject("test-ns",
 					syncertest.ManagementEnabled,
 					syncertest.IgnoreMutationAnnotation,
 					core.Annotation("foo", "bar")),
 			},
-			ignoredObjs: []client.Object{(k8sobjects.UnstructuredObject(kinds.Namespace(), syncertest.ManagementEnabled, core.Name("test-ns")))},
+			ignoredObjs: []client.Object{
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					syncertest.ManagementEnabled),
+			},
 			expectedObjs: []client.Object{
 				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
 					syncertest.ManagementEnabled,
@@ -263,6 +274,25 @@ func TestHandleIgnoredObjects(t *testing.T) {
 				k8sobjects.NamespaceObject("test-ns",
 					syncertest.ManagementEnabled,
 					syncertest.IgnoreMutationAnnotation),
+			},
+		},
+		{
+			name: "an object exists with the ignore mutation annotation but it is declared without it",
+			declaredObjs: []client.Object{
+				k8sobjects.NamespaceObject("test-ns",
+					syncertest.ManagementEnabled),
+			},
+			ignoredObjs: []client.Object{
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					syncertest.ManagementEnabled,
+					syncertest.IgnoreMutationAnnotation,
+					core.Annotation("foo", "bar"),
+				),
+			},
+			expectedObjs: []client.Object{
+				k8sobjects.UnstructuredObject(kinds.Namespace(), core.Name("test-ns"),
+					syncertest.ManagementEnabled,
+					core.Annotation("foo", "bar")),
 			},
 		},
 	}

--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -197,32 +197,31 @@ func (r *Resources) GetDeclared(id core.ID) (*unstructured.Unstructured, string,
 
 // DeclaredUnstructureds returns all resource objects declared in the source,
 // along with the source commit.
-func (r *Resources) DeclaredUnstructureds() ([]*unstructured.Unstructured, string) {
+func (r *Resources) DeclaredUnstructureds() []*unstructured.Unstructured {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 	if r.declaredObjectsMap == nil || r.declaredObjectsMap.Len() == 0 {
-		return nil, r.commit
+		return nil
 	}
 	var objects []*unstructured.Unstructured
 	for pair := r.declaredObjectsMap.Front(); pair != nil; pair = pair.Next() {
 		objects = append(objects, pair.Value)
 	}
-	return objects, r.commit
+	return objects
 }
 
-// DeclaredObjects returns all resource objects declared in the source, along
-// with the source commit.
-func (r *Resources) DeclaredObjects() ([]client.Object, string) {
+// DeclaredObjects returns all resource objects declared in the source
+func (r *Resources) DeclaredObjects() []client.Object {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 	if r.declaredObjectsMap == nil || r.declaredObjectsMap.Len() == 0 {
-		return nil, r.commit
+		return nil
 	}
 	var objects []client.Object
 	for pair := r.declaredObjectsMap.Front(); pair != nil; pair = pair.Next() {
 		objects = append(objects, pair.Value)
 	}
-	return objects, r.commit
+	return objects
 }
 
 // DeclaredGVKs returns the set of all GroupVersionKind found in the source,
@@ -244,7 +243,7 @@ func (r *Resources) DeclaredGVKs() (map[schema.GroupVersionKind]struct{}, string
 func (r *Resources) DeclaredCRDs() ([]*v1beta1.CustomResourceDefinition, status.MultiError) {
 	// DeclaredUnstructureds handles the mutex, so this method doesn't need to lock.
 	var crds []*v1beta1.CustomResourceDefinition
-	declaredObjs, _ := r.DeclaredUnstructureds()
+	declaredObjs := r.DeclaredUnstructureds()
 	for _, obj := range declaredObjs {
 		if obj.GroupVersionKind().GroupKind() != kinds.CustomResourceDefinition() {
 			continue

--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -106,24 +106,6 @@ func (r *Resources) IgnoredObjects() []client.Object {
 	return objects
 }
 
-// GetIgnoredObjsCache returns a copy of the ignoredObjsMap
-func (r *Resources) GetIgnoredObjsCache() *orderedmap.OrderedMap[core.ID, client.Object] {
-	//TODO: add test to verify empty map isn't passed to ignore
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	cacheCopy := orderedmap.NewOrderedMap[core.ID, client.Object]()
-
-	if r.mutationIgnoreObjectsMap == nil {
-		return cacheCopy
-	}
-
-	for pair := r.mutationIgnoreObjectsMap.Front(); pair != nil; pair = pair.Next() {
-		cacheCopy.Set(pair.Key, pair.Value.DeepCopyObject().(client.Object))
-	}
-
-	return cacheCopy
-}
-
 // DeleteIgnored deletes an ignore-mutation object from the ignored cache
 func (r *Resources) DeleteIgnored(id core.ID) bool {
 	r.mutex.RLock()

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -248,8 +248,11 @@ func TestGetIgnored(t *testing.T) {
 	dr.UpdateIgnored(ignoredObj)
 	o, found = dr.GetIgnored(id)
 
+	expectedO := o.DeepCopyObject().(client.Object)
+	expectedO, _ = reconcile.AsUnstructuredSanitized(expectedO)
+
 	assert.True(t, found)
-	testutil.AssertEqual(t, ignoredObj, o)
+	testutil.AssertEqual(t, expectedO, o)
 }
 
 func TestUpdateIgnored(t *testing.T) {
@@ -291,7 +294,12 @@ func TestIgnoredObjsCache(t *testing.T) {
 	cache = dr.GetIgnoredObjsCache()
 	foundObj, _ := cache.Get(id)
 
-	testutil.AssertEqual(t, ignoredObj, foundObj)
+	cachedIgnoredObj := ignoredObj.DeepCopy()
+	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "status")
+	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "metadata", "managedFields")
+
+	testutil.AssertEqual(t, cachedIgnoredObj, foundObj)
 
 	foundObj.SetName("foo")
 

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -29,31 +30,34 @@ import (
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metrics"
 	"kpt.dev/configsync/pkg/syncer/reconcile"
+	"kpt.dev/configsync/pkg/syncer/syncertest"
 	"kpt.dev/configsync/pkg/testing/testmetrics"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	obj1 = k8sobjects.CustomResourceDefinitionV1Beta1Object()
-	obj2 = k8sobjects.ResourceQuotaObject()
+	obj1       = k8sobjects.CustomResourceDefinitionV1Beta1Object()
+	obj2       = k8sobjects.ResourceQuotaObject()
+	ignoredObj = k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation)
 
 	testSet = []client.Object{obj1, obj2}
 	nilSet  = []client.Object{nil}
 )
 
-func TestUpdate(t *testing.T) {
+func TestUpdateDeclared(t *testing.T) {
 	dr := Resources{}
 	objects := testSet
 	commit := "1"
 	expectedIDs := getIDs(objects)
 
-	newObjects, err := dr.Update(context.Background(), objects, commit)
+	newObjects, err := dr.UpdateDeclared(context.Background(), objects, commit)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
 	for _, id := range expectedIDs {
-		if _, ok := dr.objectMap.Get(id); !ok {
+		if _, ok := dr.declaredObjectsMap.Get(id); !ok {
 			t.Errorf("ID %v not found in the declared resource", id)
 		}
 	}
@@ -76,7 +80,7 @@ func TestMutateImpossible(t *testing.T) {
 	o2.SetResourceVersion(wantResourceVersion)
 
 	expectedCommit := "example"
-	_, err := dr.Update(context.Background(), []client.Object{o1, o2}, expectedCommit)
+	_, err := dr.UpdateDeclared(context.Background(), []client.Object{o1, o2}, expectedCommit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +89,7 @@ func TestMutateImpossible(t *testing.T) {
 	o1.SetResourceVersion("version 1++")
 	o2.SetResourceVersion("version 1++")
 
-	got1, commit, found := dr.Get(core.IDOf(o1))
+	got1, commit, found := dr.GetDeclared(core.IDOf(o1))
 	require.Equal(t, expectedCommit, commit)
 	if !found {
 		t.Fatalf("got dr.Get = %v, %t, want dr.Get = obj, true", got1, found)
@@ -93,7 +97,7 @@ func TestMutateImpossible(t *testing.T) {
 	if diff := cmp.Diff(wantResourceVersion, got1.GetResourceVersion()); diff != "" {
 		t.Error(diff)
 	}
-	got2, commit, found := dr.Get(core.IDOf(o2))
+	got2, commit, found := dr.GetDeclared(core.IDOf(o2))
 	require.Equal(t, expectedCommit, commit)
 	if !found {
 		t.Fatalf("got dr.Get = %v, %t, want dr.Get = obj, true", got2, found)
@@ -106,7 +110,7 @@ func TestMutateImpossible(t *testing.T) {
 	got1.SetResourceVersion("version 2")
 	got2.SetResourceVersion("version 2")
 
-	got3, commit, found := dr.Get(core.IDOf(o1))
+	got3, commit, found := dr.GetDeclared(core.IDOf(o1))
 	require.Equal(t, expectedCommit, commit)
 	if !found {
 		t.Fatalf("got dr.Get = %v, %t, want dr.Get = obj, true", got3, found)
@@ -114,7 +118,7 @@ func TestMutateImpossible(t *testing.T) {
 	if diff := cmp.Diff(wantResourceVersion, got3.GetResourceVersion()); diff != "" {
 		t.Error(diff)
 	}
-	got4, commit, found := dr.Get(core.IDOf(o2))
+	got4, commit, found := dr.GetDeclared(core.IDOf(o2))
 	require.Equal(t, expectedCommit, commit)
 	if !found {
 		t.Fatalf("got dr.Get = %v, %t, want dr.Get = obj, true", got4, found)
@@ -136,7 +140,7 @@ func asUnstructured(t *testing.T, o client.Object) *unstructured.Unstructured {
 func TestDeclarations(t *testing.T) {
 	dr := Resources{}
 	expectedCommit := "example"
-	objects, err := dr.Update(context.Background(), testSet, expectedCommit)
+	objects, err := dr.UpdateDeclared(context.Background(), testSet, expectedCommit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,15 +171,15 @@ func TestDeclarations(t *testing.T) {
 	}
 }
 
-func TestGet(t *testing.T) {
+func TestGetDeclared(t *testing.T) {
 	dr := Resources{}
 	expectedCommit := "example"
-	_, err := dr.Update(context.Background(), testSet, expectedCommit)
+	_, err := dr.UpdateDeclared(context.Background(), testSet, expectedCommit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, commit, found := dr.Get(core.IDOf(obj1))
+	actual, commit, found := dr.GetDeclared(core.IDOf(obj1))
 	require.Equal(t, expectedCommit, commit)
 	if !found {
 		t.Fatal("got not found, want found")
@@ -188,7 +192,7 @@ func TestGet(t *testing.T) {
 func TestGVKSet(t *testing.T) {
 	dr := Resources{}
 	expectedCommit := "example"
-	_, err := dr.Update(context.Background(), testSet, expectedCommit)
+	_, err := dr.UpdateDeclared(context.Background(), testSet, expectedCommit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +211,7 @@ func TestGVKSet(t *testing.T) {
 func TestResources_InternalErrorMetricValidation(t *testing.T) {
 	m := testmetrics.RegisterMetrics(metrics.InternalErrorsView)
 	dr := Resources{}
-	if _, err := dr.Update(context.Background(), nilSet, "unused"); err != nil {
+	if _, err := dr.UpdateDeclared(context.Background(), nilSet, "unused"); err != nil {
 		t.Fatal(err)
 	}
 	wantMetrics := []*view.Row{
@@ -229,4 +233,81 @@ func getIDs(objects []client.Object) []core.ID {
 		IDs = append(IDs, core.IDOf(obj))
 	}
 	return IDs
+}
+
+func TestGetIgnored(t *testing.T) {
+	id := core.IDOf(ignoredObj)
+	dr := Resources{}
+
+	o, found := dr.GetIgnored(id)
+	assert.Nil(t, o)
+	assert.False(t, found)
+
+	dr.UpdateIgnored(ignoredObj)
+	o, found = dr.GetIgnored(id)
+
+	assert.True(t, found)
+	testutil.AssertEqual(t, ignoredObj, o)
+}
+
+func TestUpdateIgnored(t *testing.T) {
+	dr := Resources{}
+	id := core.IDOf(ignoredObj)
+
+	dr.UpdateIgnored(ignoredObj)
+	o, found := dr.GetIgnored(id)
+	assert.True(t, found)
+
+	o.SetName("new-name")
+	assert.NotEqual(t, "new-name", obj1.Name)
+}
+
+func TestIgnoredObjects(t *testing.T) {
+	dr := Resources{}
+
+	ignored := dr.IgnoredObjects()
+	assert.Nil(t, ignored)
+
+	dr.UpdateIgnored(ignoredObj)
+	ignored = dr.IgnoredObjects()
+	assert.Contains(t, ignored, ignoredObj)
+}
+
+func TestIgnoredObjsCache(t *testing.T) {
+	dr := Resources{}
+	id := core.IDOf(ignoredObj)
+
+	cache := dr.GetIgnoredObjsCache()
+
+	assert.NotNil(t, cache)
+
+	dr.UpdateIgnored(ignoredObj)
+
+	_, found := cache.Get(id)
+	assert.False(t, found, "object was found in the supposed cache copy")
+
+	cache = dr.GetIgnoredObjsCache()
+	foundObj, _ := cache.Get(id)
+
+	testutil.AssertEqual(t, ignoredObj, foundObj)
+
+	foundObj.SetName("foo")
+
+	testutil.AssertNotEqual(t, ignoredObj, foundObj, "objects should not be equal if found is a copy")
+
+}
+
+func TestDeleteIgnored(t *testing.T) {
+	id := core.IDOf(ignoredObj)
+	dr := Resources{}
+	deleted := dr.DeleteIgnored(id)
+	ignored := dr.IgnoredObjects()
+
+	assert.False(t, deleted)
+	assert.NotContains(t, ignored, ignoredObj)
+
+	dr.UpdateIgnored(ignoredObj)
+	deleted = dr.DeleteIgnored(id)
+	assert.True(t, deleted)
+	assert.NotContains(t, ignored, ignoredObj)
 }

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -285,7 +285,7 @@ func TestIgnoredObjects(t *testing.T) {
 
 	ignoredObjs = dr.IgnoredObjects()
 
-	assert.NotContains(t, ignoredObjs, foundObj, "foundObj shouldn't have been modified in mutationIgnoreObjectsMap")
+	assert.NotContains(t, ignoredObjs, foundObj, "foundObj shouldn't have been modified in mutationIgnoredObjectsMap")
 }
 
 func TestDeleteIgnored(t *testing.T) {

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -148,8 +148,7 @@ func TestDeclarations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, commit := dr.DeclaredUnstructureds()
-	require.Equal(t, expectedCommit, commit)
+	got := dr.DeclaredUnstructureds()
 
 	// Sort got decls to ensure determinism.
 	sort.Slice(got, func(i, j int) bool {

--- a/pkg/declared/resources_test.go
+++ b/pkg/declared/resources_test.go
@@ -270,41 +270,22 @@ func TestUpdateIgnored(t *testing.T) {
 func TestIgnoredObjects(t *testing.T) {
 	dr := Resources{}
 
-	ignored := dr.IgnoredObjects()
-	assert.Nil(t, ignored)
+	ignoredObjs := dr.IgnoredObjects()
+	assert.Nil(t, ignoredObjs)
 
 	dr.UpdateIgnored(ignoredObj)
-	ignored = dr.IgnoredObjects()
-	assert.Contains(t, ignored, ignoredObj)
-}
+	ignoredObjs = dr.IgnoredObjects()
 
-func TestIgnoredObjsCache(t *testing.T) {
-	dr := Resources{}
-	id := core.IDOf(ignoredObj)
+	cachedIgnoredObj := asUnstructured(t, ignoredObj.DeepCopy())
+	assert.Contains(t, ignoredObjs, cachedIgnoredObj)
 
-	cache := dr.GetIgnoredObjsCache()
-
-	assert.NotNil(t, cache)
-
-	dr.UpdateIgnored(ignoredObj)
-
-	_, found := cache.Get(id)
-	assert.False(t, found, "object was found in the supposed cache copy")
-
-	cache = dr.GetIgnoredObjsCache()
-	foundObj, _ := cache.Get(id)
-
-	cachedIgnoredObj := ignoredObj.DeepCopy()
-	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "status")
-	unstructured.RemoveNestedField(cachedIgnoredObj.Object, "metadata", "managedFields")
-
-	testutil.AssertEqual(t, cachedIgnoredObj, foundObj)
-
+	foundObj := ignoredObjs[0]
 	foundObj.SetName("foo")
+	foundObj = asUnstructured(t, foundObj)
 
-	testutil.AssertNotEqual(t, ignoredObj, foundObj, "objects should not be equal if found is a copy")
+	ignoredObjs = dr.IgnoredObjects()
 
+	assert.NotContains(t, ignoredObjs, foundObj, "foundObj shouldn't have been modified in mutationIgnoreObjectsMap")
 }
 
 func TestDeleteIgnored(t *testing.T) {

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -177,7 +177,7 @@ const (
 // This annotation is set by Config Sync on a managed resource.
 const OwningInventoryKey = "config.k8s.io/owning-inventory"
 
-// HNCManagedBy is the annotatiƒon that indicates the namespace hierarchy is
+// HNCManagedBy is the annotation that indicates the namespace hierarchy is
 // not managed by the Hierarchical Namespace Controller (http://bit.ly/k8s-hnc-design) but
 // someone else, "configmanagement.gke.io" in this case.
 // This annotation is set by Config Sync on a managed namespace resource.

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -177,7 +177,7 @@ const (
 // This annotation is set by Config Sync on a managed resource.
 const OwningInventoryKey = "config.k8s.io/owning-inventory"
 
-// HNCManagedBy is the annotation that indicates the namespace hierarchy is
+// HNCManagedBy is the annotatiƒon that indicates the namespace hierarchy is
 // not managed by the Hierarchical Namespace Controller (http://bit.ly/k8s-hnc-design) but
 // someone else, "configmanagement.gke.io" in this case.
 // This annotation is set by Config Sync on a managed namespace resource.

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -144,13 +144,6 @@ func RemoveConfigSyncMetadata(obj client.Object) bool {
 func UpdateConfigSyncMetadata(fromObj client.Object, toObj client.Object) {
 	csAnnotations, csLabels := getConfigSyncMetadata(fromObj)
 
-	// toObj object has the lifecycle annotation but not the fromObj object
-	// This is necessary as otherwise, the annotation won't be removed when using SSA
-	if fromObj.GetAnnotations()[LifecycleMutationAnnotation] == "" &&
-		toObj.GetAnnotations()[LifecycleMutationAnnotation] == IgnoreMutation {
-		csAnnotations[LifecycleMutationAnnotation] = ""
-	}
-
 	core.AddAnnotations(toObj, csAnnotations)
 	core.AddLabels(toObj, csLabels)
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -154,3 +154,25 @@ func RemoveApplySetPartOfLabel(obj client.Object, applySetID string) bool {
 	obj.SetLabels(labels)
 	return true
 }
+
+// GetConfigSyncMetadata gets all Config Sync annotations and labels from the given resource
+func GetConfigSyncMetadata(obj client.Object) (map[string]string, map[string]string) {
+	configSyncAnnotations := map[string]string{}
+	configSyncLabels := map[string]string{}
+
+	annotations := obj.GetAnnotations()
+
+	for k, v := range annotations {
+		if isConfigSyncAnnotation(k, v) {
+			configSyncAnnotations[k] = v
+		}
+	}
+
+	labels := obj.GetLabels()
+	for k, v := range labels {
+		if isConfigSyncLabel(k, v) {
+			configSyncLabels[k] = v
+		}
+	}
+	return configSyncAnnotations, configSyncLabels
+}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -248,13 +248,13 @@ func TestUpdateConfigSyncMetadata(t *testing.T) {
 			name:        "fromObj doesn't have the ignore mutation annotation but toObj does",
 			fromObj:     k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled),
 			toObj:       k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation),
-			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, core.Annotation(metadata.LifecycleMutationAnnotation, "")),
+			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, syncertest.IgnoreMutationAnnotation),
 		},
 		{
 			name:        "fromObj doesn't have a non-CS annotation but toObj does",
 			fromObj:     k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled),
 			toObj:       k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation, core.Annotation("foo", "bar")),
-			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, core.Annotation(metadata.LifecycleMutationAnnotation, ""), core.Annotation("foo", "bar")),
+			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, syncertest.IgnoreMutationAnnotation, core.Annotation("foo", "bar")),
 		},
 	}
 

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -224,3 +224,46 @@ func TestRemoveApplySetPartOfLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateConfigSyncMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromObj     client.Object
+		toObj       client.Object
+		expectedObj client.Object
+	}{
+		{
+			name:        "fromObj + toObj don't have CS metadata",
+			fromObj:     k8sobjects.NamespaceObject("test-ns"),
+			toObj:       k8sobjects.NamespaceObject("test-ns"),
+			expectedObj: k8sobjects.NamespaceObject("test-ns"),
+		},
+		{
+			name:        "fromObj has the ignore mutation annotation but toObj doesn't",
+			fromObj:     k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation, syncertest.ManagementEnabled),
+			toObj:       k8sobjects.NamespaceObject("test-ns"),
+			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation, syncertest.ManagementEnabled),
+		},
+		{
+			name:        "fromObj doesn't have the ignore mutation annotation but toObj does",
+			fromObj:     k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled),
+			toObj:       k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation),
+			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, core.Annotation(metadata.LifecycleMutationAnnotation, "")),
+		},
+		{
+			name:        "fromObj doesn't have a non-CS annotation but toObj does",
+			fromObj:     k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled),
+			toObj:       k8sobjects.NamespaceObject("test-ns", syncertest.IgnoreMutationAnnotation, core.Annotation("foo", "bar")),
+			expectedObj: k8sobjects.NamespaceObject("test-ns", syncertest.ManagementEnabled, core.Annotation(metadata.LifecycleMutationAnnotation, ""), core.Annotation("foo", "bar")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			toObj, err := kinds.ObjectAsClientObject(tc.toObj.DeepCopyObject())
+			require.NoError(t, err)
+			metadata.UpdateConfigSyncMetadata(tc.fromObj, toObj)
+			testutil.AssertEqual(t, tc.expectedObj, toObj)
+		})
+	}
+}

--- a/pkg/parse/root_reconciler_test.go
+++ b/pkg/parse/root_reconciler_test.go
@@ -674,6 +674,7 @@ func TestRootReconciler_ParseAndUpdate(t *testing.T) {
 				ApplyOutputs: []applierfake.ApplierOutputs{
 					{}, // One Apply call
 				},
+				ApplyClient: syncertest.NewClient(t, core.Scheme, tc.existingObjects...),
 			}
 			tc.existingObjects = append(tc.existingObjects, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			files := []cmpath.Absolute{

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -126,7 +126,7 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 
 	// Apply the declared resources
 	if !cache.applied {
-		declaredObjs, _ := u.Resources.DeclaredObjects()
+		declaredObjs := u.Resources.DeclaredObjects()
 		klog.Infof("%v objects that were declared: %v", len(declaredObjs), core.GKNNs(declaredObjs))
 
 		if err := u.apply(ctx, cache.source.commit); err != nil {

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/applier"
+	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/metrics"
@@ -115,6 +116,7 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 		if err != nil {
 			return err
 		}
+
 		// Only mark the declared resources as updated if there were no (non-blocking) parse errors.
 		// This ensures the update will be retried until parsing fully succeeds.
 		if cache.parse.parserErrs == nil {
@@ -125,7 +127,9 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 	// Apply the declared resources
 	if !cache.applied {
 		declaredObjs, _ := u.Resources.DeclaredObjects()
-		if err := u.apply(ctx, declaredObjs, cache.source.commit); err != nil {
+		klog.Infof("%v objects that were declared: %v", len(declaredObjs), core.GKNNs(declaredObjs))
+
+		if err := u.apply(ctx, cache.source.commit); err != nil {
 			return err
 		}
 		// Only mark the commit as applied if there were no (non-blocking) parse errors.
@@ -171,7 +175,7 @@ func (u *Updater) declare(ctx context.Context, objs []client.Object, commit stri
 	return objs, nil
 }
 
-func (u *Updater) apply(ctx context.Context, objs []client.Object, commit string) status.MultiError {
+func (u *Updater) apply(ctx context.Context, commit string) status.MultiError {
 	// Collect errors into a MultiError
 	var err status.MultiError
 	eventHandler := func(event applier.Event) {
@@ -191,7 +195,7 @@ func (u *Updater) apply(ctx context.Context, objs []client.Object, commit string
 	klog.Info("Applier starting...")
 	start := time.Now()
 	u.SyncErrorCache.ResetApplyErrors()
-	objStatusMap, syncStats := u.Applier.Apply(ctx, eventHandler, objs)
+	objStatusMap, syncStats := u.Applier.Apply(ctx, eventHandler, u.Resources)
 	if !syncStats.Empty() {
 		klog.Infof("Applier made new progress: %s", syncStats.String())
 		objStatusMap.Log(klog.V(0))

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/applier"
-	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
 	"kpt.dev/configsync/pkg/importer/filesystem"
 	"kpt.dev/configsync/pkg/metrics"
@@ -126,9 +125,6 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 
 	// Apply the declared resources
 	if !cache.applied {
-		declaredObjs := u.Resources.DeclaredObjects()
-		klog.Infof("%v objects that were declared: %v", len(declaredObjs), core.GKNNs(declaredObjs))
-
 		if err := u.apply(ctx, cache.source.commit); err != nil {
 			return err
 		}

--- a/pkg/parse/updater.go
+++ b/pkg/parse/updater.go
@@ -161,7 +161,7 @@ func (u *Updater) update(ctx context.Context, cache *cacheForCommit) status.Mult
 
 func (u *Updater) declare(ctx context.Context, objs []client.Object, commit string) ([]client.Object, status.MultiError) {
 	klog.V(1).Info("Declared resources updating...")
-	objs, err := u.Resources.Update(ctx, objs, commit)
+	objs, err := u.Resources.UpdateDeclared(ctx, objs, commit)
 	u.SyncErrorCache.SetValidationErrs(err)
 	if err != nil {
 		klog.Warningf("Failed to validate declared resources: %v", err)

--- a/pkg/remediator/reconcile/reconciler.go
+++ b/pkg/remediator/reconcile/reconciler.go
@@ -76,7 +76,7 @@ func newReconciler(
 func (r *reconciler) Remediate(ctx context.Context, id core.ID, obj client.Object) status.Error {
 	start := time.Now()
 
-	declU, commit, found := r.declared.Get(id)
+	declU, commit, found := r.declared.GetDeclared(id)
 	// Yes, this if block is necessary because Go is pedantic about nil interfaces.
 	// 1) var decl client.Object = declU results in a panic.
 	// 2) Using declU as a client.Object results in a panic.

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -533,7 +533,7 @@ func TestRemediator_Reconcile_Metrics(t *testing.T) {
 func makeDeclared(t *testing.T, commit string, objs ...client.Object) *declared.Resources {
 	t.Helper()
 	d := &declared.Resources{}
-	if _, err := d.Update(context.Background(), objs, commit); err != nil {
+	if _, err := d.UpdateDeclared(context.Background(), objs, commit); err != nil {
 		// Test precondition; fail early.
 		t.Fatal(err)
 	}

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -445,6 +445,11 @@ func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string
 			core.IDOf(object), object.GetGeneration())
 	}
 
+	// Update drifted objects in the Resources ignored cache
+	if _, found := w.resources.GetIgnored(core.IDOf(object)); found {
+		w.resources.UpdateIgnored(object)
+		klog.Infof("Updating object '%v' in the ignore mutation cache", core.GKNN(object))
+	}
 	w.queue.Add(object)
 	return object.GetResourceVersion(), false, nil
 }

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -448,7 +448,7 @@ func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string
 	// Update drifted objects in the Resources ignored cache
 	if _, found := w.resources.GetIgnored(core.IDOf(object)); found {
 		w.resources.UpdateIgnored(object)
-		klog.Infof("Updating object '%v' in the ignore mutation cache", core.GKNN(object))
+		klog.V(3).Infof("Updating object '%v' in the ignore mutation cache", core.GKNN(object))
 	}
 	w.queue.Add(object)
 	return object.GetResourceVersion(), false, nil

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -459,7 +459,7 @@ func (w *filteredWatcher) shouldProcess(object client.Object) bool {
 		return true
 	}
 
-	decl, commit, found := w.resources.Get(id)
+	decl, commit, found := w.resources.GetDeclared(id)
 	if !found {
 		// The resource is neither declared nor managed by the same reconciler, so don't manage it.
 		return false

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,7 @@ import (
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/remediator/queue"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/syncer/reconcile"
 	"kpt.dev/configsync/pkg/syncer/syncertest"
 	testfake "kpt.dev/configsync/pkg/syncer/syncertest/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +56,7 @@ func TestFilteredWatcher(t *testing.T) {
 	syncName := "rs"
 
 	deployment1 := k8sobjects.DeploymentObject(core.Name("hello"))
-	deployment1Beta := k8sobjects.DeploymentObject(core.Name("hello"))
+	deployment1Beta := k8sobjects.DeploymentObject(core.Name("hello"), syncertest.IgnoreMutationAnnotation)
 	deployment1Beta.GetObjectKind().SetGroupVersionKind(deployment1Beta.GroupVersionKind().GroupKind().WithVersion("beta1"))
 
 	deployment2 := k8sobjects.DeploymentObject(core.Name("world"))
@@ -67,12 +69,14 @@ func TestFilteredWatcher(t *testing.T) {
 	deploymentForRoot := k8sobjects.DeploymentObject(core.Name("managed-by-root"), difftest.ManagedBy(declared.RootScope, "any-rs"))
 
 	testCases := []struct {
-		name     string
-		declared []client.Object
-		watches  [][]action
-		timeout  *time.Duration
-		want     []core.ID
-		wantErr  status.Error
+		name                  string
+		declared              []client.Object
+		watches               [][]action
+		timeout               *time.Duration
+		want                  []core.ID
+		wantErr               status.Error
+		ignored               []client.Object
+		expectedCachedIgnored []client.Object
 	}{
 		{
 			name: "Enqueue events for declared resources",
@@ -319,6 +323,55 @@ func TestFilteredWatcher(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "with objects in the ignore mutation cache",
+			declared: []client.Object{
+				deployment1,
+				deployment2,
+				deployment3,
+			},
+			watches: [][]action{{
+				{
+					event: watch.Added,
+					obj:   deployment1,
+				},
+				{
+					event: watch.Modified,
+					obj:   deployment2,
+				},
+				{
+					event: watch.Deleted,
+					obj:   deployment3,
+				},
+				{
+					stopRun: true,
+				},
+			}},
+			want: []core.ID{
+				core.IDOf(deployment1),
+				core.IDOf(deployment2),
+				core.IDOf(deployment3),
+			},
+			ignored: []client.Object{
+				func() client.Object {
+					dCopy := deployment2.DeepCopy()
+					core.SetAnnotation(dCopy, "foo", "bar")
+					return dCopy
+				}(),
+				func() client.Object {
+					dCopy := deployment3.DeepCopy()
+					core.SetAnnotation(dCopy, "foo", "bar")
+					return dCopy
+				}(),
+			},
+			expectedCachedIgnored: []client.Object{
+				func() client.Object {
+					u, _ := reconcile.AsUnstructuredSanitized(deployment2)
+					return u
+				}(),
+				&queue.Deleted{Object: deployment3},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -333,6 +386,10 @@ func TestFilteredWatcher(t *testing.T) {
 			}
 			if _, err := dr.UpdateDeclared(ctx, tc.declared, "unused"); err != nil {
 				t.Fatalf("unexpected error %v", err)
+			}
+
+			if tc.ignored != nil {
+				dr.UpdateIgnored(tc.ignored...)
 			}
 
 			watches := make(chan watch.Interface) // TODO: test startWatch errors
@@ -387,6 +444,8 @@ func TestFilteredWatcher(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("did not get desired object IDs: %v", diff)
 			}
+
+			assert.Equal(t, tc.expectedCachedIgnored, dr.IgnoredObjects())
 		})
 	}
 }

--- a/pkg/remediator/watch/filteredwatcher_test.go
+++ b/pkg/remediator/watch/filteredwatcher_test.go
@@ -331,7 +331,7 @@ func TestFilteredWatcher(t *testing.T) {
 			} else {
 				ctx, cancel = context.WithCancel(ctx)
 			}
-			if _, err := dr.Update(ctx, tc.declared, "unused"); err != nil {
+			if _, err := dr.UpdateDeclared(ctx, tc.declared, "unused"); err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
 

--- a/pkg/syncer/reconcile/as_unstructured.go
+++ b/pkg/syncer/reconcile/as_unstructured.go
@@ -57,6 +57,10 @@ func AsUnstructuredSanitized(o client.Object) (*unstructured.Unstructured, statu
 
 	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(u.Object, "status")
+
+	// This field is populated when the object is fetched from the cluster, so it
+	// needs to be removed before the object is updated and sent to the Applier.
+	// SSA does not accept objects with this field.
 	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 	return u, nil
 }

--- a/pkg/syncer/reconcile/as_unstructured.go
+++ b/pkg/syncer/reconcile/as_unstructured.go
@@ -36,6 +36,7 @@ func AsUnstructured(o client.Object) (*unstructured.Unstructured, status.Error) 
 // fields:
 // - metadata.creationTimestamp
 // - status
+// - metadata.managedFields
 //
 // These fields must not be set in the source, so we can safely drop them from
 // the current live manifest, because we won't ever need to be reverted.
@@ -56,5 +57,6 @@ func AsUnstructuredSanitized(o client.Object) (*unstructured.Unstructured, statu
 
 	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(u.Object, "status")
+	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 	return u, nil
 }

--- a/pkg/syncer/syncertest/reconcile.go
+++ b/pkg/syncer/syncertest/reconcile.go
@@ -36,4 +36,6 @@ var (
 	ManagementInvalid = core.Annotation(metadata.ResourceManagementKey, "invalid")
 	// TokenAnnotation sets the sync token annotation on the object
 	TokenAnnotation = core.Annotation(metadata.SyncTokenAnnotationKey, Token)
+	// IgnoreMutationAnnotation sets the ignore mutation annotation on the object
+	IgnoreMutationAnnotation = core.Annotation(metadata.LifecycleMutationAnnotation, metadata.IgnoreMutation)
 )


### PR DESCRIPTION
A cache has been added to Resources which stores the cluster state of all objects with the ignore-mutation annotation. The Applier uses the in-memory config with the declared CS metadata applied on top of it instead of only the declared object.