### PR TITLE
chore: bump github.com/jstemmer/go-junit-report/v2 from 2.0.0 to 2.1.0

### DIFF
--- a/cmd/junit-report/resetfailure/reset_failure.go
+++ b/cmd/junit-report/resetfailure/reset_failure.go
@@ -17,7 +17,6 @@ package resetfailure
 import (
 	"encoding/xml"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
@@ -78,20 +77,5 @@ func updateReport(t *junit.Testsuites, path string) error {
 	if err != nil {
 		return err
 	}
-	return writeXML(t, f)
-}
-
-// copied from https://github.com/jstemmer/go-junit-report/blob/075629ad5f2934f016fa8fe79deb821f98bd8b44/junit/junit.go#L41
-// TODO: remove the duplicate when a new go-junit-report release is available.
-func writeXML(t *junit.Testsuites, w io.Writer) error {
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "\t")
-	if err := enc.Encode(t); err != nil {
-		return err
-	}
-	if err := enc.Flush(); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "\n")
-	return err
+	return t.WriteXML(f)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-containerregistry v0.20.4
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.6.0
-	github.com/jstemmer/go-junit-report/v2 v2.0.0
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/open-policy-agent/cert-controller v0.10.2-0.20240531181455-2649f121ab97
 	github.com/prometheus/client_golang v1.20.4

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
-github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -35,11 +35,6 @@ echo "Tests took $(( end_time - start_time )) seconds"
 # enables running this script more flexibly, e.g. without docker in docker.
 if [[ -n "${ARTIFACTS}" && -d "${ARTIFACTS}" ]]; then
   echo "Creating junit xml report"
-  # Go 1.20 started using "=== NAME" when tests resume instead of "=== CONT".
-  # go-junit-report does not yet properly parse "=== NAME", so this hack enables
-  # proper parsing.
-  # TODO: revert when fixed https://github.com/jstemmer/go-junit-report/issues/169
-  sed -i -e 's/=== NAME/=== CONT/g' test_results.txt
   go-junit-report --subtest-mode=exclude-parents < test_results.txt > "${ARTIFACTS}/junit_report.xml"
   if [ "$exit_code" -eq 0 ]; then
     echo "Running junit-report post processor"

--- a/vendor/github.com/jstemmer/go-junit-report/v2/Makefile
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/Makefile
@@ -18,6 +18,7 @@ release: test
 	$(MAKE) GOOS=linux GOARCH=amd64 build/go-junit-report-$(VERSION)-linux-amd64.tar.gz
 	$(MAKE) GOOS=windows GOARCH=amd64 build/go-junit-report-$(VERSION)-windows-amd64.zip
 	$(MAKE) GOOS=darwin GOARCH=amd64 build/go-junit-report-$(VERSION)-darwin-amd64.tar.gz
+	$(MAKE) GOOS=darwin GOARCH=arm64 build/go-junit-report-$(VERSION)-darwin-arm64.tar.gz
 
 clean:
 	rm -f build/go-junit-report

--- a/vendor/github.com/jstemmer/go-junit-report/v2/README.md
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/README.md
@@ -3,15 +3,9 @@
 go-junit-report is a tool that converts [`go test`] output to a JUnit compatible
 XML report, suitable for use with applications such as [Jenkins].
 
