### PR TITLE
refactor: return bool from metadata methods

### DIFF
--- a/e2e/nomostest/deletion_propagation.go
+++ b/e2e/nomostest/deletion_propagation.go
@@ -55,25 +55,11 @@ func HasDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPro
 // SetDeletionPropagationPolicy sets the value of the deletion propagation
 // annotation locally (does not apply). Returns true if the object was modified.
 func SetDeletionPropagationPolicy(obj client.Object, policy metadata.DeletionPropagationPolicy) bool {
-	if HasDeletionPropagationPolicy(obj, policy) {
-		return false
-	}
-	core.SetAnnotation(obj, metadata.DeletionPropagationPolicyAnnotationKey, string(policy))
-	return true
+	return core.SetAnnotation(obj, metadata.DeletionPropagationPolicyAnnotationKey, string(policy))
 }
 
 // RemoveDeletionPropagationPolicy removes the deletion propagation annotation
 // locally (does not apply). Returns true if the object was modified.
 func RemoveDeletionPropagationPolicy(obj client.Object) bool {
-	annotations := obj.GetAnnotations()
-	// don't panic if nil
-	if len(annotations) == 0 {
-		return false
-	}
-	if _, found := annotations[metadata.DeletionPropagationPolicyAnnotationKey]; !found {
-		return false
-	}
-	delete(annotations, metadata.DeletionPropagationPolicyAnnotationKey)
-	obj.SetAnnotations(annotations)
-	return true
+	return core.RemoveAnnotations(obj, metadata.DeletionPropagationPolicyAnnotationKey)
 }

