### PR TITLE
refactor: replace commonLabels with labels.pairs in kustomization files

### DIFF
--- a/e2e/testdata/hydration/deprecated-GK/kustomization.yaml
+++ b/e2e/testdata/hydration/deprecated-GK/kustomization.yaml
@@ -18,5 +18,6 @@ helmCharts:
   version: 0.2.0
   releaseName: my-prometheus-operator
 
-commonLabels:
-  test-case: hydration
+labels:
+- pairs:
+    test-case: hydration

--- a/e2e/testdata/hydration/dry-repo-without-kustomization/base/kustomization.yaml
+++ b/e2e/testdata/hydration/dry-repo-without-kustomization/base/kustomization.yaml
@@ -20,5 +20,6 @@ helmCharts:
 commonAnnotations:
   hydration-tool: kustomize
 
-commonLabels:
-  team: monitoring
+labels:
+- pairs:
+    team: monitoring

--- a/e2e/testdata/hydration/helm-components/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components/kustomization.yaml
@@ -30,5 +30,7 @@ helmCharts:
     service:
       type: ClusterIP
 
-commonLabels:
-  test-case: hydration
+labels:
+- includeSelectors: true
+  pairs:
+    test-case: hydration

--- a/e2e/testdata/hydration/kustomize-components/base/kustomization.yaml
+++ b/e2e/testdata/hydration/kustomize-components/base/kustomization.yaml
@@ -18,5 +18,6 @@ resources:
 - role.yaml
 - networkpolicy.yaml
 
-commonLabels:
-  test-case: hydration
+labels:
+- pairs:
+    test-case: hydration

--- a/e2e/testdata/hydration/namespace-repo/base/kustomization.yaml
+++ b/e2e/testdata/hydration/namespace-repo/base/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
 - role.yaml
 - networkpolicy.yaml
 
-commonLabels:
-  test-case: hydration
+labels:
+- pairs:
+    test-case: hydration

--- a/e2e/testdata/hydration/relative-path/overlays/dev/kustomization.yaml
+++ b/e2e/testdata/hydration/relative-path/overlays/dev/kustomization.yaml
@@ -17,7 +17,7 @@ kind: Kustomization
 bases:
 - ../../base
 patches:
-# ServiceAccount - make name unique per environ 
+# ServiceAccount - make name unique per environ
 - target:
     kind: ServiceAccount
     name: foo-ksa
@@ -25,7 +25,7 @@ patches:
     - op: replace
       path: /metadata/name
       value: foo-ksa-dev
-# Pod creators - give all FooCorp developers access 
+# Pod creators - give all FooCorp developers access
 - target:
     kind: RoleBinding
     name: pod-creators
@@ -33,5 +33,7 @@ patches:
     - op: replace
       path: /subjects/0/name
       value: developers-all@foo-corp.com
-commonLabels:
-  environment: dev
+
+labels:
+- pairs:
+    environment: dev

--- a/e2e/testdata/hydration/remote-base/kustomization.yaml
+++ b/e2e/testdata/hydration/remote-base/kustomization.yaml
@@ -15,5 +15,6 @@
 resources:
 - overlay
 
-commonLabels:
-  test-case: hydration
+labels:
+- pairs:
+    test-case: hydration

--- a/e2e/testdata/hydration/remote-resources-kustomization.yaml
+++ b/e2e/testdata/hydration/remote-resources-kustomization.yaml
@@ -15,5 +15,6 @@
 resources:
 - github.com/config-sync-examples/kustomize-components?ref=main
 
-commonLabels:
-  test-case: hydration
+labels:
+- pairs:
+    test-case: hydration


### PR DESCRIPTION
This pull request involves several updates to `kustomization.yaml` files across different directories in the `e2e/testdata/hydration` folder. The main change is the replacement of `commonLabels` with `labels` that include a `pairs` key.

Why?

Gets rid of noise

```
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```