-[![Build status][github-actions-badge]][github-actions-link]
-
-The test output parser and JUnit XML report generator are also available as Go
-packages. This can be helpful if you want to create your own custom JUnit
-reports for example. See the package documentation on pkg.go.dev for more
-information:
-
-- [go-junit-report/v2/pkg/parser/gotest]
-- [go-junit-report/v2/pkg/junit]
+[![Build status](https://github.com/jstemmer/go-junit-report/actions/workflows/main.yml/badge.svg)](https://github.com/jstemmer/go-junit-report/actions)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jstemmer/go-junit-report/v2.svg)](https://pkg.go.dev/github.com/jstemmer/go-junit-report/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jstemmer/go-junit-report/v2)](https://goreportcard.com/report/github.com/jstemmer/go-junit-report/v2)
 
 ## Install from package (recommended)
 
@@ -23,7 +17,7 @@ page.
 Download and install the latest stable version from source by running:
 
 ```bash
-go install github.com/jstemmer/go-junit-report@latest
+go install github.com/jstemmer/go-junit-report/v2@latest
 ```
 
 ## Usage
@@ -85,16 +79,60 @@ Run `go-junit-report -help` for a list of all supported flags.
 | `-subtest-mode`       | set subtest `mode`, modes are: `ignore-parent-results`, `exclude-parents`       |
 | `-version`            | print version and exit                                                          |
 
+## Go packages
+
+The test output parser and JUnit XML report generator are also available as Go
+packages. This can be helpful if you want to use the `go test` output parser or
+create your own custom JUnit reports for example. See the package documentation
+on pkg.go.dev for more information:
+
+- [github.com/jstemmer/go-junit-report/v2/parser/gotest]
+- [github.com/jstemmer/go-junit-report/v2/junit]
+
+## Changelog
+
+### v2.1.0
+
+- Fix #147: Make timestamps in generated report more accurate.
+- Fix #140: Escape illegal XML characters in junit output.
+- Fix #145: Handle build errors in test packages with the `_test` suffix.
+- Fix #145: Don't ignore build errors that did not belong to a package.
+- Fix #134: Json test output was not parsed correctly when using the `-race` flag in `go test`.
+- Add support for `=== NAME` lines introduced in Go1.20
+- junit: Add File attribute to `testsuite`.
+- junit: Allow multiple properties with the same name.
+- junit: Add the `Testsuites.WriteXML` convenience method.
+
+### v2.0.0
+
+- Support for parsing `go test -json` output.
+- Distinguish between build/runtime errors and test failures.
+- JUnit report now includes output for all tests and benchmarks, and global output that doesn't belong to any test.
+- Use full Go package name in generated report instead of only last path segment.
+- Add support for reading skipped/failed benchmarks.
+- Add `-subtest-mode` flag to exclude or ignore results of subtest parent tests.
+- Add `-in` and `-out` flags for specifying input and output files respectively.
+- Add `-iocopy` flag to copy stdin directly to stdout.
+- Add `-prop` flags to set key/value properties in generated report.
+- Add `-parser` flag to switch between regular `go test` (default) and `go test -json` parsing.
+- Output in JUnit XML is written in `<![CDATA[]]>` tags for improved readability.
+- Add `hostname`, `timestamp` and `id` attributes to JUnit XML.
+- Improve accuracy of benchmark time calculation and update formatting in report.
+- No longer strip leading whitespace from test output.
+- The `formatter` and `parser` packages have been replaced with `junit` and `parser/gotest` packages respectively.
+- Add support for parsing lines longer than 64KiB.
+- The JUnit errors/failures attributes are now required fields.
+- Drop support for parsing pre-Go1.13 test output.
+- Deprecate `-go-version` flag.
+
 ## Contributing
 
 See [CONTRIBUTING.md].
 
 [`go test`]: https://pkg.go.dev/cmd/go#hdr-Test_packages
 [Jenkins]: https://www.jenkins.io/
-[github-actions-badge]: https://github.com/jstemmer/go-junit-report/actions/workflows/main.yml/badge.svg
-[github-actions-link]: https://github.com/jstemmer/go-junit-report/actions
-[go-junit-report/v2/pkg/parser/gotest]: https://pkg.go.dev/github.com/jstemmer/go-junit-report/v2/pkg/parser/gotest
-[go-junit-report/v2/pkg/junit]: https://pkg.go.dev/github.com/jstemmer/go-junit-report/v2/pkg/junit
+[github.com/jstemmer/go-junit-report/v2/parser/gotest]: https://pkg.go.dev/github.com/jstemmer/go-junit-report/v2/parser/gotest
+[github.com/jstemmer/go-junit-report/v2/junit]: https://pkg.go.dev/github.com/jstemmer/go-junit-report/v2/junit
 [Releases]: https://github.com/jstemmer/go-junit-report/releases
 [testing]: https://pkg.go.dev/testing
 [CONTRIBUTING.md]: https://github.com/jstemmer/go-junit-report/blob/master/CONTRIBUTING.md

--- a/vendor/github.com/jstemmer/go-junit-report/v2/internal/gojunitreport/go-junit-report.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/internal/gojunitreport/go-junit-report.go
@@ -64,32 +64,21 @@ func (c Config) Run(input io.Reader, output io.Writer) (*gtr.Report, error) {
 		}
 	}
 
-	if err = c.writeXML(output, report); err != nil {
+	if err = c.writeJunitXML(output, report); err != nil {
 		return nil, err
 	}
 	return &report, nil
 }
 
-func (c Config) writeXML(w io.Writer, report gtr.Report) error {
+func (c Config) writeJunitXML(w io.Writer, report gtr.Report) error {
 	testsuites := junit.CreateFromReport(report, c.Hostname)
-
 	if !c.SkipXMLHeader {
 		_, err := fmt.Fprintf(w, xml.Header)
 		if err != nil {
 			return err
 		}
 	}
-
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "\t")
-	if err := enc.Encode(testsuites); err != nil {
-		return err
-	}
-	if err := enc.Flush(); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "\n")
-	return err
+	return testsuites.WriteXML(w)
 }
 
 func (c Config) gotestOptions() []gotest.Option {

--- a/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
@@ -5,6 +5,7 @@ package junit
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -36,6 +37,20 @@ func (t *Testsuites) AddSuite(ts Testsuite) {
 	t.Disabled += ts.Disabled
 }
 
+// WriteXML writes the XML representation of Testsuites t to writer w.
+func (t *Testsuites) WriteXML(w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}
+
 // Testsuite is a single JUnit testsuite containing testcases.
 type Testsuite struct {
 	// required attributes
@@ -52,6 +67,7 @@ type Testsuite struct {
 	Skipped   int    `xml:"skipped,attr,omitempty"`
 	Time      string `xml:"time,attr"`                // duration in seconds
 	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
+	File      string `xml:"file,attr,omitempty"`
 
 	Properties *[]Property `xml:"properties>property,omitempty"`
 	Testcases  []Testcase  `xml:"testcase,omitempty"`
@@ -73,24 +89,24 @@ func (t *Testsuite) AddProperty(name, value string) {
 // AddTestcase adds Testcase tc to this Testsuite.
 func (t *Testsuite) AddTestcase(tc Testcase) {
 	t.Testcases = append(t.Testcases, tc)
-	t.Tests += 1
+	t.Tests++
 
 	if tc.Error != nil {
-		t.Errors += 1
+		t.Errors++
 	}
 
 	if tc.Failure != nil {
-		t.Failures += 1
+		t.Failures++
 	}
 
 	if tc.Skipped != nil {
-		t.Skipped += 1
+		t.Skipped++
 	}
 }
 
 // SetTimestamp sets the timestamp in this Testsuite.
-func (ts *Testsuite) SetTimestamp(t time.Time) {
-	ts.Timestamp = t.Format(time.RFC3339)
+func (t *Testsuite) SetTimestamp(timestamp time.Time) {
+	t.Timestamp = timestamp.Format(time.RFC3339)
 }
 
 // Testcase represents a single test with its results.
@@ -143,12 +159,12 @@ func CreateFromReport(report gtr.Report, hostname string) Testsuites {
 			suite.SetTimestamp(pkg.Timestamp)
 		}
 
-		for k, v := range pkg.Properties {
-			suite.AddProperty(k, v)
+		for _, p := range pkg.Properties {
+			suite.AddProperty(p.Name, p.Value)
 		}
 
 		if len(pkg.Output) > 0 {
-			suite.SystemOut = &Output{Data: formatOutput(pkg.Output, 0)}
+			suite.SystemOut = &Output{Data: formatOutput(pkg.Output)}
 		}
 
 		if pkg.Coverage > 0 {
@@ -209,20 +225,20 @@ func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
 	if test.Result == gtr.Fail {
 		tc.Failure = &Result{
 			Message: "Failed",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if test.Result == gtr.Skip {
 		tc.Skipped = &Result{
 			Message: "Skipped",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if test.Result == gtr.Unknown {
 		tc.Error = &Result{
 			Message: "No test result found",
-			Data:    formatOutput(test.Output, test.Level),
+			Data:    formatOutput(test.Output),
 		}
 	} else if len(test.Output) > 0 {
-		tc.SystemOut = &Output{Data: formatOutput(test.Output, test.Level)}
+		tc.SystemOut = &Output{Data: formatOutput(test.Output)}
 	}
 	return tc
 }
@@ -234,6 +250,28 @@ func formatDuration(d time.Duration) string {
 }
 
 // formatOutput combines the lines from the given output into a single string.
-func formatOutput(output []string, indent int) string {
-	return strings.Join(output, "\n")
+func formatOutput(output []string) string {
+	return escapeIllegalChars(strings.Join(output, "\n"))
+}
+
+func escapeIllegalChars(str string) string {
+	return strings.Map(func(r rune) rune {
+		if isInCharacterRange(r) {
+			return r
+		}
+		return '\uFFFD'
+	}, str)
+}
+
+// Decide whether the given rune is in the XML Character Range, per
+// the Char production of https://www.xml.com/axml/testaxml.htm,
+// Section 2.2 Characters.
+// From: encoding/xml/xml.go
+func isInCharacterRange(r rune) (inrange bool) {
+	return r == 0x09 ||
+		r == 0x0A ||
+		r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
 }

--- a/vendor/github.com/jstemmer/go-junit-report/v2/main.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/main.go
@@ -1,3 +1,6 @@
+// go-junit-report converts `go test` output to a JUnit compatible XML report.
+//
+// See README.md for more information and usage examples.
 package main
 
 import (
@@ -11,8 +14,9 @@ import (
 	"github.com/jstemmer/go-junit-report/v2/parser/gotest"
 )
 
+// Current release information printed by the -version flag.
 var (
-	Version   = "v2.0.0-dev"
+	Version   = "v2.1.0-dev"
 	Revision  = "HEAD"
 	BuildTime string
 )

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/event.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/event.go
@@ -1,12 +1,17 @@
 package gotest
 
-import "time"
+import (
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
+)
 
 // Event is a single event in a Go test or benchmark.
 type Event struct {
 	Type string `json:"type"`
 
 	Name     string        `json:"name,omitempty"`
+	Package  string        `json:"pkg,omitempty"`
 	Result   string        `json:"result,omitempty"`
 	Duration time.Duration `json:"duration,omitempty"`
 	Data     string        `json:"data,omitempty"`
@@ -22,4 +27,11 @@ type Event struct {
 	MBPerSec    float64 `json:"benchmark_mb_per_sec,omitempty"`
 	BytesPerOp  int64   `json:"benchmark_bytes_per_op,omitempty"`
 	AllocsPerOp int64   `json:"benchmark_allocs_per_op,omitempty"`
+}
+
+func (e *Event) applyMetadata(m *reader.Metadata) {
+	if e == nil || m == nil {
+		return
+	}
+	e.Package = m.Package
 }

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/gotest.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/gotest.go
@@ -3,7 +3,6 @@ package gotest
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -12,6 +11,13 @@ import (
 	"time"
 
 	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
+)
+
+const (
+	// maxLineSize is the maximum amount of bytes we'll read for a single line.
+	// Lines longer than maxLineSize will be truncated.
+	maxLineSize = 4 * 1024 * 1024
 )
 
 var (
@@ -31,11 +37,12 @@ var (
 		`(?:\s+(\d+\.\d+)s)?` +
 		// 4: cached indicator (optional)
 		`(?:\s+(\(cached\)))?` +
-		// 5: [status message] (optional)
+		// 5: coverage percentage (optional)
+		// 6: coverage package list (optional)
+		`(?:\s+coverage:\s+(?:\[no\sstatements\]|(\d+\.\d+)%\sof\sstatements(?:\sin\s(.+))?))?` +
+		// 7: [status message] (optional)
 		`(?:\s+(\[[^\]]+\]))?` +
-		// 6: coverage percentage (optional)
-		// 7: coverage package list (optional)
-		`(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s(.+))?)?$`)
+		`$`)
 )
 
 // Option defines options that can be passed to gotest.New.
@@ -102,12 +109,6 @@ func SetSubtestMode(mode SubtestMode) Option {
 	}
 }
 
-const (
-	// maxLineSize is the maximum amount of bytes we'll read for a single line.
-	// Lines longer than maxLineSize will be truncated.
-	maxLineSize = 4 * 1024 * 1024
-)
-
 // Parser is a Go test output Parser.
 type Parser struct {
 	packageName string
@@ -130,44 +131,28 @@ func NewParser(options ...Option) *Parser {
 // Parse parses Go test output from the given io.Reader r and returns
 // gtr.Report.
 func (p *Parser) Parse(r io.Reader) (gtr.Report, error) {
+	return p.parse(reader.NewLimitedLineReader(r, maxLineSize))
+}
+
+func (p *Parser) parse(r reader.LineReader) (gtr.Report, error) {
 	p.events = nil
-	s := bufio.NewReader(r)
+
+	rb := newReportBuilder()
+	rb.packageName = p.packageName
+	rb.subtestMode = p.subtestMode
+	if p.timestampFunc != nil {
+		rb.timestampFunc = p.timestampFunc
+	}
+
 	for {
-		line, isPrefix, err := s.ReadLine()
+		line, metadata, err := r.ReadLine()
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			return gtr.Report{}, err
 		}
 
-		if !isPrefix {
-			p.parseLine(string(line))
-			continue
-		}
-
-		// Line is incomplete, keep reading until we reach the end of the line.
-		var buf bytes.Buffer
-		buf.Write(line) // ignore err, always nil
-		for isPrefix {
-			line, isPrefix, err = s.ReadLine()
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				return gtr.Report{}, err
-			}
-
-			if buf.Len() >= maxLineSize {
-				// Stop writing to buf if we exceed maxLineSize. We continue
-				// reading however to make sure we consume the entire line.
-				continue
-			}
-
-			buf.Write(line) // ignore err, always nil
-		}
-
-		if buf.Len() > maxLineSize {
-			buf.Truncate(maxLineSize)
-		}
+		var evs []Event
 
 		// Lines that exceed bufio.MaxScanTokenSize are not expected to contain
 		// any relevant test infrastructure output, so instead of parsing them
@@ -177,54 +162,19 @@ func (p *Parser) Parse(r io.Reader) (gtr.Report, error) {
 		// reading lines up to bufio.MaxScanTokenSize in length. Since this
 		// turned out to be fine in almost all cases, it seemed an appropriate
 		// value to use to decide whether or not to attempt parsing this line.
-		if buf.Len() > bufio.MaxScanTokenSize {
-			p.output(buf.String())
+		if len(line) > bufio.MaxScanTokenSize {
+			evs = p.output(line)
 		} else {
-			p.parseLine(buf.String())
+			evs = p.parseLine(line)
 		}
-	}
-	return p.report(p.events), nil
-}
 
-// report generates a gtr.Report from the given list of events.
-func (p *Parser) report(events []Event) gtr.Report {
-	rb := newReportBuilder()
-	rb.packageName = p.packageName
-	rb.subtestMode = p.subtestMode
-	if p.timestampFunc != nil {
-		rb.timestampFunc = p.timestampFunc
-	}
-	for _, ev := range events {
-		switch ev.Type {
-		case "run_test":
-			rb.CreateTest(ev.Name)
-		case "pause_test":
-			rb.PauseTest(ev.Name)
-		case "cont_test":
-			rb.ContinueTest(ev.Name)
-		case "end_test":
-			rb.EndTest(ev.Name, ev.Result, ev.Duration, ev.Indent)
-		case "run_benchmark":
-			rb.CreateBenchmark(ev.Name)
-		case "benchmark":
-			rb.BenchmarkResult(ev.Name, ev.Iterations, ev.NsPerOp, ev.MBPerSec, ev.BytesPerOp, ev.AllocsPerOp)
-		case "end_benchmark":
-			rb.EndBenchmark(ev.Name, ev.Result)
-		case "status":
-			rb.End()
-		case "summary":
-			rb.CreatePackage(ev.Name, ev.Result, ev.Duration, ev.Data)
-		case "coverage":
-			rb.Coverage(ev.CovPct, ev.CovPackages)
-		case "build_output":
-			rb.CreateBuildError(ev.Name)
-		case "output":
-			rb.AppendOutput(ev.Data)
-		default:
-			fmt.Printf("unhandled event type: %v\n", ev.Type)
+		for _, ev := range evs {
+			ev.applyMetadata(metadata)
+			rb.ProcessEvent(ev)
+			p.events = append(p.events, ev)
 		}
 	}
-	return rb.Build()
+	return rb.Build(), nil
 }
 
 // Events returns the events created by the parser.
@@ -234,76 +184,73 @@ func (p *Parser) Events() []Event {
 	return events
 }
 
-func (p *Parser) parseLine(line string) {
+func (p *Parser) parseLine(line string) (events []Event) {
 	if strings.HasPrefix(line, "=== RUN ") {
-		p.runTest(strings.TrimSpace(line[8:]))
+		return p.runTest(strings.TrimSpace(line[8:]))
 	} else if strings.HasPrefix(line, "=== PAUSE ") {
-		p.pauseTest(strings.TrimSpace(line[10:]))
+		return p.pauseTest(strings.TrimSpace(line[10:]))
 	} else if strings.HasPrefix(line, "=== CONT ") {
-		p.contTest(strings.TrimSpace(line[9:]))
+		return p.contTest(strings.TrimSpace(line[9:]))
+	} else if strings.HasPrefix(line, "=== NAME ") {
+		// for compatibility with gotest 1.20+ https://go-review.git.corp.google.com/c/go/+/443596
+		return p.contTest(strings.TrimSpace(line[9:]))
 	} else if matches := regexEndTest.FindStringSubmatch(line); len(matches) == 5 {
-		p.endTest(line, matches[1], matches[2], matches[3], matches[4])
+		return p.endTest(line, matches[1], matches[2], matches[3], matches[4])
 	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 2 {
-		p.status(matches[1])
+		return p.status(matches[1])
 	} else if matches := regexSummary.FindStringSubmatch(line); len(matches) == 8 {
-		p.summary(matches[1], matches[2], matches[3], matches[4], matches[5], matches[6], matches[7])
+		return p.summary(matches[1], matches[2], matches[3], matches[4], matches[7], matches[5], matches[6])
 	} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 3 {
-		p.coverage(matches[1], matches[2])
+		return p.coverage(matches[1], matches[2])
 	} else if matches := regexBenchmark.FindStringSubmatch(line); len(matches) == 2 {
-		p.runBench(matches[1])
+		return p.runBench(matches[1])
 	} else if matches := regexBenchSummary.FindStringSubmatch(line); len(matches) == 7 {
-		p.benchSummary(matches[1], matches[2], matches[3], matches[4], matches[5], matches[6])
+		return p.benchSummary(matches[1], matches[2], matches[3], matches[4], matches[5], matches[6])
 	} else if matches := regexEndBenchmark.FindStringSubmatch(line); len(matches) == 3 {
-		p.endBench(matches[1], matches[2])
+		return p.endBench(matches[1], matches[2])
 	} else if strings.HasPrefix(line, "# ") {
-		// TODO(jstemmer): this should just be output; we should detect build output when building report
 		fields := strings.Fields(strings.TrimPrefix(line, "# "))
 		if len(fields) == 1 || len(fields) == 2 {
-			p.buildOutput(fields[0])
-		} else {
-			p.output(line)
+			return p.buildOutput(fields[0])
 		}
-	} else {
-		p.output(line)
 	}
+	return p.output(line)
 }
 
-func (p *Parser) add(event Event) {
-	p.events = append(p.events, event)
+func (p *Parser) runTest(name string) []Event {
+	return []Event{{Type: "run_test", Name: name}}
 }
 
-func (p *Parser) runTest(name string) {
-	p.add(Event{Type: "run_test", Name: name})
+func (p *Parser) pauseTest(name string) []Event {
+	return []Event{{Type: "pause_test", Name: name}}
 }
 
-func (p *Parser) pauseTest(name string) {
-	p.add(Event{Type: "pause_test", Name: name})
+func (p *Parser) contTest(name string) []Event {
+	return []Event{{Type: "cont_test", Name: name}}
 }
 
-func (p *Parser) contTest(name string) {
-	p.add(Event{Type: "cont_test", Name: name})
-}
-
-func (p *Parser) endTest(line, indent, result, name, duration string) {
+func (p *Parser) endTest(line, indent, result, name, duration string) []Event {
+	var events []Event
 	if idx := strings.Index(line, fmt.Sprintf("%s--- %s:", indent, result)); idx > 0 {
-		p.output(line[:idx])
+		events = append(events, p.output(line[:idx])...)
 	}
 	_, n := stripIndent(indent)
-	p.add(Event{
+	events = append(events, Event{
 		Type:     "end_test",
 		Name:     name,
 		Result:   result,
 		Indent:   n,
 		Duration: parseSeconds(duration),
 	})
+	return events
 }
 
-func (p *Parser) status(result string) {
-	p.add(Event{Type: "status", Result: result})
+func (p *Parser) status(result string) []Event {
+	return []Event{{Type: "status", Result: result}}
 }
 
-func (p *Parser) summary(result, name, duration, cached, status, covpct, packages string) {
-	p.add(Event{
+func (p *Parser) summary(result, name, duration, cached, status, covpct, packages string) []Event {
+	return []Event{{
 		Type:        "summary",
 		Result:      result,
 		Name:        name,
@@ -311,26 +258,26 @@ func (p *Parser) summary(result, name, duration, cached, status, covpct, package
 		Data:        strings.TrimSpace(cached + " " + status),
 		CovPct:      parseFloat(covpct),
 		CovPackages: parsePackages(packages),
-	})
+	}}
 }
 
-func (p *Parser) coverage(percent, packages string) {
-	p.add(Event{
+func (p *Parser) coverage(percent, packages string) []Event {
+	return []Event{{
 		Type:        "coverage",
 		CovPct:      parseFloat(percent),
 		CovPackages: parsePackages(packages),
-	})
+	}}
 }
 
-func (p *Parser) runBench(name string) {
-	p.add(Event{
+func (p *Parser) runBench(name string) []Event {
+	return []Event{{
 		Type: "run_benchmark",
 		Name: name,
-	})
+	}}
 }
 
-func (p *Parser) benchSummary(name, iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp string) {
-	p.add(Event{
+func (p *Parser) benchSummary(name, iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp string) []Event {
+	return []Event{{
 		Type:        "benchmark",
 		Name:        name,
 		Iterations:  parseInt(iterations),
@@ -338,26 +285,26 @@ func (p *Parser) benchSummary(name, iterations, nsPerOp, mbPerSec, bytesPerOp, a
 		MBPerSec:    parseFloat(mbPerSec),
 		BytesPerOp:  parseInt(bytesPerOp),
 		AllocsPerOp: parseInt(allocsPerOp),
-	})
+	}}
 }
 
-func (p *Parser) endBench(result, name string) {
-	p.add(Event{
+func (p *Parser) endBench(result, name string) []Event {
+	return []Event{{
 		Type:   "end_benchmark",
 		Name:   name,
 		Result: result,
-	})
+	}}
 }
 
-func (p *Parser) buildOutput(packageName string) {
-	p.add(Event{
+func (p *Parser) buildOutput(packageName string) []Event {
+	return []Event{{
 		Type: "build_output",
 		Name: packageName,
-	})
+	}}
 }
 
-func (p *Parser) output(line string) {
-	p.add(Event{Type: "output", Data: line})
+func (p *Parser) output(line string) []Event {
+	return []Event{{Type: "output", Data: line}}
 }
 
 func parseSeconds(s string) time.Duration {

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector/collector.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector/collector.go
@@ -14,10 +14,14 @@ type line struct {
 }
 
 // Output stores output lines grouped by id. Output can be retrieved for one or
-// more ids and output of different ids can be merged together, all while
-// preserving their original order based on the time it was collected.
+// more ids and output for different ids can be merged together, while
+// preserving their insertion original order based on the time it was
+// collected.
+// Output also tracks the active id, so you can append output without providing
+// an id.
 type Output struct {
-	m map[int][]line
+	m  map[int][]line
+	id int // active id
 }
 
 // New returns a new output collector.
@@ -27,11 +31,17 @@ func New() *Output {
 
 // Clear deletes all output for the given id.
 func (o *Output) Clear(id int) {
-	o.m[id] = nil
+	delete(o.m, id)
 }
 
-// Append appends the given line of text to the output of the specified id.
-func (o *Output) Append(id int, text string) {
+// Append appends the given line of text to the output of the currently active
+// id.
+func (o *Output) Append(text string) {
+	o.m[o.id] = append(o.m[o.id], line{time.Now(), text})
+}
+
+// AppendToID appends the given line of text to the output of the given id.
+func (o *Output) AppendToID(id int, text string) {
 	o.m[id] = append(o.m[id], line{time.Now(), text})
 }
 
@@ -78,4 +88,10 @@ func (o *Output) Merge(fromID, intoID int) {
 	})
 	o.m[intoID] = merged
 	delete(o.m, fromID)
+}
+
+// SetActiveID sets the active id. Text appended to this output will be
+// associated with the active id.
+func (o *Output) SetActiveID(id int) {
+	o.id = id
 }

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader/reader.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader/reader.go
@@ -1,0 +1,122 @@
+package reader
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+)
+
+// LineReader is an interface to read lines with optional Metadata.
+type LineReader interface {
+	ReadLine() (string, *Metadata, error)
+}
+
+// Metadata contains metadata that belongs to a line.
+type Metadata struct {
+	Package string
+}
+
+// LimitedLineReader reads lines from an io.Reader object with a configurable
+// line size limit. Lines exceeding the limit will be truncated, but read
+// completely from the underlying io.Reader.
+type LimitedLineReader struct {
+	r     *bufio.Reader
+	limit int
+}
+
+var _ LineReader = &LimitedLineReader{}
+
+// NewLimitedLineReader returns a LimitedLineReader to read lines from r with a
+// maximum line size of limit.
+func NewLimitedLineReader(r io.Reader, limit int) *LimitedLineReader {
+	return &LimitedLineReader{r: bufio.NewReader(r), limit: limit}
+}
+
+// ReadLine returns the next line from the underlying reader. The length of the
+// line will not exceed the configured limit. ReadLine either returns a line or
+// it returns an error, never both.
+func (r *LimitedLineReader) ReadLine() (string, *Metadata, error) {
+	line, isPrefix, err := r.r.ReadLine()
+	if err != nil {
+		return "", nil, err
+	}
+
+	if !isPrefix {
+		return string(line), nil, nil
+	}
+
+	// Line is incomplete, keep reading until we reach the end of the line.
+	var buf bytes.Buffer
+	buf.Write(line) // ignore err, always nil
+	for isPrefix {
+		line, isPrefix, err = r.r.ReadLine()
+		if err != nil {
+			return "", nil, err
+		}
+
+		if buf.Len() >= r.limit {
+			// Stop writing to buf if we exceed the limit. We continue reading
+			// however to make sure we consume the entire line.
+			continue
+		}
+
+		buf.Write(line) // ignore err, always nil
+	}
+
+	if buf.Len() > r.limit {
+		buf.Truncate(r.limit)
+	}
+	return buf.String(), nil, nil
+}
+
+// Event represents a JSON event emitted by `go test -json`.
+type Event struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+// JSONEventReader reads JSON events from an io.Reader object.
+type JSONEventReader struct {
+	r *LimitedLineReader
+}
+
+var _ LineReader = &JSONEventReader{}
+
+// jsonLineLimit is the maximum size of a single JSON line emitted by `go test
+// -json`.
+const jsonLineLimit = 64 * 1024
+
+// NewJSONEventReader returns a JSONEventReader to read the data in JSON
+// events from r.
+func NewJSONEventReader(r io.Reader) *JSONEventReader {
+	return &JSONEventReader{NewLimitedLineReader(r, jsonLineLimit)}
+}
+
+// ReadLine returns the next line from the underlying reader.
+func (r *JSONEventReader) ReadLine() (string, *Metadata, error) {
+	for {
+		line, _, err := r.r.ReadLine()
+		if err != nil {
+			return "", nil, err
+		}
+		if len(line) == 0 || line[0] != '{' {
+			return line, nil, nil
+		}
+		event := &Event{}
+		if err := json.Unmarshal([]byte(line), event); err != nil {
+			return "", nil, err
+		}
+		if event.Output == "" {
+			// Skip events without output
+			continue
+		}
+		return strings.TrimSuffix(event.Output, "\n"), &Metadata{Package: event.Package}, nil
+	}
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/json.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/json.go
@@ -1,12 +1,10 @@
 package gotest
 
 import (
-	"bufio"
-	"encoding/json"
 	"io"
-	"time"
 
 	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
 )
 
 // NewJSONParser returns a new Go test json output parser.
@@ -14,7 +12,7 @@ func NewJSONParser(options ...Option) *JSONParser {
 	return &JSONParser{gp: NewParser(options...)}
 }
 
-// Parser is a Go test json output Parser.
+// JSONParser is a `go test -json` output Parser.
 type JSONParser struct {
 	gp *Parser
 }
@@ -22,56 +20,10 @@ type JSONParser struct {
 // Parse parses Go test json output from the given io.Reader r and returns
 // gtr.Report.
 func (p *JSONParser) Parse(r io.Reader) (gtr.Report, error) {
-	return p.gp.Parse(newJSONReader(r))
+	return p.gp.parse(reader.NewJSONEventReader(r))
 }
 
 // Events returns the events created by the parser.
 func (p *JSONParser) Events() []Event {
 	return p.gp.Events()
-}
-
-type jsonEvent struct {
-	Time    time.Time
-	Action  string
-	Package string
-	Test    string
-	Elapsed float64 // seconds
-	Output  string
-}
-
-type jsonReader struct {
-	r   *bufio.Reader
-	buf []byte
-}
-
-func newJSONReader(reader io.Reader) *jsonReader {
-	return &jsonReader{r: bufio.NewReader(reader)}
-}
-
-func (j *jsonReader) Read(p []byte) (int, error) {
-	var err error
-	for len(j.buf) == 0 {
-		j.buf, err = j.readNextLine()
-		if err != nil {
-			return 0, err
-		}
-	}
-	n := copy(p, j.buf)
-	j.buf = j.buf[n:]
-	return n, nil
-}
-
-func (j jsonReader) readNextLine() ([]byte, error) {
-	line, err := j.r.ReadBytes('\n')
-	if err != nil {
-		return nil, err
-	}
-	if len(line) == 0 || line[0] != '{' {
-		return line, nil
-	}
-	var event jsonEvent
-	if err := json.Unmarshal(line, &event); err != nil {
-		return nil, err
-	}
-	return []byte(event.Output), nil
 }

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/report_builder.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/report_builder.go
@@ -1,6 +1,8 @@
 package gotest
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,23 +16,20 @@ const (
 
 // reportBuilder helps build a test Report from a collection of events.
 //
-// The reportBuilder keeps track of the active context whenever a test or build
-// error is created. This is necessary because the test parser do not contain
-// any state themselves and simply just emit an event for every line that is
-// read. By tracking the active context, any output that is appended to the
-// reportBuilder gets attributed to the correct test or build error.
+// The reportBuilder delegates to the packageBuilder for creating packages from
+// basic test events, but keeps track of build errors itself. The reportBuilder
+// is also responsible for generating unique test id's.
+//
+// Test output is collected by the output collector, which also keeps track of
+// the currently active test so output is automatically associated with the
+// correct test.
 type reportBuilder struct {
-	packages    []gtr.Package
-	tests       map[int]gtr.Test
-	buildErrors map[int]gtr.Error
-	runErrors   map[int]gtr.Error
+	packageBuilders map[string]*packageBuilder
+	buildErrors     map[int]gtr.Error
 
-	// state
-	nextID    int               // next free unused id
-	lastID    int               // most recently created id
-	output    *collector.Output // output collected for each id
-	coverage  float64           // coverage percentage
-	parentIDs map[int]struct{}  // set of test id's that contain subtests
+	nextID   int               // next free unused id
+	output   *collector.Output // output collected for each id
+	packages []gtr.Package     // completed packages
 
 	// options
 	packageName   string
@@ -41,286 +40,202 @@ type reportBuilder struct {
 // newReportBuilder creates a new reportBuilder.
 func newReportBuilder() *reportBuilder {
 	return &reportBuilder{
-		tests:         make(map[int]gtr.Test),
-		buildErrors:   make(map[int]gtr.Error),
-		runErrors:     make(map[int]gtr.Error),
-		nextID:        1,
-		output:        collector.New(),
-		parentIDs:     make(map[int]struct{}),
-		timestampFunc: time.Now,
+		packageBuilders: make(map[string]*packageBuilder),
+		buildErrors:     make(map[int]gtr.Error),
+		nextID:          1,
+		output:          collector.New(),
+		timestampFunc:   time.Now,
 	}
 }
 
-// newID returns a new unique id and sets the active context this id.
-func (b *reportBuilder) newID() int {
+// getPackageBuilder returns the packageBuilder for the given packageName. If
+// no packageBuilder exists for the given package, a new one is created.
+func (b *reportBuilder) getPackageBuilder(packageName string) *packageBuilder {
+	pb, ok := b.packageBuilders[packageName]
+	if !ok {
+		output := b.output
+		if packageName != "" {
+			output = collector.New()
+		}
+		pb = newPackageBuilder(b.generateID, output)
+		b.packageBuilders[packageName] = pb
+	}
+	return pb
+}
+
+// ProcessEvent takes a test event and adds it to the report.
+func (b *reportBuilder) ProcessEvent(ev Event) {
+	switch ev.Type {
+	case "run_test":
+		b.getPackageBuilder(ev.Package).CreateTest(ev.Name)
+	case "pause_test":
+		b.getPackageBuilder(ev.Package).PauseTest(ev.Name)
+	case "cont_test":
+		b.getPackageBuilder(ev.Package).ContinueTest(ev.Name)
+	case "end_test":
+		b.getPackageBuilder(ev.Package).EndTest(ev.Name, ev.Result, ev.Duration, ev.Indent)
+	case "run_benchmark":
+		b.getPackageBuilder(ev.Package).CreateTest(ev.Name)
+	case "benchmark":
+		b.getPackageBuilder(ev.Package).BenchmarkResult(ev.Name, ev.Iterations, ev.NsPerOp, ev.MBPerSec, ev.BytesPerOp, ev.AllocsPerOp)
+	case "end_benchmark":
+		b.getPackageBuilder(ev.Package).EndTest(ev.Name, ev.Result, 0, 0)
+	case "status":
+		b.getPackageBuilder(ev.Package).End()
+	case "summary":
+		// The summary marks the end of a package. We can now create the actual
+		// package from all the events we've processed so far for this package.
+		b.packages = append(b.packages, b.CreatePackage(ev.Package, ev.Name, ev.Result, ev.Duration, ev.Data))
+	case "coverage":
+		b.getPackageBuilder(ev.Package).Coverage(ev.CovPct, ev.CovPackages)
+	case "build_output":
+		b.CreateBuildError(ev.Name)
+	case "output":
+		if ev.Package != "" {
+			b.getPackageBuilder(ev.Package).Output(ev.Data)
+		} else {
+			b.output.Append(ev.Data)
+		}
+	default:
+		// This shouldn't happen, but just in case print a warning and ignore
+		// this event.
+		fmt.Printf("reportBuilder: unhandled event type: %v\n", ev.Type)
+	}
+}
+
+// newID returns a new unique id.
+func (b *reportBuilder) generateID() int {
 	id := b.nextID
-	b.lastID = id
-	b.nextID += 1
+	b.nextID++
 	return id
 }
 
-// flush creates a new package in this report containing any tests we've
-// collected so far. This is necessary when a test did not end with a summary.
-func (b *reportBuilder) flush() {
-	if len(b.tests) > 0 {
-		b.CreatePackage(b.packageName, "", 0, "")
-	}
-}
-
-// Build returns the new Report containing all the tests and output created so
-// far.
+// Build returns the new Report containing all the tests, build errors and
+// their output created from the processed events.
 func (b *reportBuilder) Build() gtr.Report {
-	b.flush()
+	// Create packages for any leftover package builders.
+	for name, pb := range b.packageBuilders {
+		if pb.IsEmpty() {
+			continue
+		}
+		b.packages = append(b.packages, b.CreatePackage(name, b.packageName, "", 0, ""))
+	}
+
+	// Create packages for any leftover build errors.
+	for _, buildErr := range b.buildErrors {
+		b.packages = append(b.packages, b.CreatePackage("", buildErr.Name, "", 0, ""))
+	}
 	return gtr.Report{Packages: b.packages}
-}
-
-// CreateTest adds a test with the given name to the report, and marks it as
-// active.
-func (b *reportBuilder) CreateTest(name string) {
-	if parentID, ok := b.findTestParentID(name); ok {
-		b.parentIDs[parentID] = struct{}{}
-	}
-	id := b.newID()
-	b.tests[id] = gtr.NewTest(id, name)
-}
-
-// PauseTest marks the active context as no longer active. Any results or
-// output added to the report after calling PauseTest will no longer be assumed
-// to belong to this test.
-func (b *reportBuilder) PauseTest(name string) {
-	b.lastID = 0
-}
-
-// ContinueTest finds the test with the given name and marks it as active. If
-// more than one test exist with this name, the most recently created test will
-// be used.
-func (b *reportBuilder) ContinueTest(name string) {
-	b.lastID, _ = b.findTest(name)
-}
-
-// EndTest finds the test with the given name, sets the result, duration and
-// level. If more than one test exists with this name, the most recently
-// created test will be used. If no test exists with this name, a new test is
-// created.
-func (b *reportBuilder) EndTest(name, result string, duration time.Duration, level int) {
-	id, ok := b.findTest(name)
-	if !ok {
-		// test did not exist, create one
-		// TODO: Likely reason is that the user ran go test without the -v
-		// flag, should we report this somewhere?
-		b.CreateTest(name)
-		id = b.lastID
-	}
-
-	t := b.tests[id]
-	t.Result = parseResult(result)
-	t.Duration = duration
-	t.Level = level
-	b.tests[id] = t
-	b.lastID = 0
-}
-
-// End marks the active context as no longer active.
-func (b *reportBuilder) End() {
-	b.lastID = 0
-}
-
-// CreateBenchmark adds a benchmark with the given name to the report, and
-// marks it as active. If more than one benchmark exists with this name, the
-// most recently created benchmark will be updated. If no benchmark exists with
-// this name, a new benchmark is created.
-func (b *reportBuilder) CreateBenchmark(name string) {
-	b.CreateTest(name)
-}
-
-// BenchmarkResult updates an existing or adds a new test with the given
-// results and marks it as active. If an existing test with this name exists
-// but without result, then that one is updated. Otherwise a new one is added
-// to the report.
-func (b *reportBuilder) BenchmarkResult(name string, iterations int64, nsPerOp, mbPerSec float64, bytesPerOp, allocsPerOp int64) {
-	id, ok := b.findTest(name)
-	if !ok || b.tests[id].Result != gtr.Unknown {
-		b.CreateTest(name)
-		id = b.lastID
-	}
-
-	benchmark := Benchmark{iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp}
-	test := gtr.NewTest(id, name)
-	test.Result = gtr.Pass
-	test.Duration = benchmark.ApproximateDuration()
-	SetBenchmarkData(&test, benchmark)
-	b.tests[id] = test
-}
-
-// EndBenchmark finds the benchmark with the given name and sets the result. If
-// more than one benchmark exists with this name, the most recently created
-// benchmark will be used. If no benchmark exists with this name, a new
-// benchmark is created.
-func (b *reportBuilder) EndBenchmark(name, result string) {
-	b.EndTest(name, result, 0, 0)
 }
 
 // CreateBuildError creates a new build error and marks it as active.
 func (b *reportBuilder) CreateBuildError(packageName string) {
-	id := b.newID()
+	id := b.generateID()
+	b.output.SetActiveID(id)
 	b.buildErrors[id] = gtr.Error{ID: id, Name: packageName}
 }
 
-// CreatePackage adds a new package with the given name to the Report. This
-// package contains all the build errors, output, tests and benchmarks created
-// so far. Afterwards all state is reset.
-func (b *reportBuilder) CreatePackage(name, result string, duration time.Duration, data string) {
+// CreatePackage returns a new package containing all the build errors, output,
+// tests and benchmarks created so far. The optional packageName is used to
+// find the correct reportBuilder. The newPackageName is the actual package
+// name that will be given to the returned package, which should be used in
+// case the packageName was unknown until this point.
+func (b *reportBuilder) CreatePackage(packageName, newPackageName, result string, duration time.Duration, data string) gtr.Package {
 	pkg := gtr.Package{
-		Name:     name,
-		Duration: duration,
+		Name:      newPackageName,
+		Duration:  duration,
+		Timestamp: b.timestampFunc(),
 	}
 
-	if b.timestampFunc != nil {
-		pkg.Timestamp = b.timestampFunc()
-	}
-
-	// Build errors are treated somewhat differently. Rather than having a
-	// single package with all build errors collected so far, we only care
-	// about the build errors for this particular package.
+	// First check if this package contained a build error. If that's the case,
+	// we won't find any tests in this package.
 	for id, buildErr := range b.buildErrors {
-		if buildErr.Name == name {
-			if len(b.tests) > 0 {
-				panic("unexpected tests found in build error package")
-			}
-			buildErr.ID = id
-			buildErr.Duration = duration
-			buildErr.Cause = data
-			buildErr.Output = b.output.Get(id)
-
+		if buildErr.Name == newPackageName || strings.TrimSuffix(buildErr.Name, "_test") == newPackageName {
 			pkg.BuildError = buildErr
-			b.packages = append(b.packages, pkg)
+			pkg.BuildError.ID = id
+			pkg.BuildError.Duration = duration
+			pkg.BuildError.Cause = data
+			pkg.BuildError.Output = b.output.Get(id)
 
 			delete(b.buildErrors, id)
-			// TODO: reset state
-			// TODO: buildErrors shouldn't reset/use nextID/lastID, they're more like a global cache
-			return
+			b.output.SetActiveID(0)
+			return pkg
 		}
 	}
 
-	// If we've collected output, but there were no tests then either there
-	// actually were no tests, or there was some other non-build error.
-	if b.output.Contains(globalID) && len(b.tests) == 0 {
+	// Get the packageBuilder for this package and make sure it's deleted, so
+	// future events for this package will use a new packageBuilder.
+	pb := b.getPackageBuilder(packageName)
+	delete(b.packageBuilders, packageName)
+	pb.output.SetActiveID(0)
+
+	// If the packageBuilder is empty, we never received any events for this
+	// package so there's no need to continue.
+	if pb.IsEmpty() {
+		// However, we should at least report an error if the result says we
+		// failed.
 		if parseResult(result) == gtr.Fail {
 			pkg.RunError = gtr.Error{
-				Name:   name,
-				Output: b.output.Get(globalID),
+				Name: newPackageName,
 			}
-		} else if b.output.Contains(globalID) {
-			pkg.Output = b.output.Get(globalID)
 		}
-		b.packages = append(b.packages, pkg)
-		b.output.Clear(globalID)
-		return
+		return pkg
+	}
+
+	// If we've collected output, but there were no tests, then this package
+	// had a runtime error or it simply didn't have any tests.
+	if pb.output.Contains(globalID) && len(pb.tests) == 0 {
+		if parseResult(result) == gtr.Fail {
+			pkg.RunError = gtr.Error{
+				Name:   newPackageName,
+				Output: pb.output.Get(globalID),
+			}
+		} else {
+			pkg.Output = pb.output.Get(globalID)
+		}
+		pb.output.Clear(globalID)
+		return pkg
 	}
 
 	// If the summary result says we failed, but there were no failing tests
 	// then something else must have failed.
-	if parseResult(result) == gtr.Fail && len(b.tests) > 0 && !b.containsFailures() {
+	if parseResult(result) == gtr.Fail && len(pb.tests) > 0 && !pb.containsFailures() {
 		pkg.RunError = gtr.Error{
-			Name:   name,
-			Output: b.output.Get(globalID),
+			Name:   newPackageName,
+			Output: pb.output.Get(globalID),
 		}
-		b.output.Clear(globalID)
+		pb.output.Clear(globalID)
 	}
 
-	// Collect tests for this package, maintaining insertion order.
+	// Collect tests for this package
 	var tests []gtr.Test
-	for id := 1; id < b.nextID; id++ {
-		if t, ok := b.tests[id]; ok {
-			if b.isParent(id) {
-				if b.subtestMode == IgnoreParentResults {
-					t.Result = gtr.Pass
-				} else if b.subtestMode == ExcludeParents {
-					b.output.Merge(id, globalID)
-					continue
-				}
+	for id, t := range pb.tests {
+		if pb.isParent(id) {
+			if b.subtestMode == IgnoreParentResults {
+				t.Result = gtr.Pass
+			} else if b.subtestMode == ExcludeParents {
+				pb.output.Merge(id, globalID)
+				continue
 			}
-			t.Output = b.output.Get(id)
-			tests = append(tests, t)
-			continue
 		}
+		t.Output = pb.output.Get(id)
+		tests = append(tests, t)
 	}
-	tests = b.groupBenchmarksByName(tests)
+	tests = groupBenchmarksByName(tests, b.output)
 
-	pkg.Coverage = b.coverage
-	pkg.Output = b.output.Get(globalID)
-	pkg.Tests = tests
-	b.packages = append(b.packages, pkg)
+	// Sort packages by id to ensure we maintain insertion order.
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].ID < tests[j].ID
+	})
 
-	// reset state, except for nextID to ensure all id's are unique.
-	b.lastID = 0
-	b.output.Clear(globalID)
-	b.coverage = 0
-	b.tests = make(map[int]gtr.Test)
-	b.parentIDs = make(map[int]struct{})
+	pkg.Tests = groupBenchmarksByName(tests, pb.output)
+	pkg.Coverage = pb.coverage
+	pkg.Output = pb.output.Get(globalID)
+	pb.output.Clear(globalID)
+	return pkg
 }
 
-// Coverage sets the code coverage percentage.
-func (b *reportBuilder) Coverage(pct float64, packages []string) {
-	b.coverage = pct
-}
-
-// AppendOutput appends the given text to the currently active context. If no
-// active context exists, the output is assumed to belong to the package.
-func (b *reportBuilder) AppendOutput(text string) {
-	b.output.Append(b.lastID, text)
-}
-
-// findTest returns the id of the most recently created test with the given
-// name if it exists.
-func (b *reportBuilder) findTest(name string) (int, bool) {
-	// check if this test was lastID
-	if t, ok := b.tests[b.lastID]; ok && t.Name == name {
-		return b.lastID, true
-	}
-	for i := b.nextID; i > 0; i-- {
-		if test, ok := b.tests[i]; ok && test.Name == name {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-func (b *reportBuilder) findTestParentID(name string) (int, bool) {
-	parent := dropLastSegment(name)
-	for parent != "" {
-		if id, ok := b.findTest(parent); ok {
-			return id, true
-		}
-		parent = dropLastSegment(parent)
-	}
-	return 0, false
-}
-
-func (b *reportBuilder) isParent(id int) bool {
-	_, ok := b.parentIDs[id]
-	return ok
-}
-
-func dropLastSegment(name string) string {
-	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
-		return name[:idx]
-	}
-	return ""
-}
-
-// containsFailures return true if the current list of tests contains at least
-// one failing test or an unknown result.
-func (b *reportBuilder) containsFailures() bool {
-	for _, test := range b.tests {
-		if test.Result == gtr.Fail || test.Result == gtr.Unknown {
-			return true
-		}
-	}
-	return false
-}
-
-// parseResult returns a Result for the given string r.
+// parseResult returns a gtr.Result for the given result string r.
 func parseResult(r string) gtr.Result {
 	switch r {
 	case "PASS":
@@ -336,7 +251,9 @@ func parseResult(r string) gtr.Result {
 	}
 }
 
-func (b *reportBuilder) groupBenchmarksByName(tests []gtr.Test) []gtr.Test {
+// groupBenchmarksByName groups tests with the Benchmark prefix if they have
+// the same name and combines their output.
+func groupBenchmarksByName(tests []gtr.Test, output *collector.Output) []gtr.Test {
 	if len(tests) == 0 {
 		return nil
 	}
@@ -383,7 +300,7 @@ func (b *reportBuilder) groupBenchmarksByName(tests []gtr.Test) []gtr.Test {
 
 		group.Duration = combinedDuration(byName[group.Name])
 		group.Result = groupResults(byName[group.Name])
-		group.Output = b.output.GetAll(ids...)
+		group.Output = output.GetAll(ids...)
 		if count > 0 {
 			total.Iterations /= int64(count)
 			total.NsPerOp /= float64(count)
@@ -397,6 +314,7 @@ func (b *reportBuilder) groupBenchmarksByName(tests []gtr.Test) []gtr.Test {
 	return grouped
 }
 
+// combinedDuration returns the sum of the durations of the given tests.
 func combinedDuration(tests []gtr.Test) time.Duration {
 	var total time.Duration
 	for _, test := range tests {
@@ -405,6 +323,7 @@ func combinedDuration(tests []gtr.Test) time.Duration {
 	return total
 }
 
+// groupResults returns the result we should use for a collection of tests.
 func groupResults(tests []gtr.Test) gtr.Result {
 	var result gtr.Result
 	for _, test := range tests {
@@ -416,4 +335,165 @@ func groupResults(tests []gtr.Test) gtr.Result {
 		}
 	}
 	return result
+}
+
+// packageBuilder helps build a gtr.Package from a collection of test events.
+type packageBuilder struct {
+	generateID func() int
+	output     *collector.Output
+
+	tests     map[int]gtr.Test
+	parentIDs map[int]struct{} // set of test id's that contain subtests
+	coverage  float64          // coverage percentage
+}
+
+// newPackageBuilder creates a new packageBuilder. New tests will be assigned
+// an ID returned by the generateID function. The activeIDSetter is called to
+// set or reset the active test id.
+func newPackageBuilder(generateID func() int, output *collector.Output) *packageBuilder {
+	return &packageBuilder{
+		generateID: generateID,
+		output:     output,
+		tests:      make(map[int]gtr.Test),
+		parentIDs:  make(map[int]struct{}),
+	}
+}
+
+// IsEmpty returns true if this package builder does not have any tests and has
+// not collected any global output.
+func (b packageBuilder) IsEmpty() bool {
+	return len(b.tests) == 0 && !b.output.Contains(0)
+}
+
+// CreateTest adds a test with the given name to the package, marks it as
+// active and returns its generated id.
+func (b *packageBuilder) CreateTest(name string) int {
+	if parentID, ok := b.findTestParentID(name); ok {
+		b.parentIDs[parentID] = struct{}{}
+	}
+	id := b.generateID()
+	b.output.SetActiveID(id)
+	b.tests[id] = gtr.NewTest(id, name)
+	return id
+}
+
+// PauseTest marks the test with the given name no longer active. Any results
+// or output added to the package after calling PauseTest will no longer be
+// associated with this test.
+func (b *packageBuilder) PauseTest(name string) {
+	b.output.SetActiveID(0)
+}
+
+// ContinueTest finds the test with the given name and marks it as active. If
+// more than one test exist with this name, the most recently created test will
+// be used.
+func (b *packageBuilder) ContinueTest(name string) {
+	id, _ := b.findTest(name)
+	b.output.SetActiveID(id)
+}
+
+// EndTest finds the test with the given name, sets the result, duration and
+// level. If more than one test exists with this name, the most recently
+// created test will be used. If no test exists with this name, a new test is
+// created. The test is then marked as no longer active.
+func (b *packageBuilder) EndTest(name, result string, duration time.Duration, level int) {
+	id, ok := b.findTest(name)
+	if !ok {
+		// test did not exist, create one
+		// TODO: Likely reason is that the user ran go test without the -v
+		// flag, should we report this somewhere?
+		id = b.CreateTest(name)
+	}
+
+	t := b.tests[id]
+	t.Result = parseResult(result)
+	t.Duration = duration
+	t.Level = level
+	b.tests[id] = t
+	b.output.SetActiveID(0)
+}
+
+// End resets the active test.
+func (b *packageBuilder) End() {
+	b.output.SetActiveID(0)
+}
+
+// BenchmarkResult updates an existing or adds a new test with the given
+// results and marks it as active. If an existing test with this name exists
+// but without result, then that one is updated. Otherwise a new one is added
+// to the report.
+func (b *packageBuilder) BenchmarkResult(name string, iterations int64, nsPerOp, mbPerSec float64, bytesPerOp, allocsPerOp int64) {
+	id, ok := b.findTest(name)
+	if !ok || b.tests[id].Result != gtr.Unknown {
+		id = b.CreateTest(name)
+	}
+	b.output.SetActiveID(id)
+
+	benchmark := Benchmark{iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp}
+	test := gtr.NewTest(id, name)
+	test.Result = gtr.Pass
+	test.Duration = benchmark.ApproximateDuration()
+	SetBenchmarkData(&test, benchmark)
+	b.tests[id] = test
+}
+
+// Coverage sets the code coverage percentage.
+func (b *packageBuilder) Coverage(pct float64, packages []string) {
+	b.coverage = pct
+}
+
+// Output appends data to the output of this package.
+func (b *packageBuilder) Output(data string) {
+	b.output.Append(data)
+}
+
+// findTest returns the id of the most recently created test with the given
+// name if it exists.
+func (b *packageBuilder) findTest(name string) (int, bool) {
+	var maxid int
+	for id, test := range b.tests {
+		if maxid < id && test.Name == name {
+			maxid = id
+		}
+	}
+	return maxid, maxid > 0
+}
+
+// findTestParentID searches the existing tests in this package for a parent of
+// the test with the given name, and returns its id if one is found.
+func (b *packageBuilder) findTestParentID(name string) (int, bool) {
+	parent := dropLastSegment(name)
+	for parent != "" {
+		if id, ok := b.findTest(parent); ok {
+			return id, true
+		}
+		parent = dropLastSegment(parent)
+	}
+	return 0, false
+}
+
+// isParent returns true if the test with the given id has sub tests.
+func (b *packageBuilder) isParent(id int) bool {
+	_, ok := b.parentIDs[id]
+	return ok
+}
+
+// dropLastSegment strips the last `/` and everything following it from the
+// given name. If no `/` was found, the empty string is returned.
+func dropLastSegment(name string) string {
+	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
+		return name[:idx]
+	}
+	return ""
+}
+
+// containsFailures return true if this package contains at least one failing
+// test or a test with an unknown result.
+func (b *packageBuilder) containsFailures() bool {
+	for _, test := range b.tests {
+		if test.Result == gtr.Fail || test.Result == gtr.Unknown {
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/jstemmer/go-junit-report/v2 v2.0.0
+# github.com/jstemmer/go-junit-report/v2 v2.1.0
 ## explicit; go 1.13
 github.com/jstemmer/go-junit-report/v2
 github.com/jstemmer/go-junit-report/v2/gtr
@@ -357,6 +357,7 @@ github.com/jstemmer/go-junit-report/v2/internal/gojunitreport
 github.com/jstemmer/go-junit-report/v2/junit
 github.com/jstemmer/go-junit-report/v2/parser/gotest
 github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector
+github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader
 # github.com/klauspost/compress v1.18.0
 ## explicit; go 1.22
 github.com/klauspost/compress


### PR DESCRIPTION
This release includes fixes for several workarounds that are implemented in our CI tooling.

The go-junit-report binary was changed to be installed at runtime, which addresses the reason this bump failed in the previous attempt.

Related: https://github.com/GoogleContainerTools/kpt-config-sync/pull/1688