### PR TITLE
chore: bump otelcontribcol to 0.103.0-gke.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ COSIGN := $(BIN_DIR)/cosign
 GIT_SYNC_VERSION := v4.3.0-gke.1__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.103.0-gke.4
+OTELCONTRIBCOL_VERSION := v0.103.0-gke.5
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.


### PR DESCRIPTION
This is the latest patch version and contains some low severity CVE fixes.