### PR TITLE
chore: use scheme to get GVK of typed objects

### DIFF
--- a/e2e/testcases/composition_test.go
+++ b/e2e/testcases/composition_test.go
@@ -141,7 +141,7 @@ func TestComposition(t *testing.T) {
 	// and RootSync level-1 is manage by RootSync root-sync (level-0),
 	// we need to make RepoSync level-1 depend on both RoleBindings,
 	// so the RoleBindings are deleted after both RepoSyncs.
-	nt.Must(nomostest.SetDependencies(lvl1Sync, lvl2RB, lvl3RB))
+	nt.Must(nomostest.SetDependencies(lvl1Sync, nt.Scheme, lvl2RB, lvl3RB))
 	lvl1Path := filepath.Join(lvl0SubDir, fmt.Sprintf("rootsync-%s.yaml", lvl1NN.Name))
 	nt.T.Logf("Adding RootSync %s to the shared repository: %s", lvl1NN.Name, lvl1Path)
 	nt.Must(lvl0Repo.Add(lvl1Path, lvl1Sync))

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -169,7 +169,7 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	nt.T.Logf("Add RepoSync %s to RootSync %s", repoSync3Key, configsync.RootSyncName)
 	nrs3 := nomostest.RepoSyncObjectV1Alpha1FromNonRootRepo(nt, repoSync3Key)
 	// Ensure the RoleBinding is deleted after the RepoSync
-	nt.Must(nomostest.SetDependencies(nrs3, nrb3))
+	nt.Must(nomostest.SetDependencies(nrs3, nt.Scheme, nrb3))
 	nt.Must(rootSync0GitRepo.Add(fmt.Sprintf("acme/reposyncs/%s.yaml", repoSync3Key.Name), nrs3))
 	nt.Must(rootSync0GitRepo.Add(fmt.Sprintf("acme/namespaces/%s/rb-%s.yaml", testNs, repoSync3Key.Name), nrb3))
 	nt.Must(rootSync0GitRepo.CommitAndPush("Adding RepoSync: " + repoSync3Key.String()))
@@ -190,7 +190,7 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 	nt.T.Logf("Add RepoSync %s to RootSync %s", repoSync5Key, rootSync1ID.Name)
 	nrs5 := nomostest.RepoSyncObjectV1Beta1FromNonRootRepo(nt, repoSync5Key)
 	// Ensure the RoleBinding is deleted after the RepoSync
-	nt.Must(nomostest.SetDependencies(nrs5, nrb5))
+	nt.Must(nomostest.SetDependencies(nrs5, nt.Scheme, nrb5))
 	nt.Must(rootSync1GitRepo.Add(fmt.Sprintf("acme/reposyncs/%s.yaml", repoSync5Key.Name), nrs5))
 	nt.Must(rootSync1GitRepo.Add(fmt.Sprintf("acme/namespaces/%s/rb-%s.yaml", testNs, repoSync5Key.Name), nrb5))
 	nt.Must(rootSync1GitRepo.CommitAndPush("Adding RepoSync: " + repoSync5Key.String()))

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -584,7 +584,7 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), d
 	// Builds a map of id -> resource
 	resourceMap := make(map[core.ID]client.Object)
 	for _, obj := range resources {
-		resourceMap[idFrom(ObjMetaFromObject(obj))] = obj
+		resourceMap[idFrom(ObjMetaFromUnstructured(obj))] = obj
 	}
 
 	events := s.clientSet.KptApplier.Run(ctx, s.inventory, object.UnstructuredSet(resources), options)

--- a/pkg/applier/utils_test.go
+++ b/pkg/applier/utils_test.go
@@ -90,7 +90,7 @@ func TestObjMetaFrom(t *testing.T) {
 			Kind:  "Deployment",
 		},
 	}
-	actual := ObjMetaFromObject(d)
+	actual := mustObjMetaFromObject(t, d)
 	if actual != expected {
 		t.Errorf("expected %v but got %v", expected, actual)
 	}
@@ -98,7 +98,7 @@ func TestObjMetaFrom(t *testing.T) {
 
 func TestIDFrom(t *testing.T) {
 	d := k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))
-	meta := ObjMetaFromObject(d)
+	meta := mustObjMetaFromObject(t, d)
 	id := idFrom(meta)
 	if id != core.IDOf(d) {
 		t.Errorf("expected %v but got %v", core.IDOf(d), id)
@@ -115,47 +115,47 @@ func TestRemoveFrom(t *testing.T) {
 		{
 			name: "toRemove is empty",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: nil,
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "all toRemove are in the original list",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "some toRemove are not in the original list",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default")),
 				k8sobjects.ConfigMapObject(core.Name("cm"), core.Namespace("default")),
 			},
 			expected: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
 			},
 		},
 		{
 			name: "toRemove are the same as original objects",
 			allObjMeta: []object.ObjMetadata{
-				ObjMetaFromObject(k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
-				ObjMetaFromObject(k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default"))),
+				mustObjMetaFromObject(t, k8sobjects.ServiceObject(core.Name("service"), core.Namespace("default"))),
 			},
 			objs: []client.Object{
 				k8sobjects.DeploymentObject(core.Name("deploy"), core.Namespace("default")),
@@ -306,4 +306,15 @@ func TestHandleIgnoredObjects(t *testing.T) {
 			testutil.AssertEqual(t, tc.expectedObjs, allObjs)
 		})
 	}
+}
+
+// mustObjMetaFromObject constructs an ObjMetadata representing the Object.
+//
+// Fails the test if the GroupKind is not set and not registered in core.Scheme.
+func mustObjMetaFromObject(t *testing.T, obj client.Object) object.ObjMetadata {
+	objMeta, err := ObjMetaFromObject(obj, core.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return objMeta
 }


### PR DESCRIPTION
Change ObjMetaFromObject to use the Scheme to get the GVK from typed objects, instead of relying on the code to populate the GVK on all objects. This requires handling errors when the type is unknown.

This is a prerequisite for removing the GVK from typed objects.