### PR TITLE
test: use Watcher for validating Stalled errors

### DIFF
--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -1497,9 +1497,13 @@ func SetupFakeSSHCreds(nt *NT, rsKind string, rsRef types.NamespacedName, auth c
 	nt.T.Logf("The %s/%s Secret doesn't exist with auth %q, so creating a fake one", rsRef.Namespace, secretName, auth)
 	msg := fmt.Sprintf("Secret %s not found: create one to allow client authentication", secretName)
 	if rsKind == kinds.RootSyncV1Beta1().Kind {
-		nt.WaitForRootSyncStalledError(rsRef.Name, "Validation", msg)
+		if err := nt.Watcher.WatchForRootSyncStalledError(rsRef.Name, "Validation", msg); err != nil {
+			return err
+		}
 	} else {
-		nt.WaitForRepoSyncStalledError(rsRef.Namespace, rsRef.Name, "Validation", msg)
+		if err := nt.Watcher.WatchForRepoSyncStalledError(rsRef.Namespace, rsRef.Name, "Validation", msg); err != nil {
+			return err
+		}
 	}
 	secret.Data = map[string][]byte{"ssh": {}}
 	if err = nt.KubeClient.Create(secret); err != nil {

--- a/e2e/nomostest/testpredicates/predicates.go
+++ b/e2e/nomostest/testpredicates/predicates.go
@@ -1018,6 +1018,64 @@ func RepoSyncHasSyncError(errCode, errMessage string, resources []v1beta1.Resour
 	}
 }
 
+// RootSyncHasStalledError returns an error if the RootSync does not have the
+// specified Stalled error reason and message.
+// TODO: update this with standard errCode checking once stalled always has code
+func RootSyncHasStalledError(reason, message string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		rs, ok := o.(*v1beta1.RootSync)
+		if !ok {
+			return WrongTypeErr(o, &v1beta1.RootSync{})
+		}
+		stalledCondition := rootsync.GetCondition(rs.Status.Conditions, v1beta1.RootSyncStalled)
+		if stalledCondition == nil {
+			return fmt.Errorf("stalled condition not found")
+		}
+		if stalledCondition.Status != metav1.ConditionTrue {
+			return fmt.Errorf("expected status.conditions['Stalled'].status is True, got %s", stalledCondition.Status)
+		}
+		if stalledCondition.Reason != reason {
+			return fmt.Errorf("expected status.conditions['Stalled'].reason is %s, got %s", reason, stalledCondition.Reason)
+		}
+		if !strings.Contains(stalledCondition.Message, message) {
+			return fmt.Errorf("expected status.conditions['Stalled'].message to contain %s, got %s", message, stalledCondition.Message)
+		}
+		return nil
+	}
+}
+
+// RepoSyncHasStalledError returns an error if the RepoSync does not have the
+// specified Stalled error reason and message.
+// TODO: update this with standard errCode checking once stalled always has code
+func RepoSyncHasStalledError(reason, message string) Predicate {
+	return func(o client.Object) error {
+		if o == nil {
+			return ErrObjectNotFound
+		}
+		rs, ok := o.(*v1beta1.RepoSync)
+		if !ok {
+			return WrongTypeErr(o, &v1beta1.RepoSync{})
+		}
+		stalledCondition := reposync.GetCondition(rs.Status.Conditions, v1beta1.RepoSyncStalled)
+		if stalledCondition == nil {
+			return fmt.Errorf("stalled condition not found")
+		}
+		if stalledCondition.Status != metav1.ConditionTrue {
+			return fmt.Errorf("expected status.conditions['Stalled'].status is True, got %s", stalledCondition.Status)
+		}
+		if stalledCondition.Reason != reason {
+			return fmt.Errorf("expected status.conditions['Stalled'].reason is %s, got %s", reason, stalledCondition.Reason)
+		}
+		if !strings.Contains(stalledCondition.Message, message) {
+			return fmt.Errorf("expected status.conditions['Stalled'].message to contain %s, got %s", message, stalledCondition.Message)
+		}
+		return nil
+	}
+}
+
 // HasFinalizer returns a predicate that tests that an Object has the specified finalizer.
 func HasFinalizer(name string) Predicate {
 	return func(o client.Object) error {

--- a/e2e/nomostest/testwatcher/watch.go
+++ b/e2e/nomostest/testwatcher/watch.go
@@ -445,3 +445,21 @@ func (w *Watcher) WatchForRepoSyncSourceError(ns, rsName, code, message string, 
 	opts = append(opts, WatchPredicates(predicates...))
 	return w.WatchObject(kinds.RepoSyncV1Beta1(), rsName, ns, opts...)
 }
+
+// WatchForRootSyncStalledError waits until the given error is present on the RootSync resource
+func (w *Watcher) WatchForRootSyncStalledError(rsName, reason, message string, opts ...WatchOption) error {
+	predicates := []testpredicates.Predicate{
+		testpredicates.RootSyncHasStalledError(reason, message),
+	}
+	opts = append(opts, WatchPredicates(predicates...))
+	return w.WatchObject(kinds.RootSyncV1Beta1(), rsName, configsync.ControllerNamespace, opts...)
+}
+
+// WatchForRepoSyncStalledError waits until the given error is present on the RepoSync resource
+func (w *Watcher) WatchForRepoSyncStalledError(ns, rsName, reason, message string, opts ...WatchOption) error {
+	predicates := []testpredicates.Predicate{
+		testpredicates.RepoSyncHasStalledError(reason, message),
+	}
+	opts = append(opts, WatchPredicates(predicates...))
+	return w.WatchObject(kinds.RepoSyncV1Beta1(), rsName, ns, opts...)
+}

--- a/e2e/testcases/basic_test.go
+++ b/e2e/testcases/basic_test.go
@@ -259,8 +259,8 @@ func TestMaxRootSyncNameLength(t *testing.T) {
 		fmt.Sprintf("%s/ns.yaml", rootSyncTooLongName),
 		k8sobjects.NamespaceObject(rootSyncTooLongName)))
 	nt.Must(repo.CommitAndPush("create RootSync with too long name"))
-	nt.WaitForRootSyncStalledError(rootSyncTooLongName, "Validation",
-		"maximum RootSync name length is 38, but found 39")
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rootSyncTooLongName, "Validation",
+		"maximum RootSync name length is 38, but found 39"))
 
 	// Test scenario for RootSync with exactly the max name length
 	rootSyncMaxLengthName := strings.Repeat("y", 38)
