### PR TITLE
feat: validate RSync length in reconciler-manager

### DIFF
--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -30,7 +30,6 @@ import (
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
-	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
@@ -259,8 +258,8 @@ func TestMaxRootSyncNameLength(t *testing.T) {
 		fmt.Sprintf("%s/ns.yaml", rootSyncTooLongName),
 		k8sobjects.NamespaceObject(rootSyncTooLongName)))
 	nt.Must(repo.CommitAndPush("create RootSync with too long name"))
-	nt.WaitForRootSyncSyncError(rootSyncTooLongName, applier.ApplierErrorCode,
-		"must be no more than 63 characters", nil)
+	nt.WaitForRootSyncStalledError(rootSyncTooLongName, "Validation",
+		"maximum RootSync name length is 38, but found 39")
 
 	// Test scenario for RootSync with exactly the max name length
 	rootSyncMaxLengthName := strings.Repeat("y", 38)
@@ -318,7 +317,7 @@ func TestMaxRepoSyncNameLength(t *testing.T) {
 			core.Name(repoSyncTooLongNN.Name), core.Namespace(repoSyncTooLongNN.Namespace))))
 	nt.Must(repo.CommitAndPush("create RepoSync with too long NN"))
 	nt.WaitForRepoSyncStalledError(repoSyncTooLongNN.Namespace, repoSyncTooLongNN.Name,
-		"Deployment", "must be no more than 63 characters")
+		"Validation", "maximum combined length of RepoSync name and namespace is 45, but found 46")
 
 	// Test scenario for RepoSync with exactly the max name length
 	repoSyncMaxLengthNN := types.NamespacedName{

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -801,8 +801,7 @@ func TestControllerValidationErrors(t *testing.T) {
 		nt.Must(nomostest.DeleteObjectsAndWait(nt, rsTooLong))
 	})
 	nt.WaitForRepoSyncStalledError(rsTooLong.Namespace, rsTooLong.Name, "Validation",
-		fmt.Sprintf(`Invalid reconciler name "%s": must be no more than %d characters.`,
-			core.NsReconcilerName(rsTooLong.Namespace, rsTooLong.Name), validation.DNS1123SubdomainMaxLength))
+		`maximum combined length of RepoSync name and namespace is 45, but found 260`)
 
 	nt.T.Logf("Validate an invalid config with a long RepoSync Secret name")
 	rsInvalidSecretRef := k8sobjects.RepoSyncObjectV1Beta1(testNs, "repo-test")

--- a/pkg/reconcilermanager/constants.go
+++ b/pkg/reconcilermanager/constants.go
@@ -188,3 +188,14 @@ const (
 	// HelmCACert is the OS env variable key for the Helm sync CA cert file path.
 	HelmCACert = "HELM_CA_CERT"
 )
+
+const (
+	// MaxRepoSyncNNLength length is the maximum number of characters for a RepoSync name + namespace.
+	// The ns-reconciler deployment label is constructed as "ns-reconciler-<ns>-<name>-<len(name)>"
+	// Thus, the max length name + namespace for a RepoSync is 45 characters.
+	MaxRepoSyncNNLength = 45
+	// MaxRootSyncNameLength length is the maximum number of characters for a RootSync name.
+	// The name max length is 63 - len("config-management-system_") due to the inventory-id label.
+	// Thus, the max length name for a RootSync is 38 characters.
+	MaxRootSyncNameLength = 38
+)

--- a/pkg/reconcilermanager/controllers/reposync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller_test.go
@@ -4602,6 +4602,33 @@ For more information, see https://g.co/cloud/acm-errors#knv1061`))
 	}
 }
 
+func TestValidateRepoSyncName(t *testing.T) {
+	testCases := map[string]struct {
+		name      string
+		namespace string
+		expectErr error
+	}{
+		"valid name/namespace": {
+			name:      strings.Repeat("x", 30),
+			namespace: strings.Repeat("n", 15),
+			expectErr: nil,
+		},
+		"invalid name/namespace": {
+			name:      strings.Repeat("x", 30),
+			namespace: strings.Repeat("n", 16),
+			expectErr: fmt.Errorf("maximum combined length of RepoSync name and namespace is 45, but found 46"),
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			rs := &v1beta1.RepoSync{}
+			rs.Name = tc.name
+			rs.Namespace = tc.namespace
+			require.Equal(t, tc.expectErr, validateRepoSyncName(rs))
+		})
+	}
+}
+
 func validateRepoSyncStatus(t *testing.T, want *v1beta1.RepoSync, fakeClient *syncerFake.Client) {
 	t.Helper()
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -841,9 +841,23 @@ func (r *RootSyncReconciler) populateContainerEnvs(ctx context.Context, rs *v1be
 	return result
 }
 
+// This check surfaces the RootSync name length constraint earlier as a validation error.
+func validateRootSyncName(rs *v1beta1.RootSync) error {
+	nameLength := len(rs.Name)
+	if nameLength > reconcilermanager.MaxRootSyncNameLength {
+		return fmt.Errorf("maximum RootSync name length is %d, but found %d",
+			reconcilermanager.MaxRootSyncNameLength, nameLength)
+	}
+	return nil
+}
+
 func (r *RootSyncReconciler) validateRootSync(ctx context.Context, rs *v1beta1.RootSync, reconcilerName string) error {
 	if rs.Namespace != configsync.ControllerNamespace {
 		return fmt.Errorf("RootSync objects are only allowed in the %s namespace, not in %s", configsync.ControllerNamespace, rs.Namespace)
+	}
+
+	if err := validateRootSyncName(rs); err != nil {
+		return err
 	}
 
 	if err := validation.IsDNS1123Subdomain(reconcilerName); err != nil {

--- a/pkg/reconcilermanager/controllers/rootsync_controller_test.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -4285,6 +4286,29 @@ For more information, see https://g.co/cloud/acm-errors#knv1061`))
 	wantDeployments := map[core.ID]*appsv1.Deployment{core.IDOf(rootDeployment): rootDeployment}
 	if err := validateDeployments(wantDeployments, fakeDynamicClient); err != nil {
 		t.Errorf("Deployment validation failed. err: %v", err)
+	}
+}
+
+func TestValidateRootSyncName(t *testing.T) {
+	testCases := map[string]struct {
+		name      string
+		expectErr error
+	}{
+		"valid name": {
+			name:      strings.Repeat("x", 38),
+			expectErr: nil,
+		},
+		"invalid name": {
+			name:      strings.Repeat("x", 39),
+			expectErr: fmt.Errorf("maximum RootSync name length is 38, but found 39"),
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			rs := &v1beta1.RootSync{}
+			rs.Name = tc.name
+			require.Equal(t, tc.expectErr, validateRootSyncName(rs))
+		})
 	}
 }
 


### PR DESCRIPTION
This adds validation logic for the maximum RSync name/namespace length in the reconciler-manager. This constraint already existed due to labels which were mapped from the RSync name/namespace. This change just adds explicit validation so that the errors are caught earlier and a clear error message is emitted.