### PR TITLE
ci: group updates to k8s.io dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,8 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # kind requires us to also update the image digests in code
   - dependency-name: sigs.k8s.io/kind
+  groups:
+    k8s.io:
+      applies-to: version-updates
+      patterns:
+      - "k8s.io/*"


### PR DESCRIPTION
This groups version updates to k8s.io dependencies and should reduce the number of PRs