### PR TITLE
[WIP] Add Stabilizing status condition

### DIFF
--- a/internal/third_party/github.com/GoogleContainerTools/kpt/README.md
+++ b/internal/third_party/github.com/GoogleContainerTools/kpt/README.md
@@ -1,3 +1,15 @@
 # github.com/GoogleContainerTools/kpt
 
-Vendored from https://github.com/GoogleContainerTools/kpt, to allow local patches.
+Vendored from https://github.com/GoogleContainerTools/kpt, to apply local patches.
+
+Local modifications:
+-  Update `pkg/live/inventoryrg.go`:
+  - Fix `InventoryResourceGroup.Apply` & `ApplyWithPrune` to correctly update
+    `status.observedGeneration` after updating the spec.
+  - Change `InventoryResourceGroup` to expose the wrapped Unstructured object as
+    a parent object, allowing direct access to the object getters and setters.
+    This allows Config Sync to set inventory metadata before each apply.
+  - Change `InventoryResourceGroup.Apply` & `ApplyWithPrune` to update the
+    wrapped Unstructured object after each spec and status update.
+    This allows Config Sync to read the last known inventory state without
+    re-fetching it (excluding status updates from the ResourceGroup controller).

--- a/internal/third_party/github.com/GoogleContainerTools/kpt/pkg/live/object_status.go
+++ b/internal/third_party/github.com/GoogleContainerTools/kpt/pkg/live/object_status.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+// ActuationStatusToKstatus contains the logic/rules to convert from
+// ResourceStatus to kstatus.Status.
+// If conversion is not needed, the original status field is returned.
+func ActuationStatusToKstatus(status actuation.ObjectStatus) kstatus.Status {
+	if status.Actuation == actuation.ActuationSucceeded && status.Reconcile == actuation.ReconcileSucceeded {
+		switch status.Strategy {
+		case actuation.ActuationStrategyApply:
+			return kstatus.CurrentStatus
+		case actuation.ActuationStrategyDelete:
+			return kstatus.NotFoundStatus
+		}
+	}
+	// Terminating, InProgress, and Failed are unknowable without access to the
+	// object spec & status, and sometimes its children.
+	// TODO: add kstatus to the actuation.ObjectStatus, so this information isn't lost
+	// For now, the ResourceGroup controller has to immediately update the
+	// ResourceGroup status to add this extra info.
+	return kstatus.UnknownStatus
+}

--- a/manifests/resourcegroup-crd.yaml
+++ b/manifests/resourcegroup-crd.yaml
@@ -175,11 +175,10 @@ spec:
               observedGeneration:
                 default: 0
                 description: |-
-                  observedGeneration is the most recent generation observed.
-                  It corresponds to the Object's generation, which is updated on
-                  mutation by the API Server.
-                  Everytime the controller does a successful reconcile, it sets
-                  observedGeneration to match ResourceGroup.metadata.generation.
+                  observedGeneration is updated to the latest metadata.generation every
+                  time the status is updated, so you can tell whether the current status
+                  reflects the current metadata and spec. It defaults to zero when created
+                  so you can tell whether any controller has acted on the spec yet or not.
                 format: int64
                 type: integer
               resourceStatuses:

--- a/pkg/api/configsync/register.go
+++ b/pkg/api/configsync/register.go
@@ -27,6 +27,11 @@ const (
 	// This avoids conflicts between the reconciler and reconciler-manager.
 	FieldManager = GroupName
 
+	// StabilizingFieldManager is the field manager name used by the
+	// StabilizingController. It's deliberately unique to allow it to apply the
+	// Stabilizing condition independently from the other conditions.
+	StabilizingFieldManager = ConfigSyncPrefix + "stabilizing-controller"
+
 	// ControllerNamespace is the Namespace used for Nomos controllers
 	ControllerNamespace = "config-management-system"
 )

