### PR TITLE
chore: extract reconciler.Render method

### DIFF
--- a/pkg/parse/reconciler.go
+++ b/pkg/parse/reconciler.go
@@ -17,6 +17,7 @@ package parse
 import (
 	"context"
 
+	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/status"
 )
 
@@ -32,12 +33,19 @@ type Reconciler interface {
 	// ReconcilerState returns the current state of the parser/reconciler.
 	ReconcilerState() *ReconcilerState
 
+	// Render waits for the hydration-controller sidecar to render the source
+	// manifests on the shared source volume.
+	// Updates the RSync status (rendering status and syncing condition).
+	//
+	// Render is exposed for use by DefaultRunFunc.
+	Render(context.Context, *SourceStatus) status.MultiError
+
 	// Read source manifests from the shared source volume.
 	// Waits for rendering, if enabled.
 	// Updates the RSync status (source, rendering, and syncing condition).
 	//
 	// Read is exposed for use by DefaultRunFunc.
-	Read(ctx context.Context, trigger string, sourceState *sourceState) status.MultiError
+	Read(ctx context.Context, trigger string, sourceStatus *SourceStatus, syncDir cmpath.Absolute) status.MultiError
 
 	// ParseAndUpdate parses objects from the source manifests, validates them,
 	// and then syncs them to the cluster with the Updater.

--- a/pkg/status/transient_error.go
+++ b/pkg/status/transient_error.go
@@ -24,3 +24,19 @@ var transientErrorBuilder = NewErrorBuilder(TransientErrorCode)
 func TransientError(err error) Error {
 	return transientErrorBuilder.Wrap(err).Build()
 }
+
+// AllTransientErrors returns true if the MultiError is non-nil, non-empty, and
+// contains only TransientErrors.
+func AllTransientErrors(multiErr MultiError) bool {
+	if multiErr == nil {
+		return false
+	}
+	errs := multiErr.Errors()
+	for _, err := range errs {
+		if err.Code() != TransientErrorCode {
+			return false
+		}
+	}
+	// MultiError shouldn't be empty, but check just in case
+	return len(errs) > 0
+}


### PR DESCRIPTION
- The new Render method handles checking the done file written by the hydration-controller sidecar.
- The code has been cleaned up a bit to handle errors as soon as possible, following the Return Early Pattern, which reduces cyclomatic complexity and improves readability.
- To avoid the Render method calling state.invalidate(errs) directly, the Render method now returns a TransientError when rendering is still in-progress. This is caught by state.invalidate and handled by logging at the info level, instead of as an error. It still causes a retry
- Added a RenderedCommit method that returns read errors instead of just logging them. This is used by the Render method, which should error if the done file cannot be read, unless it was not found. The original doneCommit now wraps RenderedCommit and log errors when called by the hydration-controller.
- Remove ReconcilerState.reset, which is no longer needed, because returning the TransientError causes state.invalidate to be called, which handles logging and setting needToRetry and lastApplied.