### PR TITLE
test: cleanup ResourceGroup controller e2e tests

### DIFF
--- a/e2e/nomostest/testkubeclient/client.go
+++ b/e2e/nomostest/testkubeclient/client.go
@@ -78,12 +78,12 @@ func (tc *KubeClient) Get(name, namespace string, obj client.Object) error {
 	return tc.Client.Get(tc.Context, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 }
 
-// List is identical to List defined for clietc.Client, but without requiring Context.
+// List is identical to List defined for client.Client, but without requiring Context.
 func (tc *KubeClient) List(obj client.ObjectList, opts ...client.ListOption) error {
 	return tc.Client.List(tc.Context, obj, opts...)
 }
 
-// Create is identical to Create defined for clietc.Client, but without requiring Context.
+// Create is identical to Create defined for client.Client, but without requiring Context.
 func (tc *KubeClient) Create(obj client.Object, opts ...client.CreateOption) error {
 	if err := tc.ObjectTypeMustExist(obj); err != nil {
 		return err
@@ -94,7 +94,7 @@ func (tc *KubeClient) Create(obj client.Object, opts ...client.CreateOption) err
 	return tc.Client.Create(tc.Context, obj, opts...)
 }
 
-// Update is identical to Update defined for clietc.Client, but without requiring Context.
+// Update is identical to Update defined for client.Client, but without requiring Context.
 // All fields will be adopted by the nomostest field manager.
 func (tc *KubeClient) Update(obj client.Object, opts ...client.UpdateOption) error {
 	if err := tc.ObjectTypeMustExist(obj); err != nil {
@@ -103,6 +103,18 @@ func (tc *KubeClient) Update(obj client.Object, opts ...client.UpdateOption) err
 	tc.Logger.Debugf("updating %s", fmtObj(obj))
 	opts = append(opts, client.FieldOwner(FieldManager))
 	return tc.Client.Update(tc.Context, obj, opts...)
+}
+
+// UpdateStatus is identical to Status().Update defined for client.Client, but
+// without requiring Context.
+// All fields will be adopted by the nomostest field manager.
+func (tc *KubeClient) UpdateStatus(obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if err := tc.ObjectTypeMustExist(obj); err != nil {
+		return err
+	}
+	tc.Logger.Debugf("updating status %s", fmtObj(obj))
+	opts = append(opts, client.FieldOwner(FieldManager))
+	return tc.Client.Status().Update(tc.Context, obj, opts...)
 }
 
 // Apply wraps Patch to perform a server-side apply.

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -433,13 +433,13 @@ func TestImporterIgnoresNonSelectedCustomResources(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add test cluster and cluster registry data"))
 
 	nt.T.Log("Add CRs (not targeted to this cluster) without its CRD")
-	cr := anvilCR("v1", "e2e-test-anvil", 10)
+	cr := newAnvilObject("v1", "e2e-test-anvil", 10)
 	cr.SetAnnotations(map[string]string{metadata.ClusterNameSelectorAnnotationKey: testClusterSelectorName})
 	nsObj := namespaceObject(backendNamespace, map[string]string{})
 	nt.Must(rootSyncGitRepo.Add(
 		fmt.Sprintf("acme/namespaces/eng/%s/namespace.yaml", backendNamespace), nsObj))
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/anvil.yaml", cr))
-	cr2 := anvilCR("v1", "e2e-test-anvil-2", 10)
+	cr2 := newAnvilObject("v1", "e2e-test-anvil-2", 10)
 	cr2.SetAnnotations(legacyTestClusterSelectorAnnotation)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/eng/backend/anvil-2.yaml", cr2))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add a custom resource without its CRD"))

--- a/e2e/testcases/custom_resource_definitions_test.go
+++ b/e2e/testcases/custom_resource_definitions_test.go
@@ -43,7 +43,7 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 	nt.Must(rootSyncGitRepo.Add("acme/cluster/anvil-crd.yaml", crd))
 	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
-	anvilObj := anvilCR("v1", "heavy", 10)
+	anvilObj := newAnvilObject("v1", "heavy", 10)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvil-v1.yaml", anvilObj))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Adding Anvil CRD and one Anvil CR"))
 	nt.Must(nt.WatchForAllSyncs())