@@ -314,8 +314,8 @@ func TestMaxRepoSyncNameLength(t *testing.T) {
 		k8sobjects.ConfigMapObject(
 			core.Name(repoSyncTooLongNN.Name), core.Namespace(repoSyncTooLongNN.Namespace))))
 	nt.Must(repo.CommitAndPush("create RepoSync with too long NN"))
-	nt.WaitForRepoSyncStalledError(repoSyncTooLongNN.Namespace, repoSyncTooLongNN.Name,
-		"Validation", "maximum combined length of RepoSync name and namespace is 45, but found 46")
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(repoSyncTooLongNN.Namespace, repoSyncTooLongNN.Name,
+		"Validation", "maximum combined length of RepoSync name and namespace is 45, but found 46"))
 
 	// Test scenario for RepoSync with exactly the max name length
 	repoSyncMaxLengthNN := types.NamespacedName{

--- a/e2e/testcases/github_test.go
+++ b/e2e/testcases/github_test.go
@@ -87,8 +87,8 @@ func TestGithubAppRootSync(t *testing.T) {
 		},
 	}
 	nt.Must(nt.KubeClient.Apply(rs))
-	nt.WaitForRootSyncStalledError(rs.Name, "Validation",
-		`Secret empty-secret not found: create one to allow client authentication`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rs.Name, "Validation",
+		`Secret empty-secret not found: create one to allow client authentication`))
 	// Verify reconciler-manager checks validity of Secret data fields
 	nt.T.Log("The reconciler-manager should report a validation error for invalid Secret")
 	emptySecret := k8sobjects.SecretObject(emptySecretNN.Name, core.Namespace(rootSyncNN.Namespace))
@@ -96,8 +96,8 @@ func TestGithubAppRootSync(t *testing.T) {
 		nt.Must(nt.KubeClient.Delete(emptySecret))
 	})
 	nt.Must(nt.KubeClient.Create(emptySecret))
