### PR TITLE
fix: ignore gcloud operations list warnings

### DIFF
--- a/e2e/nomostest/clusters/gke.go
+++ b/e2e/nomostest/clusters/gke.go
@@ -83,6 +83,7 @@ func listOperations(ctx context.Context, t testing.NTB, name string) ([]string, 
 		"--project", *e2e.GCPProject,
 		"--filter", fmt.Sprintf("status = RUNNING AND targetLink ~ ^.*/%s$", name),
 		"--format", "value(name)",
+		"--no-user-output-enabled", // mute warnings
 	}
 	if *e2e.GCPZone != "" {
 		args = append(args, "--zone", *e2e.GCPZone)


### PR DESCRIPTION
- Warnings printed to STDERR were being captured as in-progress operations, causing listOperations to error. This change fixes that issue by disabling human output for that command.