### PR TITLE
test: Revert parsing hack for go-junit-report

### DIFF
--- a/build/prow/e2e/Dockerfile
+++ b/build/prow/e2e/Dockerfile
@@ -33,7 +33,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 # Get go-junit-report
-RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.1.0
 
 # Build e2e image
 FROM ${DOCKER_CLI_IMAGE} as gke-e2e

--- a/cmd/junit-report/resetfailure/reset_failure.go
+++ b/cmd/junit-report/resetfailure/reset_failure.go
@@ -17,7 +17,6 @@ package resetfailure
 import (
 	"encoding/xml"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
@@ -78,20 +77,5 @@ func updateReport(t *junit.Testsuites, path string) error {
 	if err != nil {
 		return err
 	}
-	return writeXML(t, f)
-}
-
-// copied from https://github.com/jstemmer/go-junit-report/blob/075629ad5f2934f016fa8fe79deb821f98bd8b44/junit/junit.go#L41
-// TODO: remove the duplicate when a new go-junit-report release is available.
-func writeXML(t *junit.Testsuites, w io.Writer) error {
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "\t")
-	if err := enc.Encode(t); err != nil {
-		return err
-	}
-	if err := enc.Flush(); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "\n")
-	return err
+	return t.WriteXML(f)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.6.0
-	github.com/jstemmer/go-junit-report/v2 v2.0.0
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/open-policy-agent/cert-controller v0.10.2-0.20240531181455-2649f121ab97
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
-github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -35,11 +35,6 @@ echo "Tests took $(( end_time - start_time )) seconds"
 # enables running this script more flexibly, e.g. without docker in docker.
 if [[ -n "${ARTIFACTS}" && -d "${ARTIFACTS}" ]]; then
   echo "Creating junit xml report"
-  # Go 1.20 started using "=== NAME" when tests resume instead of "=== CONT".
-  # go-junit-report does not yet properly parse "=== NAME", so this hack enables
-  # proper parsing.
-  # TODO: revert when fixed https://github.com/jstemmer/go-junit-report/issues/169
-  sed -i -e 's/=== NAME/=== CONT/g' test_results.txt
   go-junit-report --subtest-mode=exclude-parents < test_results.txt > "${ARTIFACTS}/junit_report.xml"
   if [ "$exit_code" -eq 0 ]; then
     echo "Running junit-report post processor"

--- a/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
@@ -5,6 +5,7 @@ package junit
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -36,6 +37,20 @@ func (t *Testsuites) AddSuite(ts Testsuite) {
 	t.Disabled += ts.Disabled
 }
 
+// WriteXML writes the XML representation of Testsuites t to writer w.
+func (t *Testsuites) WriteXML(w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}
+
 // Testsuite is a single JUnit testsuite containing testcases.
 type Testsuite struct {
 	// required attributes
@@ -52,6 +67,7 @@ type Testsuite struct {
 	Skipped   int    `xml:"skipped,attr,omitempty"`
 	Time      string `xml:"time,attr"`                // duration in seconds
 	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
+	File      string `xml:"file,attr,omitempty"`
 
 	Properties *[]Property `xml:"properties>property,omitempty"`
 	Testcases  []Testcase  `xml:"testcase,omitempty"`
@@ -73,24 +89,24 @@ func (t *Testsuite) AddProperty(name, value string) {
 // AddTestcase adds Testcase tc to this Testsuite.
 func (t *Testsuite) AddTestcase(tc Testcase) {
 	t.Testcases = append(t.Testcases, tc)
-	t.Tests += 1
+	t.Tests++
 
 	if tc.Error != nil {
-		t.Errors += 1
+		t.Errors++
 	}
 
 	if tc.Failure != nil {
-		t.Failures += 1
+		t.Failures++
 	}
 
 	if tc.Skipped != nil {
-		t.Skipped += 1
+		t.Skipped++
 	}
 }
 
 // SetTimestamp sets the timestamp in this Testsuite.
-func (ts *Testsuite) SetTimestamp(t time.Time) {
-	ts.Timestamp = t.Format(time.RFC3339)
+func (t *Testsuite) SetTimestamp(timestamp time.Time) {
+	t.Timestamp = timestamp.Format(time.RFC3339)
 }
 
 // Testcase represents a single test with its results.
@@ -143,12 +159,12 @@ func CreateFromReport(report gtr.Report, hostname string) Testsuites {
 			suite.SetTimestamp(pkg.Timestamp)
 		}
 
-		for k, v := range pkg.Properties {
-			suite.AddProperty(k, v)
+		for _, p := range pkg.Properties {
+			suite.AddProperty(p.Name, p.Value)
 		}
 
 		if len(pkg.Output) > 0 {
-			suite.SystemOut = &Output{Data: formatOutput(pkg.Output, 0)}
+			suite.SystemOut = &Output{Data: formatOutput(pkg.Output)}
 		}
 
 		if pkg.Coverage > 0 {
@@ -209,20 +225,20 @@ func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
 	if test.Result == gtr.Fail {
 		tc.Failure = &Result{
 			Message: "Failed",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if test.Result == gtr.Skip {
 		tc.Skipped = &Result{
 			Message: "Skipped",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if test.Result == gtr.Unknown {
 		tc.Error = &Result{
 			Message: "No test result found",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if len(test.Output) > 0 {
-		tc.SystemOut = &Output{Data: formatOutput(test.Output, test.Level)}
+		tc.SystemOut = &Output{Data: formatOutput(test.Output)}
 	}
 	return tc
 }
@@ -234,6 +250,28 @@ func formatDuration(d time.Duration) string {
 }
 
 // formatOutput combines the lines from the given output into a single string.
-func formatOutput(output []string, indent int) string {
-	return strings.Join(output, "\n")
+func formatOutput(output []string) string {
+	return escapeIllegalChars(strings.Join(output, "\n"))
+}
+
+func escapeIllegalChars(str string) string {
+	return strings.Map(func(r rune) rune {
+		if isInCharacterRange(r) {
+			return r
+		}
+		return '\uFFFD'
+	}, str)
+}
+
+// Decide whether the given rune is in the XML Character Range, per
+// the Char production of https://www.xml.com/axml/testaxml.htm,
+// Section 2.2 Characters.
+// From: encoding/xml/xml.go
+func isInCharacterRange(r rune) (inrange bool) {
+	return r == 0x09 ||
+		r == 0x0A ||
+		r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/jstemmer/go-junit-report/v2 v2.0.0
+# github.com/jstemmer/go-junit-report/v2 v2.1.0
 ## explicit; go 1.13
 github.com/jstemmer/go-junit-report/v2/gtr
 github.com/jstemmer/go-junit-report/v2/junit


### PR DESCRIPTION
This hack is no longer required as https://github.com/jstemmer/go-junit-report/issues/169 was fixed