### PR TITLE
test: refine ResourceGroup expectations

### DIFF
--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -1373,8 +1373,8 @@ func ResourceGroupStatusEquals(expected v1alpha1.ResourceGroupStatus) Predicate 
 			}
 		}
 		if !equality.Semantic.DeepEqual(found, expected) {
-			return fmt.Errorf("expected %s to have status: %s, but got %s",
-				kinds.ObjectSummary(obj), log.AsJSON(expected), log.AsJSON(found))
+			return fmt.Errorf("ResourceGroup %s status does not match expected value:\nDiff (- Expected, + Found)\n%s",
+				client.ObjectKeyFromObject(rg), log.AsYAMLDiff(expected, found))
 		}
 		return nil
 	}

--- a/e2e/nomostest/testresourcegroup/resourcegroup.go
+++ b/e2e/nomostest/testresourcegroup/resourcegroup.go
@@ -71,6 +71,7 @@ func GenerateResourceStatus(resources []v1alpha1.ObjMetadata, s v1alpha1.Status,
 func EmptyStatus() v1alpha1.ResourceGroupStatus {
 	return v1alpha1.ResourceGroupStatus{
 		Conditions: []v1alpha1.Condition{
+			// Reconciling condition is deprecated and will always be False.
 			{
 				Type:    v1alpha1.Reconciling,
 				Status:  v1alpha1.FalseConditionStatus,


### PR DESCRIPTION
Update resourceGroupHasReconciled to make it easier to debug the errors, by grouping all the status checks together, so there's one big diff when it fails.
Use ResourceGroupStatusEquals because it already handles removing the timestamps before comparison.