### PR TITLE
chore: update Debian base image version to bookworm-v1.0.4-gke.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ GO_DIR := $(OUTPUT_DIR)/go
 GOLANG_IMAGE_VERSION := 1.23.4
 GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
-# When updating you can use this command: 
-# gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*" 
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.5
+# When updating you can use this command:
+# gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*"
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.6
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options


### PR DESCRIPTION
This pull request includes an update to the `Makefile` to use a newer version of the Debian base image.