@@ -55,7 +55,7 @@ func mustRemoveCustomResourceWithDefinition(nt *nomostest.NT, crd client.Object)
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("heavy", "foo", anvilCR("v1", "", 0))
+	err = nt.Validate("heavy", "foo", newAnvilObject("v1", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -128,13 +128,13 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	crdObj := rootSyncGitRepo.MustGet(nt.T, "acme/cluster/anvil-crd.yaml")
 	nsObj := k8sobjects.NamespaceObject("prod")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/ns.yaml", nsObj))
-	anvilObj := anvilCR("v1", "e2e-test-anvil", 10)
+	anvilObj := newAnvilObject("v1", "e2e-test-anvil", 10)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/anvil.yaml", anvilObj))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Adding Anvil CRD and one Anvil CR"))
 	nt.Must(nt.WatchForAllSyncs())
 	nt.RenewClient()
 
-	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
+	err = nt.Validate("e2e-test-anvil", "prod", newAnvilObject("v1", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func addAndRemoveCustomResource(nt *nomostest.NT, dir string, crd string) {
 	nt.Must(rootSyncGitRepo.Remove("acme/namespaces/prod/anvil.yaml"))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Removing Anvil CR but leaving Anvil CRD"))
 	nt.Must(nt.WatchForAllSyncs())
-	err = nt.ValidateNotFound("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
+	err = nt.ValidateNotFound("e2e-test-anvil", "prod", newAnvilObject("v1", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func mustRemoveUnManagedCustomResource(nt *nomostest.NT, dir string, crd string)
 	}
 
 	// Apply the CustomResource.
-	cr := anvilCR("v1", "e2e-test-anvil", 100)
+	cr := newAnvilObject("v1", "e2e-test-anvil", 100)
 	cr.SetNamespace("prod")
 	err = nt.KubeClient.Create(cr)
 	if err != nil {
@@ -341,7 +341,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	}
 	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/anvil-crd.yaml", crdContent))
 	crdObj := rootSyncGitRepo.MustGet(nt.T, "acme/cluster/anvil-crd.yaml")
-	anvilObj := anvilCR("v1", "e2e-test-anvil", 10)
+	anvilObj := newAnvilObject("v1", "e2e-test-anvil", 10)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/anvil.yaml", anvilObj))
 	nsObj := k8sobjects.NamespaceObject("prod")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/ns.yaml", nsObj))
@@ -349,7 +349,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.Must(nt.WatchForAllSyncs())
 	nt.RenewClient()
 
-	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v1", "", 10))
+	err = nt.Validate("e2e-test-anvil", "prod", newAnvilObject("v1", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Updating the Anvil CRD"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v2", "", 10))
+	err = nt.Validate("e2e-test-anvil", "prod", newAnvilObject("v2", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 		nt.T.Fatal(err)
 	}
 	nt.Must(rootSyncGitRepo.AddFile("acme/cluster/anvil-crd.yaml", crdContent))
-	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/anvil.yaml", anvilCR("v2", "e2e-test-anvil", 10)))
+	nt.Must(rootSyncGitRepo.Add("acme/namespaces/prod/anvil.yaml", newAnvilObject("v2", "e2e-test-anvil", 10)))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Update the Anvil CRD and CR"))
 	nt.Must(nt.WatchForAllSyncs())
 
@@ -401,7 +401,7 @@ func addUpdateNamespaceScopedCRD(nt *nomostest.NT, dir string, crd string) {
 		nt.T.Fatal(err)
 	}
 
-	err = nt.Validate("e2e-test-anvil", "prod", anvilCR("v2", "", 10))
+	err = nt.Validate("e2e-test-anvil", "prod", newAnvilObject("v2", "", 10))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -501,7 +501,7 @@ func hasTwoVersions(obj client.Object) error {
 }
 
 func clusteranvilCR(version, name string, weight int64) *unstructured.Unstructured {
-	u := anvilCR(version, name, weight)
+	u := newAnvilObject(version, name, weight)
 	gvk := u.GroupVersionKind()
 	gvk.Kind = "ClusterAnvil"
 	u.SetGroupVersionKind(gvk)

--- a/e2e/testcases/multiversion_test.go
+++ b/e2e/testcases/multiversion_test.go
@@ -48,35 +48,35 @@ func TestMultipleVersions_CustomResourceV1(t *testing.T) {
 	// Add the v1 Anvils and verify they are created.
 	nsObj := k8sobjects.NamespaceObject("foo")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/ns.yaml", nsObj))
-	anvilv1Obj := anvilCR("v1", "first", 10)
+	anvilv1Obj := newAnvilObject("v1", "first", 10)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
-	anvilv2Obj := anvilCR("v2", "second", 100)
+	anvilv2Obj := newAnvilObject("v2", "second", 100)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Adding v1 and v2 Anvil CRs"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	err := nt.Validate("first", "foo", anvilCR("v1", "", 0))
+	err := nt.Validate("first", "foo", newAnvilObject("v1", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate("second", "foo", anvilCR("v2", "", 0))
+	err = nt.Validate("second", "foo", newAnvilObject("v2", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
 
 	// Modify the v1 Anvils and verify they are updated.
-	anvilv1Obj = anvilCR("v1", "first", 20)
+	anvilv1Obj = newAnvilObject("v1", "first", 20)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv1.yaml", anvilv1Obj))
-	anvilv2Obj = anvilCR("v2", "second", 200)
+	anvilv2Obj = newAnvilObject("v2", "second", 200)
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/foo/anvilv2.yaml", anvilv2Obj))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Modifying v1 and v2 Anvil CRs"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	err = nt.Validate("first", "foo", anvilCR("v1", "", 0))
+	err = nt.Validate("first", "foo", newAnvilObject("v1", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
-	err = nt.Validate("second", "foo", anvilCR("v2", "", 0))
+	err = nt.Validate("second", "foo", newAnvilObject("v2", "", 0))
 	if err != nil {
 		nt.T.Fatal(err)
 	}
@@ -155,9 +155,9 @@ func anvilV1CRD() *apiextensionsv1.CustomResourceDefinition {
 	return crd
 }
 
-func anvilCR(version, name string, weight int64) *unstructured.Unstructured {
+func newAnvilObject(version, name string, weight int64) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(anvilGVK(version))
+	u.SetGroupVersionKind(newAnvilGVK(version))
 	if name != "" {
 		u.SetName(name)
 	}
@@ -169,7 +169,7 @@ func anvilCR(version, name string, weight int64) *unstructured.Unstructured {
 	return u
 }
 
-func anvilGVK(version string) schema.GroupVersionKind {
+func newAnvilGVK(version string) schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   "acme.com",
 		Version: version,

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -23,7 +23,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"kpt.dev/configsync/e2e/nomostest"
-	"kpt.dev/configsync/e2e/nomostest/retry"
 	nomostesting "kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/e2e/nomostest/testresourcegroup"
@@ -32,12 +31,12 @@ import (
 	"kpt.dev/configsync/pkg/api/configmanagement"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
-	"kpt.dev/configsync/pkg/applier"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/reconcilermanager"
 	"kpt.dev/configsync/pkg/resourcegroup"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestResourceGroupController(t *testing.T) {
@@ -61,21 +60,11 @@ func TestResourceGroupController(t *testing.T) {
 	nt.Must(rootSyncGitRepo.CommitAndPush("Adding a ConfigMap to repo"))
 	nt.Must(nt.WatchForAllSyncs())
 
-	// Checking that the ResourceGroup controller captures the status of the
-	// managed resources.
-	id := applier.InventoryID(configsync.RootSyncName, configsync.ControllerNamespace)
-	_, err := retry.Retry(60*time.Second, func() error {
-		rg := resourcegroup.Unstructured(configsync.RootSyncName, configsync.ControllerNamespace, id)
-		err := nt.Validate(configsync.RootSyncName, configsync.ControllerNamespace, rg,
-			testpredicates.AllResourcesReconciled(nt.Scheme))
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), configsync.RootSyncName, configsync.ControllerNamespace,
+		testwatcher.WatchPredicates(
+			testpredicates.AllResourcesReconciled(nt.Scheme),
+		)))
 }
 
 func TestResourceGroupControllerInKptGroup(t *testing.T) {
@@ -88,24 +77,25 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
-		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
-			nt.T.Error(err)
-		}
+		ns := k8sobjects.NamespaceObject(namespace)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, ns))
 	})
-	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)))
+
+	nt.T.Log("Create a ResourceGroup")
 	rgNN := types.NamespacedName{
 		Name:      "group-a",
 		Namespace: namespace,
 	}
 	resourceID := rgNN.Name
+	nt.T.Cleanup(func() {
+		rg := testresourcegroup.New(rgNN, resourceID)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, rg))
+	})
 	rg := testresourcegroup.New(rgNN, resourceID)
-	if err := nt.KubeClient.Create(rg); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(rg))
 
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
@@ -113,6 +103,7 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
 
+	nt.T.Log("Add a ConfigMap to the ResourceGroup spec")
 	resources := []v1alpha1.ObjMetadata{
 		{
 			Name:      "example",
@@ -123,28 +114,48 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			},
 		},
 	}
-	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
-		rg.Spec.Resources = resources
-	}))
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	rg.Spec.Resources = resources
+	nt.Must(nt.KubeClient.Update(rg))
 
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
+	expectedStatus.ObservedGeneration = 2
+	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
+		{
+			ObjMetadata: resources[0],
+			Status:      v1alpha1.NotFound,
+		},
+	}
+	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
+		testwatcher.WatchPredicates(
+			testpredicates.ResourceGroupStatusEquals(expectedStatus),
+		)))
+
+	nt.T.Log("Create a ResourceGroup to use as a Subgroup")
 	subRGNN := types.NamespacedName{
 		Name:      "group-b",
 		Namespace: rgNN.Namespace,
 	}
