### PR TITLE
Use docker hub for golang image, not google-go.pkg.dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 # Base image used for all golang containers
 # Uses trusted google-built golang image
 GOLANG_IMAGE_VERSION := 1.22.5
-GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
+GOLANG_IMAGE := golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command: 
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 


### PR DESCRIPTION
To be able to build container images for both arm64 and amd64 we need a container image for each architecture. This change moves to using the upstream docker hub registry, that unlike google-go.pkg.dev contains images for both architectures.

Obviously, an even better way to resolve this would be to have the currently referenced repository be updated to hold images for both architectures. Feel free to do that :)

I'll kick off the CLA process with my employer after I have pushed this, to have something to reference in my conversation with legal. Hopefully it shouldn't take too long