### PR TITLE
test: fix stress test being OOMKilled

### DIFF
--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -1373,8 +1373,8 @@ func ResourceGroupStatusEquals(expected v1alpha1.ResourceGroupStatus) Predicate 
 			}
 		}
 		if !equality.Semantic.DeepEqual(found, expected) {
-			return fmt.Errorf("ResourceGroup %s status does not match expected value:\nDiff (- Expected, + Found)\n%s",
-				client.ObjectKeyFromObject(rg), log.AsYAMLDiff(expected, found))
+			return fmt.Errorf("ResourceGroup %s status does not match expected value:\nExpected:\n%s\nFound:\n%s",
+				client.ObjectKeyFromObject(rg), log.AsYAML(expected), log.AsYAML(found))
 		}
 		return nil
 	}


### PR DESCRIPTION
ResourceGroupStatusEquals was recently modified to print a diff when the status didn't match expectations. This helps debugging when the ResourceGroup status is small, but when it's large it can cause significant memory use, sometimes more than 30GB. This was causing some of the stress tests to be OOMKilled.

Note: OOMKill can still happen when --debug is used, because it still prints YAML diffs for each watch event.

Fixes: b/406880508