--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -384,9 +384,10 @@ func setupMetricsServiceAccount(nt *nomostest.NT) {
 		if err := nt.KubeClient.Get(DefaultMonitorKSA, configmanagement.MonitoringNamespace, ksa); err != nil {
 			nt.T.Fatalf("failed to get service account: %v", err)
 		}
-		core.SetAnnotation(ksa, "iam.gke.io/gcp-service-account", gsaEmail)
-		if err := nt.KubeClient.Update(ksa); err != nil {
-			nt.T.Fatalf("failed to set service account annotation: %v", err)
+		if core.SetAnnotation(ksa, "iam.gke.io/gcp-service-account", gsaEmail) {
+			if err := nt.KubeClient.Update(ksa); err != nil {
+				nt.T.Fatalf("failed to set service account annotation: %v", err)
+			}
 		}
 		nt.Must(nt.WatchForAllSyncs())
 	}

--- a/pkg/core/decorate.go
+++ b/pkg/core/decorate.go
@@ -18,26 +18,32 @@ package core
 // some non-objects (such as PodTemplates) define annotations but are not objects.
 type Annotated interface {
 	GetAnnotations() map[string]string
-	SetAnnotations(annotations map[string]string)
+	SetAnnotations(map[string]string)
 }
 
 // SetAnnotation sets the annotation on the passed annotated object to value.
-func SetAnnotation(obj Annotated, annotation, value string) {
-	as := obj.GetAnnotations()
-	if as == nil {
-		as = make(map[string]string)
+// Returns true if the object was modified.
+func SetAnnotation(obj Annotated, annotation, value string) bool {
+	aMap := obj.GetAnnotations()
+	if aMap != nil {
+		if existing, found := aMap[annotation]; found && existing == value {
+			return false
+		}
+	} else {
+		aMap = make(map[string]string)
 	}
-	as[annotation] = value
-	obj.SetAnnotations(as)
+	aMap[annotation] = value
+	obj.SetAnnotations(aMap)
+	return true
 }
 
 // GetAnnotation gets the annotation value on the passed annotated object for a given key.
 func GetAnnotation(obj Annotated, annotation string) string {
-	as := obj.GetAnnotations()
-	if as == nil {
+	aMap := obj.GetAnnotations()
+	if aMap == nil {
 		return ""
 	}
-	value, found := as[annotation]
+	value, found := aMap[annotation]
 	if found {
 		return value
 	}
@@ -46,11 +52,11 @@ func GetAnnotation(obj Annotated, annotation string) string {
 
 // GetLabel gets the label value on the passed object for a given key.
 func GetLabel(obj Labeled, label string) string {
-	as := obj.GetLabels()
-	if as == nil {
+	lMap := obj.GetLabels()
+	if lMap == nil {
 		return ""
 	}
-	value, found := as[label]
+	value, found := lMap[label]
 	if found {
 		return value
 	}
@@ -58,62 +64,106 @@ func GetLabel(obj Labeled, label string) string {
 }
 
 // RemoveAnnotations removes the passed set of annotations from obj.
-func RemoveAnnotations(obj Annotated, annotations ...string) {
-	as := obj.GetAnnotations()
-	for _, a := range annotations {
-		delete(as, a)
+// Returns true if the object was modified.
+func RemoveAnnotations(obj Annotated, annotations ...string) bool {
+	aMap := obj.GetAnnotations()
+	if len(aMap) == 0 {
+		return false
 	}
-	obj.SetAnnotations(as)
+	updated := false
+	for _, a := range annotations {
+		if _, found := aMap[a]; found {
+			delete(aMap, a)
+			updated = true
+		}
+	}
+	if updated {
+		obj.SetAnnotations(aMap)
+	}
+	return updated
 }
 
 // RemoveLabels removes the passed set of labels from obj.
-func RemoveLabels(obj Labeled, labels ...string) {
-	actual := obj.GetLabels()
-	for _, label := range labels {
-		delete(actual, label)
+// Returns true if the object was modified.
+func RemoveLabels(obj Labeled, labels ...string) bool {
+	lMap := obj.GetLabels()
+	if len(lMap) == 0 {
+		return false
 	}
-	obj.SetLabels(actual)
+	updated := false
+	for _, label := range labels {
+		if _, found := lMap[label]; found {
+			delete(lMap, label)
+			updated = true
+		}
+	}
+	if updated {
+		obj.SetLabels(lMap)
+	}
+	return updated
 }
 
 // AddAnnotations adds the specified annotations to the object.
-func AddAnnotations(obj Annotated, annotations map[string]string) {
-	existing := obj.GetAnnotations()
-	if existing == nil {
-		existing = make(map[string]string, len(annotations))
+// Returns true if the object was modified.
+func AddAnnotations(obj Annotated, annotations map[string]string) bool {
+	aMap := obj.GetAnnotations()
+	if aMap == nil {
+		aMap = make(map[string]string, len(annotations))
 	}
+	updated := false
 	for key, value := range annotations {
-		existing[key] = value
+		if existing, found := aMap[key]; !found || existing != value {
+			aMap[key] = value
+			updated = true
+		}
 	}
-	obj.SetAnnotations(existing)
+	if updated {
+		obj.SetAnnotations(aMap)
+	}
+	return updated
 }
 
 // Labeled is the interface defined by types with labeled. Note that
 // some non-objects (such as PodTemplates) define labels but are not objects.
 type Labeled interface {
 	GetLabels() map[string]string
-	SetLabels(annotations map[string]string)
+	SetLabels(map[string]string)
 }
 
 // SetLabel sets label on obj to value.
-func SetLabel(obj Labeled, label, value string) {
-	ls := obj.GetLabels()
-	if ls == nil {
-		ls = make(map[string]string)
+// Returns true if the object was modified.
+func SetLabel(obj Labeled, label, value string) bool {
+	lMap := obj.GetLabels()
+	if lMap != nil {
+		if existing, found := lMap[label]; found && existing == value {
+			return false
+		}
+	} else {
+		lMap = make(map[string]string)
 	}
-	ls[label] = value
-	obj.SetLabels(ls)
+	lMap[label] = value
+	obj.SetLabels(lMap)
+	return true
 }
 
 // AddLabels adds the specified labels to the object.
-func AddLabels(obj Labeled, labels map[string]string) {
-	existing := obj.GetLabels()
-	if existing == nil {
-		existing = make(map[string]string, len(labels))
+// Returns true if the object was modified.
+func AddLabels(obj Labeled, labels map[string]string) bool {
+	lMap := obj.GetLabels()
+	if lMap == nil {
+		lMap = make(map[string]string, len(labels))
 	}
+	updated := false
 	for key, value := range labels {
-		existing[key] = value
+		if existing, found := lMap[key]; !found || existing != value {
+			lMap[key] = value
+			updated = true
+		}
 	}
-	obj.SetLabels(existing)
+	if updated {
+		obj.SetLabels(lMap)
+	}
+	return updated
 }
 
 // copyMap returns a copy of the passed map. Otherwise the Labels or Annotations maps will have two

--- a/pkg/core/decorate_test.go
+++ b/pkg/core/decorate_test.go
@@ -1,0 +1,1136 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+type mockAnnotated struct {
+	annotations map[string]string
+}
+
+func (m *mockAnnotated) GetAnnotations() map[string]string {
+	return m.annotations
+}
+
+func (m *mockAnnotated) SetAnnotations(annotations map[string]string) {
+	m.annotations = annotations
+}
+
+type mockLabeled struct {
+	labels map[string]string
+}
+
+func (m *mockLabeled) GetLabels() map[string]string {
+	return m.labels
+}
+
+func (m *mockLabeled) SetLabels(labels map[string]string) {
+	m.labels = labels
+}
+
+func TestSetAnnotation(t *testing.T) {
+	type args struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Nil Annotations - New Annotation",
+			initial: nil,
+			args: args{
+				key:   "testKey",
+				value: "testValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"testKey": "testValue",
+			},
+		},
+		{
+			name: "Existing Annotations - New Annotation",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				key:   "newKey",
+				value: "newValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "existingValue",
+				"newKey":      "newValue",
+			},
+		},
+		{
+			name: "Existing Annotations - Update Existing Annotation",
+			initial: map[string]string{
+				"existingKey": "oldValue",
+			},
+			args: args{
+				key:   "existingKey",
+				value: "newValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "newValue",
+			},
+		},
+		{
+			name: "Existing Annotations - Same Annotation Value",
+			initial: map[string]string{
+				"sameKey": "sameValue",
+			},
+			args: args{
+				key:   "sameKey",
+				value: "sameValue",
+			},
+			want: false,
+			expected: map[string]string{
+				"sameKey": "sameValue",
+			},
+		},
+		{
+			name: "Existing Annotations - Empty Annotation Key",
+			initial: map[string]string{
+				"": "existingValue",
+			},
+			args: args{
+				key:   "",
+				value: "emptyKeyTest",
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyTest",
+			},
+		},
+		{
+			name: "Existing Annotations - Empty Annotation Value",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				key:   "emptyValueKey",
+				value: "",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey":   "existingValue",
+				"emptyValueKey": "",
+			},
+		},
+		{
+			name:    "Nil Annotations - Empty Annotation Key",
+			initial: nil,
+			args: args{
+				key:   "",
+				value: "emptyKeyTest",
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyTest",
+			},
+		},
+		{
+			name:    "Nil Annotations - Empty Annotation Value",
+			initial: nil,
+			args: args{
+				key:   "emptyValueKey",
+				value: "",
+			},
+			want: true,
+			expected: map[string]string{
+				"emptyValueKey": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockAnnotated{annotations: tt.initial}
+
+			got := SetAnnotation(obj, tt.args.key, tt.args.value)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetAnnotations())
+		})
+	}
+}
+
+func TestGetAnnotation(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name    string
+		initial map[string]string
+		args    args
+		want    string
+	}{
+		{
+			name:    "Nil Annotations - Get Non-existent",
+			initial: nil,
+			args: args{
+				key: "testKey",
+			},
+			want: "",
+		},
+		{
+			name: "Existing Annotations - Get Existing",
+			initial: map[string]string{
+				"testKey":   "testValue",
+				"otherKey":  "otherValue",
+				"":          "emptyKeyVal",
+				"valueOnly": "",
+			},
+			args: args{
+				key: "testKey",
+			},
+			want: "testValue",
+		},
+		{
+			name: "Existing Annotations - Get Non-existent",
+			initial: map[string]string{
+				"testKey": "testValue",
+			},
+			args: args{
+				key: "nonExistentKey",
+			},
+			want: "",
+		},
+		{
+			name: "Existing Annotations - Get Empty Key",
+			initial: map[string]string{
+				"": "emptyKeyVal",
+			},
+			args: args{
+				key: "",
+			},
+			want: "emptyKeyVal",
+		},
+		{
+			name: "Existing Annotations - Get Key with Empty Value",
+			initial: map[string]string{
+				"valueOnly": "",
+			},
+			args: args{
+				key: "valueOnly",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockAnnotated{annotations: tt.initial}
+
+			got := GetAnnotation(obj, tt.args.key)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRemoveAnnotations(t *testing.T) {
+	type args struct {
+		keys []string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Empty Annotations - No Removal",
+			initial: map[string]string{},
+			args: args{
+				keys: []string{"key1"},
+			},
+			want:     false,
+			expected: map[string]string{},
+		},
+		{
+			name:    "Nil Annotations - No Removal",
+			initial: nil,
+			args: args{
+				keys: []string{"key1"},
+			},
+			want:     false,
+			expected: nil,
+		},
+		{
+			name: "Remove Single Existing Annotation",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove Multiple Existing Annotations",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+			args: args{
+				keys: []string{"key1", "key3"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove Non-existent Annotation",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				keys: []string{"nonExistent"},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Remove Mix of Existing and Non-existent Annotations",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1", "nonExistent"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove All Annotations",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1", "key2"},
+			},
+			want:     true,
+			expected: map[string]string{},
+		},
+		{
+			name: "Remove Empty Annotation Key",
+			initial: map[string]string{
+				"":     "emptyKeyVal",
+				"key1": "value1",
+			},
+			args: args{
+				keys: []string{""},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Remove Multiple - Including Empty Key and Non-existent",
+			initial: map[string]string{
+				"":     "emptyKeyVal",
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"", "key1", "nonExistent"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name:    "Empty Annotations - Try to Remove Non-existent",
+			initial: map[string]string{},
+			args: args{
+				keys: []string{"nonExistent"},
+			},
+			want:     false,
+			expected: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockAnnotated{annotations: tt.initial}
+
+			got := RemoveAnnotations(obj, tt.args.keys...)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetAnnotations())
+		})
+	}
+}
+
+func TestAddAnnotations(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Nil Annotations - Add New",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Annotations - Add New",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				annotations: map[string]string{
+					"newKey1": "newValue1",
+					"newKey2": "newValue2",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "existingValue",
+				"newKey1":     "newValue1",
+				"newKey2":     "newValue2",
+			},
+		},
+		{
+			name: "Existing Annotations - Update Existing",
+			initial: map[string]string{
+				"key1": "oldValue",
+				"key2": "value2",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key1": "newValue",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "newValue",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Same",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key1": "value1",
+				},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Empty Map",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Mix of New and Same",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "value2",
+					"key1": "value1",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Mix of New and Updated",
+			initial: map[string]string{
+				"key1": "oldValue",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "newValue",
+					"key1": "updatedValue",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "updatedValue",
+				"key2": "newValue",
+			},
+		},
+		{
+			name:    "Nil Annotations - Add Empty Key",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"": "emptyKeyVal",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyVal",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Empty Key",
+			initial: map[string]string{
+				"": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"": "emptyKeyVal",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyVal",
+			},
+		},
+		{
+			name:    "Nil Annotations - Add Empty Value",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"key1": "",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "",
+			},
+		},
+		{
+			name: "Existing Annotations - Add Empty Value",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockAnnotated{annotations: tt.initial}
+
+			got := AddAnnotations(obj, tt.args.annotations)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetAnnotations())
+		})
+	}
+}
+
+func TestSetLabel(t *testing.T) {
+	type args struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Nil Labels - New Label",
+			initial: nil,
+			args: args{
+				key:   "testKey",
+				value: "testValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"testKey": "testValue",
+			},
+		},
+		{
+			name: "Existing Labels - New Label",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				key:   "newKey",
+				value: "newValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "existingValue",
+				"newKey":      "newValue",
+			},
+		},
+		{
+			name: "Existing Labels - Update Existing Label",
+			initial: map[string]string{
+				"existingKey": "oldValue",
+			},
+			args: args{
+				key:   "existingKey",
+				value: "newValue",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "newValue",
+			},
+		},
+		{
+			name: "Existing Labels - Same Label Value",
+			initial: map[string]string{
+				"sameKey": "sameValue",
+			},
+			args: args{
+				key:   "sameKey",
+				value: "sameValue",
+			},
+			want: false,
+			expected: map[string]string{
+				"sameKey": "sameValue",
+			},
+		},
+		{
+			name: "Existing Labels - Empty Label Key",
+			initial: map[string]string{
+				"": "existingValue",
+			},
+			args: args{
+				key:   "",
+				value: "emptyKeyTest",
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyTest",
+			},
+		},
+		{
+			name: "Existing Labels - Empty Label Value",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				key:   "emptyValueKey",
+				value: "",
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey":   "existingValue",
+				"emptyValueKey": "",
+			},
+		},
+		{
+			name:    "Nil Labels - Empty Label Key",
+			initial: nil,
+			args: args{
+				key:   "",
+				value: "emptyKeyTest",
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyTest",
+			},
+		},
+		{
+			name:    "Nil Labels - Empty Label Value",
+			initial: nil,
+			args: args{
+				key:   "emptyValueKey",
+				value: "",
+			},
+			want: true,
+			expected: map[string]string{
+				"emptyValueKey": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockLabeled{labels: tt.initial}
+
+			got := SetLabel(obj, tt.args.key, tt.args.value)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetLabels())
+		})
+	}
+}
+
+func TestGetLabel(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name    string
+		initial map[string]string
+		args    args
+		want    string
+	}{
+		{
+			name:    "Nil Labels - Get Non-existent",
+			initial: nil,
+			args: args{
+				key: "testKey",
+			},
+			want: "",
+		},
+		{
+			name: "Existing Labels - Get Existing",
+			initial: map[string]string{
+				"testKey":   "testValue",
+				"otherKey":  "otherValue",
+				"":          "emptyKeyVal",
+				"valueOnly": "",
+			},
+			args: args{
+				key: "testKey",
+			},
+			want: "testValue",
+		},
+		{
+			name: "Existing Labels - Get Non-existent",
+			initial: map[string]string{
+				"testKey": "testValue",
+			},
+			args: args{
+				key: "nonExistentKey",
+			},
+			want: "",
+		},
+		{
+			name: "Existing Labels - Get Empty Key",
+			initial: map[string]string{
+				"": "emptyKeyVal",
+			},
+			args: args{
+				key: "",
+			},
+			want: "emptyKeyVal",
+		},
+		{
+			name: "Existing Labels - Get Key with Empty Value",
+			initial: map[string]string{
+				"valueOnly": "",
+			},
+			args: args{
+				key: "valueOnly",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockLabeled{labels: tt.initial}
+
+			got := GetLabel(obj, tt.args.key)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRemoveLabels(t *testing.T) {
+	type args struct {
+		keys []string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Empty Labels - No Removal",
+			initial: map[string]string{},
+			args: args{
+				keys: []string{"key1"},
+			},
+			want:     false,
+			expected: map[string]string{},
+		},
+		{
+			name:    "Nil Labels - No Removal",
+			initial: nil,
+			args: args{
+				keys: []string{"key1"},
+			},
+			want:     false,
+			expected: nil,
+		},
+		{
+			name: "Remove Single Existing Label",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove Multiple Existing Labels",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+			args: args{
+				keys: []string{"key1", "key3"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove Non-existent Label",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				keys: []string{"nonExistent"},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Remove Mix of Existing and Non-existent Labels",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1", "nonExistent"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Remove All Labels",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"key1", "key2"},
+			},
+			want:     true,
+			expected: map[string]string{},
+		},
+		{
+			name: "Remove Empty Label Key",
+			initial: map[string]string{
+				"":     "emptyKeyVal",
+				"key1": "value1",
+			},
+			args: args{
+				keys: []string{""},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Remove Multiple - Including Empty Key and Non-existent",
+			initial: map[string]string{
+				"":     "emptyKeyVal",
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				keys: []string{"", "key1", "nonExistent"},
+			},
+			want: true,
+			expected: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name:    "Empty Labels - Try to Remove Non-existent",
+			initial: map[string]string{},
+			args: args{
+				keys: []string{"nonExistent"},
+			},
+			want:     false,
+			expected: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockLabeled{labels: tt.initial}
+
+			got := RemoveLabels(obj, tt.args.keys...)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetLabels())
+		})
+	}
+}
+
+func TestAddLabels(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name     string
+		initial  map[string]string
+		args     args
+		want     bool
+		expected map[string]string
+	}{
+		{
+			name:    "Nil Labels - Add New",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Labels - Add New",
+			initial: map[string]string{
+				"existingKey": "existingValue",
+			},
+			args: args{
+				annotations: map[string]string{
+					"newKey1": "newValue1",
+					"newKey2": "newValue2",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"existingKey": "existingValue",
+				"newKey1":     "newValue1",
+				"newKey2":     "newValue2",
+			},
+		},
+		{
+			name: "Existing Labels - Update Existing",
+			initial: map[string]string{
+				"key1": "oldValue",
+				"key2": "value2",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key1": "newValue",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "newValue",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Labels - Add Same",
+			initial: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key1": "value1",
+				},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Labels - Add Empty Map",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{},
+			},
+			want: false,
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Existing Labels - Add Mix of New and Same",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "value2",
+					"key1": "value1",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Existing Labels - Add Mix of New and Updated",
+			initial: map[string]string{
+				"key1": "oldValue",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "newValue",
+					"key1": "updatedValue",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "updatedValue",
+				"key2": "newValue",
+			},
+		},
+		{
+			name:    "Nil Labels - Add Empty Key",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"": "emptyKeyVal",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyVal",
+			},
+		},
+		{
+			name: "Existing Labels - Add Empty Key",
+			initial: map[string]string{
+				"": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"": "emptyKeyVal",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"": "emptyKeyVal",
+			},
+		},
+		{
+			name:    "Nil Labels - Add Empty Value",
+			initial: nil,
+			args: args{
+				annotations: map[string]string{
+					"key1": "",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "",
+			},
+		},
+		{
+			name: "Existing Labels - Add Empty Value",
+			initial: map[string]string{
+				"key1": "value1",
+			},
+			args: args{
+				annotations: map[string]string{
+					"key2": "",
+				},
+			},
+			want: true,
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &mockLabeled{labels: tt.initial}
+
+			got := AddLabels(obj, tt.args.annotations)
+			require.Equal(t, tt.want, got)
+			testutil.AssertEqual(t, tt.expected, obj.GetLabels())
+		})
+	}
+}


### PR DESCRIPTION
Return true when the labels or annotations were changed, to allow skipping update calls when there's no change.