### PR TITLE
chore: clarify remediator logs with prefix

### DIFF
--- a/pkg/remediator/reconcile/worker.go
+++ b/pkg/remediator/reconcile/worker.go
@@ -53,36 +53,36 @@ func NewWorker(scope declared.Scope, syncName string, a syncerreconcile.Applier,
 // Run starts the Worker pulling objects from its queue for remediation. This
 // call blocks until the given context is cancelled.
 func (w *Worker) Run(ctx context.Context) {
-	klog.V(1).Info("Worker starting...")
+	klog.V(1).Info("Remediator worker starting...")
 	ctx, cancel := context.WithCancel(ctx)
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		// Attempt to drain the queue
 		for {
 			if err := w.processNextObject(ctx); err != nil {
 				if err == queue.ErrShutdown {
-					klog.Infof("Worker stopping: %v", err)
+					klog.Infof("Remediator worker stopping: %v", err)
 					cancel()
 					return
 				}
 				if status.IsContextCanceledError(err) {
-					klog.Infof("Worker stopping: %v", err)
+					klog.Infof("Remediator worker stopping: %v", err)
 					return
 				}
-				klog.Errorf("Worker error (retry scheduled): %v", err)
+				klog.Errorf("Remediator worker failed (retry scheduled): %v", err)
 				return
 			}
 		}
 		// Once an attempt has been made for every object in the queue,
 		// sleep for ~1s before retrying.
 	}, 1*time.Second)
-	klog.V(3).Info("Worker stopped")
+	klog.V(3).Info("Remediator worker stopped")
 }
 
 // processNextObject remediates object received from the queue.
 // Returns an error if the context is cancelled, the queue is shut down, or
 // processing the item failed.
 func (w *Worker) processNextObject(ctx context.Context) error {
-	klog.V(3).Info("Worker waiting for new object...")
+	klog.V(3).Info("Remediator worker waiting for new object...")
 	obj, err := w.objectQueue.Get(ctx)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (w *Worker) processNextObject(ctx context.Context) error {
 		return nil
 	}
 	defer w.objectQueue.Done(obj)
-	klog.V(3).Infof("Worker processing object %q (generation: %d)",
+	klog.V(3).Infof("Remediator worker processing object: %s (generation: %d)",
 		queue.GVKNNOf(obj), obj.GetGeneration())
 	return w.process(ctx, obj)
 }
@@ -110,7 +110,7 @@ func (w *Worker) process(ctx context.Context, obj client.Object) error {
 		if err != nil {
 			// Failed to confirm object state. Enqueue for retry.
 			w.objectQueue.Retry(obj)
-			return fmt.Errorf("failed to remediate %q: %w", id, err)
+			return fmt.Errorf("failed to remediate object: %s: %w", id, err)
 		}
 		if queue.WasDeleted(ctx, latestObj) {
 			// Confirmed not on the server.
@@ -136,14 +136,18 @@ func (w *Worker) process(ctx context.Context, obj client.Object) error {
 			// This means our cached version of the object isn't the same as the one
 			// on the cluster. We need to refresh the cached version.
 			if refreshErr := w.refresh(ctx, obj); refreshErr != nil {
-				klog.Errorf("Worker unable to update cached version of %q: %v", id, refreshErr)
+				if status.IsContextCanceledError(err) {
+					klog.Infof("Remediator worker failed to refresh the object cache: %s: %v", id, refreshErr)
+				} else {
+					klog.Errorf("Remediator worker failed to refresh the object cache: %s: %v", id, refreshErr)
+				}
 			}
 		}
 		w.objectQueue.Retry(obj)
-		return fmt.Errorf("failed to remediate %q: %w", id, err)
+		return fmt.Errorf("failed to remediate object: %s: %w", id, err)
 	}
 
-	klog.V(3).Infof("Worker reconciled %q", id)
+	klog.V(3).Infof("Remediator worker reconciled object: %s", id)
 	w.objectQueue.Forget(obj)
 	return nil
 }
@@ -171,7 +175,7 @@ func (w *Worker) getObject(ctx context.Context, obj client.Object) (client.Objec
 			return queue.MarkDeleted(ctx, obj), nil
 		}
 		// Surface any other errors
-		return uObj, status.APIServerError(err, "failed to get updated object for worker cache", obj)
+		return uObj, status.APIServerError(err, "failed to get updated object for remediator worker cache", obj)
 	}
 	return uObj, nil
 }

