### PR TITLE
fix: tollerate stale resource group discovery

### DIFF
--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
@@ -63,7 +63,7 @@ func TestReconcile(t *testing.T) {
 
 	// Setup the controller
 	channelKpt = make(chan event.GenericEvent)
-	resolver, err := typeresolver.NewTypeResolver(mgr, logger)
+	resolver, err := typeresolver.ForManager(mgr, logger)
 	assert.NoError(t, err)
 	resMap := resourcemap.NewResourceMap()
 	err = NewRGController(mgr, channelKpt, logger, resolver, resMap, 0)

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -55,7 +55,7 @@ func TestRootReconciler(t *testing.T) {
 
 	logger := reconcilerKpt.log.WithValues("Controller", "Root")
 	ctx = context.WithValue(context.TODO(), contextRootControllerKey, logger)
-	resolver, err := typeresolver.NewTypeResolver(mgr, logger)
+	resolver, err := typeresolver.ForManager(mgr, logger)
 	assert.NoError(t, err)
 	reconcilerKpt.resolver = resolver
 

--- a/pkg/resourcegroup/controllers/runner/run.go
+++ b/pkg/resourcegroup/controllers/runner/run.go
@@ -128,11 +128,13 @@ func registerControllersForGroup(mgr ctrl.Manager, logger logr.Logger, group str
 	channel := make(chan event.GenericEvent)
 
 	klog.Info("adding the type resolver")
-	resolver, err := typeresolver.NewTypeResolver(mgr, logger.WithName("TypeResolver"))
+	resolver, err := typeresolver.ForManager(mgr, logger.WithName("TypeResolver"))
 	if err != nil {
 		return fmt.Errorf("unable to set up the type resolver: %w", err)
 	}
-	resolver.Refresh()
+	if err := resolver.Refresh(); err != nil {
+		return fmt.Errorf("unable to initialize the type resolver resource cache: %w", err)
+	}
 
 	klog.Info("adding the Root controller for group " + group)
 	resMap := resourcemap.NewResourceMap()

--- a/pkg/resourcegroup/controllers/typeresolver/fake_discovery.go
+++ b/pkg/resourcegroup/controllers/typeresolver/fake_discovery.go
@@ -1,0 +1,159 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeresolver
+
+import (
+	"fmt"
+
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/openapi"
+	restclient "k8s.io/client-go/rest"
+)
+
+// FakeDiscoveryClient implements discovery.DiscoveryInterface and fakes out the
+// method calls.
+type FakeDiscoveryClient struct {
+	GroupsAndMaybeResourcesCalls          int
+	GroupsAndMaybeResourcesOutputs        []FakeDiscoveryGroupsAndMaybeResourcesOutput
+	ServerResourcesForGroupVersionCalls   int
+	ServerResourcesForGroupVersionInputs  []FakeDiscoveryServerResourcesForGroupVersionInput
+	ServerResourcesForGroupVersionOutputs []FakeDiscoveryServerResourcesForGroupVersionOutput
+	ServerPreferredResourcesCalls         int
+	ServerPreferredResourcesOutputs       []FakeDiscoveryServerPreferredResourcesOutput
+}
+
+var _ discovery.AggregatedDiscoveryInterface = &FakeDiscoveryClient{}
+
+// FakeDiscoveryGroupsAndMaybeResourcesOutput represents the output of
+// FakeDiscoveryClient.GroupsAndMaybeResources
+type FakeDiscoveryGroupsAndMaybeResourcesOutput struct {
+	Groups              *metav1.APIGroupList
+	Resources           map[schema.GroupVersion]*metav1.APIResourceList
+	FailedGroupVersions map[schema.GroupVersion]error
+	Error               error
+}
+
+// FakeDiscoveryServerResourcesForGroupVersionInput represents the input to
+// FakeDiscoveryClient.ServerResourcesForGroupVersion
+type FakeDiscoveryServerResourcesForGroupVersionInput struct {
+	GroupVersion string
+}
+
+// FakeDiscoveryServerResourcesForGroupVersionOutput represents the output of
+// FakeDiscoveryClient.ServerResourcesForGroupVersion
+type FakeDiscoveryServerResourcesForGroupVersionOutput struct {
+	Resources *metav1.APIResourceList
+	Error     error
+}
+
+// FakeDiscoveryServerPreferredResourcesOutput represents the output of
+// FakeDiscoveryClient.ServerPreferredResources
+type FakeDiscoveryServerPreferredResourcesOutput struct {
+	Resources []*metav1.APIResourceList
+	Error     error
+}
+
+// GroupsAndMaybeResources returns the API groups and their resources, if
+// available, otherwise just the groups.
+func (dc *FakeDiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
+	if dc.GroupsAndMaybeResourcesCalls >= len(dc.GroupsAndMaybeResourcesOutputs) {
+		panic(fmt.Sprintf("Expected only %d calls to FakeDiscoveryClient.GroupsAndMaybeResources, "+
+			"but got more. Update FakeDiscoveryClient.GroupsAndMaybeResourcesOutput if this is expected.",
+			len(dc.GroupsAndMaybeResourcesOutputs)))
+	}
+	outputs := dc.GroupsAndMaybeResourcesOutputs[dc.GroupsAndMaybeResourcesCalls]
+	dc.GroupsAndMaybeResourcesCalls++
+	return outputs.Groups, outputs.Resources, outputs.FailedGroupVersions, outputs.Error
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group
+// and version.
+func (dc *FakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	dc.ServerResourcesForGroupVersionInputs = append(dc.ServerResourcesForGroupVersionInputs, FakeDiscoveryServerResourcesForGroupVersionInput{
+		GroupVersion: groupVersion,
+	})
+	if dc.ServerResourcesForGroupVersionCalls >= len(dc.ServerResourcesForGroupVersionOutputs) {
+		panic(fmt.Sprintf("Expected only %d calls to FakeDiscoveryClient.ServerResourcesForGroupVersion, "+
+			"but got more. Update FakeDiscoveryClient.ServerResourcesForGroupVersionOutputs if this is expected.",
+			len(dc.ServerResourcesForGroupVersionOutputs)))
+	}
+	outputs := dc.ServerResourcesForGroupVersionOutputs[dc.ServerResourcesForGroupVersionCalls]
+	dc.ServerResourcesForGroupVersionCalls++
+	return outputs.Resources, outputs.Error
+}
+
+// ServerGroupsAndResources returns the supported groups and resources for all
+// groups and versions.
+func (dc *FakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+// ServerPreferredResources returns the supported resources with the version
+// preferred by the server.
+func (dc *FakeDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	if dc.ServerPreferredResourcesCalls >= len(dc.ServerPreferredResourcesOutputs) {
+		panic(fmt.Sprintf("Expected only %d calls to FakeDiscoveryClient.ServerPreferredResources, "+
+			"but got more. Update FakeDiscoveryClient.ServerPreferredResourcesOutputs if this is expected.",
+			len(dc.ServerPreferredResourcesOutputs)))
+	}
+	outputs := dc.ServerPreferredResourcesOutputs[dc.ServerPreferredResourcesCalls]
+	dc.ServerPreferredResourcesCalls++
+	return outputs.Resources, outputs.Error
+}
+
+// ServerPreferredNamespacedResources returns the supported namespaced resources
+// with the version preferred by the server.
+func (dc *FakeDiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+// ServerGroups returns the supported groups, with information like supported
+// versions and the preferred version.
+func (dc *FakeDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
+	panic("unimplemented")
+}
+
+// ServerVersion retrieves and parses the server's version.
+func (dc *FakeDiscoveryClient) ServerVersion() (*version.Info, error) {
+	panic("unimplemented")
+}
+
+// OpenAPISchema retrieves and parses the swagger API schema the server supports.
+func (dc *FakeDiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	panic("unimplemented")
+}
+
+// OpenAPIV3 returns the OpenAPI v3 client.
+func (dc *FakeDiscoveryClient) OpenAPIV3() openapi.Client {
+	panic("unimplemented")
+}
+
+// RESTClient returns a RESTClient that is used to communicate with API server
+// by this client implementation.
+func (dc *FakeDiscoveryClient) RESTClient() restclient.Interface {
+	panic("unimplemented")
+}
+
+// WithLegacy returns a copy of current discovery client that will only receive
+// the legacy discovery format, or pointer to current discovery client if it
+// does not support legacy-only discovery.
+func (dc *FakeDiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
+	panic("unimplemented")
+}

--- a/pkg/resourcegroup/controllers/typeresolver/typeresolver_test.go
+++ b/pkg/resourcegroup/controllers/typeresolver/typeresolver_test.go
@@ -15,10 +15,16 @@
 package typeresolver
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
 func TestResolve(t *testing.T) {
@@ -48,6 +54,240 @@ func TestResolve(t *testing.T) {
 			gvk, found := r.Resolve(tc.input)
 			assert.Equal(t, tc.expectFound, found)
 			assert.Equal(t, tc.expectVersion, gvk.Version)
+		})
+	}
+}
+
+// TestRefresh tests that TypeResolver.Refresh tolerates ErrGroupDiscoveryFailed
+// errors, but only if all the wrapped group errors are StaleGroupVersionError.
+// All the discovered resources should then be resolvable to the version
+// preferred by the server with TypeResolver.Resolve.
+func TestRefresh(t *testing.T) {
+	coreGV := schema.GroupVersion{
+		Group:   "core",
+		Version: "v1",
+	}
+	coreAPIGroup := metav1.APIGroup{
+		Name: coreGV.Group,
+		Versions: []metav1.GroupVersionForDiscovery{
+			{
+				GroupVersion: coreGV.String(),
+				Version:      coreGV.Version,
+			},
+		},
+		PreferredVersion: metav1.GroupVersionForDiscovery{
+			GroupVersion: coreGV.String(),
+			Version:      coreGV.Version,
+		},
+		ServerAddressByClientCIDRs: []metav1.ServerAddressByClientCIDR{}, // unused
+	}
+	nsGVK := schema.GroupVersionKind{
+		Group:   coreGV.Group,
+		Version: coreGV.Version,
+		Kind:    "Namespace",
+	}
+	nsAPIResource := metav1.APIResource{
+		Name:         "namespaces",
+		SingularName: "namespace",
+		Kind:         nsGVK.Kind,
+		Group:        nsGVK.Group,
+		Version:      nsGVK.Version,
+	}
+	anvilGVK := schema.GroupVersionKind{
+		Group:   "acme.com",
+		Version: "v1",
+		Kind:    "Anvil",
+	}
+	tests := []struct {
+		name                     string
+		setupFakeDiscoveryClient func(*FakeDiscoveryClient)
+		expectedError            error
+		expectedGVKs             map[schema.GroupKind]schema.GroupVersionKind
+	}{
+		{
+			name: "all groups available from aggregated resource request",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{
+							Groups: []metav1.APIGroup{
+								coreAPIGroup,
+							},
+						},
+						Resources: map[schema.GroupVersion]*metav1.APIResourceList{
+							coreGV: {
+								APIResources: []metav1.APIResource{
+									nsAPIResource,
+								},
+							},
+						},
+						FailedGroupVersions: nil,
+						Error:               nil,
+					},
+				}
+			},
+			expectedError: nil,
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    nsGVK,
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+		{
+			name: "all groups available from legacy resource requests",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{
+							Groups: []metav1.APIGroup{
+								coreAPIGroup,
+							},
+						},
+						Resources:           nil, // must be nil to trigger ServerResourcesForGroupVersion call
+						FailedGroupVersions: nil,
+						Error:               nil,
+					},
+				}
+				fakeDC.ServerResourcesForGroupVersionOutputs = []FakeDiscoveryServerResourcesForGroupVersionOutput{
+					{
+						Resources: &metav1.APIResourceList{
+							APIResources: []metav1.APIResource{
+								nsAPIResource,
+							},
+						},
+						Error: nil,
+					},
+				}
+			},
+			expectedError: nil,
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    nsGVK,
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+		{
+			name: "group error with one stale group",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{
+							Groups: []metav1.APIGroup{
+								coreAPIGroup,
+							},
+						},
+						Resources: map[schema.GroupVersion]*metav1.APIResourceList{
+							coreGV: {
+								APIResources: []metav1.APIResource{
+									nsAPIResource,
+								},
+							},
+						},
+						FailedGroupVersions: map[schema.GroupVersion]error{
+							anvilGVK.GroupVersion(): discovery.StaleGroupVersionError{},
+						},
+						Error: nil,
+					},
+				}
+			},
+			expectedError: nil,
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    nsGVK,
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+		{
+			name: "group error with one other error",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{},
+						// Resources must be non-nil to avoid ServerResourcesForGroupVersion call
+						Resources: map[schema.GroupVersion]*metav1.APIResourceList{},
+						FailedGroupVersions: map[schema.GroupVersion]error{
+							coreGV: fmt.Errorf("other error"),
+						},
+						Error: nil,
+					},
+				}
+			},
+			expectedError: fmt.Errorf("discovery of API resources failed: %w",
+				&discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{
+						coreGV: fmt.Errorf("other error"),
+					},
+				}),
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    {}, // expect not found
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+		{
+			name: "group error with one stale and one other error",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{},
+						// Resources must be non-nil to avoid ServerResourcesForGroupVersion call
+						Resources: map[schema.GroupVersion]*metav1.APIResourceList{},
+						FailedGroupVersions: map[schema.GroupVersion]error{
+							coreGV:                  fmt.Errorf("other error"),
+							anvilGVK.GroupVersion(): discovery.StaleGroupVersionError{},
+						},
+						Error: nil,
+					},
+				}
+			},
+			expectedError: fmt.Errorf("discovery of API resources failed: %w",
+				&discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{
+						coreGV:                  fmt.Errorf("other error"),
+						anvilGVK.GroupVersion(): discovery.StaleGroupVersionError{},
+					},
+				}),
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    {}, // expect not found
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+		{
+			name: "non-group error",
+			setupFakeDiscoveryClient: func(fakeDC *FakeDiscoveryClient) {
+				fakeDC.GroupsAndMaybeResourcesOutputs = []FakeDiscoveryGroupsAndMaybeResourcesOutput{
+					{
+						Groups: &metav1.APIGroupList{},
+						// Resources must be non-nil to avoid ServerResourcesForGroupVersion call
+						Resources:           map[schema.GroupVersion]*metav1.APIResourceList{},
+						FailedGroupVersions: nil,
+						Error:               fmt.Errorf("other error"),
+					},
+				}
+			},
+			expectedError: fmt.Errorf("discovery of API resources failed: %w",
+				fmt.Errorf("other error")),
+			expectedGVKs: map[schema.GroupKind]schema.GroupVersionKind{
+				nsGVK.GroupKind():    {}, // expect not found
+				anvilGVK.GroupKind(): {}, // expect not found
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDC := &FakeDiscoveryClient{}
+			if tc.setupFakeDiscoveryClient != nil {
+				tc.setupFakeDiscoveryClient(fakeDC)
+			}
+			logger := testr.New(t)
+			resolver := NewTypeResolver(fakeDC, logger)
+			err := resolver.Refresh()
+			testerrors.AssertEqual(t, err, tc.expectedError)
+			require.Equal(t, fakeDC.ServerResourcesForGroupVersionCalls, len(fakeDC.ServerResourcesForGroupVersionInputs))
+
+			for gk, expectedGVK := range tc.expectedGVKs {
+				gvk, found := resolver.Resolve(gk)
+				assert.Equal(t, !expectedGVK.Empty(), found)
+				if found {
+					assert.Equal(t, expectedGVK, gvk)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
- This change allows the resource-group-controller-manager to use cached resource group records when the records are stale due to unavailable APIService backends, like metrics-server, which often has only one replica.
- All other discovery errors will now also cause the TypeResolver controller to retry discovery, with logging and retry backoff handled by the controller manager.
- If discovery fails when the TypeResolver is first created, it will cause the process to error and exit. Then the container runtime should restart the container.
- This should prevent ResourceGroup status from marking all resources as NotFound when discovery fails.

Fixes: b/379943950

Note: This only fixes the problem in the resource-group-controller-manager, and only when Aggregated Discovery is enabled, which is what handles server-side caching of the resource groups. We have other similar but different workarounds in place in the reconciler, which uses slightly methods on the DiscoveryClient and RESTMapper.