### PR TITLE
test: truncate Pod logs for each test case

### DIFF
--- a/e2e/nomostest/new.go
+++ b/e2e/nomostest/new.go
@@ -181,6 +181,7 @@ func SharedTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		HelmProvider:            sharedNt.HelmProvider,
 		HelmClient:              sharedNt.HelmClient,
 		OCIClient:               sharedNt.OCIClient,
+		testStartTime:           time.Now(),
 	}
 
 	t.Logf("using shared test env: %s, cluster version: %s, cluster hash: %s, support bursting: %t", nt.ClusterName, nt.ClusterVersion, nt.ClusterHash, nt.ClusterSupportsBursting)
@@ -274,6 +275,7 @@ func FreshTestEnv(t nomostesting.NTB, opts *ntopts.New) *NT {
 		HelmProvider:            registryproviders.NewHelmProvider(*e2e.HelmProvider, opts.ClusterName, shell, helmClient),
 		HelmClient:              helmClient,
 		OCIClient:               ociClient,
+		testStartTime:           time.Now(),
 	}
 
 	nt.detectClusterVersion()

--- a/e2e/nomostest/nt.go
+++ b/e2e/nomostest/nt.go
@@ -202,6 +202,9 @@ type NT struct {
 
 	// repoSyncPermissions will grant a list of PolicyRules to NS reconcilers
 	repoSyncPermissions []rbacv1.PolicyRule
+
+	// testStartTime is a timestamp which records when the current test started
+	testStartTime time.Time
 }
 
 // Must not error.
@@ -463,7 +466,11 @@ func (nt *NT) MustKubectl(args ...string) []byte {
 func (nt *NT) PodLogs(namespace, deployment, container string, previousPodLog bool) {
 	nt.T.Helper()
 
-	args := []string{"logs", fmt.Sprintf("deployment/%s", deployment), "-n", namespace}
+	args := []string{"logs", fmt.Sprintf("deployment/%s", deployment),
+		"-n", namespace,
+		// truncate logs to avoid excessive log output from long-running containers such as reconciler-manager
+		"--since-time", nt.testStartTime.Format(time.RFC3339),
+	}
 	if previousPodLog {
 		args = append(args, "-p")
 	}


### PR DESCRIPTION
There are some long lived containers, such as reconciler-manager, which will accumulate a large amount of logs over the duration of the test suite. When a test fails, it dumps the Pod logs and can result in a large quantity of logs which are not relevant to the failed test.

This truncates the logs based on the start time of the test, to ensure only relevant logs are included.