### PR TITLE
chore: extract Reconciler.Fetch method

### DIFF
--- a/pkg/parse/reconciler.go
+++ b/pkg/parse/reconciler.go
@@ -33,6 +33,13 @@ type Reconciler interface {
 	// ReconcilerState returns the current state of the parser/reconciler.
 	ReconcilerState() *ReconcilerState
 
+	// Fetch waits for the *-sync sidecars to fetch the source manifests to the
+	// shared source volume.
+	// Updates the RSync status (source status and syncing condition).
+	//
+	// Fetch is exposed for use by DefaultRunFunc.
+	Fetch(context.Context) (sourceStatus *SourceStatus, syncPath cmpath.Absolute, errs status.MultiError)
+
 	// Render waits for the hydration-controller sidecar to render the source
 	// manifests on the shared source volume.
 	// Updates the RSync status (rendering status and syncing condition).
@@ -41,7 +48,7 @@ type Reconciler interface {
 	Render(context.Context, *SourceStatus) status.MultiError
 
 	// Read source manifests from the shared source volume.
-	// Waits for rendering, if enabled.
+	// Errors if rendering is required but not enabled.
 	// Updates the RSync status (source, rendering, and syncing condition).
 	//
 	// Read is exposed for use by DefaultRunFunc.

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -53,9 +53,9 @@ type ReconcilerState struct {
 }
 
 type checkpoint struct {
-	// sourcePath caches the source path that was last successfully applied.
+	// syncPath caches the sync path that was last successfully applied.
 	// Set to the empty string if the last attempt failed.
-	sourcePath cmpath.Absolute
+	syncPath cmpath.Absolute
 	// lastUpdateTime is the last time the checkpoint was updated.
 	// AKA: Last successful sync.
 	// TODO: Surface this timestamp in the RSync status API
@@ -68,23 +68,23 @@ type checkpoint struct {
 
 // updateCheckpoint records the last known source path, updates the
 // timestamps, and logs the message.
-func (s *ReconcilerState) updateCheckpoint(c clock.Clock, newSourcePath cmpath.Absolute) {
+func (s *ReconcilerState) updateCheckpoint(c clock.Clock, newSyncPath cmpath.Absolute) {
 	now := nowMeta(c)
 	// Check for transition
 	transitioned := false
-	if s.checkpoint.sourcePath != newSourcePath {
+	if s.checkpoint.syncPath != newSyncPath {
 		transitioned = true
-		s.checkpoint.sourcePath = newSourcePath
+		s.checkpoint.syncPath = newSyncPath
 		s.checkpoint.lastTransitionTime = now
 	}
 	// Record when the checkpoint was last updated
 	s.checkpoint.lastUpdateTime = now
-	if newSourcePath == invalidSyncPath {
+	if newSyncPath == invalidSyncPath {
 		klog.Info("Reconciler checkpoint invalidated")
 	} else if transitioned {
-		klog.Infof("Reconciler checkpoint updated with new source path: %s", newSourcePath)
+		klog.Infof("Reconciler checkpoint updated with new sync path: %s", newSyncPath)
 	} else {
-		klog.Infof("Reconciler checkpoint updated with existing source path: %s", newSourcePath)
+		klog.Infof("Reconciler checkpoint updated with existing sync path: %s", newSyncPath)
 	}
 }
 


### PR DESCRIPTION
- Extract reconciler.Fetch & method to simplify DefaultRunFunc
- Rename checkpoint.sourcePath to syncPath to match rename elsewhere
- Clarify some inline comments

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1481
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1482
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1484
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1485
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1488