### PR TITLE
Remove explicit GOARCH from build/all/Dockerfile

### DIFF
--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 ARG VERSION
 
 # Build all our stuff.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on \
   go install \
     -mod=vendor \
     -ldflags "-X kpt.dev/configsync/pkg/version.VERSION=${VERSION}" \


### PR DESCRIPTION
With GOARCH unset, docker buildx multi arch will build the arches specified by the --platform argument