### PR TITLE
test: fix TestOtelCollectorDeployment expectation

### DIFF
--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -49,7 +49,7 @@ const (
 	DefaultMonitorKSA             = "default"
 	MonitorGSA                    = "e2e-test-metric-writer"
 	MetricExportErrorCaption      = "One or more TimeSeries could not be written"
-	UnrecognizedLabelErrorCaption = "Unrecognized metric labels"
+	UnrecognizedLabelErrorCaption = "unrecognized metric labels"
 	GCMMetricPrefix               = "custom.googleapis.com/opencensus/config_sync"
 )
 


### PR DESCRIPTION
Cloud Monitoring recently changed the error message to be lowercase (cl/745657726). Update our expectation to match.