### PR TITLE
test: add target to update expect kustomization file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,17 @@ test-kustomization:
 		OTELCONTRIBCOL_VERSION=placeholder
 	@./scripts/test-kustomization.sh
 
+# helper make target for generating the expected output
+.PHONY: update-expected-kustomization
+update-expected-kustomization:
+	$(MAKE) build-manifests \
+		STAGING_DIR=$(OUTPUT_DIR)/testing \
+		REGISTRY=gcr.io/cs-test \
+		IMAGE_TAG=placeholder \
+		GIT_SYNC_VERSION=placeholder \
+		OTELCONTRIBCOL_VERSION=placeholder
+	UPDATE_EXPECTED_OUTPUT="true" ./scripts/test-kustomization.sh
+
 # Runs unit tests and linter.
 .PHONY: test
 test: test-unit test-kustomization lint test-post-sync

--- a/scripts/test-kustomization.sh
+++ b/scripts/test-kustomization.sh
@@ -19,4 +19,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
 out=$(kustomize build --load-restrictor=LoadRestrictionsNone "${REPO_ROOT}/test/kustomization" | sed -e "s|gcr.io/cs-test/|example.com/|g")
 
-diff "${REPO_ROOT}/test/kustomization/expected.yaml" <( echo "${out}" )
+expected_file="${REPO_ROOT}/test/kustomization/expected.yaml"
+
+if [[ "${UPDATE_EXPECTED_OUTPUT:-}" == "true" ]]; then
+  echo "${out}" > "${expected_file}"
+  exit 0
+fi
+
+diff "${expected_file}" <( echo "${out}" )


### PR DESCRIPTION
This adds a make target to help with updating the expected.yaml file for the kustomization test.