### PR TITLE
test: fix ResourceGroup expectations

### DIFF
--- a/e2e/nomostest/sync.go
+++ b/e2e/nomostest/sync.go
@@ -17,16 +17,21 @@ package nomostest
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"kpt.dev/configsync/e2e/nomostest/testpredicates"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/parse"
 	"kpt.dev/configsync/pkg/reposync"
 	"kpt.dev/configsync/pkg/resourcegroup"
 	"kpt.dev/configsync/pkg/rootsync"
 	"kpt.dev/configsync/pkg/util/log"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -266,7 +271,7 @@ func statusHasSyncDirAndNoErrors(status v1beta1.Status, sourceType configsync.So
 	return nil
 }
 
-func resourceGroupHasReconciled(sourceHash string) testpredicates.Predicate {
+func resourceGroupHasReconciled(commit string, scheme *runtime.Scheme) testpredicates.Predicate {
 	return func(o client.Object) error {
 		if o == nil {
 			return testpredicates.ErrObjectNotFound
@@ -276,47 +281,49 @@ func resourceGroupHasReconciled(sourceHash string) testpredicates.Predicate {
 			return testpredicates.WrongTypeErr(o, &v1alpha1.ResourceGroup{})
 		}
 
-		// Status is disabled for this ResourceGroup, skip all status checks
+		// If status is disabled for this ResourceGroup, skip all status checks
 		if resourcegroup.IsStatusDisabled(rg) {
 			return testpredicates.ResourceGroupHasNoStatus()(o)
 		}
 
-		if len(rg.Spec.Resources) != len(rg.Status.ResourceStatuses) {
-			return fmt.Errorf("length of spec.resources (%d) does not equal length of status.resourceStatuses (%d)",
-				len(rg.Spec.Resources), len(rg.Status.ResourceStatuses))
+		// Test status.observedGeneration matches metadata.generation
+		if err := testpredicates.HasObservedLatestGeneration(scheme)(o); err != nil {
+			return err
 		}
 
-		resourceCount := make(map[v1alpha1.ObjMetadata]int)
-		for _, s := range rg.Status.ResourceStatuses {
-			if err := resourceStatusIsCurrent(s, sourceHash); err != nil {
-				return fmt.Errorf("object %s is not current: %w", s.ObjMetadata, err)
-			}
-			resourceCount[s.ObjMetadata]++
+		// Test that metadata.deletionTimestamp is missing, and conditions do not include Reconciling=True or Stalled=True
+		if err := testpredicates.StatusEquals(scheme, kstatus.CurrentStatus)(o); err != nil {
+			return err
 		}
 
-		for _, o := range rg.Spec.Resources {
-			if count, ok := resourceCount[o]; ok && count > 0 {
-				resourceCount[o]--
-			} else {
-				return fmt.Errorf("spec.resources does not equal status.resourceStatuses")
+		// Test that Stalled condition exists and is "False".
+		// This ensures the condition wasn't removed by the applier.
+		if err := testpredicates.HasConditionStatus(scheme, string(v1alpha1.Stalled), corev1.ConditionFalse)(o); err != nil {
+			return err
+		}
+
+		// Test that all the spec.resources exist in the status.resourceStatuses,
+		// and that all deleted objects were removed by the applier.
+		shortCommit := resourcegroup.TruncateSourceHash(commit)
+		found := rg.Status.ResourceStatuses
+		expected := make([]v1alpha1.ResourceStatus, len(rg.Spec.Resources))
+		for i, resource := range rg.Spec.Resources {
+			expected[i] = v1alpha1.ResourceStatus{
+				ObjMetadata: *resource.DeepCopy(),
+				Status:      v1alpha1.Current,
+				Strategy:    v1alpha1.Apply,
+				Actuation:   v1alpha1.ActuationSucceeded,
+				Reconcile:   v1alpha1.ReconcileSucceeded,
+				SourceHash:  shortCommit,
+				Conditions:  nil,
 			}
 		}
+		if !equality.Semantic.DeepEqual(found, expected) {
+			return fmt.Errorf("status.resourceStatuses does not match expected value in %s:\nDiff (- Expected, + Found)\n%s",
+				kinds.ObjectSummary(o), log.AsYAMLDiff(expected, found))
+		}
+
+		// Note: status.subgroupStatuses is ignored
 		return nil
 	}
-}
-
-func resourceStatusIsCurrent(rs v1alpha1.ResourceStatus, sourceHash string) error {
-	if rs.Status != v1alpha1.Current {
-		return fmt.Errorf("resourceStatus.status is not %s. Got %s", v1alpha1.Current, rs.Status)
-	}
-	if rs.Actuation != v1alpha1.ActuationSucceeded {
-		return fmt.Errorf("resourceStatus.actuation is not %s. Got %s", v1alpha1.ActuationSucceeded, rs.Actuation)
-	}
-	if rs.Reconcile != v1alpha1.ReconcileSucceeded {
-		return fmt.Errorf("resourceStatus.reconcile is not %s. Got %s", v1alpha1.ReconcileSucceeded, rs.Reconcile)
-	}
-	if rs.SourceHash != resourcegroup.TruncateSourceHash(sourceHash) {
-		return fmt.Errorf("resourceStatus.sourceHash is not %s. Got %s", sourceHash, rs.SourceHash)
-	}
-	return nil
 }

--- a/e2e/testcases/status_enablement_test.go
+++ b/e2e/testcases/status_enablement_test.go
@@ -46,13 +46,13 @@ func TestStatusEnabledAndDisabled(t *testing.T) {
 	rootSync := k8sobjects.RootSyncObjectV1Alpha1(configsync.RootSyncName)
 	// Override the statusMode for root-reconciler
 	nt.MustMergePatch(rootSync, `{"spec": {"override": {"statusMode": "disabled"}}}`)
-	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
+	nt.Must(nt.WatchForAllSyncs())
 
 	namespaceName := "status-test"
 	nt.Must(rootSyncGitRepo.Add("acme/ns.yaml", namespaceObject(namespaceName, nil)))
 	nt.Must(rootSyncGitRepo.Add("acme/cm1.yaml", k8sobjects.ConfigMapObject(core.Name("cm1"), core.Namespace(namespaceName))))
 	nt.Must(rootSyncGitRepo.CommitAndPush("Add a namespace and a configmap"))
-	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
+	nt.Must(nt.WatchForAllSyncs())
 
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(),
 		configsync.RootSyncName, configsync.ControllerNamespace,

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -257,8 +257,7 @@ func TestStressLargeRequest(t *testing.T) {
 	nomostest.SetExpectedGitCommit(nt, rootSyncID, commit)
 
 	nt.T.Logf("Wait for the sync to complete")
-	// Skip ResourceGroup checks because the managed objects do not reconcile
-	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
+	nt.Must(nt.WatchForAllSyncs())
 }
 
 // TestStress100CRDs applies 100 CRDs and validates that syncing still works.
@@ -342,8 +341,7 @@ func TestStressManyDeployments(t *testing.T) {
 
 	// Validate that the resources sync without the reconciler running out of
 	// memory, getting OOMKilled, and crash looping.
-	// Skip ResourceGroup checks because it takes too long for this many Deployments to reconcile
-	nt.Must(nt.WatchForAllSyncs(nomostest.SkipAllResourceGroupChecks()))
+	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Logf("Verify the number of Deployment objects")
 	nt.Must(validateNumberOfObjectsEquals(nt, kinds.Deployment(), deployCount,


### PR DESCRIPTION
- Conditions will be empty when status is disabled
- status.observedGeneration will be 0 when status is disabled
- Validate status.resourceStatuses with DeepEqual and log the yaml diff on error

Extracted:
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1601
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1602
- https://github.com/GoogleContainerTools/kpt-config-sync/pull/1603