+	nt.T.Cleanup(func() {
+		subRG := testresourcegroup.New(subRGNN, subRGNN.Name)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, subRG))
+	})
 	subRG := testresourcegroup.New(subRGNN, subRGNN.Name)
-	if err := nt.KubeClient.Create(subRG); err != nil {
-		nt.T.Fatal(err)
+	nt.Must(nt.KubeClient.Create(subRG))
+
+	nt.T.Log("Add the new ResourceGroup as a Subgroup to the ResourceGroup spec")
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	rg.Spec.Subgroups = []v1alpha1.GroupMetadata{
+		{
+			Name:      subRGNN.Name,
+			Namespace: subRGNN.Namespace,
+		},
 	}
+	nt.Must(nt.KubeClient.Update(rg))
 
-	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
-		rg.Spec.Subgroups = []v1alpha1.GroupMetadata{
-			{
-				Name:      subRGNN.Name,
-				Namespace: subRGNN.Namespace,
-			},
-		}
-	}))
-
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ObservedGeneration = 3
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
@@ -169,17 +180,15 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			},
 		},
 	}
-
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		), testwatcher.WatchTimeout(time.Minute)))
 
-	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, resourceID); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.T.Log("Simulate the Reconciler applying the managed resources")
+	nt.Must(testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, resourceID))
 
