### PR TITLE
fix: surface source status update error

### DIFF
--- a/pkg/parse/run.go
+++ b/pkg/parse/run.go
@@ -278,7 +278,7 @@ func (r *reconciler) Read(ctx context.Context, trigger string, sourceState *sour
 	var setSourceStatusErr error
 	if state.status.needToSetSourceStatus(sourceStatus) {
 		klog.V(3).Info("Updating source status (after parse)")
-		setSourceStatusErr := r.SyncStatusClient().SetSourceStatus(ctx, sourceStatus)
+		setSourceStatusErr = r.SyncStatusClient().SetSourceStatus(ctx, sourceStatus)
 		if setSourceStatusErr == nil {
 			state.status.SourceStatus = sourceStatus
 			state.status.SyncingConditionLastUpdate = sourceStatus.LastUpdate


### PR DESCRIPTION
The setSourceStatusErr here was being re-initialized inside an if statement, which means it would always be nil outside the if statement.

This fix allows the source status update error to be returned and logged correctly when the checkpoint is invalidated.

The bug this fixes is relatively minor, because SetSourceStatus has its own internal retries. So it's unlikely that SetSourceStatus will return an error unless something is seriously wrong. However, if it does happen, it needs to be logged because the RSync status won't have been updated.