-	nt.WaitForRootSyncStalledError(rs.Name, "Validation",
-		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rs.Name, "Validation",
+		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`))
 	// Verify reconciler can sync using client ID
 	nt.T.Log("The reconciler should successfully sync using githubapp auth with client ID")
 	secretWithClientIDNN := types.NamespacedName{Name: "githubapp-creds-clientid", Namespace: rootSyncNN.Namespace}
@@ -188,8 +188,8 @@ func TestGithubAppRepoSync(t *testing.T) {
 		},
 	}
 	nt.Must(nt.KubeClient.Apply(rs))
-	nt.WaitForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
-		`Secret empty-secret not found: create one to allow client authentication`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
+		`Secret empty-secret not found: create one to allow client authentication`))
 	// Verify reconciler-manager checks validity of Secret data fields
 	nt.T.Log("The reconciler-manager should report a validation error for invalid Secret")
 	emptySecret := k8sobjects.SecretObject(emptySecretNN.Name, core.Namespace(repoSyncNN.Namespace))
@@ -197,8 +197,8 @@ func TestGithubAppRepoSync(t *testing.T) {
 		nt.Must(nt.KubeClient.Delete(emptySecret))
 	})
 	nt.Must(nt.KubeClient.Create(emptySecret))
-	nt.WaitForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
-		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(rs.Namespace, rs.Name, "Validation",
+		`git secretType was set as "githubapp" but github-app-private-key key is not present in empty-secret secret`))
 	// Verify reconciler can sync using client ID
 	nt.T.Log("The reconciler should successfully sync using githubapp auth with client ID")
 	secretWithClientIDNN := types.NamespacedName{

--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -766,7 +766,7 @@ func TestControllerValidationErrors(t *testing.T) {
 	t.Cleanup(func() {
 		nt.Must(nomostest.DeleteObjectsAndWait(nt, rootSync))
 	})
-	// Can't use WaitForRootSyncStalledError because it doesn't take other namespaces
+	// Can't use WatchForRootSyncStalledError because it doesn't take other namespaces
 	expectedCondition := &v1beta1.RootSyncCondition{
 		Type:    v1beta1.RootSyncStalled,
 		Status:  metav1.ConditionTrue,
@@ -788,8 +788,8 @@ func TestControllerValidationErrors(t *testing.T) {
 	t.Cleanup(func() {
 		nt.Must(nomostest.DeleteObjectsAndWait(nt, rsControllerNamespace))
 	})
-	nt.WaitForRepoSyncStalledError(rsControllerNamespace.Namespace, rsControllerNamespace.Name, "Validation",
-		"RepoSync objects are not allowed in the config-management-system namespace")
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(rsControllerNamespace.Namespace, rsControllerNamespace.Name, "Validation",
+		`RepoSync objects are not allowed in the config-management-system namespace`))
 
 	nt.T.Logf("Validate an invalid config with a long RepoSync name")
 	longBytes := make([]byte, validation.DNS1123SubdomainMaxLength)
@@ -804,8 +804,8 @@ func TestControllerValidationErrors(t *testing.T) {
 	t.Cleanup(func() {
 		nt.Must(nomostest.DeleteObjectsAndWait(nt, rsTooLong))
 	})
-	nt.WaitForRepoSyncStalledError(rsTooLong.Namespace, rsTooLong.Name, "Validation",
-		`maximum combined length of RepoSync name and namespace is 45, but found 260`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(rsTooLong.Namespace, rsTooLong.Name, "Validation",
+		`maximum combined length of RepoSync name and namespace is 45, but found 260`))
 
 	nt.T.Logf("Validate an invalid config with a long RepoSync Secret name")
 	rsInvalidSecretRef := k8sobjects.RepoSyncObjectV1Beta1(testNs, "repo-test")
@@ -821,9 +821,9 @@ func TestControllerValidationErrors(t *testing.T) {
 	t.Cleanup(func() {
 		nt.Must(nomostest.DeleteObjectsAndWait(nt, rsInvalidSecretRef))
 	})
-	nt.WaitForRepoSyncStalledError(rsInvalidSecretRef.Namespace, rsInvalidSecretRef.Name, "Validation",
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(rsInvalidSecretRef.Namespace, rsInvalidSecretRef.Name, "Validation",
 		fmt.Sprintf(`The managed secret name "%s-%s" is invalid: must be no more than %d characters. To fix it, update '.spec.git.secretRef.name'`,
-			core.NsReconcilerName(rsInvalidSecretRef.Namespace, rsInvalidSecretRef.Name), veryLongName, validation.DNS1123SubdomainMaxLength))
+			core.NsReconcilerName(rsInvalidSecretRef.Namespace, rsInvalidSecretRef.Name), veryLongName, validation.DNS1123SubdomainMaxLength)))
 }
 
 func rootPodRole() *rbacv1.Role {

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -216,10 +216,12 @@ func TestSwitchFromGitToOciDelegated(t *testing.T) {
 	rs := k8sobjects.RepoSyncObjectV1Beta1(repoSyncID.Namespace, repoSyncID.Name)
 	nt.T.Log("Manually patch RepoSync object to miss Git spec when sourceType is git")
 	nt.MustMergePatch(rs, `{"spec":{"sourceType":"git", "git":null, "oci": null}}`)
-	nt.WaitForRepoSyncStalledError(repoSyncID.Namespace, repoSyncID.Name, "Validation", `KNV1061: RepoSyncs must specify spec.git when spec.sourceType is "git"`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(repoSyncID.Namespace, repoSyncID.Name, "Validation",
+		`KNV1061: RepoSyncs must specify spec.git when spec.sourceType is "git"`))
 	nt.T.Log("Manually patch RepoSync object to miss OCI spec when sourceType is oci")
 	nt.MustMergePatch(rs, `{"spec":{"sourceType":"oci"}}`)
-	nt.WaitForRepoSyncStalledError(repoSyncID.Namespace, repoSyncID.Name, "Validation", `KNV1061: RepoSyncs must specify spec.oci when spec.sourceType is "oci"`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(repoSyncID.Namespace, repoSyncID.Name, "Validation",
+		`KNV1061: RepoSyncs must specify spec.oci when spec.sourceType is "oci"`))
 }
 
 // resourceQuotaHasHardPods validates if the RepoSync has the expected sourceType.

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -46,18 +46,21 @@ func TestSyncingThroughAProxy(t *testing.T) {
 		testwatcher.WatchPredicates(hasReadyReplicas(1))))
 	nt.T.Log("Verify the NoOpProxyError")
 	rs := k8sobjects.RootSyncObjectV1Beta1(rootSyncID.Name)
-	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rs.Name, "Validation",
+		`KNV1061: RootSyncs which specify spec.git.proxy must also specify spec.git.auth as one of "none", "cookiefile" or "token"`))
 
 	nt.T.Log("Set auth type to cookiefile")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "cookiefile"}}}`)
 	nt.T.Log("Verify the secretRef error")
 	nt.Must(nomostest.SetupFakeSSHCreds(nt, rootSyncID.Kind, rootSyncID.ObjectKey, configsync.AuthCookieFile, controllers.GitCredentialVolume))
