### PR TITLE
chore: bump Go version used by build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE_VERSION := 1.22.5
+GOLANG_IMAGE_VERSION := 1.23.4
 GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command: 


### PR DESCRIPTION
This updates the Go version contained in the build/CI images in preparation for bumping the Go version in the module.