### PR TITLE
test: refactor some unit tests to use exact errors

### DIFF
--- a/pkg/declared/namespace_safeguard_test.go
+++ b/pkg/declared/namespace_safeguard_test.go
@@ -15,7 +15,6 @@
 package declared
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/elliotchance/orderedmap/v2"
@@ -24,6 +23,7 @@ import (
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/status"
+	"kpt.dev/configsync/pkg/testing/testerrors"
 )
 
 func TestDontDeleteAllNamespaces(t *testing.T) {
@@ -95,9 +95,7 @@ func TestDontDeleteAllNamespaces(t *testing.T) {
 			}
 
 			got := deletesAllNamespaces(previous, current)
-			if !errors.Is(got, tc.want) {
-				t.Errorf("got deletesAllNamespaces() = %v, want %v", got, tc.want)
-			}
+			testerrors.AssertEqual(t, got, tc.want)
 		})
 	}
 }

--- a/pkg/remediator/reconcile/reconciler_test.go
+++ b/pkg/remediator/reconcile/reconciler_test.go
@@ -16,7 +16,6 @@ package reconcile
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -592,9 +591,7 @@ func TestRemediator_Reconcile_Metrics(t *testing.T) {
 			m := testmetrics.RegisterMetrics(views...)
 
 			err := reconciler.Remediate(context.Background(), core.IDOf(obj), tc.actual)
-			if !errors.Is(err, tc.wantError) {
-				t.Errorf("Unexpected error: want:\n%v\ngot:\n%v", tc.wantError, err)
-			}
+			testerrors.AssertEqual(t, tc.wantError, err)
 
 			if tc.want == nil {
 				fakeClient.Check(t)


### PR DESCRIPTION
- Removes reference to obsolete bug
- Cleans some tests up by validating errors by their exact type and message and not just their error code