### PR TITLE
refactor supervisor constructor

### DIFF
--- a/pkg/applier/destroyer_test.go
+++ b/pkg/applier/destroyer_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/applier/stats"
@@ -256,8 +255,7 @@ func TestDestroy(t *testing.T) {
 				// TODO: Add tests to cover disabling objects
 				// TODO: Add tests to cover status mode
 			}
-			destroyer, err := NewNamespaceSupervisor(cs, "test-namespace", "rs", 5*time.Minute)
-			require.NoError(t, err)
+			destroyer := NewSupervisor(cs, "test-namespace", "rs", 5*time.Minute)
 
 			var errs status.MultiError
 			eventHandler := func(event Event) {

--- a/pkg/applier/utils.go
+++ b/pkg/applier/utils.go
@@ -15,16 +15,13 @@
 package applier
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/api/kpt.dev/v1alpha1"
 	"kpt.dev/configsync/pkg/core"
 	"kpt.dev/configsync/pkg/declared"
@@ -169,23 +166,6 @@ func getObjectSize(u *unstructured.Unstructured) (int, error) {
 		return 0, err
 	}
 	return len(data), nil
-}
-
-func annotateStatusMode(ctx context.Context, c client.Client, u *unstructured.Unstructured, statusMode string) error {
-	err := c.Get(ctx, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, u)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	annotations := u.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	annotations[metadata.StatusModeKey] = statusMode
-	u.SetAnnotations(annotations)
-	return c.Update(ctx, u, client.FieldOwner(configsync.FieldManager))
 }
 
 func refsFromIDs(ids ...core.ID) []mutation.ResourceReference {


### PR DESCRIPTION
* refactor: streamline the supervisor constructor

This refactors the supervisor constructor to consolidate the
RepoSync/RootSync supervisors into a single constructor.

The AnnotateStatusMode step is also moved to a separate interface method
so that the constructor does not make api calls or return an error.

* fix: retry on conflict for annotating RG status mode

This wraps AnnotateStatusMode so that it handles conflict errors
gracefully instead of causing the reconciler to crash.