-	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `git secretType was set as "cookiefile" but cookie_file key is not present`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rs.Name, "Validation",
+		`git secretType was set as "cookiefile" but cookie_file key is not present`))
 
 	nt.T.Log("Set auth type to token")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "token"}}}`)
 	nt.T.Log("Verify the secretRef error")
-	nt.WaitForRootSyncStalledError(rs.Name, "Validation", `git secretType was set as "token" but token key is not present`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rs.Name, "Validation",
+		`git secretType was set as "token" but token key is not present`))
 
 	nt.T.Log("Set auth type to none")
 	nt.MustMergePatch(rs, `{"spec": {"git": {"auth": "none", "secretRef": {"name":""}}}}`)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -170,8 +170,8 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 	if err = nomostest.SetupFakeSSHCreds(nt, rootSync.Kind, nomostest.RootSyncNN(rootSync.Name), configsync.AuthToken, controllers.GitCredentialVolume); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRootSyncStalledError(rootSync.Name,
-		"Validation", `git secretType was set as "token" but token key is not present in git-creds secret`)
+	nt.Must(nt.Watcher.WatchForRootSyncStalledError(rootSync.Name, "Validation",
+		`git secretType was set as "token" but token key is not present in git-creds secret`))
 
 	t.Log("Validate the RepoSync")
 	repoSync := k8sobjects.RepoSyncObjectV1Beta1(repoSyncID.Namespace, repoSyncID.Name)
@@ -200,8 +200,8 @@ func TestReconcilerManagerTeardownInvalidRSyncs(t *testing.T) {
 	if err = nomostest.SetupFakeSSHCreds(nt, repoSync.Kind, nomostest.RepoSyncNN(repoSync.Namespace, repoSync.Name), configsync.AuthToken, "ssh-key"); err != nil {
 		nt.T.Fatal(err)
 	}
-	nt.WaitForRepoSyncStalledError(repoSync.Namespace, repoSync.Name,
-		"Validation", `git secretType was set as "token" but token key is not present in ssh-key secret`)
+	nt.Must(nt.Watcher.WatchForRepoSyncStalledError(repoSync.Namespace, repoSync.Name,
+		"Validation", `git secretType was set as "token" but token key is not present in ssh-key secret`))
 
 	t.Log("Delete the RootSync and wait for it to be not found")
 	err = nomostest.DeleteObjectsAndWait(nt, rootSync)


### PR DESCRIPTION
This refactors the Stalled condition validation to use the Watcher, similar to the validation for other conditions. This completes the refactoring of moving the condition validation from using the previous polling mechanism to using the watch mechanism. Streamlined error code validation for Stalled errors will be added in a subsequent change.