### PR TITLE
test: default to creating clusters for KinD only if -create-clusters=false

### DIFF
--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -58,7 +58,7 @@ func setDefaultArgs() {
 	}
 	// default to creating clusters for KinD. this is an acceptable default for
 	// KinD, but for GKE the user should explicitly request creating clusters.
-	if *e2e.TestCluster == e2e.Kind && len(*e2e.ClusterNames) == 0 {
+	if *e2e.TestCluster == e2e.Kind && len(*e2e.ClusterNames) == 0 && *e2e.CreateClusters == e2e.CreateClustersDisabled {
 		*e2e.CreateClusters = e2e.CreateClustersEnabled
 	}
 


### PR DESCRIPTION
This allows for `create-clusters` to be set to `lazy` for local development