--- a/pkg/api/configsync/v1beta1/reposync_types.go
+++ b/pkg/api/configsync/v1beta1/reposync_types.go
@@ -110,6 +110,8 @@ const (
 	RepoSyncStalled RepoSyncConditionType = "Stalled"
 	// RepoSyncSyncing means that the namespace reconciler is processing a hash (git commit hash or OCI image digest).
 	RepoSyncSyncing RepoSyncConditionType = "Syncing"
+	// RootSyncStabilizing means that the namespace reconciler is waiting for all the synced resources to reconcile.
+	RepoSyncStabilizing RepoSyncConditionType = "Stabilizing"
 	// RepoSyncReconcilerFinalizing means that the namespace reconciler finalizer is processing deletion of managed resources.
 	RepoSyncReconcilerFinalizing RepoSyncConditionType = "ReconcilerFinalizing"
 	// RepoSyncReconcilerFinalizerFailure means that the namespace reconciler finalizer has errored, blocking deletion.

--- a/pkg/api/configsync/v1beta1/rootsync_types.go
+++ b/pkg/api/configsync/v1beta1/rootsync_types.go
@@ -110,6 +110,8 @@ const (
 	RootSyncStalled RootSyncConditionType = "Stalled"
 	// RootSyncSyncing means that the root reconciler is processing a hash (git commit hash or OCI image digest).
 	RootSyncSyncing RootSyncConditionType = "Syncing"
+	// RootSyncStabilizing means that the root reconciler is waiting for all the synced resources to reconcile.
+	RootSyncStabilizing RootSyncConditionType = "Stabilizing"
 	// RootSyncReconcilerFinalizing means that the root reconciler finalizer is processing deletion of managed resources.
 	RootSyncReconcilerFinalizing RootSyncConditionType = "ReconcilerFinalizing"
 	// RootSyncReconcilerFinalizerFailure means that the root reconciler finalizer has errored, blocking deletion.

--- a/pkg/api/kpt.dev/v1alpha1/resourcegroup_types.go
+++ b/pkg/api/kpt.dev/v1alpha1/resourcegroup_types.go
@@ -63,11 +63,10 @@ type ResourceGroupStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// observedGeneration is the most recent generation observed.
-	// It corresponds to the Object's generation, which is updated on
-	// mutation by the API Server.
-	// Everytime the controller does a successful reconcile, it sets
-	// observedGeneration to match ResourceGroup.metadata.generation.
+	// observedGeneration is updated to the latest metadata.generation every
+	// time the status is updated, so you can tell whether the current status
+	// reflects the current metadata and spec. It defaults to zero when created
+	// so you can tell whether any controller has acted on the spec yet or not.
 	// +optional
 	// +kubebuilder:default:=0
 	ObservedGeneration int64 `json:"observedGeneration"`

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -587,6 +587,11 @@ func (s *supervisor) applyInner(ctx context.Context, eventHandler func(Event), d
 		resourceMap[idFrom(ObjMetaFromUnstructured(obj))] = obj
 	}
 
+	// Update the source-commit annotation on the inventory.
+	// This is used by the StabilizingController.
+	core.SetAnnotation(s.inventory,
+		metadata.SourceCommitAnnotationKey, declaredResources.GetCommit())
+
 	events := s.clientSet.KptApplier.Run(ctx, s.inventory, object.UnstructuredSet(resources), options)
 	for e := range events {
 		switch e.Type {

--- a/pkg/core/scheme.go
+++ b/pkg/core/scheme.go
@@ -40,6 +40,7 @@ import (
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
+	kptv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 )
 
 // Scheme is a reference to the global scheme.
@@ -70,6 +71,9 @@ func init() {
 	utilruntime.Must(configsyncv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(configsyncv1alpha1.RegisterConversions(scheme.Scheme))
 	utilruntime.Must(scheme.Scheme.SetVersionPriority(configsyncv1beta1.SchemeGroupVersion, configsyncv1alpha1.SchemeGroupVersion))
+
+	// Kpt types
+	utilruntime.Must(kptv1alpha1.AddToScheme(scheme.Scheme))
 
 	// Hub/Fleet types
 	utilruntime.Must(hubv1.AddToScheme(scheme.Scheme))

--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -239,3 +239,10 @@ func (r *Resources) DeclaredCRDs(scheme *runtime.Scheme) ([]*apiextensionsv1.Cus
 	}
 	return crds, nil
 }
+
+// GetCommit returns the source commit connected with the declared resources.
+func (r *Resources) GetCommit() string {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.commit
+}

--- a/pkg/declared/scope.go
+++ b/pkg/declared/scope.go
@@ -15,11 +15,13 @@
 package declared
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RootScope is the scope that includes both cluster-scoped and namespace-scoped
@@ -91,4 +93,23 @@ func ReconcilerNameFromScope(syncScope Scope, syncName string) string {
 		return core.RootReconcilerName(syncName)
 	}
 	return core.NsReconcilerName(syncScope.String(), syncName)
+}
+
+// SyncKeyFromScope returns the Sync name & namespace as an ObjectKey.
+func SyncKeyFromScope(syncScope Scope, syncName string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      syncName,
+		Namespace: syncScope.SyncNamespace(),
+	}
+}
+
+// SyncIDFromScope returns the Sync ID from the Scope and name.
+func SyncIDFromScope(syncScope Scope, syncName string) core.ID {
+	return core.ID{
+		GroupKind: schema.GroupKind{
+			Group: configsync.GroupName,
+			Kind:  syncScope.SyncKind(),
+		},
+		ObjectKey: SyncKeyFromScope(syncScope, syncName),
+	}
 }

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -150,6 +150,12 @@ const (
 	// This annotation is set by Config Sync on the RootSync/RepoSync object
 	// to indicate the exact image that should be synced.
 	ImageToSyncAnnotationKey = configsync.ConfigSyncPrefix + "image-to-sync"
+
+	// SourceCommitAnnotationKey is the annotation key that stores the commit of
+	// the source used to sync from. For Git, it's the commit. For OCI, it's the
+	// image checksum. For Helm, it's the chart version.
+	// This annotation is set by Config Sync on ResourceGroup inventory objects.
+	SourceCommitAnnotationKey = configsync.ConfigSyncPrefix + "source-commit"
 )
 
 // Lifecycle annotations

--- a/pkg/reconciler/stabilizing/stabilizing_controller.go
+++ b/pkg/reconciler/stabilizing/stabilizing_controller.go
@@ -1,0 +1,422 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stabilizing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	"kpt.dev/configsync/pkg/core"
+	"kpt.dev/configsync/pkg/metadata"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
+	"kpt.dev/configsync/pkg/reposync"
+	"kpt.dev/configsync/pkg/rootsync"
+	"kpt.dev/configsync/pkg/util/log"
+	"kpt.dev/configsync/pkg/util/mutate"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	logFieldController      = "controller"
+	logFieldSyncKind        = "sync.kind"
+	logFieldSyncName        = "sync.name"
+	logFieldSyncNamespace   = "sync.namespace"
+	logFieldObjectKind      = "metadata.kind"
+	logFieldName            = "metadata.name"
+	logFieldNamespace       = "metadata.namespace"
+	logFieldResourceVersion = "metadata.resourceVersion"
+	logFieldGeneration      = "metadata.generation"
+	logFieldOperation       = "operation"
+	logFieldOperationStatus = "operation.status"
+)
+
+// Reason indicates the reason for a particular Stabilizing status.
+type Reason string
+
+const (
+	// ReasonPending indicates that Syncing is pending or in-progress
+	ReasonPending Reason = "Pending"
+	// ReasonBlocked indicates that Syncing failed
+	ReasonBlocked Reason = "Blocked"
+	// ReasonInProgress indicates that Stabilizing is in-progress
+	ReasonInProgress Reason = "InProgress"
+	// ReasonFailed indicates that Stabilizing has failed
+	ReasonFailed Reason = "Failed"
+	// ReasonSucceeded indicates that Stabilizing has succeeded
+	ReasonSucceeded Reason = "Succeeded"
+)
+
+// Controller watches the ResourceGroup inventory and updates the Stabilizing
+// status condition.
+type Controller struct {
+	*controllers.LoggingController
+	client client.Client
+	syncID core.ID
+}
+
+var _ reconcile.Reconciler = &Controller{}
+
+// NewController constructs a new stabilizing.Controller.
+func NewController(
+	kubeClient client.Client,
+	log logr.Logger,
+	syncID core.ID,
+) *Controller {
+	return &Controller{
+		LoggingController: controllers.NewLoggingController(log),
+		client:            kubeClient,
+		syncID:            syncID,
+	}
+}
+
+// Reconcile checks the ResourceGroup status and updates the Stabilizing status
+// condition on the RSync.
+func (r *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	ctx = r.SetLoggerValues(ctx,
+		logFieldController, "StabilizingController",
+		logFieldSyncKind, r.syncID.Kind,
+		logFieldSyncName, r.syncID.Name,
+		logFieldSyncNamespace, r.syncID.Namespace)
+	r.Logger(ctx).V(5).Info("Reconcile starting")
+
+	rgObj := &v1alpha1.ResourceGroup{}
+	if err := r.client.Get(ctx, req.NamespacedName, rgObj); err != nil {
+		switch {
+		case meta.IsNoMatchError(err):
+			return reconcile.Result{},
+				fmt.Errorf("ResourceGroup CRD not installed or established: %w", err)
+		case apierrors.IsNotFound(err):
+			r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: ResourceGroup object not found")
+			return reconcile.Result{}, nil
+		default:
+			return reconcile.Result{},
+				fmt.Errorf("getting ResourceGroup object from cache: %s: %w",
+					req.NamespacedName, err)
+		}
+	}
+
+	if rgObj.Status.ObservedGeneration != rgObj.Generation {
+		r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: ResourceGroup status update pending")
+		return reconcile.Result{}, nil
+	}
+	if rgObj.DeletionTimestamp != nil {
+		r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: ResourceGroup being deleted")
+		return reconcile.Result{}, nil
+	}
+
+	stabilizingCondition, err := computeStabilizingCondition(rgObj)
+	if err != nil {
+		return reconcile.Result{},
+			fmt.Errorf("failed to compute stabilizing status: %w", err)
+	}
+
+	if err := r.applyStabilizingCondition(ctx, stabilizingCondition); err != nil {
+		return reconcile.Result{},
+			fmt.Errorf("failed to apply stabilizing status condition on object: %v, %w",
+				r.syncID, err)
+	}
+
+	r.Logger(ctx).V(5).Info("Reconcile completed")
+	return reconcile.Result{}, nil
+}
+
+func computeStabilizingCondition(rgObj *v1alpha1.ResourceGroup) (SyncCondition, error) {
+	actuationStatusCounts := map[v1alpha1.Actuation]int{
+		v1alpha1.ActuationFailed:    0,
+		v1alpha1.ActuationSkipped:   0,
+		v1alpha1.ActuationPending:   0,
+		v1alpha1.ActuationSucceeded: 0,
+	}
+	reconcileStatusCounts := map[v1alpha1.Reconcile]int{
+		v1alpha1.ReconcileFailed:    0,
+		v1alpha1.ReconcileSkipped:   0,
+		v1alpha1.ReconcilePending:   0,
+		v1alpha1.ReconcileSucceeded: 0,
+	}
+
+	for i, objStatus := range rgObj.Status.ResourceStatuses {
+		switch objStatus.Actuation {
+		case v1alpha1.ActuationFailed, v1alpha1.ActuationSkipped, v1alpha1.ActuationPending, v1alpha1.ActuationSucceeded:
+			actuationStatusCounts[objStatus.Actuation]++
+		default:
+			return SyncCondition{},
+				fmt.Errorf("invalid ResourceGroup field value: status.resourceStatuses[%d].actuation: `%s`",
+					i, objStatus.Actuation)
+		}
+		switch objStatus.Reconcile {
+		case v1alpha1.ReconcileFailed, v1alpha1.ReconcileSkipped, v1alpha1.ReconcilePending, v1alpha1.ReconcileSucceeded:
+			reconcileStatusCounts[objStatus.Reconcile]++
+		default:
+			return SyncCondition{},
+				fmt.Errorf("invalid ResourceGroup field value: status.resourceStatuses[%d].actuation: `%s`",
+					i, objStatus.Actuation)
+		}
+	}
+
+	// Get the source commit from the inventory
+	commit := core.GetAnnotation(rgObj, metadata.SourceCommitAnnotationKey)
+
+	syncCondition := SyncCondition{
+		Type:   SyncStabilizing,
+		Commit: commit,
+	}
+
+	switch {
+	case actuationStatusCounts[v1alpha1.ActuationFailed] > 0:
+		syncCondition.Status = v1.ConditionFalse
+		syncCondition.Reason = string(ReasonBlocked)
+		syncCondition.Message = fmt.Sprintf("Stabilizing blocked: %d objects have failed actuation",
+			actuationStatusCounts[v1alpha1.ActuationFailed])
+	case reconcileStatusCounts[v1alpha1.ReconcileFailed] > 0:
+		syncCondition.Status = v1.ConditionFalse
+		syncCondition.Reason = string(ReasonFailed)
+		syncCondition.Message = fmt.Sprintf("Stabilizing failed: %d objects have failed reconciliation",
+			reconcileStatusCounts[v1alpha1.ReconcileFailed])
+	case actuationStatusCounts[v1alpha1.ActuationPending] > 0:
+		syncCondition.Status = v1.ConditionFalse
+		syncCondition.Reason = string(ReasonPending)
+		syncCondition.Message = fmt.Sprintf("Stabilizing pending: %d objects are pending actuation",
+			actuationStatusCounts[v1alpha1.ActuationPending])
+	case reconcileStatusCounts[v1alpha1.ReconcilePending] > 0:
+		syncCondition.Status = v1.ConditionTrue
+		syncCondition.Reason = string(ReasonInProgress)
+		syncCondition.Message = fmt.Sprintf("Stabilizing in progress: %d objects are pending reconciliation",
+			reconcileStatusCounts[v1alpha1.ReconcilePending])
+	default:
+		// We're ignoring skipped actuation/reconcile, because it doesn't
+		// indicate success or failure. The applier gets to decide what skipped
+		// means and whether to surface the error or not. For example, a skipped
+		// object may just be getting deliberately abandoned/unmanaged.
+		syncCondition.Status = v1.ConditionFalse
+		syncCondition.Reason = string(ReasonSucceeded)
+		syncCondition.Message = fmt.Sprintf("Stabilizing succeeded: %d objects have reconciled",
+			reconcileStatusCounts[v1alpha1.ReconcileSucceeded])
+	}
+
+	return syncCondition, nil
+}
+
+// SyncConditionType is an enum of types of conditions for RootSyncs.
+type SyncConditionType string
+
+const (
+	// SyncStabilizing is a mirror of the RootSync & RepoSync Stabilizing
+	// condition types that can be used internally to represent either type,
+	// since they are identical.
+	SyncStabilizing SyncConditionType = "Stabilizing"
+)
+
+// SyncCondition is a mirror of the RootSync & RepoSync condition structs that
+// can be used internally to represent either type, since they are identical.
+type SyncCondition struct {
+	// type of RepoSync condition.
+	Type SyncConditionType `json:"type"`
+	// status of the condition, one of True, False, Unknown.
+	Status metav1.ConditionStatus `json:"status"`
+	// The last time this condition was updated.
+	// +nullable
+	// +optional
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	// Last time the condition transitioned from one status to another.
+	// +nullable
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	// The reason for the condition's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty"`
+	// A human readable message indicating details about the transition.
+	// +optional
+	Message string `json:"message,omitempty"`
+	// hash of the source of truth. It can be a git commit hash, or an OCI image digest.
+	// +optional
+	Commit string `json:"commit,omitempty"`
+	// errors is a list of errors that occurred in the process.
+	// This field is used to track errors when the condition type is Reconciling or Stalled.
+	// When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+	// avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+	// +optional
+	Errors []v1beta1.ConfigSyncError `json:"errors,omitempty"`
+}
+
+func (r *Controller) applyStabilizingCondition(ctx context.Context, condition SyncCondition) error {
+	switch r.syncID.Kind {
+	case configsync.RootSyncKind:
+		if err := r.applyRootSyncStabilizingCondition(ctx, condition); err != nil {
+			return err
+		}
+	case configsync.RepoSyncKind:
+		if err := r.applyRepoSyncStabilizingCondition(ctx, condition); err != nil {
+			return err
+		}
+	default:
+		// Already validated by Register method
+		return fmt.Errorf("invalid sync ID: %v", r.syncID)
+	}
+	return nil
+}
+
+func (r *Controller) applyRootSyncStabilizingCondition(ctx context.Context, condition SyncCondition) error {
+	key := r.syncID.ObjectKey
+	rsObj := &v1beta1.RootSync{}
+	if err := r.client.Get(ctx, key, rsObj); err != nil {
+		return fmt.Errorf("getting RootSync: %s: %w", key, err)
+	}
+	_, err := mutate.Status(ctx, r.client, rsObj, func() error {
+		if rsObj.Status.ObservedGeneration != rsObj.Generation {
+			r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: RootSync status update pending")
+			return &mutate.NoUpdateError{}
+		}
+		if rsObj.DeletionTimestamp != nil {
+			r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: RootSync being deleted")
+			return &mutate.NoUpdateError{}
+		}
+		oldCondition := rootsync.GetCondition(rsObj.Status.Conditions, v1beta1.RootSyncConditionType(condition.Type))
+		oldCondition = oldCondition.DeepCopy()
+		now := metav1.Now()
+		updated, transitioned := rootsync.SetStabilizing(rsObj, condition.Status, condition.Reason, condition.Message, condition.Commit, condition.Errors, now)
+		if !updated {
+			return &mutate.NoUpdateError{}
+		}
+		newCondition := rootsync.GetCondition(rsObj.Status.Conditions, v1beta1.RootSyncConditionType(condition.Type))
+		if r.Logger(ctx).V(1).Enabled() {
+			// diff includes line-breaks, which breaks log parsing
+			if r.Logger(ctx).V(5).Enabled() {
+				ctx = r.SetLoggerValues(ctx,
+					"diff", fmt.Sprintf("Diff (- Old, + New):\n%s",
+						log.AsYAMLDiff(oldCondition, newCondition)))
+			}
+			r.Logger(ctx).Info("Updating sync status",
+				logFieldOperation, "update",
+				logFieldOperationStatus, computeOperationStatus(updated, transitioned),
+				logFieldGeneration, rsObj.Generation,
+				logFieldResourceVersion, rsObj.ResourceVersion)
+		}
+		return nil
+	}, client.FieldOwner(configsync.FieldManager))
+	if err != nil {
+		return fmt.Errorf("Sync status update failed: %w", err)
+	}
+	return nil
+}
+
+func (r *Controller) applyRepoSyncStabilizingCondition(ctx context.Context, condition SyncCondition) error {
+	key := r.syncID.ObjectKey
+	rsObj := &v1beta1.RepoSync{}
+	if err := r.client.Get(ctx, key, rsObj); err != nil {
+		return fmt.Errorf("getting RepoSync: %s: %w", key, err)
+	}
+	_, err := mutate.Status(ctx, r.client, rsObj, func() error {
+		if rsObj.Status.ObservedGeneration != rsObj.Generation {
+			r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: RepoSync status update pending")
+			return &mutate.NoUpdateError{}
+		}
+		if rsObj.DeletionTimestamp != nil {
+			r.Logger(ctx).V(1).Info("Skipping Stabilizing condition update: RepoSync being deleted")
+			return &mutate.NoUpdateError{}
+		}
+		oldCondition := reposync.GetCondition(rsObj.Status.Conditions, v1beta1.RepoSyncConditionType(condition.Type))
+		oldCondition = oldCondition.DeepCopy()
+		now := metav1.Now()
+		updated, transitioned := reposync.SetStabilizing(rsObj, condition.Status, condition.Reason, condition.Message, condition.Commit, condition.Errors, now)
+		if !updated {
+			return &mutate.NoUpdateError{}
+		}
+		newCondition := reposync.GetCondition(rsObj.Status.Conditions, v1beta1.RepoSyncConditionType(condition.Type))
+		if r.Logger(ctx).V(1).Enabled() {
+			// diff includes line-breaks, which breaks log parsing
+			if r.Logger(ctx).V(5).Enabled() {
+				ctx = r.SetLoggerValues(ctx,
+					"diff", fmt.Sprintf("Diff (- Old, + New):\n%s",
+						log.AsYAMLDiff(oldCondition, newCondition)))
+			}
+			r.Logger(ctx).Info("Updating sync status",
+				logFieldOperation, "update",
+				logFieldOperationStatus, computeOperationStatus(updated, transitioned),
+				logFieldGeneration, rsObj.Generation,
+				logFieldResourceVersion, rsObj.ResourceVersion)
+		}
+		return nil
+	}, client.FieldOwner(configsync.FieldManager))
+	if err != nil {
+		return fmt.Errorf("Sync status update failed: %w", err)
+	}
+	return nil
+}
+
+func computeOperationStatus(updated, transitioned bool) string {
+	var opStatus string
+	switch {
+	case transitioned:
+		opStatus = "transition"
+	case updated:
+		opStatus = "update"
+	default:
+		opStatus = "skipped"
+	}
+	return opStatus
+}
+
+// Register the RGController with the ReconcilerManager.
+func (r *Controller) Register(mgr controllerruntime.Manager) error {
+	b := controllerruntime.NewControllerManagedBy(mgr).
+		Named("StabilizingController").
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		})
+	// Watch a single RSync and reconcile its status (or at least part of it).
+	switch r.syncID.Kind {
+	case configsync.RootSyncKind:
+		b = b.For(&v1beta1.RootSync{},
+			builder.WithPredicates(newKeySelectorPredicate(r.syncID.ObjectKey)))
+	case configsync.RepoSyncKind:
+		b = b.For(&v1beta1.RepoSync{},
+			builder.WithPredicates(newKeySelectorPredicate(r.syncID.ObjectKey)))
+	default:
+		return fmt.Errorf("invalid sync ID: %v", r.syncID)
+	}
+	// Watch a single ResourceGroup, the one that matches the RSync.
+	// ResourceGroup ObjectKey == RSync ObjectKey.
+	b = b.Watches(&v1alpha1.ResourceGroup{},
+		handler.EnqueueRequestsFromMapFunc(mapResourceGroupToRSync),
+		builder.WithPredicates(newKeySelectorPredicate(r.syncID.ObjectKey)))
+	return b.Complete(r)
+}
+
+func newKeySelectorPredicate(key client.ObjectKey) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return client.ObjectKeyFromObject(obj) == key
+	})
+}
+
+// mapResourceGroupToRSync maps ResourceGroup to RSync by ObjectKey.
+func mapResourceGroupToRSync(_ context.Context, obj client.Object) []reconcile.Request {
+	return []reconcile.Request{
+		{NamespacedName: client.ObjectKeyFromObject(obj)},
+	}
+}

