### PR TITLE
fix: reconfigure controllers to use klog via logr

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -47,10 +47,11 @@ func main() {
 	flag.DurationVar(&cacheSyncTimeout, "cache-sync-timeout", configuration.CacheSyncTimeout, "The duration of time to wait while informers synchronize.")
 
 	log.Setup()
-	setupLog := textlogger.NewLogger(textlogger.NewConfig()).WithName("setup")
+	logger := textlogger.NewLogger(textlogger.NewConfig())
+	setupLog := logger.WithName("setup")
 
 	profiler.Service()
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	ctrl.SetLogger(logger)
 
 	setupLog.Info("starting manager")
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -64,6 +65,7 @@ func main() {
 		Controller: config.Controller{
 			CacheSyncTimeout: cacheSyncTimeout,
 		},
+		Logger: logger.WithName("controller-manager"),
 	})
 	if err != nil {
 		setupLog.Error(err, "starting manager")

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -132,7 +132,8 @@ var flags = struct {
 func main() {
 	log.Setup()
 	profiler.Service()
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	logger := textlogger.NewLogger(textlogger.NewConfig())
+	ctrl.SetLogger(logger)
 
 	if *debug {
 		status.EnablePanicOnMisuse()
@@ -183,6 +184,7 @@ func main() {
 	}
 
 	opts := reconciler.Options{
+		Logger:                   logger,
 		ClusterName:              *clusterName,
 		FightDetectionThreshold:  *fightDetectionThreshold,
 		NumWorkers:               *workers,

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -63,7 +63,7 @@ func (r *reconcilerBase) cleanup(ctx context.Context, obj client.Object) error {
 	uObj.SetName(id.Name)
 	uObj.SetNamespace(id.Namespace)
 	uObj.SetGroupVersionKind(gvk)
-	r.logger(ctx).Info("Deleting managed object",
+	r.Logger(ctx).V(3).Info("Deleting managed object",
 		logFieldObjectRef, id.ObjectKey.String(),
 		logFieldObjectKind, id.Kind)
 	err = watch.DeleteAndWait(ctx, r.watcher, uObj, deleteWaitTimeout)
@@ -86,7 +86,7 @@ func (r *reconcilerBase) cleanup(ctx context.Context, obj client.Object) error {
 		// If not a timeout, assume the delete failed.
 		return NewObjectOperationErrorWithID(err, id, OperationDelete)
 	}
-	r.logger(ctx).Info("Managed object delete successful",
+	r.Logger(ctx).Info("Deleting managed object successful",
 		logFieldObjectRef, id.ObjectKey.String(),
 		logFieldObjectKind, id.Kind)
 	return nil
@@ -152,7 +152,7 @@ func (r *RepoSyncReconciler) deleteSharedRoleBinding(ctx context.Context, reconc
 	if err := r.client.Get(ctx, rbKey, rb); err != nil {
 		if apierrors.IsNotFound(err) {
 			// already deleted
-			r.logger(ctx).Info("Managed object already deleted",
+			r.Logger(ctx).V(3).Info("Managed object already deleted",
 				logFieldObjectRef, rbKey.String(),
 				logFieldObjectKind, "RoleBinding")
 			return nil
@@ -169,9 +169,15 @@ func (r *RepoSyncReconciler) deleteSharedRoleBinding(ctx context.Context, reconc
 		// Delete the whole RB
 		return r.cleanup(ctx, rb)
 	}
+	r.Logger(ctx).V(3).Info("Updating managed object",
+		logFieldObjectRef, rbKey.String(),
+		logFieldObjectKind, "RoleBinding")
 	if err := r.client.Update(ctx, rb, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return NewObjectOperationError(err, rb, OperationUpdate)
 	}
+	r.Logger(ctx).Info("Updating managed object successful",
+		logFieldObjectRef, rbKey.String(),
+		logFieldObjectKind, "RoleBinding")
 	return nil
 }
 
@@ -244,7 +250,7 @@ func (r *reconcilerBase) deleteSharedClusterRoleBinding(ctx context.Context, nam
 	if err := r.client.Get(ctx, crbKey, crb); err != nil {
 		if apierrors.IsNotFound(err) {
 			// already deleted
-			r.logger(ctx).Info("Managed object already deleted",
+			r.Logger(ctx).V(3).Info("Managed object already deleted",
 				logFieldObjectRef, crbKey.String(),
 				logFieldObjectKind, "ClusterRoleBinding")
 			return nil
@@ -261,8 +267,14 @@ func (r *reconcilerBase) deleteSharedClusterRoleBinding(ctx context.Context, nam
 		// No change
 		return nil
 	}
+	r.Logger(ctx).V(3).Info("Updating managed object",
+		logFieldObjectRef, crbKey.String(),
+		logFieldObjectKind, "ClusterRoleBinding")
 	if err := r.client.Update(ctx, crb, client.FieldOwner(reconcilermanager.FieldManager)); err != nil {
 		return NewObjectOperationError(err, crb, OperationUpdate)
 	}
+	r.Logger(ctx).Info("Updating managed object successful",
+		logFieldObjectRef, crbKey.String(),
+		logFieldObjectKind, "ClusterRoleBinding")
 	return nil
 }

--- a/pkg/reconcilermanager/controllers/helm_value_files.go
+++ b/pkg/reconcilermanager/controllers/helm_value_files.go
@@ -136,6 +136,9 @@ func (r *RepoSyncReconciler) upsertHelmConfigMap(ctx context.Context, cmsCMRef, 
 	cmsConfigMap.Name = cmsCMRef.Name
 	cmsConfigMap.Namespace = cmsCMRef.Namespace
 
+	r.Logger(ctx).V(3).Info("Upserting managed object",
+		logFieldObjectRef, cmsCMRef.String(),
+		logFieldObjectKind, "ConfigMap")
 	op, err := CreateOrUpdate(ctx, r.client, cmsConfigMap, func() error {
 		// TODO: Eventually remove the annotations and use the labels for list filtering, to optimize cleanup.
 		// We can't remove the annotations until v1.16.0 is no longer supported.
@@ -156,7 +159,7 @@ func (r *RepoSyncReconciler) upsertHelmConfigMap(ctx context.Context, cmsCMRef, 
 		return op, err
 	}
 	if op != controllerutil.OperationResultNone {
-		r.logger(ctx).Info("Managed object upsert successful",
+		r.Logger(ctx).Info("Upserting managed object successful",
 			logFieldObjectRef, cmsCMRef.String(),
 			logFieldObjectKind, "ConfigMap",
 			logFieldOperation, op)

--- a/pkg/reconcilermanager/controllers/logging_controller.go
+++ b/pkg/reconcilermanager/controllers/logging_controller.go
@@ -33,18 +33,25 @@ func (c contextKey) String() string {
 // values, in the context.Context.
 const contextKeyLogger = contextKey("logger")
 
-// loggingController is a parent class for a controller that logs.
+// LoggingController is a parent class for a controller that logs.
 // The logger can be stored in the context with contextual values.
 //
 // Use lc.logger(ctx) to retrieve the logger.
 // Use ctx = lc.setLoggerValues(ctx, key, value) to add key/value pairs.
-type loggingController struct {
+type LoggingController struct {
 	log logr.Logger
 }
 
-// logger returns a logr.Logger, either from the context or from
+// NewLoggingController constructs a new LoggingController
+func NewLoggingController(log logr.Logger) *LoggingController {
+	return &LoggingController{
+		log: log,
+	}
+}
+
+// Logger returns a logr.Logger, either from the context or from
 // reconcilerBase.log.
-func (lc *loggingController) logger(ctx context.Context) logr.Logger {
+func (lc *LoggingController) Logger(ctx context.Context) logr.Logger {
 	logger := ctx.Value(contextKeyLogger)
 	if logger != nil {
 		return logger.(logr.Logger)
@@ -52,9 +59,9 @@ func (lc *loggingController) logger(ctx context.Context) logr.Logger {
 	return lc.log
 }
 
-// setLoggerValues sets key/value pairs on the logger stored in the context.
+// SetLoggerValues sets key/value pairs on the logger stored in the context.
 // If not initially present, the default logger is added to the context.
 // See logr.Logger.WithValues for more details about how values work.
-func (lc *loggingController) setLoggerValues(ctx context.Context, keysAndValues ...interface{}) context.Context {
-	return context.WithValue(ctx, contextKeyLogger, lc.logger(ctx).WithValues(keysAndValues...))
+func (lc *LoggingController) SetLoggerValues(ctx context.Context, keysAndValues ...interface{}) context.Context {
+	return context.WithValue(ctx, contextKeyLogger, lc.Logger(ctx).WithValues(keysAndValues...))
 }

--- a/pkg/reconcilermanager/controllers/otel_base_controller.go
+++ b/pkg/reconcilermanager/controllers/otel_base_controller.go
@@ -27,7 +27,7 @@ import (
 
 // otelBaseController implements common functionality for otel controllers.
 type otelBaseController struct {
-	loggingController
+	*LoggingController
 
 	client client.Client
 }
@@ -52,7 +52,7 @@ func (r *otelBaseController) updateDeploymentAnnotation(ctx context.Context, ann
 		return nil
 	}
 
-	r.logger(ctx).V(3).Info("Patching object",
+	r.Logger(ctx).V(3).Info("Patching object",
 		logFieldObjectRef, key.String(),
 		logFieldObjectKind, "Deployment",
 		annotationKey, annotationValue)
@@ -61,7 +61,7 @@ func (r *otelBaseController) updateDeploymentAnnotation(ctx context.Context, ann
 	if err != nil {
 		return status.APIServerErrorf(err, "failed to patch Deployment: %s", key)
 	}
-	r.logger(ctx).Info("Patching object successful",
+	r.Logger(ctx).Info("Patching object successful",
 		logFieldObjectRef, key.String(),
 		logFieldObjectKind, "Deployment",
 		annotationKey, annotationValue)

--- a/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_manager_test.go
@@ -570,6 +570,8 @@ func testDriftProtection(t *testing.T, fakeClient *syncerFake.Client, testReconc
 func startControllerManager(ctx context.Context, t *testing.T, fakeClient *syncerFake.Client, testReconciler Controller) <-chan error {
 	t.Helper()
 
+	testLogger := testr.New(t)
+
 	// start sub-context so we can cancel & stop the manager in case of pre-return error
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -577,8 +579,8 @@ func startControllerManager(ctx context.Context, t *testing.T, fakeClient *synce
 
 	t.Log("building controller-manager")
 	mgr, err := controllerruntime.NewManager(&rest.Config{}, controllerruntime.Options{
+		Logger: testLogger.WithName("controller-manager"),
 		Scheme: core.Scheme,
-		Logger: testr.New(t),
 		BaseContext: func() context.Context {
 			return ctx
 		},

--- a/pkg/reconcilermanager/controllers/secret.go
+++ b/pkg/reconcilermanager/controllers/secret.go
@@ -154,6 +154,9 @@ func (r *reconcilerBase) upsertSecret(ctx context.Context, cmsSecretRef types.Na
 	cmsSecret.Name = cmsSecretRef.Name
 	cmsSecret.Namespace = cmsSecretRef.Namespace
 
+	r.Logger(ctx).V(3).Info("Upserting managed object",
+		logFieldObjectRef, cmsSecretRef.String(),
+		logFieldObjectKind, "Secret")
 	op, err := CreateOrUpdate(ctx, r.client, cmsSecret, func() error {
 		core.AddLabels(cmsSecret, labelMap)
 		// Copy user secret data & type to managed secret
@@ -165,7 +168,7 @@ func (r *reconcilerBase) upsertSecret(ctx context.Context, cmsSecretRef types.Na
 		return op, err
 	}
 	if op != controllerutil.OperationResultNone {
-		r.logger(ctx).Info("Managed object upsert successful",
+		r.Logger(ctx).Info("Upserting managed object successful",
 			logFieldObjectRef, cmsSecretRef.String(),
 			logFieldObjectKind, "Secret",
 			logFieldOperation, op)

--- a/pkg/reconcilermanager/controllers/secret_test.go
+++ b/pkg/reconcilermanager/controllers/secret_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -26,6 +25,7 @@ import (
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/metadata"
 	"kpt.dev/configsync/pkg/reconcilermanager"
+	"kpt.dev/configsync/pkg/testing/testcontroller"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -193,12 +193,11 @@ func TestUpsertAuthSecret(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			log := logr.Discard()
+			logger := testcontroller.NewTestLogger(t)
 			r := reconcilerBase{
-				loggingController: loggingController{
-					log: log,
-				},
-				client: tc.client,
+				LoggingController: NewLoggingController(logger),
+				scheme:            tc.client.Scheme(),
+				client:            tc.client,
 			}
 			labelMap := ManagedObjectLabelMap(configsync.RepoSyncKind, types.NamespacedName{
 				Name:      tc.reposync.Name,

--- a/pkg/resourcegroup/controllers/handler/handler_test.go
+++ b/pkg/resourcegroup/controllers/handler/handler_test.go
@@ -18,11 +18,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcemap"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -63,11 +63,12 @@ func (m fakeMapping) SetStatus(_ v1alpha1.ObjMetadata, _ *resourcemap.CachedStat
 }
 
 func TestEventHandler(t *testing.T) {
+	testLogger := testr.New(t)
 	ch := make(chan event.GenericEvent)
 	h := EnqueueEventToChannel{
 		Mapping: fakeMapping{},
 		Channel: ch,
-		Log:     textlogger.NewLogger(textlogger.NewConfig()),
+		Log:     testLogger,
 	}
 	u := &unstructured.Unstructured{}
 
@@ -86,17 +87,18 @@ func TestEventHandler(t *testing.T) {
 }
 
 func TestEventHandlerMultipleHandlers(t *testing.T) {
+	testLogger := testr.New(t)
 	ch := make(chan event.GenericEvent)
 	h1 := EnqueueEventToChannel{
 		Mapping: fakeMapping{},
 		Channel: ch,
-		Log:     textlogger.NewLogger(textlogger.NewConfig()),
+		Log:     testLogger,
 	}
 
 	h2 := EnqueueEventToChannel{
 		Mapping: fakeMapping{},
 		Channel: ch,
-		Log:     textlogger.NewLogger(textlogger.NewConfig()),
+		Log:     testLogger,
 		GVK:     schema.GroupVersionKind{Kind: "MyKind"},
 	}
 

--- a/pkg/resourcegroup/controllers/root/main_test.go
+++ b/pkg/resourcegroup/controllers/root/main_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	v1 "kpt.dev/configsync/pkg/api/hub/v1"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	"kpt.dev/configsync/pkg/reconcilermanager/controllers"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcemap"
 	"kpt.dev/configsync/pkg/resourcegroup/controllers/watch"
 	"kpt.dev/configsync/pkg/testing/testcontroller"
@@ -76,11 +77,11 @@ func NewReconciler(mgr manager.Manager, logger logr.Logger) (*Reconciler, error)
 		return nil, err
 	}
 	r := &Reconciler{
-		Client:  mgr.GetClient(),
-		cfg:     mgr.GetConfig(),
-		log:     logger,
-		resMap:  resmap,
-		watches: watches,
+		LoggingController: controllers.NewLoggingController(logger),
+		client:            mgr.GetClient(),
+		cfg:               mgr.GetConfig(),
+		resMap:            resmap,
+		watches:           watches,
 	}
 	obj := &v1alpha1.ResourceGroup{}
 	_, err = ctrl.NewControllerManagedBy(mgr).

--- a/pkg/resourcegroup/controllers/typeresolver/typeresolver_test.go
+++ b/pkg/resourcegroup/controllers/typeresolver/typeresolver_test.go
@@ -15,15 +15,16 @@
 package typeresolver
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	"kpt.dev/configsync/pkg/testing/testcontroller"
 	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
@@ -275,9 +276,10 @@ func TestRefresh(t *testing.T) {
 			if tc.setupFakeDiscoveryClient != nil {
 				tc.setupFakeDiscoveryClient(fakeDC)
 			}
-			logger := testr.New(t)
+			logger := testcontroller.NewTestLogger(t)
 			resolver := NewTypeResolver(fakeDC, logger)
-			err := resolver.Refresh()
+			ctx := context.Background() // TODO: use t.Context() after Go upgrade
+			err := resolver.Refresh(ctx)
 			testerrors.AssertEqual(t, err, tc.expectedError)
 			require.Equal(t, fakeDC.ServerResourcesForGroupVersionCalls, len(fakeDC.ServerResourcesForGroupVersionInputs))
 

--- a/pkg/resourcegroup/controllers/watch/filteredwatcher.go
+++ b/pkg/resourcegroup/controllers/watch/filteredwatcher.go
@@ -149,7 +149,7 @@ func waitUntilNextRetry(retries int) {
 // filters the event and pushes the object contained
 // in the event to the controller work queue.
 func (w *filteredWatcher) Run(context.Context) error {
-	klog.Infof("Watch started for %s", w.gvk)
+	klog.V(3).Infof("Watch started for %s", w.gvk)
 	var resourceVersion string
 	var retriesForWatchError int
 
@@ -168,7 +168,7 @@ func (w *filteredWatcher) Run(context.Context) error {
 
 		eventCount := 0
 		ignoredEventCount := 0
-		klog.Infof("(Re)starting watch for %s at resource version %q", w.gvk, resourceVersion)
+		klog.V(3).Infof("(Re)starting watch for %s at resource version %q", w.gvk, resourceVersion)
 		for event := range w.base.ResultChan() {
 			w.pruneErrors()
 			newVersion, ignoreEvent, err := w.handle(event)
@@ -197,10 +197,10 @@ func (w *filteredWatcher) Run(context.Context) error {
 				resourceVersion = newVersion
 			}
 		}
-		klog.Infof("Ending watch for %s at resource version %q (total events: %d, ignored events: %d)",
+		klog.V(3).Infof("Ending watch for %s at resource version %q (total events: %d, ignored events: %d)",
 			w.gvk, resourceVersion, eventCount, ignoredEventCount)
 	}
-	klog.Infof("Watch stopped for %s", w.gvk)
+	klog.V(3).Infof("Watch stopped for %s", w.gvk)
 	return nil
 }
 


### PR DESCRIPTION
- Use dot syntax in logr field key names, unless specifically referencing a resource field name. 
- Log API operations at level 3 before the call, and level 1 after the call, only if the operation was not skipped, to reduce noise.
- Make the before and after logs similar syntax (e.g. deleting, upserting, applying, patching)
- Don't log errors from controller Reconcile methods, unless they're not returned, because the controller-runtime will log the returned error for us.
- Use APIServerError even for controller errors, because it has help text for RBAC forbidden errors
- Use level 3 for controller Reconcile method start/finish logs to reduce noise

Depends on https://github.com/GoogleContainerTools/kpt-config-sync/pull/1553 & https://github.com/GoogleContainerTools/kpt-config-sync/pull/1565