### PR TITLE
test: fix TestSplitRSyncsWithDeletion on CSR

### DIFF
--- a/e2e/testcases/sync_ordering_test.go
+++ b/e2e/testcases/sync_ordering_test.go
@@ -688,8 +688,8 @@ func TestSplitRSyncsWithDeletion(t *testing.T) {
 		o.SetNamespace("foo")
 		return o
 	}
-	tenantNS1 := "tenant-ns-1"
-	tenantNS2 := "tenant-ns-2"
+	tenantNS1 := frontendNamespace
+	tenantNS2 := backendNamespace
 	cm1 := func() *corev1.ConfigMap {
 		return k8sobjects.ConfigMapObject(core.Name("cm1"), core.Namespace(tenantNS1))
 	}
@@ -697,10 +697,10 @@ func TestSplitRSyncsWithDeletion(t *testing.T) {
 		return k8sobjects.ServiceAccountObject("sa1", core.Namespace(tenantNS2))
 	}
 	rootSync := nomostest.DefaultRootSyncID
-	rootSync1 := core.RootSyncID("root-sync-1")
-	rootSync2 := core.RootSyncID("root-sync-2")
-	repoSync1 := core.RepoSyncID("repo-sync-1", tenantNS1)
-	repoSync2 := core.RepoSyncID("repo-sync-2", tenantNS2)
+	rootSync1 := core.RootSyncID("sync-x")
+	rootSync2 := core.RootSyncID("sync-y")
+	repoSync1 := core.RepoSyncID(configsync.RepoSyncName, tenantNS1)
+	repoSync2 := core.RepoSyncID(configsync.RepoSyncName, tenantNS2)
 	nt := nomostest.New(t, nomostesting.Lifecycle,
 		ntopts.SyncWithGitSource(rootSync, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(rootSync1, ntopts.Unstructured),

--- a/e2e/testinfra/terraform/modules/service_account/service_account.tf
+++ b/e2e/testinfra/terraform/modules/service_account/service_account.tf
@@ -48,9 +48,9 @@ resource "google_service_account_iam_member" "k8s_sa_binding" {
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-test-ns-rs-test-2-9]",
     # RepoSync used in TestNamespaceRepo_Delegated, TestDeleteRepoSync_Delegated_AndRepoSyncV1Alpha1, TestDeleteRepoSync_Centralized_AndRepoSyncV1Alpha1, TestManageSelfRepoSync, TestDeleteNamespaceReconcilerDeployment, TestReconcilerManagerRootSyncCRDMissing.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-bookstore]",
-    # RepoSync used in TestNoSSLVerifyV1Alpha1, TestNoSSLVerifyV1Beta1, TestOverrideGitSyncDepthV1Alpha1, TestOverrideGitSyncDepthV1Beta1, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1.
+    # RepoSync used in TestNoSSLVerifyV1Alpha1, TestNoSSLVerifyV1Beta1, TestOverrideGitSyncDepthV1Alpha1, TestOverrideGitSyncDepthV1Beta1, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1, TestSplitRSyncsWithDeletion.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-backend]",
-    # RepoSync used in TestOverrideRepoSyncLogLevel, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1.
+    # RepoSync used in TestOverrideRepoSyncLogLevel, TestOverrideReconcilerResourcesV1Alpha1, TestOverrideReconcilerResourcesV1Beta1, TestSplitRSyncsWithDeletion.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-frontend]",
     # RootSync used in TestRootSyncRoleRefs, TestNamespaceStrategyMultipleRootSyncs.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-a]",
@@ -64,7 +64,7 @@ resource "google_service_account_iam_member" "k8s_sa_binding" {
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-invalid-teardown]",
     # RepoSync used in TestReconcilerManagerTeardownRepoSyncWithReconcileTimeout.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/ns-reconciler-reconcile-timeout]",
-    # RootSync used in TestNamespaceStrategyMultipleRootSyncs.
+    # RootSync used in TestNamespaceStrategyMultipleRootSyncs, TestSplitRSyncsWithDeletion.
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-x]",
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[config-management-system/root-reconciler-sync-y]",
     # RootSync and RepoSync used in TestComposition


### PR DESCRIPTION
Tests on CSR require workload identity bindings to be created for every RSync. The new TestSplitRSyncsWithDeletion test case used new RSync names that did not have workload identity bindings.

This fixes the issue by changing the RSync names to reuse already provisioned workload identity bindings.