### PR TITLE
test: add ResourceGroup assertions to WatchForSync

### DIFF
--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -1319,6 +1319,25 @@ func containerArgsContains(container *corev1.Container, expectedArg string) erro
 	return fmt.Errorf("expected arg not found: %s", expectedArg)
 }
 
+// ResourceGroupHasNoStatus verifies the status of the ResourceGroup is empty.
+func ResourceGroupHasNoStatus() Predicate {
+	return func(obj client.Object) error {
+		if obj == nil {
+			return ErrObjectNotFound
+		}
+		rg, ok := obj.(*v1alpha1.ResourceGroup)
+		if !ok {
+			return WrongTypeErr(obj, &v1alpha1.ResourceGroup{})
+		}
+		emptyStatus := v1alpha1.ResourceGroupStatus{}
+		if !equality.Semantic.DeepEqual(emptyStatus, rg.Status) {
+			return fmt.Errorf("found non-empty status in %s:\nDiff (- Expected, + Found)\n%s",
+				kinds.ObjectSummary(rg), log.AsYAMLDiff(emptyStatus, rg.Status))
+		}
+		return nil
+	}
+}
+
 // ResourceGroupStatusEquals checks that the RootSync's spec.override matches
 // the specified RootSyncOverrideSpec.
 func ResourceGroupStatusEquals(expected v1alpha1.ResourceGroupStatus) Predicate {

--- a/e2e/nomostest/testresourcegroup/resourcegroup.go
+++ b/e2e/nomostest/testresourcegroup/resourcegroup.go
@@ -26,8 +26,8 @@ import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/metadata"
-	"kpt.dev/configsync/pkg/resourcegroup/controllers/resourcegroup"
-	"kpt.dev/configsync/pkg/resourcegroup/controllers/status"
+	"kpt.dev/configsync/pkg/resourcegroup"
+	resourcegroupcontroller "kpt.dev/configsync/pkg/resourcegroup/controllers/resourcegroup"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -75,13 +75,13 @@ func EmptyStatus() v1alpha1.ResourceGroupStatus {
 			{
 				Type:    v1alpha1.Reconciling,
 				Status:  v1alpha1.FalseConditionStatus,
-				Reason:  resourcegroup.FinishReconciling,
+				Reason:  resourcegroupcontroller.FinishReconciling,
 				Message: "finish reconciling",
 			},
 			{
 				Type:    v1alpha1.Stalled,
 				Status:  v1alpha1.FalseConditionStatus,
-				Reason:  resourcegroup.FinishReconciling,
+				Reason:  resourcegroupcontroller.FinishReconciling,
 				Message: "finish reconciling",
 			},
 		},
@@ -112,8 +112,8 @@ func CreateOrUpdateResources(kubeClient *testkubeclient.KubeClient, resources []
 			Kind:    r.Kind,
 		})
 		u.SetAnnotations(map[string]string{
-			"config.k8s.io/owning-inventory": id,
-			status.SourceHashAnnotationKey:   "1234567890",
+			"config.k8s.io/owning-inventory":      id,
+			resourcegroup.SourceHashAnnotationKey: "1234567890",
 		})
 
 		err := kubeClient.Get(r.Name, r.Namespace, u.DeepCopy())

--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -111,7 +111,7 @@ func TestSyncDeploymentAndReplicaSet(t *testing.T) {
 	nt.T.Log("Add a corresponding deployment")
 	nt.Must(rootSyncGitRepo.Copy(fmt.Sprintf("%s/deployment-helloworld.yaml", yamlDir), "acme/namespaces/dir/deployment.yaml"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add corresponding deployment"))
-	nt.Must(nt.WatchForAllSyncs())
+	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
 
 	nt.T.Log("check that the deployment was created")
 	if err := nt.Validate("hello-world", "dir", &appsv1.Deployment{}); err != nil {

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -486,7 +486,9 @@ func TestConflictingDefinitions_NamespaceToRoot(t *testing.T) {
 	nt.T.Logf("Remove the Role from the Namespace repo %s", repoSyncKey)
 	nt.Must(repoSyncGitRepo.Remove(podRoleFilePath))
 	nt.Must(repoSyncGitRepo.CommitAndPush("remove conflicting pod role from Namespace repo"))
-	nt.Must(nt.WatchForAllSyncs())
+	// rs-test tries to delete the Role, but since it is also being managed by root-sync
+	// it may Timeout waiting for the deletion to reconcile.
+	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
 
 	nt.T.Logf("Ensure the Role still matches the one in the Root repo %s", rootSyncKey.Name)
 	err = nt.Validate("pods", testNs, &rbacv1.Role{},
@@ -620,7 +622,9 @@ func TestConflictingDefinitions_RootToRoot(t *testing.T) {
 	nt.T.Logf("Remove the declaration from RootSync %s", rootSyncID.Name)
 	nt.Must(rootSyncGitRepo.Remove(podRoleFilePath))
 	nt.Must(rootSyncGitRepo.CommitAndPush("remove conflicting pod role"))
-	nt.Must(nt.WatchForAllSyncs())
+	// root-sync tries to delete the Role, but since it is also being managed by root-test
+	// it may Timeout waiting for the deletion to reconcile.
+	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
 
 	nt.T.Logf("Ensure the Role is managed by RootSync %s", rootSync2ID.Name)
 	// The pod role may be deleted from the cluster after it was removed from the `root-sync` Root repo.

--- a/e2e/testcases/override_reconcile_timeout_test.go
+++ b/e2e/testcases/override_reconcile_timeout_test.go
@@ -96,7 +96,7 @@ func TestOverrideReconcileTimeout(t *testing.T) {
 	nt.Must(rootSyncGitRepo.Add("acme/pod-1.yaml", pod1))
 	nt.Must(rootSyncGitRepo.Add("acme/ns-1.yaml", k8sobjects.NamespaceObject(namespaceName)))
 	nt.Must(rootSyncGitRepo.CommitAndPush(fmt.Sprintf("Add namespace/%s & pod/%s (never ready)", namespaceName, pod1Name)))
-	nt.Must(nt.WatchForAllSyncs())
+	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
 	expectActuationStatus := "Succeeded"
 	expectReconcileStatus := "Timeout"
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), "root-sync", "config-management-system",

--- a/pkg/resourcegroup/resourcegroup_test.go
+++ b/pkg/resourcegroup/resourcegroup_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+package resourcegroup
 
 import (
 	"fmt"


### PR DESCRIPTION
This adds validation for the ResourceGroup status in the WatchForSync function, which is used extensively in the test framework to validate RSyncs and wait for them to finish syncing.

This will cause WatchForSync to now also wait for all synced objects to reconcile and for the ResourceGroup to be current. This is intended to provide test coverage for the resource-group-controller when integrated with Config Sync.