### PR TITLE
Remove buildx builder instance after image push

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -333,6 +333,7 @@ build-push-sync-status-watch-controller:
 		-t $(E2E_TEST_IMAGE_SYNC_STATUS_WATCH_CONTROLLER) \
 		--push \
 		examples/post-sync/
+	docker buildx rm multi-arch-builder || true
 
 .PHONY: deploy
 deploy:


### PR DESCRIPTION
Postsync status watch controller supports multi-arch builds by using a dedicated builder. This PR ensures the Docker builder is cleaned up afterward to prevent interference with other image builds.