### PR TITLE
feat: prevent ResourceGroup conflicts in applier

### DIFF
--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -150,6 +150,9 @@ const (
 	// This annotation is set by Config Sync on the RootSync/RepoSync object
 	// to indicate the exact image that should be synced.
 	ImageToSyncAnnotationKey = configsync.ConfigSyncPrefix + "image-to-sync"
+
+	// ApplierRunning indicates on the ResourceGroup that the applier is currently running.
+	ApplierRunning = configsync.ConfigSyncPrefix + "applier-running"
 )
 
 // Lifecycle annotations

--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"kpt.dev/configsync/pkg/metadata"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,6 +113,11 @@ func (r *reconciler) reconcileKpt(ctx context.Context, req ctrl.Request, logger 
 
 	// ResourceGroup is in the process of being deleted
 	if resgroup.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Applier is still running for this ResourceGroup
+	if val, ok := resgroup.Annotations[metadata.ApplierRunning]; ok && val == "true" {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/resourcegroup/controllers/root/root_controller.go
+++ b/pkg/resourcegroup/controllers/root/root_controller.go
@@ -108,6 +108,11 @@ func (r *Reconciler) reconcileKptGroup(ctx context.Context, logger logr.Logger, 
 		return ctrl.Result{}, err
 	}
 
+	// Applier is still running for this ResourceGroup
+	if val, ok := resgroup.Annotations[metadata.ApplierRunning]; ok && val == "true" {
+		return ctrl.Result{}, nil
+	}
+
 	// ResourceGroup CR is created from ConfigSync and set to disable the status
 	if isStatusDisabled(resgroup) {
 		return r.reconcileDisabledResourceGroup(ctx, req, resgroup)
@@ -252,6 +257,11 @@ func (ResourceGroupPredicate) Update(e event.UpdateEvent) bool {
 	}
 	rgOld, ok := e.ObjectOld.(*v1alpha1.ResourceGroup)
 	if !ok {
+		return false
+	}
+
+	// Applier is still running for this ResourceGroup
+	if val, ok := rgNew.Annotations[metadata.ApplierRunning]; ok && val == "true" {
 		return false
 	}
 


### PR DESCRIPTION
The applier often encounters resource conflicts when updating the ResourceGroup object due to frequent updates by the resource-group-controller. These become even more frequent in an upcoming update which aims to minimize the number of Get requests performed by the applier.

Resource conflicts are avoided by setting an annotation before and after the applier runs, and pausing updates in the resource-group-controller while the annotation is set.