### PR TITLE
Update gcloud image to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.4
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options
-GCLOUD_IMAGE_VERSION := 449.0.0
+GCLOUD_IMAGE_VERSION := 513.0.0
 GCLOUD_IMAGE := gcr.io/google.com/cloudsdktool/google-cloud-cli:$(GCLOUD_IMAGE_VERSION)-slim
 # Base image used for docker cli install, primarily used for test images.
 DOCKER_CLI_IMAGE_VERSION := 20.10.14


### PR DESCRIPTION
The gcloud image was updated to the latest version by updating the GCLOUD_IMAGE_VERSION variable in the Makefile. This change affects the following files:
- build/buildenv/Dockerfile
- build/prow/e2e/Dockerfile
- build/prow/vulnerability-scanner/Dockerfile

No other files needed to be changed because the GCLOUD_IMAGE_VERSION variable is used to set the image in all Dockerfiles.