### PR TITLE
feat: Delete the ResourceGroup when the RSync is deleted

### DIFF
--- a/e2e/testcases/reconciler_finalizer_test.go
+++ b/e2e/testcases/reconciler_finalizer_test.go
@@ -128,6 +128,10 @@ func TestReconcilerFinalizer_Orphan(t *testing.T) {
 				testpredicates.HasLabel(metadata.ApplySetPartOfLabel, applySetID),
 			))
 	})
+	tg.Go(func() error {
+		// ResourceGroup SHOULD have been deleted
+		return nt.Watcher.WatchForNotFound(kinds.ResourceGroup(), rootSync.GetName(), rootSync.GetNamespace())
+	})
 
 	nt.Must(tg.Wait())
 
@@ -348,6 +352,9 @@ func TestReconcilerFinalizer_MultiLevelForeground(t *testing.T) {
 		return nt.Watcher.WatchForNotFound(kinds.Namespace(), namespace1.GetName(), namespace1.GetNamespace())
 	})
 	tg.Go(func() error {
+		return nt.Watcher.WatchForNotFound(kinds.ResourceGroup(), rootSync.GetName(), rootSync.GetNamespace())
+	})
+	tg.Go(func() error {
 		return nt.Watcher.WatchForNotFound(kinds.RootSyncV1Beta1(), rootSync.GetName(), rootSync.GetNamespace())
 	})
 	if err := tg.Wait(); err != nil {
@@ -462,6 +469,9 @@ func TestReconcilerFinalizer_MultiLevelMixed(t *testing.T) {
 	tg.Go(func() error {
 		// RepoSync should delete quickly without finalizing
 		return nt.Watcher.WatchForNotFound(kinds.RepoSyncV1Beta1(), repoSync.GetName(), repoSync.GetNamespace())
+	})
+	tg.Go(func() error {
+		return nt.Watcher.WatchForNotFound(kinds.ResourceGroup(), rootSync.GetName(), rootSync.GetNamespace())
 	})
 	tg.Go(func() error {
 		// After RepoSync and Deployment1 are deleted, the RootSync should have its finalizer removed and be garbage collected

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -45,6 +45,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/testwatcher"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/configsync/v1beta1"
+	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/core/k8sobjects"
 	"kpt.dev/configsync/pkg/kinds"
@@ -396,6 +397,11 @@ func validateRootSyncDependencies(nt *nomostest.NT, rsName string) []client.Obje
 	setNN(rootSyncSA, client.ObjectKeyFromObject(rootSyncReconciler))
 	rootSyncDependencies = append(rootSyncDependencies, rootSyncSA)
 
+	resourceGroup := &v1alpha1.ResourceGroup{}
+	resourceGroup.Name = rsName
+	resourceGroup.Namespace = configsync.ControllerNamespace
+	rootSyncDependencies = append(rootSyncDependencies, resourceGroup)
+
 	for _, obj := range rootSyncDependencies {
 		err := nt.Validate(obj.GetName(), obj.GetNamespace(), obj)
 		require.NoError(nt.T, err)
@@ -422,6 +428,12 @@ func validateRepoSyncDependencies(nt *nomostest.NT, ns, rsName string) []client.
 	repoSyncSA := &corev1.ServiceAccount{}
 	setNN(repoSyncSA, client.ObjectKeyFromObject(repoSyncReconciler))
 	repoSyncDependencies = append(repoSyncDependencies, repoSyncSA)
+
+	resourceGroup := &v1alpha1.ResourceGroup{}
+	resourceGroup.Name = rsName
+	resourceGroup.Namespace = ns
+
+	repoSyncDependencies = append(repoSyncDependencies, resourceGroup)
 
 	// See nomostest.CreateNamespaceSecrets for creation of user secrets.
 	// The Secret is neither needed nor created when using CSR as the Git provider.

--- a/pkg/core/scheme.go
+++ b/pkg/core/scheme.go
@@ -40,7 +40,7 @@ import (
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
-	kptdevv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
+	kptv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 )
 
 // Scheme is a reference to the global scheme.
@@ -76,7 +76,7 @@ func init() {
 	utilruntime.Must(hubv1.AddToScheme(scheme.Scheme))
 
 	// ResourceGroup
-	utilruntime.Must(kptdevv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(kptv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func mustRegisterKubernetesResources() {

--- a/pkg/core/scheme.go
+++ b/pkg/core/scheme.go
@@ -40,6 +40,7 @@ import (
 	configsyncv1alpha1 "kpt.dev/configsync/pkg/api/configsync/v1alpha1"
 	configsyncv1beta1 "kpt.dev/configsync/pkg/api/configsync/v1beta1"
 	hubv1 "kpt.dev/configsync/pkg/api/hub/v1"
+	kptdevv1alpha1 "kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 )
 
 // Scheme is a reference to the global scheme.
@@ -73,6 +74,9 @@ func init() {
 
 	// Hub/Fleet types
 	utilruntime.Must(hubv1.AddToScheme(scheme.Scheme))
+
+	// ResourceGroup
+	utilruntime.Must(kptdevv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func mustRegisterKubernetesResources() {

--- a/pkg/reconcilermanager/controllers/garbage_collector.go
+++ b/pkg/reconcilermanager/controllers/garbage_collector.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"kpt.dev/configsync/pkg/api/configsync"
+	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/kinds"
 	"kpt.dev/configsync/pkg/metadata"
@@ -144,6 +145,13 @@ func (r *reconcilerBase) deleteServiceAccount(ctx context.Context, reconcilerRef
 	sa.Name = reconcilerRef.Name
 	sa.Namespace = reconcilerRef.Namespace
 	return r.cleanup(ctx, sa)
+}
+
+func (r *reconcilerBase) deleteResourceGroup(ctx context.Context, rsRef types.NamespacedName) error {
+	rg := &v1alpha1.ResourceGroup{}
+	rg.Name = rsRef.Name
+	rg.Namespace = rsRef.Namespace
+	return r.cleanup(ctx, rg)
 }
 
 func (r *RepoSyncReconciler) deleteSharedRoleBinding(ctx context.Context, reconcilerRef, rsRef types.NamespacedName) error {

--- a/pkg/reconcilermanager/controllers/reposync_controller.go
+++ b/pkg/reconcilermanager/controllers/reposync_controller.go
@@ -480,6 +480,10 @@ func (r *RepoSyncReconciler) deleteManagedObjects(ctx context.Context, reconcile
 		return fmt.Errorf("deleting service account: %w", err)
 	}
 
+	if err := r.deleteResourceGroup(ctx, rsRef); err != nil {
+		return fmt.Errorf("deleting resource group: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/reconcilermanager/controllers/rootsync_controller.go
+++ b/pkg/reconcilermanager/controllers/rootsync_controller.go
@@ -414,6 +414,10 @@ func (r *RootSyncReconciler) deleteManagedObjects(ctx context.Context, reconcile
 		return fmt.Errorf("deleting service account: %w", err)
 	}
 
+	if err := r.deleteResourceGroup(ctx, rsRef); err != nil {
+		return fmt.Errorf("deleting resource group: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- Makes sure that the ResourceGroup is deleted when the RSync is deleted, regardless of the deletion propagation policy 
- b/382533338