### PR TITLE
Add log viewer role to test runner iam

### DIFF
--- a/e2e/testcases/otel_collector_test.go
+++ b/e2e/testcases/otel_collector_test.go
@@ -407,7 +407,7 @@ func validateDeploymentLogHasFailure(nt *nomostest.NT, deployment, namespace, er
 }
 
 func validateDeploymentLogHasNoFailure(nt *nomostest.NT, deployment, namespace, errorString string, startTime time.Time) error {
-	entry, err := nt.GetPodLogs(namespace, deployment, "", true, &startTime)
+	entry, err := nt.GetPodLogs(namespace, deployment, "", false, &startTime)
 	if err != nil {
 		return err
 	}

--- a/e2e/testinfra/terraform/prow/service_accounts.tf
+++ b/e2e/testinfra/terraform/prow/service_accounts.tf
@@ -25,6 +25,7 @@ resource "google_project_iam_member" "test-runner-iam" {
     "roles/monitoring.viewer",
     "roles/secretmanager.admin",
     "roles/source.admin",
+    "roles/logging.viewer",
   ])
 
   role    = each.value


### PR DESCRIPTION
E2E test runner needs permission to list and validate logs from Cloud Logging in CI projects. 

Also fixes an issue in otel-collector test. 