### PR TITLE
test: fix helm-components chart so that it reconciles

### DIFF
--- a/e2e/testdata/hydration/compiled-json/helm-components/wordpress/secret_my-wordpress.json
+++ b/e2e/testdata/hydration/compiled-json/helm-components/wordpress/secret_my-wordpress.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "v1",
+	"items": [
+		{
+			"apiVersion": "v1",
+			"data": {
+				"wordpress-password": "YWJjZGVmZw=="
+			},
+			"kind": "Secret",
+			"metadata": {
+				"annotations": {
+					"config.kubernetes.io/origin": "configuredIn: kustomization.yaml\nconfiguredBy:\n  apiVersion: builtin\n  kind: HelmChartInflationGenerator\n"
+				},
+				"labels": {
+					"app.kubernetes.io/instance": "my-wordpress",
+					"app.kubernetes.io/managed-by": "Helm",
+					"app.kubernetes.io/name": "wordpress",
+					"helm.sh/chart": "wordpress-15.2.35",
+					"test-case": "hydration"
+				},
+				"name": "my-wordpress",
+				"namespace": "wordpress"
+			},
+			"type": "Opaque"
+		}
+	],
+	"kind": "List"
+}

--- a/e2e/testdata/hydration/compiled/helm-components/wordpress/secret_my-wordpress.yaml
+++ b/e2e/testdata/hydration/compiled/helm-components/wordpress/secret_my-wordpress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-helmCharts:
-- name: coredns
-  releaseName: my-coredns
-  namespace: coredns
-- name: wordpress
-  repo: https://charts.bitnami.com/bitnami
-  version: 15.2.35
-  releaseName: my-wordpress
+---
+apiVersion: v1
+data:
+  wordpress-password: YWJjZGVmZw==
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/origin: |
+      configuredIn: kustomization.yaml
+      configuredBy:
+        apiVersion: builtin
+        kind: HelmChartInflationGenerator
+  labels:
+    app.kubernetes.io/instance: my-wordpress
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: wordpress
+    helm.sh/chart: wordpress-15.2.35
+    test-case: hydration
+  name: my-wordpress
   namespace: wordpress
-  valuesInline:
-    wordpressPassword: abcdefg
-    mariadb:
-      auth:
-        rootPassword: abcdefg
-        password: abcdefg
-    service:
-      type: ClusterIP
-
-commonLabels:
-  test-case: hydration
+type: Opaque


### PR DESCRIPTION
The helm chart referenced a Secret which is expected to be created out of band, but the Secret did not exist. This caused the package to never reconcile.

Replacing this with an inline wordpressPassword handles creation of the Secret by the helm chart so that it can reconcile.