### PR TITLE
chore: update Debian base image version to bookworm-v1.0.4-gke.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command:
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*"
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.6
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.7
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options


### PR DESCRIPTION
[CVE-2024-56406 ](https://github.com/advisories/GHSA-p6jf-pv8c-623c)