### PR TITLE
chore: ReconcilerState cleanup

### DIFF
--- a/pkg/parse/event_handler.go
+++ b/pkg/parse/event_handler.go
@@ -95,7 +95,7 @@ func (s *EventHandler) Handle(event events.Event) events.Result {
 				Syncing:    false,
 				Commit:     state.status.SyncStatus.Commit,
 				Errs:       s.Reconciler.ReconcilerState().SyncErrors(),
-				LastUpdate: nowMeta(opts),
+				LastUpdate: nowMeta(opts.Clock),
 			}
 			if err := s.Reconciler.SetSyncStatus(s.Context, syncStatus); err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/pkg/parse/state.go
+++ b/pkg/parse/state.go
@@ -15,15 +15,20 @@
 package parse
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
 	"kpt.dev/configsync/pkg/status"
 )
 
+const invalidSyncPath = ""
+
 // ReconcilerState is the current state of the Reconciler, including progress
-// indicators and in-memory cache for each of the reconciler stages:
+// indicators and in-memory cache for each of the reconcile stages:
 // - Fetch
-// - Read
 // - Render/Hydrate
+// - Read
 // - Parse/Validate
 // - Update
 //
@@ -33,8 +38,10 @@ import (
 // TODO: break up cacheForCommit into phase-based caches
 // TODO: move sourceState into ReconcilerState so the RSync spec and status are next to each other
 type ReconcilerState struct {
-	// checkpointedSyncPath is the last checkpointed syncPath.
-	checkpointedSyncPath string
+	// checkpoint tracks the sourcePath the last time reconciling succeeded or
+	// failed. Reconciling includes multiple stages: fetch, render, read, parse,
+	// and update.
+	checkpoint checkpoint
 
 	// status contains fields that map to RSync status fields.
 	status *ReconcilerStatus
@@ -45,46 +52,100 @@ type ReconcilerState struct {
 	syncErrorCache *SyncErrorCache
 }
 
-func (s *ReconcilerState) checkpoint() {
-	applied := s.cache.source.syncPath.OSPath()
-	if applied == s.checkpointedSyncPath {
-		return
+type checkpoint struct {
+	// sourcePath caches the source path that was last successfully applied.
+	// Set to the empty string if the last attempt failed.
+	sourcePath cmpath.Absolute
+	// lastUpdateTime is the last time the checkpoint was updated.
+	// AKA: Last successful sync.
+	// TODO: Surface this timestamp in the RSync status API
+	lastUpdateTime metav1.Time
+	// lastTransitionTime is the last time the checkpoint was updated with a new sourcePath.
+	// AKA: First successful sync with this sourcePath (repo + branch + source commit + syncDir).
+	// TODO: Surface this timestamp in the RSync status API
+	lastTransitionTime metav1.Time
+}
+
+// updateCheckpoint records the last known source path, updates the
+// timestamps, and logs the message.
+func (s *ReconcilerState) updateCheckpoint(c clock.Clock, newSourcePath cmpath.Absolute) {
+	now := nowMeta(c)
+	// Check for transition
+	transitioned := false
+	if s.checkpoint.sourcePath != newSourcePath {
+		transitioned = true
+		s.checkpoint.sourcePath = newSourcePath
+		s.checkpoint.lastTransitionTime = now
 	}
-	klog.Infof("Reconciler checkpoint updated to %s", applied)
-	s.checkpointedSyncPath = applied
+	// Record when the checkpoint was last updated
+	s.checkpoint.lastUpdateTime = now
+	if newSourcePath == invalidSyncPath {
+		klog.Info("Reconciler checkpoint invalidated")
+	} else if transitioned {
+		klog.Infof("Reconciler checkpoint updated with new source path: %s", newSourcePath)
+	} else {
+		klog.Infof("Reconciler checkpoint updated with existing source path: %s", newSourcePath)
+	}
+}
+
+// RecordSyncSuccess is called after a successful sync. It records the last
+// known source path, as well as timestamps for last updated and last
+// transitioned.
+func (s *ReconcilerState) RecordSyncSuccess(c clock.Clock) {
+	klog.Info("Sync successful")
+	s.updateCheckpoint(c, s.cache.source.syncPath)
 	s.cache.needToRetry = false
 }
 
-// invalidate logs the errors, clears the state tracking information.
-// invalidate does not clean up the `s.cache`.
-func (s *ReconcilerState) invalidate(errs status.MultiError) {
-	if status.AllTransientErrors(errs) {
-		klog.Infof("Reconciler checkpoint invalidated: %v", status.FormatSingleLine(errs))
-	} else {
-		klog.Errorf("Reconciler checkpoint invalidated: %v", status.FormatSingleLine(errs))
-	}
-	// Invalidate state on error since this could be the result of switching
-	// branches or some other operation where inverting the operation would
-	// result in repeating a previous state that was checkpointed.
-	s.checkpointedSyncPath = ""
-	s.cache.needToRetry = true
-}
-
-// resetCache resets the whole cache.
-//
-// resetCache is called when a new source commit is detected.
-func (s *ReconcilerState) resetCache() {
+// RecordRenderInProgress is called when waiting for rendering status. It resets
+// the cacheForCommit, which tells the next reconcile attempt to re-parse from
+// source.
+func (s *ReconcilerState) RecordRenderInProgress() {
+	klog.Info("Rendering in progress")
+	// TODO: track render status lastUpdateTime & lastTransitionTime
+	// TODO: update parserResultUpToDate() to trigger parsing when syncPath changes, to avoid needing to reset the cache to trigger parsing when render is successful
 	s.cache = cacheForCommit{}
 }
 
-// resetPartialCache resets the whole cache except for the cached sourceState and the cached needToRetry.
-// The cached sourceState will not be reset to avoid reading all the source files unnecessarily.
-// The cached needToRetry will not be reset to avoid resetting the backoff retries.
-//
-// resetPartialCache is called when:
-//   - a force-resync happens, or
-//   - one of the watchers noticed a management conflict.
-func (s *ReconcilerState) resetPartialCache() {
+// RecordFailure is called when a sync attempt errors. It invalidates the
+// checkpoint, requests a retry, and logs the errors. Does not reset the
+// cacheForCommit.
+func (s *ReconcilerState) RecordFailure(c clock.Clock, errs status.MultiError) {
+	if status.AllTransientErrors(errs) {
+		klog.Infof("Reconcile attempt failed with transient error(s): %v", status.FormatSingleLine(errs))
+	} else {
+		klog.Errorf("Reconcile attempt failed: %v", status.FormatSingleLine(errs))
+	}
+	s.updateCheckpoint(c, invalidSyncPath)
+	s.cache.needToRetry = true
+}
+
+// RecordReadSuccess is called when read succeeds after a source change is
+// detected. It resets the cacheForCommit, which skips re-reading, but forces
+// re-parsing.
+func (s *ReconcilerState) RecordReadSuccess(source *sourceState) {
+	klog.Info("Read successful")
+	// TODO: track read status lastUpdateTime & lastTransitionTime
+	// TODO: update parserResultUpToDate() to trigger parsing when syncPath changes, to avoid needing to reset the cache to trigger parsing when read is successful
+	s.cache = cacheForCommit{
+		source: source,
+	}
+}
+
+// RecordReadFailure is called when read errors after a source change is
+// detected. It resets the cacheForCommit, forces re-reading and re-parsing.
+func (s *ReconcilerState) RecordReadFailure() {
+	klog.Info("Read attempt failed")
+	// TODO: track read status lastUpdateTime & lastTransitionTime
+	s.cache = cacheForCommit{}
+}
+
+// RecordFullSyncStart is called when a full sync attempt starts. It resets the
+// cacheForCommit, which tells the parser to re-parse from source, but keeps the
+// last known read status, to skip re-read on next sync attempt.
+// Retry request will not be reset, to avoid resetting the backoff retries.
+func (s *ReconcilerState) RecordFullSyncStart() {
+	// TODO: Does keeping the cache.source actually do anything? It seems like it always gets regenerated by Read anyway.
 	source := s.cache.source
 	needToRetry := s.cache.needToRetry
 	s.cache = cacheForCommit{}


### PR DESCRIPTION
- Rename ReconcilerState methods to reflect the reconcile stages they are called after, rather than the state that they change. This makes it cleared when the methods should be called and documents what the state change does and why.
- Rework logging for the state transitions handled by the ReconcilerState methods.
- Wrap the checkpoint "lastApplied" syncPath in a struct that captures lastUpdateTime and lastTransitionTime, like a kubernetes condition. This makes it possible to tell both when the last sync suceeded or failed and also when it first suceeded for the current commit (as long as it hasn't since failed). For now, this is only visible in the logs, but we may want to expose it via the RSync status in the future.

Ideas for future cleanup:
- Add state transition methods for each stage (fetch, render, read, parse, update)
- Untangle the Render & Read stages. Today the render status isn't updated as successful until after `readFromSource` succeeds, because it handles calling `parseHydrationState` and then looks for kustomization files to enable rendering after calling `readConfigFiles`.
- Untangle the Parse & Update stages. It's not super clear why these share a wrapper func, but it's probably just because the DefaultRunFunc was too big. They can probably be split up.
- Split up the `cacheForCommit`. It hold state for multiple stages. Each should get their own struct with lastUpdateTime, lastTransitionTime, and well named methods to update them.
- Track the syncPath when each stage completes, so we know when to skip a stage, rather that having earlier stages partially/fully reset the cache. For example, `parserResultUpToDate` checks a `hasParserResult` bool, but it should probably store the syncPath and check if it changed. If all the stages did that, then RecordRenderInProgress,  RecordReadSuccess, and RecordReadFailure wouldn't need to reset the cache. Only RecordFullSyncStart would reset the cache, because it's timer based instead of state based. 