--- a/pkg/reposync/conditions.go
+++ b/pkg/reposync/conditions.go
@@ -122,6 +122,21 @@ func SetSyncing(rs *v1beta1.RepoSync, status bool, reason, message, commit strin
 	return setCondition(rs, v1beta1.RepoSyncSyncing, conditionStatus, reason, message, commit, nil, errorSources, errorSummary, timestamp)
 }
 
+// SetStabilizing sets the Stabilizing condition.
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+func SetStabilizing(rs *v1beta1.RepoSync, status metav1.ConditionStatus, reason, message, commit string, errs []v1beta1.ConfigSyncError, timestamp metav1.Time) (updated, transitioned bool) {
+	var errorSummary *v1beta1.ErrorSummary
+	if len(errs) > 0 {
+		errorSummary = &v1beta1.ErrorSummary{
+			TotalCount:                len(errs),
+			Truncated:                 false,
+			ErrorCountAfterTruncation: len(errs),
+		}
+	}
+	return setCondition(rs, v1beta1.RepoSyncStabilizing, status, reason, message, commit, errs, nil, errorSummary, timestamp)
+}
+
 // SetReconcilerFinalizing sets the ReconcilerFinalizing condition to True.
 // Use RemoveCondition to remove this condition. It should never be set to False.
 func SetReconcilerFinalizing(rs *v1beta1.RepoSync, reason, message string) (updated bool) {

--- a/pkg/resourcegroup/controllers/metrics/record.go
+++ b/pkg/resourcegroup/controllers/metrics/record.go
@@ -40,58 +40,67 @@ const (
 	CMSNamespace = "config-management-system"
 )
 
+func record(ctx context.Context, ms ...stats.Measurement) {
+	stats.Record(ctx, ms...)
+	if klog.V(5).Enabled() {
+		for _, m := range ms {
+			klog.Infof("Metric recorded: { \"Name\": %q, \"Value\": %#v, \"Tags\": %s }", m.Measure().Name(), m.Value(), tag.FromContext(ctx))
+		}
+	}
+}
+
 // RecordReconcileDuration produces a measurement for the ReconcileDuration view.
 func RecordReconcileDuration(ctx context.Context, stallStatus string, startTime time.Time) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyStallReason, stallStatus))
 	measurement := ReconcileDuration.M(time.Since(startTime).Seconds())
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordReadyResourceCount produces a measurement for the ReadyResourceCount view.
 func RecordReadyResourceCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := ReadyResourceCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordKCCResourceCount produces a measurement for the KCCResourceCount view.
 func RecordKCCResourceCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := KCCResourceCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordResourceCount produces a measurement for the ResourceCount view.
 func RecordResourceCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := ResourceCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordResourceGroupTotal produces a measurement for the ResourceGroupTotalView
 func RecordResourceGroupTotal(ctx context.Context, count int64) {
-	stats.Record(ctx, ResourceGroupTotal.M(count))
+	record(ctx, ResourceGroupTotal.M(count))
 }
 
 // RecordNamespaceCount produces a measurement for the NamespaceCount view.
 func RecordNamespaceCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := NamespaceCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordClusterScopedResourceCount produces a measurement for ClusterScopedResourceCount view
 func RecordClusterScopedResourceCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := ClusterScopedResourceCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordCRDCount produces a measurement for RecordCRDCount view
 func RecordCRDCount(ctx context.Context, nn types.NamespacedName, count int64) {
 	tagCtx, _ := tag.New(ctx, tag.Upsert(KeyResourceGroup, nn.String()))
 	measurement := CRDCount.M(count)
-	stats.Record(tagCtx, measurement)
+	record(tagCtx, measurement)
 }
 
 // RecordPipelineError produces a measurement for PipelineErrorView