--- a/pkg/remediator/reconcile/worker_test.go
+++ b/pkg/remediator/reconcile/worker_test.go
@@ -542,7 +542,7 @@ func TestWorker_Refresh(t *testing.T) {
 			want:        k8sobjects.UnstructuredObject(kinds.Role(), core.Name(name), core.Namespace(namespace)),
 			wantDeleted: false,
 			wantErr: status.APIServerError(errors.New("some error"),
-				"failed to get updated object for worker cache",
+				"failed to get updated object for remediator worker cache",
 				k8sobjects.UnstructuredObject(kinds.Role(), core.Name(name), core.Namespace(namespace))),
 		},
 	}

--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -240,7 +240,7 @@ func findStatusErrorCauseMessage(statusErr *apierrors.StatusError, causeType met
 // filters the event and pushes the object contained
 // in the event to the controller work queue.
 func (w *filteredWatcher) Run(ctx context.Context) status.Error {
-	klog.Infof("Watch started for %s", w.gvk)
+	klog.Infof("Remediator watch started for %s", w.gvk)
 	var resourceVersion string
 	var retriesForWatchError int
 	var runErr status.Error
@@ -261,7 +261,7 @@ Watcher:
 
 		eventCount := 0
 		ignoredEventCount := 0
-		klog.V(2).Infof("(Re)starting watch for %s at resource version %q", w.gvk, resourceVersion)
+		klog.V(2).Infof("Remediator (re)starting watch for %s at resource version %q", w.gvk, resourceVersion)
 		eventCh := w.base.ResultChan()
 	EventHandler:
 		for {
@@ -290,14 +290,14 @@ Watcher:
 						break Watcher
 					}
 					if isExpiredError(err) {
-						klog.Infof("Watch for %s at resource version %q closed with: %v", w.gvk, resourceVersion, err)
+						klog.Infof("Remediator watch for %s at resource version %q closed with: %v", w.gvk, resourceVersion, err)
 						// `w.handle` may fail because we try to watch an old resource version, setting
 						// a watch on an old resource version will always fail.
 						// Reset `resourceVersion` to an empty string here so that we can start a new
 						// watch at the most recent resource version.
 						resourceVersion = ""
 					} else if w.addError(watchEventErrorType + errorID(err)) {
-						klog.Errorf("Watch for %s at resource version %q ended with: %v", w.gvk, resourceVersion, err)
+						klog.Errorf("Remediator watch for %s at resource version %q ended with: %v", w.gvk, resourceVersion, err)
 					}
 					retriesForWatchError++
 					waitUntilNextRetry(retriesForWatchError)
@@ -310,10 +310,10 @@ Watcher:
 				}
 			}
 		}
-		klog.V(2).Infof("Ending watch for %s at resource version %q (total events: %d, ignored events: %d)",
+		klog.V(2).Infof("Remediator watch ending for %s at resource version %q (total events: %d, ignored events: %d)",
 			w.gvk, resourceVersion, eventCount, ignoredEventCount)
 	}
-	klog.Infof("Watch stopped for %s", w.gvk)
+	klog.Infof("Remediator watch stopped for %s", w.gvk)
 	return runErr
 }
 