-	expectedStatus.ObservedGeneration = 3
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
 			ObjMetadata: resources[0],
@@ -187,15 +196,15 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			SourceHash:  "1234567",
 		},
 	}
-
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		), testwatcher.WatchTimeout(time.Minute)))
 
-	if err := testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, "another"); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.T.Log("Simulate a different Reconciler adopting the managed resources")
+	nt.Must(testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources, "another"))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
 			ObjMetadata: resources[0],
@@ -211,22 +220,13 @@ func TestResourceGroupControllerInKptGroup(t *testing.T) {
 			},
 		},
 	}
-
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		), testwatcher.WatchTimeout(time.Minute)))
 
-	if err := nt.KubeClient.Delete(rg); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.KubeClient.Delete(subRG); err != nil {
-		nt.T.Fatal(err)
-	}
-
-	if err := testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.T.Log("Validate that the ResourceGroupController Pods did not crash/exit/restart")
+	nt.Must(testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient))
 }
 
 func TestResourceGroupCustomResource(t *testing.T) {
@@ -239,45 +239,50 @@ func TestResourceGroupCustomResource(t *testing.T) {
 
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
-		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
-			nt.T.Error(err)
-		}
+		ns := k8sobjects.NamespaceObject(namespace)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, ns))
 	})
-	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)))
+
+	nt.T.Log("Create a ResourceGroup")
 	rgNN := types.NamespacedName{
 		Name:      "group-d",
 		Namespace: namespace,
 	}
 	resourceID := rgNN.Name
+	nt.T.Cleanup(func() {
+		rg := testresourcegroup.New(rgNN, resourceID)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, rg))
+	})
 	rg := testresourcegroup.New(rgNN, resourceID)
-	if err := nt.KubeClient.Create(rg); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(rg))
 
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
-	crdObj := anvilV1CRD()
-	crdGVK := anvilGVK("v1")
+
+	nt.T.Log("Add an Anvil object to the ResourceGroup spec")
+	anvilGVK := anvilGVK("v1")
 	resources := []v1alpha1.ObjMetadata{
 		{
 			Name:      "example",
 			Namespace: namespace,
 			GroupKind: v1alpha1.GroupKind{
-				Group: crdGVK.Group,
-				Kind:  crdGVK.Kind,
+				Group: anvilGVK.Group,
+				Kind:  anvilGVK.Kind,
 			},
 		},
 	}
