### PR TITLE
fix: don't log context canceled as an error

### DIFF
--- a/pkg/parse/event_handler.go
+++ b/pkg/parse/event_handler.go
@@ -16,11 +16,11 @@ package parse
 
 import (
 	"context"
-	"errors"
 
 	"k8s.io/klog/v2"
 	"kpt.dev/configsync/pkg/parse/events"
 	"kpt.dev/configsync/pkg/reconciler/namespacecontroller"
+	"kpt.dev/configsync/pkg/status"
 )
 
 // EventHandler is a events.Subscriber implementation that handles events and
@@ -71,7 +71,7 @@ func (s *EventHandler) Handle(event events.Event) events.Result {
 	case events.StatusUpdateEventType:
 		// Publish the sync status periodically to update remediator errors.
 		if err := s.Reconciler.UpdateSyncStatus(ctx); err != nil {
-			if errors.Is(err, context.Canceled) {
+			if status.IsContextCanceledError(err) {
 				klog.Infof("Sync status update skipped: %v", err)
 			} else {
 				klog.Warningf("Failed to update sync status: %v", err)

--- a/pkg/remediator/reconcile/worker.go
+++ b/pkg/remediator/reconcile/worker.go
@@ -64,7 +64,7 @@ func (w *Worker) Run(ctx context.Context) {
 					cancel()
 					return
 				}
-				if err == context.Canceled || err == context.DeadlineExceeded {
+				if status.IsContextCanceledError(err) {
 					klog.Infof("Worker stopping: %v", err)
 					return
 				}

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -282,7 +282,7 @@ Watcher:
 					ignoredEventCount++
 				}
 				if err != nil {
-					if errors.Is(err, context.Canceled) || isContextCancelledStatusError(err) {
+					if status.IsContextCanceledError(err) || isContextCancelledStatusError(err) {
 						// The error wrappers are especially confusing for
 						// users, so just return context.Canceled.
 						runErr = status.InternalWrapf(context.Canceled, "remediator watch stopped for %s", w.gvk)

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -16,7 +16,6 @@ package watch
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"golang.org/x/exp/maps"
@@ -288,9 +287,8 @@ func (m *Manager) startWatcher(ctx context.Context, gvk schema.GroupVersionKind,
 // threadsafe.
 func (m *Manager) runWatcher(ctx context.Context, r Runnable, gvk schema.GroupVersionKind) {
 	if err := r.Run(ctx); err != nil {
-		// TODO: Make status.Error work with errors.Is unwrapping.
-		// For now, check the Cause directly, to avoid logging a warning on shutdown.
-		if errors.Is(err.Cause(), context.Canceled) {
+		// Avoid logging a warning on shutdown.
+		if status.IsContextCanceledError(err) {
 			klog.Infof("Watcher stopped for %s: %v", gvk, context.Canceled)
 		} else {
 			klog.Warningf("Watcher errored for %s: %v", gvk, status.FormatSingleLine(err))

--- a/pkg/status/error.go
+++ b/pkg/status/error.go
@@ -15,6 +15,8 @@
 package status
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -267,4 +269,16 @@ func CountErrorByClass(errs []v1beta1.ConfigSyncError) map[string]int64 {
 		}
 	}
 	return result
+}
+
+// IsContextCanceledError returns true if the error is context.Canceled or if
+// it wraps a context.Canceled error.
+func IsContextCanceledError(err error) bool {
+	// Unwrap status.Error, because status.Error.Is only checks the error code.
+	// TODO: Make status.Error work with errors.Is unwrapping.
+	var statusErr Error
+	if errors.As(err, &statusErr) {
+		err = statusErr.Cause()
+	}
+	return errors.Is(err, context.Canceled)
 }


### PR DESCRIPTION
These errors are often distracting red herrings that hinder debugging customer issues. They should only be logged to stdout as informative, not warnings or errors.