### PR TITLE
Add gcloud auth requirement to docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,14 @@ You must have the following tools:
 * [git]
 * [make]
 * [docker]
+* [gcloud]
+* [gsutil]
+
+### Login to gcloud
+
+In order to download some build artifacts and dependencies from Google Cloud Storage (GCS) with `gsutil`, you may need to be authenticated with `gcloud`.
+
+One way to do this is with `gcloud auth login`. For other options, see https://cloud.google.com/docs/authentication/gcloud
 
 ## Checkout the code
 The first step is to check out the code for Config Sync to your local
@@ -137,4 +145,6 @@ make run-oss
 [git]: https://docs.github.com/en/get-started/quickstart/set-up-git
 [make]: https://www.gnu.org/software/make/
 [docker]: https://www.docker.com/get-started
+[gcloud]: https://cloud.google.com/sdk/docs/install
+[gsutil]: https://cloud.google.com/storage/docs/gsutil_install
 [create your own fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/kpt-config-sync/issues/1497