-	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
-		rg.Spec.Resources = resources
-	}))
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	rg.Spec.Resources = resources
+	nt.Must(nt.KubeClient.Update(rg))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ObservedGeneration = 2
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
@@ -289,32 +294,27 @@ func TestResourceGroupCustomResource(t *testing.T) {
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
-	// Create CRD and CR
+
+	nt.T.Log("Create Anvil CRD")
 	nt.T.Cleanup(func() {
 		crdObj := anvilV1CRD()
-		if err := nt.KubeClient.Delete(crdObj); err != nil && !apierrors.IsNotFound(err) {
-			nt.T.Error(err)
-		}
+		nt.Must(kubeDeleteIgnoreNotFound(nt, crdObj))
 	})
-	if err := nt.KubeClient.Create(crdObj); err != nil {
-		nt.T.Fatal(err)
-	}
-	if err := nt.Watcher.WatchForCurrentStatus(kinds.CustomResourceDefinitionV1(), crdObj.Name, ""); err != nil {
-		nt.T.Fatal(err)
-	}
-	anvilObj := anvilCR("v1", resources[0].Name, 10)
-	anvilObj.SetNamespace(resources[0].Namespace)
+	crdObj := anvilV1CRD()
+	nt.Must(nt.KubeClient.Create(crdObj))
+	nt.Must(nt.Watcher.WatchForCurrentStatus(kinds.CustomResourceDefinitionV1(), crdObj.Name, ""))
+
+	nt.T.Log("Create Anvil object")
 	nt.T.Cleanup(func() {
 		anvilObj := anvilCR("v1", resources[0].Name, 10)
 		anvilObj.SetNamespace(resources[0].Namespace)
-		if err := nt.KubeClient.Delete(anvilObj); err != nil && !apierrors.IsNotFound(err) {
-			nt.T.Error(err)
-		}
+		nt.Must(kubeDeleteIgnoreNotFound(nt, anvilObj))
 	})
-	if err := nt.KubeClient.Create(anvilObj); err != nil {
-		nt.T.Fatal(err)
-	}
-	// assert status is updated
+	anvilObj := anvilCR("v1", resources[0].Name, 10)
+	anvilObj.SetNamespace(resources[0].Namespace)
+	nt.Must(nt.KubeClient.Create(anvilObj))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
 			ObjMetadata: resources[0],
@@ -333,9 +333,11 @@ func TestResourceGroupCustomResource(t *testing.T) {
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
-	if err := nt.KubeClient.Delete(crdObj); err != nil {
-		nt.T.Fatal(err)
-	}
+
+	nt.T.Log("Delete the Anvil CRD (k8s should delete all the Anvil objects too)")
+	nt.Must(nt.KubeClient.Delete(crdObj))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
 			ObjMetadata: resources[0],
@@ -358,24 +360,25 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 
 	namespace := "resourcegroup-e2e"
 	nt.T.Cleanup(func() {
-		// all test resources are created in this namespace
-		if err := nt.KubeClient.Delete(k8sobjects.NamespaceObject(namespace)); err != nil {
-			nt.T.Error(err)
-		}
+		ns := k8sobjects.NamespaceObject(namespace)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, ns))
 	})
-	if err := nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(k8sobjects.NamespaceObject(namespace)))
+
+	nt.T.Log("Create a ResourceGroup")
 	rgNN := types.NamespacedName{
 		Name:      "group-e",
 		Namespace: namespace,
 	}
 	resourceID := rgNN.Name
+	nt.T.Cleanup(func() {
+		rg := testresourcegroup.New(rgNN, resourceID)
+		nt.Must(kubeDeleteIgnoreNotFound(nt, rg))
+	})
 	rg := testresourcegroup.New(rgNN, resourceID)
-	if err := nt.KubeClient.Create(rg); err != nil {
-		nt.T.Fatal(err)
-	}
+	nt.Must(nt.KubeClient.Create(rg))
 
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus := testresourcegroup.EmptyStatus()
 	expectedStatus.ObservedGeneration = 1
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
@@ -383,7 +386,6 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
 
