### PR TITLE
chore: DefaultRunFunc -> reconciler.Reconcile

### DIFF
--- a/pkg/parse/reconciler.go
+++ b/pkg/parse/reconciler.go
@@ -16,56 +16,36 @@ package parse
 
 import (
 	"context"
-
-	"kpt.dev/configsync/pkg/importer/filesystem/cmpath"
-	"kpt.dev/configsync/pkg/status"
 )
 
-// Reconciler represents a parser that can be pointed at and continuously parse a source.
+// Reconciler reconciles the cluster with config from the source of truth.
 // TODO: Move to reconciler package; requires unwinding dependency cycles
 type Reconciler interface {
 	// Options returns the ReconcilerOptions used by this reconciler.
 	Options() *ReconcilerOptions
-	// SyncStatusClient returns the SyncStatusClient used by this reconciler.
-	SyncStatusClient() SyncStatusClient
-	// Parser returns the Parser used by this reconciler.
-	Parser() Parser
+
 	// ReconcilerState returns the current state of the parser/reconciler.
 	ReconcilerState() *ReconcilerState
 
-	// Fetch waits for the *-sync sidecars to fetch the source manifests to the
-	// shared source volume.
-	// Updates the RSync status (source status and syncing condition).
+	// Reconcile the cluster with the source config.
 	//
-	// Fetch is exposed for use by DefaultRunFunc.
-	Fetch(context.Context) (sourceStatus *SourceStatus, syncPath cmpath.Absolute, errs status.MultiError)
+	// Reconcile has multiple phases:
+	// - Fetch - Checks the shared filesystem for new source commits fetched by
+	//     one of the *-sync sidecars.
+	// - Render - Checks the shared filesystem for source rendered by the
+	//     hydration-controller sidecar using helm or kustomize, if required.
+	// - Read - Reads the fetch and render status from the shared filesystem and
+	//     lists the source config files.
+	// - Parse - Parses resource objects from the source config files, validates
+	//    them, and adds custom metadata.
+	// - Update (aka Sync) - Updates the cluster and remediator to reflect the
+	//     latest resource object manifests in the source.
+	Reconcile(ctx context.Context, trigger string) ReconcileResult
 
-	// Render waits for the hydration-controller sidecar to render the source
-	// manifests on the shared source volume.
-	// Updates the RSync status (rendering status and syncing condition).
-	//
-	// Render is exposed for use by DefaultRunFunc.
-	Render(context.Context, *SourceStatus) status.MultiError
-
-	// Read source manifests from the shared source volume.
-	// Errors if rendering is required but not enabled.
-	// Updates the RSync status (source, rendering, and syncing condition).
-	//
-	// Read is exposed for use by DefaultRunFunc.
-	Read(ctx context.Context, trigger string, sourceStatus *SourceStatus, syncPath cmpath.Absolute) status.MultiError
-
-	// ParseAndUpdate parses objects from the source manifests, validates them,
-	// and then syncs them to the cluster with the Updater.
-	//
-	// ParseAndUpdate is exposed for use by DefaultRunFunc.
-	ParseAndUpdate(ctx context.Context, trigger string) status.MultiError
-
-	// SetSyncStatus updates `.status.sync` and the Syncing condition, if needed,
-	// as well as `state.syncStatus`  if the update is successful.
-	//
-	// SetSyncStatus is exposed for use by the EventHandler, for periodic status
-	// updates.
-	SetSyncStatus(context.Context, *SyncStatus) error
+	// UpdateSyncStatus updates the RSync status to reflect asynchronous status
+	// changes made by the remediator between Reconcile calls.
+	// Returns an error if the status update failed or was cancelled.
+	UpdateSyncStatus(context.Context) error
 }
 
 // TODO: Move to reconciler package; requires unwinding dependency cycles
@@ -83,23 +63,14 @@ func (p *reconciler) Options() *ReconcilerOptions {
 	return p.options
 }
 
-// SyncStatusClient returns the SyncStatusClient used by this reconciler.
-func (p *reconciler) SyncStatusClient() SyncStatusClient {
-	return p.syncStatusClient
-}
-
-// ReconcilerState returns the current state of the reconciler.
-func (p *reconciler) Parser() Parser {
-	return p.parser
-}
-
 // ReconcilerState returns the current state of the reconciler.
 func (p *reconciler) ReconcilerState() *ReconcilerState {
 	return p.reconcilerState
 }
 
