### PR TITLE
[WIP] Add max-object-count error to nomos vet

### DIFF
--- a/cmd/nomos/vet/vet.go
+++ b/cmd/nomos/vet/vet.go
@@ -20,11 +20,13 @@ import (
 	"github.com/spf13/cobra"
 	"kpt.dev/configsync/cmd/nomos/flags"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
 )
 
 var (
 	namespaceValue string
 	keepOutput     bool
+	maxObjectCount int
 	outPath        string
 )
 
@@ -42,6 +44,9 @@ func init() {
 
 	Cmd.Flags().BoolVar(&keepOutput, "keep-output", false,
 		`If enabled, keep the hydrated output`)
+
+	Cmd.Flags().IntVar(&maxObjectCount, "max-object-count", system.DefaultMaxObjectCount,
+		`If greater than zero, error if any repository contains more than the specified number of objects`)
 
 	Cmd.Flags().StringVar(&outPath, "output", flags.DefaultHydrationOutput,
 		`Location of the hydrated output`)
@@ -64,6 +69,11 @@ returns a non-zero error code if any issues are found.
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true
 
-		return runVet(cmd.Context(), namespaceValue, configsync.SourceFormat(flags.SourceFormat), flags.APIServerTimeout)
+		return runVet(cmd.Context(), vetOptions{
+			Namespace:        namespaceValue,
+			SourceFormat:     configsync.SourceFormat(flags.SourceFormat),
+			APIServerTimeout: flags.APIServerTimeout,
+			MaxObjectCount:   maxObjectCount,
+		})
 	},
 }

--- a/cmd/nomos/vet/vet.go
+++ b/cmd/nomos/vet/vet.go
@@ -24,10 +24,11 @@ import (
 )
 
 var (
-	namespaceValue string
-	keepOutput     bool
-	maxObjectCount int
-	outPath        string
+	namespaceValue        string
+	keepOutput            bool
+	maxObjectCount        int
+	maxInventorySizeBytes int
+	outPath               string
 )
 
 func init() {
@@ -47,6 +48,9 @@ func init() {
 
 	Cmd.Flags().IntVar(&maxObjectCount, "max-object-count", system.DefaultMaxObjectCount,
 		`If greater than zero, error if any repository contains more than the specified number of objects`)
+
+	Cmd.Flags().IntVar(&maxInventorySizeBytes, "max-inventory-size", system.DefaultMaxInventorySizeBytes,
+		`If greater than zero, error if any repository contains enough objects such that the inventory object would exceed the specified number of bytes when serialized as JSON`)
 
 	Cmd.Flags().StringVar(&outPath, "output", flags.DefaultHydrationOutput,
 		`Location of the hydrated output`)
@@ -70,10 +74,11 @@ returns a non-zero error code if any issues are found.
 		cmd.SilenceUsage = true
 
 		return runVet(cmd.Context(), vetOptions{
-			Namespace:        namespaceValue,
-			SourceFormat:     configsync.SourceFormat(flags.SourceFormat),
-			APIServerTimeout: flags.APIServerTimeout,
-			MaxObjectCount:   maxObjectCount,
+			Namespace:             namespaceValue,
+			SourceFormat:          configsync.SourceFormat(flags.SourceFormat),
+			APIServerTimeout:      flags.APIServerTimeout,
+			MaxObjectCount:        maxObjectCount,
+			MaxInventorySizeBytes: maxInventorySizeBytes,
 		})
 	},
 }

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -37,6 +37,13 @@ import (
 	"kpt.dev/configsync/pkg/status"
 )
 
+type vetOptions struct {
+	Namespace        string
+	SourceFormat     configsync.SourceFormat
+	APIServerTimeout time.Duration
+	MaxObjectCount   int
+}
+
 // vet runs nomos vet with the specified options.
 //
 // root is the OS-specific path to the Nomos policy root.