@@ -343,7 +343,7 @@ func (w *filteredWatcher) start(ctx context.Context, resourceVersion string) (bo
 	base, err := w.startWatch(ctx, options)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return false, status.InternalWrapf(err, "failed to start watch for %s", w.gvk)
+			return false, status.InternalWrapf(err, "failed to start remediator watch for %s", w.gvk)
 		} else if apierrors.IsNotFound(err) {
 			statusErr := syncerclient.ConflictWatchResourceDoesNotExist(err, w.gvk)
 			klog.Warningf("Remediator encountered a resource conflict: "+
@@ -352,7 +352,7 @@ func (w *filteredWatcher) start(ctx context.Context, resourceVersion string) (bo
 			metrics.RecordResourceConflict(ctx, w.getLatestCommit())
 			return false, statusErr
 		}
-		return false, status.APIServerErrorf(err, "failed to start watch for %s", w.gvk)
+		return false, status.APIServerErrorf(err, "failed to start remediator watch for %s", w.gvk)
 	}
 	w.base = base
 	return true, nil
@@ -385,7 +385,7 @@ func errorID(err error) string {
 // and an error indicating that a watch.Error event type is encountered and the
 // watch should be restarted.
 func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string, bool, error) {
-	klog.Infof("Handling watch event %v %v", event.Type, w.gvk)
+	klog.Infof("Remediator handling watch event %v %v", event.Type, w.gvk)
 	var deleted bool
 	switch event.Type {
 	case watch.Added, watch.Modified:
@@ -398,7 +398,7 @@ func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string
 			// For watch.Bookmark, only the ResourceVersion field of event.Object is set.
 			// Therefore, set the second argument of w.addError to watchEventBookmarkType.
 			if w.addError(watchEventBookmarkType) {
-				klog.Errorf("Unable to access metadata of Bookmark event: %v", event)
+				klog.Errorf("Remediator unable to access metadata of Bookmark event: %v", event)
 			}
 			return "", false, nil
 		}
@@ -408,7 +408,7 @@ func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string
 	// Keep the default case to catch any new watch event types added in the future.
 	default:
 		if w.addError(watchEventUnsupportedType) {
-			klog.Errorf("Unsupported watch event: %#v", event)
+			klog.Errorf("Remediator encountered unsupported watch event: %#v", event)
 		}
 		return "", false, nil
 	}
@@ -416,32 +416,32 @@ func (w *filteredWatcher) handle(ctx context.Context, event watch.Event) (string
 	// get client.Object from the runtime object.
 	object, ok := event.Object.(client.Object)
 	if !ok {
-		klog.Warningf("Received non client.Object in watch event: %T", object)
+		klog.Warningf("Remediator received non client.Object in watch event: %T", object)
 		metrics.RecordInternalError(ctx, "remediator")
 		return "", false, nil
 	}
 
 	if klog.V(5).Enabled() {
-		klog.V(5).Infof("Received watch event for object: %q (generation: %d): %s",
+		klog.V(5).Infof("Remediator received watch event for object: %q (generation: %d): %s",
 			core.IDOf(object), object.GetGeneration(), log.AsJSON(object))
 	} else {
-		klog.V(3).Infof("Received watch event for object: %q (generation: %d)",
+		klog.V(3).Infof("Remediator received watch event for object: %q (generation: %d)",
 			core.IDOf(object), object.GetGeneration())
 	}
 
 	// filter objects.
 	if !w.shouldProcess(object) {
-		klog.V(4).Infof("Ignoring event for object: %q (generation: %d)",
+		klog.V(4).Infof("Remediator ignoring event for object: %q (generation: %d)",
 			core.IDOf(object), object.GetGeneration())
 		return object.GetResourceVersion(), true, nil
 	}
 
 	if deleted {
-		klog.V(2).Infof("Received watch event for deleted object %q (generation: %d)",
+		klog.V(2).Infof("Remediator received watch event for deleted object %q (generation: %d)",
 			core.IDOf(object), object.GetGeneration())
 		object = queue.MarkDeleted(ctx, object)
 	} else {
-		klog.V(2).Infof("Received watch event for created/updated object %q (generation: %d)",
+		klog.V(2).Infof("Remediator received watch event for created/updated object %q (generation: %d)",
 			core.IDOf(object), object.GetGeneration())
 	}
 
@@ -472,7 +472,7 @@ func (w *filteredWatcher) shouldProcess(object client.Object) bool {
 	currentGVK := object.GetObjectKind().GroupVersionKind()
 	declaredGVK := decl.GroupVersionKind()
 	if currentGVK != declaredGVK {
-		klog.V(5).Infof("Received a watch event for object %q with kind %s, which does not match the declared kind %s. ",
+		klog.V(5).Infof("Remediator received a watch event for object %q with kind %s, which does not match the declared kind %s. ",
 			id, currentGVK, declaredGVK)
 		return false
 	}

--- a/pkg/remediator/watch/manager.go
+++ b/pkg/remediator/watch/manager.go
@@ -289,9 +289,9 @@ func (m *Manager) runWatcher(ctx context.Context, r Runnable, gvk schema.GroupVe
 	if err := r.Run(ctx); err != nil {
 		// Avoid logging a warning on shutdown.
 		if status.IsContextCanceledError(err) {
-			klog.Infof("Watcher stopped for %s: %v", gvk, context.Canceled)
+			klog.Infof("Remediator watcher stopped for %s: %v", gvk, context.Canceled)
 		} else {
-			klog.Warningf("Watcher errored for %s: %v", gvk, status.FormatSingleLine(err))
+			klog.Warningf("Remediator watcher errored for %s: %v", gvk, status.FormatSingleLine(err))
 		}
 		m.mux.Lock()
 		delete(m.watcherMap, gvk)


### PR DESCRIPTION
Add a prefix to the logs from the remediator to make them easier to attribute when debugging. This should help improve the quality of error reports.

Depends on https://github.com/GoogleContainerTools/kpt-config-sync/pull/1503