### PR TITLE
Download helm and kustomize in the target docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ CRANE := $(BIN_DIR)/crane
 GOLANGCI_LINT_VERSION := v1.60.3
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 
-KUSTOMIZE_VERSION := v5.4.2-gke.0
+KUSTOMIZE_VERSION := v5.4.2
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
-HELM_VERSION := v3.15.3-gke.0
+HELM_VERSION := v3.15.3
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
@@ -237,7 +237,9 @@ DOCKER_BUILD_ARGS = \
 	--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
 	--build-arg DEBIAN_BASE_IMAGE=$(DEBIAN_BASE_IMAGE) \
 	--build-arg GCLOUD_IMAGE=$(GCLOUD_IMAGE) \
-	--build-arg DOCKER_CLI_IMAGE=$(DOCKER_CLI_IMAGE)
+	--build-arg DOCKER_CLI_IMAGE=$(DOCKER_CLI_IMAGE) \
+	--build-arg KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) \
+	--build-arg HELM_VERSION=$(HELM_VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile.build
+++ b/Makefile.build
@@ -14,7 +14,7 @@ pull-buildenv:
 
 build-buildenv: build/buildenv/Dockerfile
 	@echo "+++ Creating the docker container for $(BUILDENV_IMAGE)"
-	@docker buildx build $(DOCKER_BUILD_QUIET) \
+	docker buildx build $(DOCKER_BUILD_QUIET) \
 		build/buildenv \
 		-t $(BUILDENV_IMAGE) \
 		$(DOCKER_BUILD_ARGS)
@@ -35,11 +35,11 @@ build: $(OUTPUT_DIR) pull-buildenv
 
 # NOTE: this rule depends on OUTPUT_DIR because buildenv needs those dirs to
 # exist in order to work.
-PLATFORMS := linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 windows_amd64
+CLI_PLATFORMS := linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 windows_amd64
 build-cli: pull-buildenv buildenv-dirs
-	@echo "+++ Compiling Nomos binaries for $(PLATFORMS)"
+	@echo "+++ Compiling Nomos binaries for $(CLI_PLATFORMS)"
 	@echo "+++ Compiling with VERSION: $(VERSION)"
-	@mkdir -p $(addprefix $(OUTPUT_DIR)/go/bin/,$(PLATFORMS))
+	@mkdir -p $(addprefix $(OUTPUT_DIR)/go/bin/,$(CLI_PLATFORMS))
 	@docker run $(DOCKER_RUN_ARGS) ./scripts/build.sh \
 		--version $(VERSION) \
 		$(PLATFORMS)
@@ -52,10 +52,17 @@ copy-cli: buildenv-dirs
 # Targets for building individual images
 BUILD_IMAGE_TARGETS := $(patsubst %,__build-image-%,$(IMAGES))
 
+# This seems to be the consensus way of replacing space with comma in a list. Oh Makefiles
+null  :=
+space := $(null) #
+comma := ,
+
+IMAGE_PLATFORMS := linux/arm64 linux/amd64
 .PHONY: $(BUILD_IMAGE_TARGETS)
-$(BUILD_IMAGE_TARGETS): "$(HELM)" "$(KUSTOMIZE)"
+$(BUILD_IMAGE_TARGETS): 
 	@echo "+++ Building the $(subst __build-image-,,$@) image: $(call gen_image_tag,$(subst __build-image-,,$@))"
-	@docker buildx build $(DOCKER_BUILD_QUIET) \
+	docker buildx build $(DOCKER_BUILD_QUIET) \
+                --platform $(subst $(space),$(comma),$(strip $(IMAGE_PLATFORMS))) \
 		--target $(subst __build-image-,,$@) \
 		-t $(call gen_image_tag,$(subst __build-image-,,$@)) \
 		-f build/all/Dockerfile \

--- a/build/all/Dockerfile
+++ b/build/all/Dockerfile
@@ -22,6 +22,10 @@ WORKDIR /workspace
 
 COPY . .
 
+ARG TARGETARCH
+ARG HELM_VERSION
+ARG KUSTOMIZE_VERSION
+
 # Version string to embed in built binary.
 ARG VERSION
 
@@ -40,6 +44,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
     ./cmd/gcenode-askpass-sidecar \
     ./cmd/resource-group
 
+RUN scripts/install-helm-in-docker.sh
+RUN scripts/install-kustomize-in-docker.sh
 
 # Concatenate vendored licenses into LICENSES.txt
 # Built in the container to include binary licenses (helm & kustomize)
@@ -62,9 +68,7 @@ FROM gcr.io/distroless/static:nonroot as hydration-controller
 WORKDIR /
 COPY --from=bins /go/bin/hydration-controller .
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
-COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
-COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 USER nonroot:nonroot
@@ -88,7 +92,6 @@ ENV HOME=/tmp
 WORKDIR /
 COPY --from=bins /go/bin/helm-sync .
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
-COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 USER nonroot:nonroot
@@ -100,9 +103,7 @@ WORKDIR /
 USER root
 COPY --from=bins /go/bin/hydration-controller .
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
-COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
-COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 USER nonroot:nonroot
@@ -164,9 +165,7 @@ RUN mkdir -p /opt/nomos/bin
 WORKDIR /opt/nomos/bin
 COPY --from=bins /go/bin/nomos nomos
 COPY --from=bins /workspace/.output/third_party/helm/helm /usr/local/bin/helm
-COPY --from=bins /workspace/.output/third_party/helm/NOTICES /third_party/helm/NOTICES
 COPY --from=bins /workspace/.output/third_party/kustomize/kustomize /usr/local/bin/kustomize
-COPY --from=bins /workspace/.output/third_party/kustomize/NOTICES /third_party/kustomize/NOTICES
 COPY --from=bins /workspace/LICENSE LICENSE
 COPY --from=bins /workspace/LICENSES.txt LICENSES.txt
 

--- a/scripts/install-helm-in-docker.sh
+++ b/scripts/install-helm-in-docker.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euox pipefail
+
+# this is set by docker build, fail if it isn't set 
+TARGETARCH=${TARGETARCH}
+
+# this should be propagated from the Makefile
+HELM_VERSION=${HELM_VERSION}
+
+TMPDIR=${TMPDIR:-/tmp}
+
+
+REPO=https://get.helm.sh
+
+TARBALL_FILENAME=helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz
+
+HELM_TARBALL=${TMPDIR}/${TARBALL_FILENAME}
+HELM_TARBALL_URL=${REPO}/$TARBALL_FILENAME
+HELM_CHECKSUM=${HELM_TARBALL}.sha256
+HELM_CHECKSUM_URL=${HELM_TARBALL_URL}.sha256
+
+
+function cleanup() {
+    rm -f "${HELM_TARBALL}"
+    rm -f "${HELM_CHECKSUM}"
+}
+trap cleanup EXIT
+
+echo "Downloading helm ${HELM_VERSION}"
+curl -L -o ${HELM_TARBALL} ${HELM_TARBALL_URL}
+curl -L -o ${HELM_CHECKSUM} ${HELM_CHECKSUM_URL}
+
+echo "Verifying helm checksum"
+echo "$(cat "${HELM_CHECKSUM}")  ${HELM_TARBALL}" | sha256sum -c
+
+tar -zxvf "${HELM_TARBALL}" -C "${TMPDIR}"
+
+mkdir -p .output/third_party/helm
+cp ${TMPDIR}/linux-${TARGETARCH}/helm .output/third_party/helm/helm

--- a/scripts/install-kustomize-in-docker.sh
+++ b/scripts/install-kustomize-in-docker.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# this script is a bit of a quick hack
+
+set -euox pipefail
+
+# this is set by docker build, fail if it isn't set 
+TARGETARCH=${TARGETARCH}
+
+# this should be propagated from the Makefile
+KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION}
+
+TMPDIR=${TMPDIR:-/tmp}
+
+
+REPO=https://github.com/kubernetes-sigs/kustomize/releases/download
+TAG=kustomize%2F${KUSTOMIZE_VERSION}
+
+TARBALL_FILENAME=kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz
+
+KUSTOMIZE_TARBALL=${TMPDIR}/${TARBALL_FILENAME}
+KUSTOMIZE_TARBALL_URL=${REPO}/${TAG}/${TARBALL_FILENAME}
+KUSTOMIZE_CHECKSUM=checksums.txt
+KUSTOMIZE_CHECKSUM_URL=${REPO}/${TAG}/${KUSTOMIZE_CHECKSUM}
+
+function cleanup() {
+    rm -f "${KUSTOMIZE_TARBALL}"
+    rm -f "${KUSTOMIZE_CHECKSUM}"
+}
+trap cleanup EXIT
+
+echo "Downloading helm ${KUSTOMIZE_VERSION}"
+curl -L -o ${KUSTOMIZE_TARBALL} ${KUSTOMIZE_TARBALL_URL}
+curl -L -o ${TMPDIR}/${KUSTOMIZE_CHECKSUM} ${KUSTOMIZE_CHECKSUM_URL}
+
+pushd ${TMPDIR}
+echo "Verifying helm checksum"
+grep ${TARBALL_FILENAME} ${KUSTOMIZE_CHECKSUM} | sha256sum -c
+popd
+
+tar -zxvf "${KUSTOMIZE_TARBALL}" -C "${TMPDIR}"
+
+mkdir -p .output/third_party/kustomize
+cp ${TMPDIR}/kustomize .output/third_party/kustomize/kustomize


### PR DESCRIPTION
Previously, helm and kustomize for a single architecture was downloaded as part of the top level make invocaiton and copied into the target docker environments.

To facilitate mulitple architectures for the resulting docker images, I have moved the artifact downloads into the docker build, extracting the target architecture from the evnironment

To complicate matters a bit, the google location for those images doesn't hold versions for arm64, so the scripts are downloading from the official release repositories of the respective upstream projects instead