@@ -105,9 +114,7 @@ func RecordPipelineError(ctx context.Context, nn types.NamespacedName, component
 	} else {
 		metricVal = 0
 	}
-	stats.Record(tagCtx, PipelineError.M(metricVal))
-	klog.Infof("Recording %s metric at component: %s, namespace: %s, reconciler: %s, sync type: %s with value %v",
-		PipelineErrorView.Name, component, nn.Namespace, reconcilerName, nn.Name, metricVal)
+	record(tagCtx, PipelineError.M(metricVal))
 }
 
 // ComputeReconcilerNameType computes the reconciler name from the ResourceGroup CR name

--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
@@ -133,7 +133,6 @@ func TestReconcile(t *testing.T) {
 	channelKpt <- event.GenericEvent{Object: resgroupKpt}
 
 	// Verify that the reconciliation modifies the ResourceGroupStatus field correctly
-	expectedStatus.ObservedGeneration = 1
 	expectedStatus.Conditions = []v1alpha1.Condition{
 		newReconcilingCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),
 		newStalledCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),
@@ -187,7 +186,6 @@ func TestReconcile(t *testing.T) {
 			Status:      v1alpha1.NotFound,
 		},
 	}
-	expectedStatus.ObservedGeneration = 2
 	expectedStatus.Conditions = []v1alpha1.Condition{
 		newReconcilingCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),
 		newStalledCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),
