### PR TITLE
Revert "test: Revert parsing hack for go-junit-report (#1667)"

### DIFF
--- a/build/prow/e2e/Dockerfile
+++ b/build/prow/e2e/Dockerfile
@@ -33,7 +33,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 # Get go-junit-report
-RUN go install github.com/jstemmer/go-junit-report/v2@v2.1.0
+RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0
 
 # Build e2e image
 FROM ${DOCKER_CLI_IMAGE} as gke-e2e

--- a/cmd/junit-report/resetfailure/reset_failure.go
+++ b/cmd/junit-report/resetfailure/reset_failure.go
@@ -17,6 +17,7 @@ package resetfailure
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
@@ -77,5 +78,20 @@ func updateReport(t *junit.Testsuites, path string) error {
 	if err != nil {
 		return err
 	}
-	return t.WriteXML(f)
+	return writeXML(t, f)
+}
+
+// copied from https://github.com/jstemmer/go-junit-report/blob/075629ad5f2934f016fa8fe79deb821f98bd8b44/junit/junit.go#L41
+// TODO: remove the duplicate when a new go-junit-report release is available.
+func writeXML(t *junit.Testsuites, w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.6.0
-	github.com/jstemmer/go-junit-report/v2 v2.1.0
+	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/open-policy-agent/cert-controller v0.10.2-0.20240531181455-2649f121ab97
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
-github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
+github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -35,6 +35,11 @@ echo "Tests took $(( end_time - start_time )) seconds"
 # enables running this script more flexibly, e.g. without docker in docker.
 if [[ -n "${ARTIFACTS}" && -d "${ARTIFACTS}" ]]; then
   echo "Creating junit xml report"
+  # Go 1.20 started using "=== NAME" when tests resume instead of "=== CONT".
+  # go-junit-report does not yet properly parse "=== NAME", so this hack enables
+  # proper parsing.
+  # TODO: revert when fixed https://github.com/jstemmer/go-junit-report/issues/169
+  sed -i -e 's/=== NAME/=== CONT/g' test_results.txt
   go-junit-report --subtest-mode=exclude-parents < test_results.txt > "${ARTIFACTS}/junit_report.xml"
   if [ "$exit_code" -eq 0 ]; then
     echo "Running junit-report post processor"

--- a/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
@@ -10,7 +10,6 @@ import (
 // Result is the result of a test.
 type Result int
 
-// Test results.
 const (
 	Unknown Result = iota
 	Pass
@@ -61,7 +60,7 @@ type Package struct {
 	Duration   time.Duration
 	Coverage   float64
 	Output     []string
-	Properties []Property
+	Properties map[string]string
 
 	Tests []Test
 
@@ -73,28 +72,10 @@ type Package struct {
 // property with the given key already exists, its old value will be
 // overwritten with the given value.
 func (p *Package) SetProperty(key, value string) {
-	// TODO(jstemmer): Delete this method in the next major release.
-	// Delete all the properties whose name is the specified key,
-	// then add the specified key-value property.
-	i := 0
-	for _, prop := range p.Properties {
-		if key != prop.Name {
-			p.Properties[i] = prop
-			i++
-		}
+	if p.Properties == nil {
+		p.Properties = make(map[string]string)
 	}
-	p.Properties = p.Properties[:i]
-	p.AddProperty(key, value)
-}
-
-// AddProperty appends a name/value property in the current package.
-func (p *Package) AddProperty(name, value string) {
-	p.Properties = append(p.Properties, Property{Name: name, Value: value})
-}
-
-// Property is a name/value property.
-type Property struct {
-	Name, Value string
+	p.Properties[key] = value
 }
 
 // Test contains the results of a single test.
@@ -135,7 +116,7 @@ func TrimPrefixSpaces(line string, indent int) string {
 	// from a test.
 	prefixLen := strings.IndexFunc(line, func(r rune) bool { return r != ' ' })
 	if prefixLen%4 == 0 {
-		// Use the subtest level to trim a consistently sized prefix from the
+		// Use the subtest level to trim a consistenly sized prefix from the
 		// output lines.
 		for i := 0; i <= indent; i++ {
 			line = strings.TrimPrefix(line, "    ")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/jstemmer/go-junit-report/v2 v2.1.0
+# github.com/jstemmer/go-junit-report/v2 v2.0.0
 ## explicit; go 1.13
 github.com/jstemmer/go-junit-report/v2/gtr
 github.com/jstemmer/go-junit-report/v2/junit


### PR DESCRIPTION
This reverts commit fd80f755de703f7848e2fc3444f840d329602c0e.

Reason for revert: This change appears to have broken the junit report parsing.