### PR TITLE
Fix retry in postsync cloud logging tests

### DIFF
--- a/e2e/testcases/postsync_logging_test.go
+++ b/e2e/testcases/postsync_logging_test.go
@@ -379,8 +379,7 @@ func waitForLogEntryInCloudLogs(nt *nomostest.NT, filter string, expectedCount i
 			lastLogs = append(lastLogs, fmt.Sprintf("%s: %v", entry.Timestamp.Format(time.RFC3339), entry.Payload))
 		}
 
-		nt.Must(assertLogEntryHasCount(lastLogs, expectedCount, commit, rname, rnamespace, messages))
-		return nil
+		return assertLogEntryHasCount(lastLogs, expectedCount, commit, rname, rnamespace, messages)
 	})
 
 	if err != nil {


### PR DESCRIPTION
Ensure waitForLogEntryInCloudLogs continuously retries until timeout when searching Cloud Logging.