### PR TITLE
chore: Bump otelcontribcol to v0.118.0-gke.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ COSIGN := $(BIN_DIR)/cosign
 GIT_SYNC_VERSION := v4.3.0-gke.16__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.118.0-gke.6
+OTELCONTRIBCOL_VERSION := v0.118.0-gke.7
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.


### PR DESCRIPTION
Fixes [CVE-2025-1386](https://github.com/advisories/GHSA-m454-3xv7-qj85)