### PR TITLE
test: Fix TestStressManyDeployments reconciling

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -211,11 +211,13 @@ var GKEClusterVersion = flag.String("gke-cluster-version", util.EnvString("GKE_C
 	"GKE cluster version to use when creating GKE clusters. Defaults to GKE_CLUSTER_VERSION env var.")
 
 // GKEMachineType is the GKE machine type to use when creating GKE clusters.
-var GKEMachineType = flag.String("gke-machine-type", util.EnvString("GKE_MACHINE_TYPE", DefaultGKEMachineType),
+// See testcases.setDefaultArgs for dynamic defaults.
+var GKEMachineType = flag.String("gke-machine-type", "",
 	"GKE machine type to use when creating GKE clusters. Defaults to GKE_MACHINE_TYPE env var.")
 
 // GKEDiskSize is the GKE disk size to use when creating GKE clusters.
-var GKEDiskSize = flag.String("gke-disk-size", util.EnvString("GKE_DISK_SIZE", DefaultGKEDiskSize),
+// See testcases.setDefaultArgs for dynamic defaults.
+var GKEDiskSize = flag.String("gke-disk-size", "",
 	"GKE disk size to use when creating GKE clusters. Defaults to GKE_DISK_SIZE env var.")
 
 // GKEDiskType is the GKE disk type to use when creating GKE clusters.
@@ -223,7 +225,8 @@ var GKEDiskType = flag.String("gke-disk-type", util.EnvString("GKE_DISK_TYPE", D
 	"GKE disk type to use when creating GKE clusters. Defaults to GKE_DISK_TYPE env var.")
 
 // GKENumNodes is the number of nodes to use when creating GKE clusters.
-var GKENumNodes = flag.Int("gke-num-nodes", util.EnvInt("GKE_NUM_NODES", DefaultGKENumNodes),
+// See testcases.setDefaultArgs for dynamic defaults.
+var GKENumNodes = flag.Int("gke-num-nodes", 0,
 	"Number of node to use when creating GKE clusters. Defaults to GKE_NUM_NODES env var.")
 
 // GKEAutopilot indicates whether to enable autopilot when creating GKE clusters.
@@ -257,12 +260,21 @@ const (
 	DefaultGKEChannel = "regular"
 	// DefaultGKEMachineType is the default GKE machine type to use when creating a cluster
 	DefaultGKEMachineType = "n2-standard-8"
+	// DefaultGKEMachineTypeForStress is the default GKE machine type to
+	// use when creating a GKE cluster for stress tests.
+	DefaultGKEMachineTypeForStress = "n2-standard-4"
 	// DefaultGKENumNodes is the default number of nodes to use when creating a GKE cluster
 	DefaultGKENumNodes = 1
+	// DefaultGKENumNodesForStress is the default number of nodes to use
+	// when creating a GKE cluster for stress tests.
+	DefaultGKENumNodesForStress = 4
 	// DefaultGKEDiskType is the default disk type to use when creating a cluster
 	DefaultGKEDiskType = "pd-ssd"
 	// DefaultGKEDiskSize is the default disk size to use when creating a GKE cluster
 	DefaultGKEDiskSize = "50Gb"
+	// DefaultGKEDiskSizeForStress is the default disk size to use when creating
+	// a GKE cluster for stress tests.
+	DefaultGKEDiskSizeForStress = "25Gb"
 	// CreateClustersEnabled indicates that clusters should be created and error
 	// if the cluster already exists.
 	CreateClustersEnabled = "true"

--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -17,7 +17,6 @@ package nomostest
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -153,7 +152,7 @@ func RestConfig(t testing.NTB, opts *ntopts.New) {
 	t.Logf("Connect to %s cluster using:\nexport KUBECONFIG=%s", *e2e.TestCluster, opts.KubeconfigPath)
 	opts.ClusterName = opts.Name
 	var cluster Cluster
-	switch strings.ToLower(*e2e.TestCluster) {
+	switch *e2e.TestCluster {
 	case e2e.Kind:
 		cluster = &clusters.KindCluster{
 			T:                 t,

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -317,6 +317,9 @@ func TestStress100CRDs(t *testing.T) {
 // This ensures that Config Sync can apply resources while the cluster control
 // plane is autoscaling up to meet demand. This requires cluster autoscaling to
 // be enabled.
+//
+// This test needs at least 10 nodes on GKE, due to the 110 pods per node limit.
+// See DefaultGKENumNodesForStressTests for the exact number of nodes per zone.
 func TestStressManyDeployments(t *testing.T) {
 	nt := nomostest.New(t, nomostesting.Reconciliation1, ntopts.StressTest,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),


### PR DESCRIPTION
For stress tests, use more smaller nodes:
- 3 -> 12 nodes
- n2-standard-8 -> n2-standard-4
- 50Gb -> 25Gb disks

This works around the 110 pod per node limit in GKE, allowing the test to schedule 1,000 pods. The pods are tiny and just sleep.