@@ -296,7 +294,6 @@ func TestReconcile(t *testing.T) {
 			Status:      v1alpha1.Current,
 		},
 	}
-	expectedStatus.ObservedGeneration = 3
 	expectedStatus.Conditions = []v1alpha1.Condition{
 		newReconcilingCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),
 		newStalledCondition(v1alpha1.FalseConditionStatus, FinishReconciling, finishReconcilingMsg),

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -46,8 +46,6 @@ const (
 )
 
 func TestRootReconciler(t *testing.T) {
-	var reconcilerKpt *Reconciler
-
 	// Configure controller-manager to log to the test logger
 	testLogger := testcontroller.NewTestLogger(t)
 	controllerruntime.SetLogger(testLogger)
@@ -67,7 +65,7 @@ func TestRootReconciler(t *testing.T) {
 	defer cancel()
 
 	logger := testLogger.WithName("controllers")
-	reconcilerKpt, err = NewReconciler(mgr, logger.WithName("root"))
+	reconcilerKpt, err := NewReconciler(mgr, logger.WithName("root"))
 	require.NoError(t, err)
 
 	resolver, err := typeresolver.ForManager(mgr, logger.WithName("typeresolver"))

--- a/pkg/rootsync/conditions.go
+++ b/pkg/rootsync/conditions.go
@@ -122,6 +122,21 @@ func SetSyncing(rs *v1beta1.RootSync, status bool, reason, message, commit strin
 	return setCondition(rs, v1beta1.RootSyncSyncing, conditionStatus, reason, message, commit, nil, errorSources, errorSummary, timestamp)
 }
 
+// SetStabilizing sets the Stabilizing condition.
+// Returns whether the condition was updated (any change) or transitioned
+// (status change).
+func SetStabilizing(rs *v1beta1.RootSync, status metav1.ConditionStatus, reason, message, commit string, errs []v1beta1.ConfigSyncError, timestamp metav1.Time) (updated, transitioned bool) {
+	var errorSummary *v1beta1.ErrorSummary
+	if len(errs) > 0 {
+		errorSummary = &v1beta1.ErrorSummary{
+			TotalCount:                len(errs),
+			Truncated:                 false,
+			ErrorCountAfterTruncation: len(errs),
+		}
+	}
+	return setCondition(rs, v1beta1.RootSyncStabilizing, status, reason, message, commit, errs, nil, errorSummary, timestamp)
+}
+
 // SetReconcilerFinalizing sets the ReconcilerFinalizing condition to True.
 // Use RemoveCondition to remove this condition. It should never be set to False.
 func SetReconcilerFinalizing(rs *v1beta1.RootSync, reason, message string) (updated bool) {

--- a/test/kustomization/expected.yaml
+++ b/test/kustomization/expected.yaml
@@ -2823,11 +2823,10 @@ spec:
               observedGeneration:
                 default: 0
                 description: |-
-                  observedGeneration is the most recent generation observed.
-                  It corresponds to the Object's generation, which is updated on
-                  mutation by the API Server.
-                  Everytime the controller does a successful reconcile, it sets
-                  observedGeneration to match ResourceGroup.metadata.generation.
+                  observedGeneration is updated to the latest metadata.generation every
+                  time the status is updated, so you can tell whether the current status
+                  reflects the current metadata and spec. It defaults to zero when created
+                  so you can tell whether any controller has acted on the spec yet or not.
                 format: int64
                 type: integer
               resourceStatuses:

--- a/vendor/github.com/GoogleContainerTools/kpt/pkg/live/object_status.go
+++ b/vendor/github.com/GoogleContainerTools/kpt/pkg/live/object_status.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+// ActuationStatusToKstatus contains the logic/rules to convert from
+// ResourceStatus to kstatus.Status.
+// If conversion is not needed, the original status field is returned.
+func ActuationStatusToKstatus(status actuation.ObjectStatus) kstatus.Status {
+	if status.Actuation == actuation.ActuationSucceeded && status.Reconcile == actuation.ReconcileSucceeded {
+		switch status.Strategy {
+		case actuation.ActuationStrategyApply:
+			return kstatus.CurrentStatus
+		case actuation.ActuationStrategyDelete:
+			return kstatus.NotFoundStatus
+		}
+	}
+	// Terminating, InProgress, and Failed are unknowable without access to the
+	// object spec & status, and sometimes its children.
+	// TODO: add kstatus to the actuation.ObjectStatus, so this information isn't lost
+	// For now, the ResourceGroup controller has to immediately update the
+	// ResourceGroup status to add this extra info.
+	return kstatus.UnknownStatus
+}


### PR DESCRIPTION
go/config-sync-stabilizing-status
b/393195894

- Add a new Stabilizing condition to the RSync status that communicates the aggregate reconciliation status of all the managed resource objects in the ResourceGroup inventory.
- Update the inventory client to expose the wrapped Unstructured object and copy metadata from it when applying the ResourceGroup. This allows the reconciler to inject metadata before each apply.
  - Update the inventory client to copy the current inventory state back into the wrapped Unstructured object, to allow reading the latest state after running the applier, without needing to get it from the server again. 
- Update the inventory client to populate the kstatus of each resource, as much as possible given that only the strategy, actuation, and reconcile status are available. Previously, it was always setting the kstatus to Unknown.
- Add a new `configsync.gke.io/source-commit` annotation to the ResourceGroup, so the stabilizing controller knows which commit the inventory was last updated for, so it can put the commit into the Stabilizing condition. This is applied by the ResourceGroup inventory client when the spec is applied. It is deliberately not a spec field, because it is not required by kpt, but that means it doesn't affect the generation and doesn't trigger updating the status observed generations.
- Fix the ResourceGroupController to correctly remove its conditions from the RG status after the status has been disabled, instead of relying on the inventory client to delete them. 

TODO:
- Add more unit tests for the new code
- Add e2e tests to validate the Stabilizing condition behavior (It appears to work according to the e2e logs, but it may not be transitioning True->False as intended yet.)

This unblocks some future enhancements:
- Update `nomos status` to show the strategy, actuation, and reconcile status fields, not just the kstatus. This should make it clearer when a NotFound status is expected or not.
- Update `nomos status` to show the `configsync.gke.io/source-commit` annotation value.
- Update `nomos status` to show the Stabilizing condition status/reason/message.
- Update the cli-utils applier to retain the kstatus too, not just the strategy, actuation, and reconcile status. Then pass it to the inventory client, so it can update whether the object is Terminating, InProgress, or Failed. The change in this PR can only tell if it's Current or NotFound.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1551
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1553
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1565
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1564
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1563
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1566
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1597
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1596
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1593
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1589
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1588
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1576
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1575
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1574
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1572
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1571
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1570