### PR TITLE
[WIP] fix: ResourceGroup controller bugs

### DIFF
--- a/e2e/nomostest/testkubeclient/client.go
+++ b/e2e/nomostest/testkubeclient/client.go
@@ -78,12 +78,12 @@ func (tc *KubeClient) Get(name, namespace string, obj client.Object) error {
 	return tc.Client.Get(tc.Context, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 }
 
-// List is identical to List defined for clietc.Client, but without requiring Context.
+// List is identical to List defined for client.Client, but without requiring Context.
 func (tc *KubeClient) List(obj client.ObjectList, opts ...client.ListOption) error {
 	return tc.Client.List(tc.Context, obj, opts...)
 }
 
-// Create is identical to Create defined for clietc.Client, but without requiring Context.
+// Create is identical to Create defined for client.Client, but without requiring Context.
 func (tc *KubeClient) Create(obj client.Object, opts ...client.CreateOption) error {
 	if err := tc.ObjectTypeMustExist(obj); err != nil {
 		return err
@@ -94,7 +94,7 @@ func (tc *KubeClient) Create(obj client.Object, opts ...client.CreateOption) err
 	return tc.Client.Create(tc.Context, obj, opts...)
 }
 
-// Update is identical to Update defined for clietc.Client, but without requiring Context.
+// Update is identical to Update defined for client.Client, but without requiring Context.
 // All fields will be adopted by the nomostest field manager.
 func (tc *KubeClient) Update(obj client.Object, opts ...client.UpdateOption) error {
 	if err := tc.ObjectTypeMustExist(obj); err != nil {
@@ -103,6 +103,18 @@ func (tc *KubeClient) Update(obj client.Object, opts ...client.UpdateOption) err
 	tc.Logger.Debugf("updating %s", fmtObj(obj))
 	opts = append(opts, client.FieldOwner(FieldManager))
 	return tc.Client.Update(tc.Context, obj, opts...)
+}
+
+// UpdateStatus is identical to Status().Update defined for client.Client, but
+// without requiring Context.
+// All fields will be adopted by the nomostest field manager.
+func (tc *KubeClient) UpdateStatus(obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if err := tc.ObjectTypeMustExist(obj); err != nil {
+		return err
+	}
+	tc.Logger.Debugf("updating status %s", fmtObj(obj))
+	opts = append(opts, client.FieldOwner(FieldManager))
+	return tc.Client.Status().Update(tc.Context, obj, opts...)
 }
 
 // Apply wraps Patch to perform a server-side apply.

--- a/pkg/core/scheme.go
+++ b/pkg/core/scheme.go
@@ -40,6 +40,7 @@ import (
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
+	kptv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 )
 
 // Scheme is a reference to the global scheme.
@@ -70,6 +71,9 @@ func init() {
 	utilruntime.Must(configsyncv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(configsyncv1alpha1.RegisterConversions(scheme.Scheme))
 	utilruntime.Must(scheme.Scheme.SetVersionPriority(configsyncv1beta1.SchemeGroupVersion, configsyncv1alpha1.SchemeGroupVersion))
+
+	// Kpt types
+	utilruntime.Must(kptv1alpha1.AddToScheme(scheme.Scheme))
 
 	// Hub/Fleet types
 	utilruntime.Must(hubv1.AddToScheme(scheme.Scheme))


### PR DESCRIPTION
- Fix e2e tests to correctly update the ResourceGroup status
- Optimize e2e tests to watch, instead of polling
- Fix the ResourceGroup controller to wait for status.observedGeneration updates by the applier inventory client. This fixes a race condition and prevents status update conflicts.
- Fix TestStatusEnabledAndDisabled to allow changes to the status.generation by the applier.
- Fix the ResourceGroup controller to skip condition updates that only change the timestamp. This avoids unnecessary updates.
- Fix the ResourceGroup controller to correctly update the kstatus and the reconcile status, not just the kstatus.
- Change ResourceGroup to skip setting Reconciling=True before imediately setting it to Reconciling=False. This avoids unnecessary updates.
- Fix ResourceGroup controller to let the controller-manager handle retries with shared backoff, instead of using inline retries with independent backoff.
- Fix ResourceGroup controller to log errors encountered when computing the reconcile status.
- Fix ResourceGroup "root" controller to remove unnecessary "optimizations" which could cause updates to be missed. The core controller already handles these skips, and the controller-manager already handles de-duping identical events. This avoids temporarily incorrect status and delayed status updates.

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1570
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1571
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1573
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1572
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1574
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1575
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1593
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1591