-// NewRootRunner creates a new runnable parser for parsing a Root repository.
-func NewRootRunner(recOpts *ReconcilerOptions, parseOpts *RootOptions) Reconciler {
+// NewRootSyncReconciler creates a new reconciler for reconciling cluster-scoped
+// and namespace-scoped resources configured with a RootSync.
+func NewRootSyncReconciler(recOpts *ReconcilerOptions, parseOpts *RootOptions) Reconciler {
 	return &reconciler{
 		options: recOpts,
 		reconcilerState: &ReconcilerState{
@@ -114,8 +85,9 @@ func NewRootRunner(recOpts *ReconcilerOptions, parseOpts *RootOptions) Reconcile
 	}
 }
 
-// NewNamespaceRunner creates a new runnable parser for parsing a Namespace repo.
-func NewNamespaceRunner(recOpts *ReconcilerOptions, parseOpts *Options) Reconciler {
+// NewRepoSyncReconciler creates a new reconciler for reconciling
+// namespace-scoped resources configured with a RepoSync.
+func NewRepoSyncReconciler(recOpts *ReconcilerOptions, parseOpts *Options) Reconciler {
 	return &reconciler{
 		options: recOpts,
 		reconcilerState: &ReconcilerState{

--- a/pkg/parse/root_reconciler_test.go
+++ b/pkg/parse/root_reconciler_test.go
@@ -735,7 +735,7 @@ func TestRootReconciler_ParseAndUpdate(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			if err := reconciler.ParseAndUpdate(context.Background(), triggerSync); err != nil {
+			if err := reconciler.parseAndUpdate(context.Background(), triggerSync); err != nil {
 				t.Fatal(err)
 			}
 
@@ -977,7 +977,7 @@ func TestRootReconciler_DeclaredFields(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			if err := reconciler.ParseAndUpdate(context.Background(), triggerSync); err != nil {
+			if err := reconciler.parseAndUpdate(context.Background(), triggerSync); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1261,7 +1261,7 @@ func TestRootReconciler_Parse_Discovery(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
+			err := reconciler.parseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			// After parsing, the objects set is processed and modified.
@@ -1368,7 +1368,7 @@ func TestRootReconciler_SourceReconcilerErrorsMetricValidation(t *testing.T) {
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
+			err := reconciler.parseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {
@@ -1477,7 +1477,7 @@ func TestRootReconciler_SourceAndSyncReconcilerErrorsMetricValidation(t *testing
 				},
 				reconcilerState: state,
 			}
-			err := reconciler.ParseAndUpdate(context.Background(), triggerSync)
+			err := reconciler.parseAndUpdate(context.Background(), triggerSync)
 			testerrors.AssertEqual(t, tc.expectedError, err, "expected error to match")
 
 			if diff := m.ValidateMetrics(metrics.ReconcilerErrorsView, tc.expectedMetrics); diff != "" {

--- a/pkg/parse/run_test.go
+++ b/pkg/parse/run_test.go
@@ -182,7 +182,7 @@ func TestSplitObjects(t *testing.T) {
 	}
 }
 
-func TestRun(t *testing.T) {
+func TestReconciler_Reconcile(t *testing.T) {
 	fakeMetaTime := metav1.Now().Rfc3339Copy() // truncate to second precision
 	fakeTime := fakeMetaTime.Time
 	fakeClock := fakeclock.NewFakeClock(fakeTime)
@@ -769,7 +769,7 @@ func TestRun(t *testing.T) {
 			fakeClient := syncerFake.NewClient(t, core.Scheme, k8sobjects.RootSyncObjectV1Beta1(rootSyncName))
 			reconciler := newRootReconciler(t, fakeClock, fakeClient, fs, tc.renderingEnabled)
 			t.Logf("start running test at %v", time.Now())
-			result := DefaultRunFunc(context.Background(), reconciler, triggerSync)
+			result := reconciler.Reconcile(context.Background(), triggerSync)
 
 			assert.Equal(t, tc.expectedSourceChanged, result.SourceChanged)
 			assert.Equal(t, tc.needRetry, reconciler.ReconcilerState().cache.needToRetry)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -314,9 +314,9 @@ func Run(opts Options) {
 			// TODO: Trigger namespace events with a buffered channel from the NamespaceController
 			pgBuilder.NamespaceControllerPeriod = time.Second
 		}
-		reconciler = parse.NewRootRunner(reconcilerOpts, rootParseOpts)
+		reconciler = parse.NewRootSyncReconciler(reconcilerOpts, rootParseOpts)
 	} else {
-		reconciler = parse.NewNamespaceRunner(reconcilerOpts, parseOpts)
+		reconciler = parse.NewRepoSyncReconciler(reconcilerOpts, parseOpts)
 	}
 
 	// Start listening to signals
@@ -425,7 +425,7 @@ func Run(opts Options) {
 	funnel := &events.Funnel{
 		Publishers: pgBuilder.Build(),
 		// Wrap the parser with an event handler that triggers the RunFunc, as needed.
-		Subscriber: parse.NewEventHandler(ctx, reconciler, nsControllerState, parse.DefaultRunFunc),
+		Subscriber: parse.NewEventHandler(ctx, reconciler, nsControllerState),
 	}
 	doneChForParser := funnel.Start(ctx)
 


### PR DESCRIPTION
- Rename DefaultRunFunc as reconciler.Reconciler.
- Remove methods from the Reconciler interface only used by reconciler.Reconcile.
- Add Reconciler.UpdateSyncStatus to simplify event handling.
- Make reconciler methods private that no longer need to be exposed.