### PR TITLE
chore: git sync update to v4.3.0-gke.3__linux_amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.3.0-gke.2__linux_amd64
+GIT_SYNC_VERSION := v4.3.0-gke.3__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.103.0-gke.5


### PR DESCRIPTION
bumping up the git-sync even though it's not clear that it's addressing any CVEs