@@ -52,7 +59,9 @@ import (
 // clusters is the set of clusters we are checking.
 //
 // Only used if allClusters is false.
-func runVet(ctx context.Context, namespace string, sourceFormat configsync.SourceFormat, apiServerTimeout time.Duration) error {
+func runVet(ctx context.Context, opts vetOptions) error {
+	namespace := opts.Namespace
+	sourceFormat := opts.SourceFormat
 	if sourceFormat == "" {
 		if namespace == "" {
 			// Default to hierarchical if --namespace is not provided.
@@ -86,11 +95,12 @@ func runVet(ctx context.Context, namespace string, sourceFormat configsync.Sourc
 
 	parser := filesystem.NewParser(&reader.File{})
 
-	validateOpts, err := hydrate.ValidateOptions(ctx, rootDir, apiServerTimeout)
+	validateOpts, err := hydrate.ValidateOptions(ctx, rootDir, opts.APIServerTimeout)
 	if err != nil {
 		return err
 	}
 	validateOpts.FieldManager = util.FieldManager
+	validateOpts.MaxObjectCount = opts.MaxObjectCount
 
 	switch sourceFormat {
 	case configsync.SourceFormatHierarchy:

--- a/cmd/nomos/vet/vet_impl.go
+++ b/cmd/nomos/vet/vet_impl.go
@@ -38,10 +38,11 @@ import (
 )
 
 type vetOptions struct {
-	Namespace        string
-	SourceFormat     configsync.SourceFormat
-	APIServerTimeout time.Duration
-	MaxObjectCount   int
+	Namespace             string
+	SourceFormat          configsync.SourceFormat
+	APIServerTimeout      time.Duration
+	MaxObjectCount        int
+	MaxInventorySizeBytes int
 }
 
 // vet runs nomos vet with the specified options.
@@ -101,6 +102,7 @@ func runVet(ctx context.Context, opts vetOptions) error {
 	}
 	validateOpts.FieldManager = util.FieldManager
 	validateOpts.MaxObjectCount = opts.MaxObjectCount
+	validateOpts.MaxInventorySizeBytes = opts.MaxInventorySizeBytes
 
 	switch sourceFormat {
 	case configsync.SourceFormatHierarchy:

--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -321,6 +321,9 @@ func Generate() AllExamples {
 	// 1069
 	result.add(validate.SelfReconcileError(k8sobjects.RootSyncV1Beta1(configsync.RootSyncName)))
 
+	// 1070
+	result.add(system.MaxObjectCountError(system.DefaultMaxObjectCount, system.DefaultMaxObjectCount+1))
+
 	// 2001
 	result.add(status.PathWrapError(errors.New("error creating directory"), "namespaces/foo"))
 

--- a/cmd/nomoserrors/examples/examples.go
+++ b/cmd/nomoserrors/examples/examples.go
@@ -324,6 +324,9 @@ func Generate() AllExamples {
 	// 1070
 	result.add(system.MaxObjectCountError(system.DefaultMaxObjectCount, system.DefaultMaxObjectCount+1))
 
+	// 1071
+	result.add(system.MaxInventorySizeError(system.DefaultMaxInventorySizeBytes, system.DefaultMaxInventorySizeBytes+1))
+
 	// 2001
 	result.add(status.PathWrapError(errors.New("error creating directory"), "namespaces/foo"))
 

--- a/pkg/importer/analyzer/validation/system/max_inventory_size_validator.go
+++ b/pkg/importer/analyzer/validation/system/max_inventory_size_validator.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"kpt.dev/configsync/pkg/status"
+)
+
+// DefaultMaxInventorySizeBytes is the default maximum byte size for a json
+// object in etcd.
+const DefaultMaxInventorySizeBytes = 1572864 // 1.5MiB in OSS Kubernetes, 3145728 (3MiB) in GKE
+
+// MaxInventorySizeCode is the error code for MaxInventorySizeError
+const MaxInventorySizeCode = "1071"
+
+var maxInventorySizeErrorBuilder = status.NewErrorBuilder(MaxInventorySizeCode)
+
+// MaxInventorySizeError reports that the source will create an inventory object
+// that is larger than can be stored in etcd.
+func MaxInventorySizeError(max, found int) status.Error {
+	return maxInventorySizeErrorBuilder.
+		Sprintf(`Maximum inventory size exceeded. `+
+			`Estimated inventory object size is %d bytes, but the maximum in etcd defaults to %d bytes. `+
+			`To fix, split the resources across multiple repositories.`,
+			found, max).
+		Build()
+}

--- a/pkg/importer/analyzer/validation/system/max_object_count_validator.go
+++ b/pkg/importer/analyzer/validation/system/max_object_count_validator.go
@@ -38,10 +38,7 @@ var maxObjectCountErrorBuilder = status.NewErrorBuilder(MaxObjectCountCode)
 func MaxObjectCountError(max, found int) status.Error {
 	return maxObjectCountErrorBuilder.
 		Sprintf(`Maximum number of objects exceeded. Found %d, but expected no more than %d. `+
-			`Reduce the number of objects being synced to this cluster in your source of truth `+
-			`to prevent your ResourceGroup inventory object from exceeding the etcd object size limit. `+
-			`For instructions on how to break up a repository into multiple repositories, see `+
-			`https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/breaking-up-repo`,
+			`To fix, split the resources across multiple repositories.`,
 			found, max).
 		Build()
 }

--- a/pkg/importer/analyzer/validation/system/max_object_count_validator.go
+++ b/pkg/importer/analyzer/validation/system/max_object_count_validator.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"kpt.dev/configsync/pkg/status"
+)
+
+// DefaultMaxObjectCount is the default maximum number of objects allowed in a
+// single inventory, if the validator is enabled.
+//
+// This is only used by nomos vet, not the reconciler. It will not block syncing.
+// The value 5000 was chosen because we have e2e tests that sync that many
+// objects without disabling the inventory status. However, it's still possible
+// to exceed the etcd object size limit if there are a lot of long errors while
+// syncing. So it's possible we may want to adjust this up or down in the future.
+const DefaultMaxObjectCount = 5000
+
+// MaxObjectCountCode is the error code for MaxObjectCount
+const MaxObjectCountCode = "1070"
+
+var maxObjectCountErrorBuilder = status.NewErrorBuilder(MaxObjectCountCode)
+
+// MaxObjectCountError reports that the source includes more than the maximum
+// number of objects.
+func MaxObjectCountError(max, found int) status.Error {
+	return maxObjectCountErrorBuilder.
+		Sprintf(`Maximum number of objects exceeded. Found %d, but expected no more than %d. `+
+			`Reduce the number of objects being synced to this cluster in your source of truth `+
+			`to prevent your ResourceGroup inventory object from exceeding the etcd object size limit. `+
+			`For instructions on how to break up a repository into multiple repositories, see `+
+			`https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/breaking-up-repo`,
+			found, max).
+		Build()
+}

--- a/pkg/validate/final/final.go
+++ b/pkg/validate/final/final.go
@@ -20,17 +20,25 @@ import (
 	"kpt.dev/configsync/pkg/validate/final/validate"
 )
 
-type finalValidator func(objs []ast.FileObject) status.MultiError
+// Options used to configure the Validate function
+type Options struct {
+	// MaxObjectCount is the maximum number of objects allowed in a single
+	// inventory. Optional. Set to a non-zero value to enable.
+	MaxObjectCount int
+}
 
-// Validation performs final validation checks against the given FileObjects.
+type validator func(objs []ast.FileObject) status.MultiError
+
+// Validate performs final validation checks against the given FileObjects.
 // This should be called after all hydration steps are complete so that it can
 // validate the final state of the repo.
-func Validation(objs []ast.FileObject) status.MultiError {
+func Validate(objs []ast.FileObject, opts Options) status.MultiError {
 	var errs status.MultiError
 	// See the note about ordering in raw.Hierarchical().
-	validators := []finalValidator{
+	validators := []validator{
 		validate.DuplicateNames,
 		validate.UnmanagedNamespaces,
+		validate.MaxObjectCount(opts.MaxObjectCount),
 	}
 	for _, validator := range validators {
 		errs = status.Append(errs, validator(objs))

--- a/pkg/validate/final/final.go
+++ b/pkg/validate/final/final.go
@@ -25,6 +25,9 @@ type Options struct {
 	// MaxObjectCount is the maximum number of objects allowed in a single
 	// inventory. Optional. Set to a non-zero value to enable.
 	MaxObjectCount int
+	// MaxInventorySizeBytes is the maximum number of JSON bytes allowed for a
+	// single inventory object. Optional. Set to a non-zero value to enable.
+	MaxInventorySizeBytes int
 }
 
 type validator func(objs []ast.FileObject) status.MultiError
@@ -39,6 +42,7 @@ func Validate(objs []ast.FileObject, opts Options) status.MultiError {
 		validate.DuplicateNames,
 		validate.UnmanagedNamespaces,
 		validate.MaxObjectCount(opts.MaxObjectCount),
+		validate.MaxInventorySize(opts.MaxInventorySizeBytes),
 	}
 	for _, validator := range validators {
 		errs = status.Append(errs, validator(objs))

--- a/pkg/validate/final/validate/max_inventory_size_validator.go
+++ b/pkg/validate/final/validate/max_inventory_size_validator.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"fmt"
+	"math"
+
+	"encoding/binary"
+
+	"github.com/GoogleContainerTools/kpt/pkg/live"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
+	"kpt.dev/configsync/pkg/status"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+const (
+	placeholderUID         = types.UID("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+	placeholderGeneration  = int64(math.MaxInt64) - 2
+	placeholderName63Chars = "this-is-a-kubernetes-object-name-that-is-very-long-indeed-and-it-has-63-characters-in-total-which-is-the-maximum-allowed-length-for-a-k8s-object-name"
+)
+
+// MaxInventorySize verifies that the number of managed resources does not
+// generate an inventory object that is larger than the specified number of
+// bytes when serialized to JSON.
+func MaxInventorySize(maxBytes int) func([]ast.FileObject) status.MultiError {
+	if maxBytes <= 0 {
+		return noOpValidator
+	}
+	return func(objs []ast.FileObject) status.MultiError {
+		invObj, err := simulateInventoryObject(objs)
+		if err != nil {
+			err := fmt.Errorf("simulating inventory object: %w", err)
+			return status.InternalWrapf(err, "Failed to validate inventory size")
+		}
+		invBytes, err := invObj.MarshalJSON()
+		if err != nil {
+			err := fmt.Errorf("serializing simulated inventory object: %w", err)
+			return status.InternalWrapf(err, "Failed to validate inventory size")
+		}
+		invByteSize := binary.Size(invBytes)
+		if invByteSize > maxBytes {
+			return system.MaxInventorySizeError(maxBytes, invByteSize)
+		}
+		return nil
+	}
+}
+
+func simulateInventoryObject(objs []ast.FileObject) (*unstructured.Unstructured, error) {
+	rgObj := &unstructured.Unstructured{}
+
+	// Add placeholder metadata
+	rgObj.SetName(placeholderName63Chars)
+	rgObj.SetNamespace(placeholderName63Chars)
+	rgObj.SetLabels(map[string]string{
+		placeholderName63Chars: placeholderName63Chars,
+	})
+	rgObj.SetAnnotations(map[string]string{
+		placeholderName63Chars: placeholderName63Chars,
+	})
+	rgObj.SetUID(placeholderUID)
+	rgObj.SetGeneration(placeholderGeneration)
+
+	// Add spec & status
+	storage := live.WrapInventoryObj(rgObj)
+	invSpec := make(object.ObjMetadataSet, len(objs))
+	invStatus := make([]actuation.ObjectStatus, len(objs))
+	for i, obj := range objs {
+		invSpec[i] = object.ObjMetadata{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+			GroupKind: obj.GroupVersionKind().GroupKind(),
+		}
+		invStatus[i] = actuation.ObjectStatus{
+			ObjectReference: inventory.ObjectReferenceFromObjMetadata(invSpec[i]),
+			Strategy:        actuation.ActuationStrategyDelete,
+			Actuation:       actuation.ActuationSucceeded,
+			Reconcile:       actuation.ReconcileSucceeded,
+			UID:             placeholderUID,
+			Generation:      placeholderGeneration,
+		}
+	}
+	// Store only updates private fields on the storage object.
+	// No API calls are made.
+	if err := storage.Store(invSpec, invStatus); err != nil {
+		return nil, fmt.Errorf("storing inventory: %w", err)
+	}
+	// GetObject only generates an Unstructured inventory from the initial
+	// object with the stored spec & status merged into it.
+	// No API calls are made.
+	invObj, err := storage.GetObject()
+	if err != nil {
+		return nil, fmt.Errorf("getting inventory from storage: %w", err)
+	}
+	return invObj, nil
+}

--- a/pkg/validate/final/validate/max_object_count_validator.go
+++ b/pkg/validate/final/validate/max_object_count_validator.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"kpt.dev/configsync/pkg/importer/analyzer/ast"
+	"kpt.dev/configsync/pkg/importer/analyzer/validation/system"
+	"kpt.dev/configsync/pkg/status"
+)
+
+// MaxObjectCount verifies that the number of managed resources does not exceed
+// the specified maximum.
+func MaxObjectCount(max int) func([]ast.FileObject) status.MultiError {
+	if max <= 0 {
+		return noOpValidator
+	}
+	return func(objs []ast.FileObject) status.MultiError {
+		found := len(objs)
+		if found > max {
+			return system.MaxObjectCountError(max, found)
+		}
+		return nil
+	}
+}
+
+func noOpValidator([]ast.FileObject) status.MultiError {
+	return nil
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -88,9 +88,12 @@ type Options struct {
 	WebhookEnabled bool
 	// FieldManager to use when performing cluster operations
 	FieldManager string
-	// MaxObjectCount is the maximum number of objects allowed to be stored in a
-	// single inventory.
+	// MaxObjectCount is the maximum number of objects allowed in a single
+	// inventory. Optional. Set to a non-zero value to enable.
 	MaxObjectCount int
+	// MaxInventorySizeBytes is the maximum number of JSON bytes allowed for a
+	// single inventory object. Optional. Set to a non-zero value to enable.
+	MaxInventorySizeBytes int
 }
 
 // Hierarchical validates and hydrates the given FileObjects from a structured,
@@ -163,7 +166,8 @@ func Hierarchical(objs []ast.FileObject, opts Options) ([]ast.FileObject, status
 	//   - checking for managed resources in unmanaged namespaces
 	//   - checking for too many objects, if configured
 	finalOpts := final.Options{
-		MaxObjectCount: opts.MaxObjectCount,
+		MaxObjectCount:        opts.MaxObjectCount,
+		MaxInventorySizeBytes: opts.MaxInventorySizeBytes,
 	}
 	finalObjects := treeObjects.Objects()
 	if errs = final.Validate(finalObjects, finalOpts); errs != nil {
@@ -242,7 +246,8 @@ func Unstructured(ctx context.Context, c client.Client, objs []ast.FileObject, o
 	//   - checking for managed resources in unmanaged namespaces
 	//   - checking for too many objects, if configured
 	finalOpts := final.Options{
-		MaxObjectCount: opts.MaxObjectCount,
+		MaxObjectCount:        opts.MaxObjectCount,
+		MaxInventorySizeBytes: opts.MaxInventorySizeBytes,
 	}
 	finalObjects := scopedObjects.Objects()
 	if errs := final.Validate(finalObjects, finalOpts); errs != nil {


### PR DESCRIPTION
### Max Object Count

- Max defaults to 5000, but is configurable with --max-object-count
- 5000 objects usually fits within 1.5MiB, as long as the managed object metadata isn't too long. In my tests with CronTab, 5k works, but 6k is too big. YMMV with different objects.

Example usage:
```
$ git clone https://github.com/config-sync-examples/crontab-crs
$ cd crontab-crs
$ wget https://raw.githubusercontent.com/GoogleContainerTools/kpt-config-sync/refs/heads/main/e2e/testdata/customresources/changed_schema_crds/old_schema_crd.yaml -O configs/crontab-crd.yaml
$ cd configs

$ nomos vet --source-format unstructured --max-inventory-size 0
Error: KNV1070: Maximum number of objects exceeded. Found 13064, but expected no more than 5000. Reduce the number of objects being synced to this cluster in your source of truth to prevent your ResourceGroup inventory object from exceeding the etcd object size limit. For instructions on how to break up a repository into multiple repositories, see https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/breaking-up-repo

For more information, see https://g.co/cloud/acm-errors#knv1070

$ nomos vet --source-format unstructured --max-inventory-size 0 --max-object-count 20000
✅ No validation issues found.

$ nomos vet --source-format unstructured --max-inventory-size 0 --max-object-count 0 # disabled
✅ No validation issues found.
```

### Max Inventory Size in Bytes

- Max defaults to 1572864 bytes (aka 1.5 MiB), but is configurable with --max-inventory-size (e.g. 3MiB = 3145728 bytes)

Example usage:
```
$ git clone https://github.com/karlkfi/crontab-crs
$ cd crontab-crs
$ git checkout karl-test-max-object-count
$ cd configs

$ nomos vet --source-format unstructured --max-object-count 0
Error: KNV1071: Maximum inventory size exceeded. Estimated inventory object size is 1601479 bytes, but the maximum in etcd defaults to 1572864 bytes. To fix, split the resources across multiple repositories.https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/breaking-up-repo

For more information, see https://g.co/cloud/acm-errors#knv1071

$ nomos vet --source-format unstructured --max-object-count 0 --max-inventory-size 3145728 # Max for GKE
✅ No validation issues found.

$ nomos vet --source-format unstructured --max-object-count 0 --max-inventory-size 0 # disabled
✅ No validation issues found.
```

### TODO
- Vet the interfaces & defaults with customers who frequently have this problem.

### Building nomos

To build your own nomos CLI:
```
$ git clone https://github.com/karlkfi/kpt-config-sync
$ cd kpt-config-sync
$ git checkout karl-nomos-vet-limit
$ make build-cli
```

Builder outputs to `./.output/go/bin/${ARCH}/nomos`
