### PR TITLE
test: update bitnami Helm charts to use OCI package

### DIFF
--- a/Makefile.oss.prow
+++ b/Makefile.oss.prow
@@ -59,6 +59,27 @@ push-test-oci-images-public: "$(CRANE)"
 	cd $(KUSTOMIZE_COMPONENTS_DIR) && crane append -f <(tar -f - -c .) -t $(KUSTOMIZE_COMPONENTS_PUBLIC_GCR_IMAGE)
 	cd $(KUSTOMIZE_COMPONENTS_DIR) && crane append -f <(tar -f - -c .) -t $(KUSTOMIZE_COMPONENTS_PUBLIC_AR_IMAGE)
 
+# The e2e test expects both versions exist as public.
+# See `TestHelmVersionRange` and `rootSyncForWordpressHelmChart` in `e2e/testcases/helm_sync_test.go`.
+WORDPRESS_HELM_CHART_VERSIONS := 15.2.35 15.4.1
+WORDPRESS_HELM_CHART_SOURCE_REPO := oci://registry-1.docker.io/bitnamicharts/wordpress
+WORDPRESS_HELM_CHART_PUBLIC_AR_REPO := oci://$(LOCATION)-docker.pkg.dev/$(TEST_INFRA_PROJECT)/config-sync-test-public
+
+# This target is run as a singleton against the ci-artifacts project, since
+# these require for the registries to be public.
+.PHONY: push-test-helm-charts-public
+push-test-helm-charts-public: "$(HELM)"
+	$(foreach version, $(WORDPRESS_HELM_CHART_VERSIONS), \
+		helm pull $(WORDPRESS_HELM_CHART_PUBLIC_AR_REPO)/wordpress \
+			--version $(version) &> /dev/null || \
+			$(MAKE) __push-test-helm-chart-from-pull VERSION=$(version);)
+
+.PHONY: __push-test-helm-chart-from-pull
+__push-test-helm-chart-from-pull: "$(HELM)"
+	helm pull $(WORDPRESS_HELM_CHART_SOURCE_REPO) --version $(VERSION)
+	@gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://$(LOCATION)-docker.pkg.dev
+	helm push wordpress-$(VERSION).tgz $(WORDPRESS_HELM_CHART_PUBLIC_AR_REPO)
+
 # The following targets are used to provision test resources in a prow environment
 
 # kustomize-components private images (per dev/prow env registry)

