### PR TITLE
test: add controllerName to rsync unit tests

### DIFF
--- a/pkg/reconcilermanager/controllers/reconciler_base.go
+++ b/pkg/reconcilermanager/controllers/reconciler_base.go
@@ -105,6 +105,9 @@ type reconcilerBase struct {
 
 	// syncKind is the kind of the sync object: RootSync or RepoSync.
 	syncKind string
+
+	// controllerName is used by tests to de-dupe controllers
+	controllerName string
 }
 
 func (r *reconcilerBase) serviceAccountSubject(reconcilerRef types.NamespacedName) rbacv1.Subject {

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -108,6 +108,7 @@ func NewRepoSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			hydrationPollingPeriod:     hydrationPollingPeriod,
 			syncKind:                   configsync.RepoSyncKind,
 			knownHostExist:             false,
+			controllerName:             "",
 		},
 		configMapWatches: make(map[string]bool),
 	}
@@ -518,6 +519,10 @@ func (r *RepoSyncReconciler) Register(mgr controllerruntime.Manager, watchFleetM
 		controllerBuilder.Watches(&hubv1.Membership{},
 			handler.EnqueueRequestsFromMapFunc(r.mapMembershipToRepoSyncs),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+	}
+
+	if r.controllerName != "" {
+		controllerBuilder.Named(r.controllerName)
 	}
 
 	ctrlr, err := controllerBuilder.Build(r)

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -322,6 +322,7 @@ func setupNSReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Client,
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RepoSyncKind),
 		cs.Client.Scheme(),
 	)
+	testReconciler.controllerName = t.Name()
 	return cs.Client, cs.DynamicClient, testReconciler
 }
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -100,6 +100,7 @@ func NewRootSyncReconciler(clusterName string, reconcilerPollingPeriod, hydratio
 			hydrationPollingPeriod:     hydrationPollingPeriod,
 			syncKind:                   configsync.RootSyncKind,
 			knownHostExist:             false,
+			controllerName:             "",
 		},
 	}
 }
@@ -460,6 +461,10 @@ func (r *RootSyncReconciler) Register(mgr controllerruntime.Manager, watchFleetM
 		controllerBuilder.Watches(&hubv1.Membership{},
 			handler.EnqueueRequestsFromMapFunc(r.mapMembershipToRootSyncs),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+	}
+
+	if r.controllerName != "" {
+		controllerBuilder.Named(r.controllerName)
 	}
 
 	ctrlr, err := controllerBuilder.Build(r)

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -209,6 +209,7 @@ func setupRootReconciler(t *testing.T, objs ...client.Object) (*syncerFake.Clien
 		controllerruntime.Log.WithName("controllers").WithName(configsync.RootSyncKind),
 		cs.Client.Scheme(),
 	)
+	testReconciler.controllerName = t.Name()
 	return cs.Client, cs.DynamicClient, testReconciler
 }
 


### PR DESCRIPTION
The next controller-runtime version requires each controller instantiation to have a unique name. By default the controller is given the name of the CRD type, e.g. rootsync/reposync.

Since each unit test instantiates a new controller, it needs a unique name.