-	nt.T.Log("Create and apply ConfigMaps")
 	resources := []v1alpha1.ObjMetadata{
 		{
 			Name:      "test-status-0",
@@ -442,11 +444,17 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 			},
 		},
 	}
+
 	nt.T.Log("Apply all but the last ConfigMap to test NotFound error")
 	nt.Must(testresourcegroup.CreateOrUpdateResources(nt.KubeClient, resources[:len(resources)-1], resourceID))
-	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
-		rg.Spec.Resources = resources
-	}))
+
+	nt.T.Log("Update the ResourceGroup spec")
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	rg.Spec.Resources = resources
+	nt.Must(nt.KubeClient.Update(rg))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	expectedStatus.ObservedGeneration = 2
 	expectedStatus.ResourceStatuses = []v1alpha1.ResourceStatus{
 		{
@@ -489,21 +497,23 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
 
-	nt.T.Log("inject resource status to verify reconcile behavior")
-	nt.Must(testresourcegroup.UpdateResourceGroup(nt.KubeClient, rgNN, func(rg *v1alpha1.ResourceGroup) {
-		rg.Status.ResourceStatuses = nil
-	}))
-	nt.T.Log("verify that the controller reconciles to the original status")
+	nt.T.Log("Update the ResourceGroup to clear resource status")
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	rg.Status.ResourceStatuses = nil
+	nt.Must(nt.KubeClient.UpdateStatus(rg))
+
+	nt.T.Log("Wait for the ResourceGroupController to update the ResourceGroup status")
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceGroupStatusEquals(expectedStatus),
 		)))
-	actualRG := &v1alpha1.ResourceGroup{}
-	if err := nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, actualRG); err != nil {
-		nt.T.Fatal(err)
-	}
-	resourceVersion := actualRG.ResourceVersion
-	nt.T.Log("Wait and check to see we don't cause an infinite/recursive reconcile loop by ensuring the resourceVersion doesn't change.")
+
+	rg = &v1alpha1.ResourceGroup{}
+	nt.Must(nt.KubeClient.Get(rgNN.Name, rgNN.Namespace, rg))
+	resourceVersion := rg.ResourceVersion
+
+	nt.T.Log("Wait 60s to validate that the ResourceGroupController doesn't make any more updates (no resourceVersion change)")
 	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceVersionNotEquals(nt.Scheme, resourceVersion),
@@ -516,12 +526,15 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	nt.T.Log("Delete the ResourceGroup")
-	if err := nt.KubeClient.Delete(rg); err != nil {
-		nt.T.Fatal(err)
+	nt.T.Log("Validate that the ResourceGroupController Pods did not crash/exit/restart")
+	nt.Must(testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient))
+}
+
+func kubeDeleteIgnoreNotFound(nt *nomostest.NT, obj client.Object) error {
+	if err := nt.KubeClient.Delete(obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
-	nt.T.Log("Assert that the controller pods did not restart")
-	if err := testresourcegroup.ValidateNoControllerPodRestarts(nt.KubeClient); err != nil {
-		nt.T.Fatal(err)
-	}
+	return nil
 }

--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -266,7 +266,7 @@ func TestResourceGroupCustomResource(t *testing.T) {
 		)))
 
 	nt.T.Log("Add an Anvil object to the ResourceGroup spec")
-	anvilGVK := anvilGVK("v1")
+	anvilGVK := newAnvilGVK("v1")
 	resources := []v1alpha1.ObjMetadata{
 		{
 			Name:      "example",
@@ -306,11 +306,11 @@ func TestResourceGroupCustomResource(t *testing.T) {
 
 	nt.T.Log("Create Anvil object")
 	nt.T.Cleanup(func() {
-		anvilObj := anvilCR("v1", resources[0].Name, 10)
+		anvilObj := newAnvilObject("v1", resources[0].Name, 10)
 		anvilObj.SetNamespace(resources[0].Namespace)
 		nt.Must(kubeDeleteIgnoreNotFound(nt, anvilObj))
 	})
-	anvilObj := anvilCR("v1", resources[0].Name, 10)
+	anvilObj := newAnvilObject("v1", resources[0].Name, 10)
 	anvilObj.SetNamespace(resources[0].Namespace)
 	nt.Must(nt.KubeClient.Create(anvilObj))
 


### PR DESCRIPTION
Pulled out most these changed from https://github.com/GoogleContainerTools/kpt-config-sync/pull/1575, which should make it easier to see the coordination changes in that PR if this one merges first.

Dependencies:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1591