### PR TITLE
test: fix coredns helm chart to reconcile

### DIFF
--- a/e2e/testdata/helm-charts/coredns/templates/configmap.yaml
+++ b/e2e/testdata/helm-charts/coredns/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/e2e/testdata/helm-charts/coredns/templates/service.yaml
+++ b/e2e/testdata/helm-charts/coredns/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/e2e/testdata/helm-charts/coredns/templates/serviceaccount.yaml
+++ b/e2e/testdata/helm-charts/coredns/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "coredns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}


### PR DESCRIPTION
The ConfigMap and Service were always created in the default namespace, which resulted in the Deployment never being able to reconcile. This change ensures the other objects are created in the same namespace as the Deployment.