### PR TITLE
chore: improve the InvalidCRDName error message

### DIFF
--- a/pkg/importer/analyzer/validation/nonhierarchical/crd_name_validator.go
+++ b/pkg/importer/analyzer/validation/nonhierarchical/crd_name_validator.go
@@ -32,9 +32,10 @@ var invalidCRDNameErrorBuilder = status.NewErrorBuilder(InvalidCRDNameErrorCode)
 // InvalidCRDNameError reports a CRD with an invalid name in the repo.
 func InvalidCRDNameError(resource client.Object, expected string) status.Error {
 	return invalidCRDNameErrorBuilder.
-		Sprintf("The CustomResourceDefinition `metadata.name` MUST be in the form: `<spec.names.plural>.<spec.group>`. "+
-			"To fix, update those fields or change `metadata.name` to %q.",
-			expected).
+		Sprintf("Invalid CustomResourceDefinition name: `%s`."+
+			" The `metadata.name` MUST be in the form: `<spec.names.plural>.<spec.group>`. "+
+			"To fix, update the spec fields or change the name to `%s`.",
+			resource.GetName(), expected).
 		BuildWithResources(resource)
 }
 


### PR DESCRIPTION
The old text mentioned the solution but not the problem. Using backticks instead of quotes also makes the error easier to read because they don't need to be escaped in yaml/json or logs.