### PR TITLE
ci: skip kind updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,5 @@ updates:
   ignore:
   - dependency-name: k8s.io/*
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # kind requires us to also update the image digests in code
+  - dependency-name: sigs.k8s.io/kind


### PR DESCRIPTION
kind update also requires updating the supported image tags