### PR TITLE
[cherry-pick] v1.21.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command:
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*"
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.7
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.4-gke.8
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.3.0-gke.16__linux_amd64
+GIT_SYNC_VERSION := v4.3.0-gke.18__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.118.0-gke.9

--- a/cmd/nomos/initialize/init.go
+++ b/cmd/nomos/initialize/init.go
@@ -58,6 +58,10 @@ initialize nonempty directories.`,
 
 		return Initialize(flags.Path, forceValue)
 	},
+	PostRunE: func(_ *cobra.Command, _ []string) error {
+		_, err := fmt.Fprintf(os.Stdout, "Done!\n")
+		return err
+	},
 }
 
 // Initialize initializes a Nomos directory

--- a/cmd/nomos/nomos.go
+++ b/cmd/nomos/nomos.go
@@ -26,7 +26,6 @@ import (
 	"kpt.dev/configsync/cmd/nomos/initialize"
 	"kpt.dev/configsync/cmd/nomos/migrate"
 	"kpt.dev/configsync/cmd/nomos/status"
-	"kpt.dev/configsync/cmd/nomos/util"
 	"kpt.dev/configsync/cmd/nomos/version"
 	"kpt.dev/configsync/cmd/nomos/vet"
 	"kpt.dev/configsync/pkg/api/configmanagement"
@@ -91,6 +90,4 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-
-	util.MustFprintf(os.Stdout, "Done!\n")
 }


### PR DESCRIPTION
The cherrypick includes essential bug fixes, dependency update for CVE fixes and test updates.

```
841149a8 (HEAD -> v1.21) test: fix workload identity for TestAdoptImplicitNamespace (#1727)
8205e4a7 test: add e2e test for adopting implicit namespace (#1721)
6befc6bc test: use Watcher for validating Stalled errors (#1723)
e281a6ce fix: typo in ManagedResourceInUnmanagedNamespace (#1722)
ff2b8f3a chore: bump base image and git-sync or CVE fix (#1719)
70228240 fix: add completion message to nomos init command only (#1717)
f915b199 test: fix hasTolerations segfault (#1693)
c0807eda test: default to creating clusters for KinD only if -create-clusters=false (#1672)
0e704455 test: add checks for Config Sync sync labels on reconciler metrics (#1666)
cca9bef0 test: wait for GKE cluster readiness (#1663)
3f6b79a0 (upstream/v1.21) ci: increase memory request and limits for helm-sync on Autopilot (#1689) (#1707)
856f7b0f test: Update Bitbucket workspace (#1664) (#1670)
372ed5d1 (tag: v1.21.1-rc.1, tag: v1.21.1) chore: bump otelcontribcol to 0.118.0-gke.9 (#1660)
```