### PR TITLE
chore: cleanup reconciler set status method usage

### DIFF
--- a/pkg/parse/reconciler.go
+++ b/pkg/parse/reconciler.go
@@ -54,8 +54,7 @@ type Reconciler interface {
 	ParseAndUpdate(ctx context.Context, trigger string) status.MultiError
 
 	// SetSyncStatus updates `.status.sync` and the Syncing condition, if needed,
-	// as well as `state.syncStatus` and `state.syncingConditionLastUpdate` if
-	// the update is successful.
+	// as well as `state.syncStatus`  if the update is successful.
 	//
 	// SetSyncStatus is exposed for use by the EventHandler, for periodic status
 	// updates.

--- a/pkg/parse/repo_sync_client.go
+++ b/pkg/parse/repo_sync_client.go
@@ -236,18 +236,16 @@ func (p *repoSyncStatusClient) GetReconcilerStatus(ctx context.Context) (*Reconc
 
 	// Read Syncing condition
 	syncing := false
-	var syncingConditionLastUpdate metav1.Time
 	for _, condition := range rs.Status.Conditions {
 		if condition.Type == v1beta1.RepoSyncSyncing {
 			if condition.Status == metav1.ConditionTrue {
 				syncing = true
 			}
-			syncingConditionLastUpdate = condition.LastUpdateTime
 			break
 		}
 	}
 
-	return reconcilerStatusFromRSyncStatus(rs.Status.Status, opts.SourceType, syncing, syncingConditionLastUpdate), nil
+	return reconcilerStatusFromRSyncStatus(rs.Status.Status, opts.SourceType, syncing), nil
 }
 
 // SetSyncStatus implements the Parser interface

--- a/pkg/parse/root_sync_client.go
+++ b/pkg/parse/root_sync_client.go
@@ -343,21 +343,19 @@ func (p *rootSyncStatusClient) GetReconcilerStatus(ctx context.Context) (*Reconc
 	}
 
 	syncing := false
-	var syncingConditionLastUpdate metav1.Time
 	for _, condition := range rs.Status.Conditions {
 		if condition.Type == v1beta1.RootSyncSyncing {
 			if condition.Status == metav1.ConditionTrue {
 				syncing = true
 			}
-			syncingConditionLastUpdate = condition.LastUpdateTime
 			break
 		}
 	}
 
-	return reconcilerStatusFromRSyncStatus(rs.Status.Status, opts.SourceType, syncing, syncingConditionLastUpdate), nil
+	return reconcilerStatusFromRSyncStatus(rs.Status.Status, opts.SourceType, syncing), nil
 }
 
-func reconcilerStatusFromRSyncStatus(rsyncStatus v1beta1.Status, sourceType configsync.SourceType, syncing bool, syncingConditionLastUpdate metav1.Time) *ReconcilerStatus {
+func reconcilerStatusFromRSyncStatus(rsyncStatus v1beta1.Status, sourceType configsync.SourceType, syncing bool) *ReconcilerStatus {
 	var sourceSpec, renderSpec, syncSpec SourceSpec
 	switch sourceType {
 	case configsync.GitSource:
@@ -458,7 +456,6 @@ func reconcilerStatusFromRSyncStatus(rsyncStatus v1beta1.Status, sourceType conf
 			Errs:       nil,
 			LastUpdate: rsyncStatus.Sync.LastUpdate,
 		},
-		SyncingConditionLastUpdate: syncingConditionLastUpdate,
 	}
 }
 

--- a/pkg/parse/status.go
+++ b/pkg/parse/status.go
@@ -32,19 +32,15 @@ type ReconcilerStatus struct {
 
 	// SyncStatus tracks info from the `Status.Sync` field of a RepoSync/RootSync.
 	SyncStatus *SyncStatus
-
-	// SyncingConditionLastUpdate tracks when the `Syncing` condition was updated most recently.
-	SyncingConditionLastUpdate metav1.Time
 }
 
 // DeepCopy returns a deep copy of the receiver.
 // Warning: Go errors are not copy-able. So this isn't a true deep-copy.
 func (s *ReconcilerStatus) DeepCopy() *ReconcilerStatus {
 	return &ReconcilerStatus{
-		SourceStatus:               s.SourceStatus.DeepCopy(),
-		RenderingStatus:            s.RenderingStatus.DeepCopy(),
-		SyncStatus:                 s.SyncStatus.DeepCopy(),
-		SyncingConditionLastUpdate: *s.SyncingConditionLastUpdate.DeepCopy(),
+		SourceStatus:    s.SourceStatus.DeepCopy(),
+		RenderingStatus: s.RenderingStatus.DeepCopy(),
+		SyncStatus:      s.SyncStatus.DeepCopy(),
 	}
 }
 


### PR DESCRIPTION
- Use the standard if err != nil pattern for all calls to set status to return early, making the code easier to read and more consistent.
- Remove unused ReconcilerStatus.SyncingConditionLastUpdate
- Use variable names consistently in run.go: newSourceStatus, newRenderStatus, newSyncStatus, and statusErr.