### PR TITLE
[cherry-pick] ci: fix vuln scan jq to use location in noteName (#1533)

### DIFF
--- a/scripts/vulnerabilities.sh
+++ b/scripts/vulnerabilities.sh
@@ -46,7 +46,7 @@ echo -n "Scanning" >&2
 for image in "${images[@]}"; do
   echo -n "."
   results=$(gcloud beta container images describe --show-package-vulnerability --format json --verbosity error "${image}")
-  status=$(echo "${results}" | jq -r '.discovery_summary.discovery[] | select(.noteName == "projects/goog-analysis/notes/PACKAGE_VULNERABILITY") | .discovery.analysisStatus')
+  status=$(echo "${results}" | jq -r '.discovery_summary.discovery[] | select(.noteName == "projects/goog-analysis/locations/us/notes/PACKAGE_VULNERABILITY") | .discovery.analysisStatus')
   if [[ "${status}" != "FINISHED_SUCCESS" ]]; then
     vuln_map[${image}]="${status}"
     scan_failure_total=$((scan_failure_total + 1))


### PR DESCRIPTION
It appears the API was updated for this json payload, it now includes a location subpath in the noteName value.