### PR TITLE
chore: bump otelcontribcol to v0.103.0-gke.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ COSIGN := $(BIN_DIR)/cosign
 GIT_SYNC_VERSION := v4.3.0-gke.11__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.103.0-gke.7
+OTELCONTRIBCOL_VERSION := v0.103.0-gke.8
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.


### PR DESCRIPTION
This resolves some CVEs in the prior version