### PR TITLE
chore: update base image versions for golang, gcloud, and docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,19 +38,20 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE_VERSION := 1.23.4
+# See go/cs-upgrade-go for updates
+GOLANG_IMAGE_VERSION := 1.24.2
 GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
-# When updating you can use this command: 
-# gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 
+# When updating you can use this command:
+# gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*"
 DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.5
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options
-GCLOUD_IMAGE_VERSION := 513.0.0
+GCLOUD_IMAGE_VERSION := 517.0.0
 GCLOUD_IMAGE := gcr.io/google.com/cloudsdktool/google-cloud-cli:$(GCLOUD_IMAGE_VERSION)-slim
 # Base image used for docker cli install, primarily used for test images.
-DOCKER_CLI_IMAGE_VERSION := 20.10.14
+DOCKER_CLI_IMAGE_VERSION := 20.10.24
 DOCKER_CLI_IMAGE := gcr.io/cloud-builders/docker:$(DOCKER_CLI_IMAGE_VERSION)
 
 # Directory containing installed go binaries.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module kpt.dev/configsync
 
-go 1.23.0
+// see go/cs-upgrade-go for updates
+go 1.24.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.1

--- a/test/docker/presync-webhook-server/go.mod
+++ b/test/docker/presync-webhook-server/go.mod
@@ -1,6 +1,7 @@
 module webhook-server
 
-go 1.23
+// see go/cs-upgrade-go for updates
+go 1.24.2
 require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/sigstore/cosign/v2 v2.4.1


### PR DESCRIPTION
This pull request includes updates to the versions of several base images used in the `Makefile`. These changes ensure that the project uses the latest versions of these images for better security, performance, and compatibility.

Version updates:

* Updated `GOLANG_IMAGE_VERSION` to `1.24.2` for the golang container base image.
* Updated `GCLOUD_IMAGE_VERSION` to `517.0.0` for the gcloud install base image.
* Updated `DOCKER_CLI_IMAGE_VERSION` to `20.10.24` for the docker CLI install base image.