### PR TITLE
Enable cloud logging API in CI projects

### DIFF
--- a/e2e/testinfra/terraform/common/services.tf
+++ b/e2e/testinfra/terraform/common/services.tf
@@ -23,7 +23,8 @@ resource "google_project_service" "services" {
     "secretmanager.googleapis.com",
     "container.googleapis.com",
     "compute.googleapis.com",
-    "monitoring.googleapis.com"
+    "monitoring.googleapis.com",
+    "logging.googleapis.com"
   ])
   service = each.value
   disable_on_destroy = false


### PR DESCRIPTION
Enable Cloud Logging API to allow collection of postsync controller logs and support postsync_logging_test verification.

Tested in a dev project to confirm that enabling the Logging API via Terraform works as expected.