--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -907,7 +907,7 @@ func rootSyncForWordpressHelmChart(nt *nomostest.NT, valuesMutator func(map[stri
 	rs.Spec.Helm = &v1beta1.HelmRootSync{
 		Namespace: "wordpress",
 		HelmBase: v1beta1.HelmBase{
-			Repo:        "https://charts.bitnami.com/bitnami",
+			Repo:        "oci://us-docker.pkg.dev/kpt-config-sync-ci-artifacts/config-sync-test-public",
 			Chart:       chartID.Name,
 			Version:     chartID.Version,
 			ReleaseName: "my-wordpress",

--- a/e2e/testdata/hydration/deprecated-GK/kustomization.yaml
+++ b/e2e/testdata/hydration/deprecated-GK/kustomization.yaml
@@ -18,5 +18,8 @@ helmCharts:
   version: 0.2.0
   releaseName: my-prometheus-operator
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/dry-repo-without-kustomization/base/kustomization.yaml
+++ b/e2e/testdata/hydration/dry-repo-without-kustomization/base/kustomization.yaml
@@ -20,5 +20,8 @@ helmCharts:
 commonAnnotations:
   hydration-tool: kustomize
 
-commonLabels:
-  team: monitoring
+labels:
+  - pairs:
+      team: monitoring
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
@@ -18,7 +18,7 @@ helmCharts:
   namespace: coredns
   valuesFile: https://raw.githubusercontent.com/config-sync-examples/helm-components/main/coredns-values.yaml
 - name: wordpress
-  repo: https://charts.bitnami.com/bitnami
+  repo: oci://us-docker.pkg.dev/kpt-config-sync-ci-artifacts/config-sync-test-public
   version: 15.2.35
   releaseName: my-wordpress
   namespace: wordpress
@@ -26,5 +26,8 @@ helmCharts:
     service:
       type: ClusterIP
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/helm-components/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components/kustomization.yaml
@@ -17,7 +17,7 @@ helmCharts:
   releaseName: my-coredns
   namespace: coredns
 - name: wordpress
-  repo: https://charts.bitnami.com/bitnami
+  repo: oci://us-docker.pkg.dev/kpt-config-sync-ci-artifacts/config-sync-test-public
   version: 15.2.35
   releaseName: my-wordpress
   namespace: wordpress
@@ -30,5 +30,8 @@ helmCharts:
     service:
       type: ClusterIP
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/helm-overlay/base/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-overlay/base/kustomization.yaml
@@ -23,5 +23,8 @@ helmCharts:
 commonAnnotations:
   hydration-tool: kustomize
 
-commonLabels:
-  team: coredns
+labels:
+  - pairs:
+      team: coredns
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/helm-overlay/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-overlay/kustomization.yaml
@@ -15,5 +15,8 @@
 resources:
 - overlay
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/kustomize-components/base/kustomization.yaml
+++ b/e2e/testdata/hydration/kustomize-components/base/kustomization.yaml
@@ -18,5 +18,8 @@ resources:
 - role.yaml
 - networkpolicy.yaml
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/namespace-repo/base/kustomization.yaml
+++ b/e2e/testdata/hydration/namespace-repo/base/kustomization.yaml
@@ -17,5 +17,8 @@ resources:
 - role.yaml
 - networkpolicy.yaml
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/relative-path/overlays/dev/kustomization.yaml
+++ b/e2e/testdata/hydration/relative-path/overlays/dev/kustomization.yaml
@@ -33,5 +33,8 @@ patches:
     - op: replace
       path: /subjects/0/name
       value: developers-all@foo-corp.com
-commonLabels:
-  environment: dev
+labels:
+  - pairs:
+      environment: dev
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/remote-base/kustomization.yaml
+++ b/e2e/testdata/hydration/remote-base/kustomization.yaml
@@ -15,5 +15,8 @@
 resources:
 - overlay
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/remote-overlay-kustomization.yaml
+++ b/e2e/testdata/hydration/remote-overlay-kustomization.yaml
@@ -15,5 +15,8 @@
 resources:
 - github.com/config-sync-examples/kustomize-components/tenant-b?ref=main
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/remote-resources-kustomization.yaml
+++ b/e2e/testdata/hydration/remote-resources-kustomization.yaml
@@ -15,5 +15,8 @@
 resources:
 - github.com/config-sync-examples/kustomize-components?ref=main
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true

--- a/e2e/testdata/hydration/resource-duplicate/kustomization.yaml
+++ b/e2e/testdata/hydration/resource-duplicate/kustomization.yaml
@@ -16,5 +16,8 @@ resources:
 - github.com/config-sync-examples/kustomize-components?ref=main
 - namespace_tenant-a.yaml
 
-commonLabels:
-  test-case: hydration
+labels:
+  - pairs:
+      test-case: hydration
+    includeSelectors: true
+    includeTemplates: true


### PR DESCRIPTION
Per
https://blog.bitnami.com/2023/04/httpsblog.bitnami.com202304bitnami-helm-charts-now-oci.html, Bitnami Helm charts are now GA as OCI packages. This commit updates its repo URL to use the OCI package, which fixes the `helm pull` error:
```
KNV1068: failed to run kustomize build in /repo/source/.worktrees/b2c6bf5708654b1c2b7fbd898b48ca206de5a47b/helm-components, stdout: : # Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
                Error: Error: looks like "https://charts.bitnami.com/bitnami" is not a valid chart repository or cannot be reached: Get "https://charts.bitnami.com/bitnami/index.yaml": dial tcp: lookup charts.bitnami.com on 10.66.32.10:53: server misbehaving
                : unable to run: 'helm pull --untar --untardir /repo/source/.worktrees/b2c6bf5708654b1c2b7fbd898b48ca206de5a47b/helm-components/charts/wordpress-15.2.35 --repo https://charts.bitnami.com/bitnami wordpress --version 15.2.35' with env=[HELM_CONFIG_HOME=/tmp/kustomize-helm-1930457181/helm HELM_CACHE_HOME=/tmp/kustomize-helm-1930457181/helm/.cache HELM_DATA_HOME=/tmp/kustomize-helm-1930457181/helm/.data] (is 'helm' installed?): exit status 1
```

Link: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-regular-csr/1868596976711372800

It also replaces the deprecated `commonLabels` with `labels` to suppress the warning.