### PR TITLE
fix: handle IsNoMatchError for remediator startWatch

### DIFF
--- a/pkg/remediator/watch/filteredwatcher.go
+++ b/pkg/remediator/watch/filteredwatcher.go
@@ -344,7 +344,7 @@ func (w *filteredWatcher) start(ctx context.Context, resourceVersion string) (bo
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return false, status.InternalWrapf(err, "failed to start remediator watch for %s", w.gvk)
-		} else if apierrors.IsNotFound(err) {
+		} else if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			statusErr := syncerclient.ConflictWatchResourceDoesNotExist(err, w.gvk)
 			klog.Warningf("Remediator encountered a resource conflict: "+
 				"%v. To resolve the conflict, the remediator will enqueue a resync "+


### PR DESCRIPTION
This error can occur when the RESTMapper fails to look up the object type, and has been observed to happen semi-frequently for the e2e TestCRDDeleteBeforeRemoveCustomResourceV1.

The e2e test is flaky because depending on the ordering of events, the conflict metric may not be recorded. This should fix the metric flakiness for this edge case.