### PR TITLE
fix: handle Helm chart names of the form <repo-name>/<chart-name>

### DIFF
--- a/pkg/reconcilermanager/controllers/util.go
+++ b/pkg/reconcilermanager/controllers/util.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -128,7 +129,8 @@ func reconcilerEnvs(opts reconcilerOptions) []corev1.EnvVar {
 		syncDir = opts.ociConfig.Dir
 	case configsync.HelmSource:
 		syncRepo = opts.helmConfig.Repo
-		syncDir = opts.helmConfig.Chart
+		syncDir = path.Base(opts.helmConfig.Chart)
+
 		if opts.helmConfig.Version != "" {
 			syncRevision = opts.helmConfig.Version
 		} else {


### PR DESCRIPTION
* This PR adds logic to handle the case where the provided spec.helm.chart value is of the form `<repo-name>/<chart-name>`. This is needed as the **reconciler** attempts to read the rendered chart at `/repo/source/<version>/<repo-name>/<chart-name>` while the chart is rendered at  `/repo/source/<version>/<chart-name>` by **helm-sync**
* b/423072233