### PR TITLE
chore: Bump git-sync to v4.3.0-gke.16__linux_amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.3.0-gke.15__linux_amd64
+GIT_SYNC_VERSION := v4.3.0-gke.16__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.118.0-gke.6


### PR DESCRIPTION
Fixes [CVE-2024-56406 ](https://github.com/advisories/GHSA-p6jf-pv8c-623c)