### PR TITLE
Exclude vendor folder from AI review

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,1 +1,1 @@
-vendor
+vendor/


### PR DESCRIPTION
From https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file#examples it seems that the trailing `/` might be necessary for it to exclude all files and subdirectories of `vendor/`