### PR TITLE
fix: add validation to spec.helm.chart

### DIFF
--- a/pkg/validate/rsync/validate/source_spec_validator.go
+++ b/pkg/validate/rsync/validate/source_spec_validator.go
@@ -199,6 +199,12 @@ func HelmSpec(helm *v1beta1.HelmBase, syncKind string) status.Error {
 		return MissingHelmChart(syncKind)
 	}
 
+	// Validates chart name such that it contains no slashes
+	// See https://helm.sh/docs/chart_best_practices/conventions/ for more details
+	if strings.Contains(helm.Chart, "/") {
+		return IllegalHelmChartName(syncKind)
+	}
+
 	// Ensure auth is a valid value.
 	// Note that Auth is a case-sensitive field, so ones with arbitrary capitalization
 	// will fail to apply.
@@ -338,6 +344,13 @@ func NoOpProxy(syncKind string) status.Error {
 	return invalidSyncBuilder.
 		Sprintf("%ss which specify spec.git.proxy must also specify spec.git.auth as one of %q, %q or %q",
 			syncKind, configsync.AuthNone, configsync.AuthCookieFile, configsync.AuthToken).
+		Build()
+}
+
+// IllegalHelmChartName reports that a RootSync/RepoSync declares an invalid helm chart name.
+func IllegalHelmChartName(syncKind string) status.Error {
+	return invalidSyncBuilder.
+		Sprintf("%s field spec.helm.chart must not contain a slash (/)", syncKind).
 		Build()
 }
 

--- a/pkg/validate/rsync/validate/source_spec_validator_test.go
+++ b/pkg/validate/rsync/validate/source_spec_validator_test.go
@@ -89,7 +89,7 @@ func repoSyncWithGit(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := k8sobjects.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
 	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
-		Repo: "fake repo",
+		Repo: "fake-repo",
 		Auth: configsync.AuthNone,
 	}
 	for _, opt := range opts {
@@ -102,7 +102,7 @@ func repoSyncWithOci(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := k8sobjects.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
 	rs.Spec.SourceType = configsync.OciSource
 	rs.Spec.Oci = &v1beta1.Oci{
-		Image: "fake image",
+		Image: "fake-image",
 		Auth:  configsync.AuthNone,
 	}
 	for _, opt := range opts {
@@ -115,8 +115,8 @@ func repoSyncWithHelm(opts ...func(*v1beta1.RepoSync)) *v1beta1.RepoSync {
 	rs := k8sobjects.RepoSyncObjectV1Beta1("test-ns", configsync.RepoSyncName)
 	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRepoSync{HelmBase: v1beta1.HelmBase{
-		Repo:  "fake repo",
-		Chart: "fake chart",
+		Repo:  "fake-repo",
+		Chart: "fake-chart",
 		Auth:  configsync.AuthNone,
 	}}
 	for _, opt := range opts {
@@ -155,7 +155,7 @@ func rootSyncWithGit(opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	rs.Spec.SourceType = configsync.GitSource
 	rs.Spec.Git = &v1beta1.Git{
-		Repo: "fake repo",
+		Repo: "fake-repo",
 		Auth: configsync.AuthNone,
 	}
 	for _, opt := range opts {
@@ -168,8 +168,8 @@ func rootSyncWithHelm(opts ...func(*v1beta1.RootSync)) *v1beta1.RootSync {
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)
 	rs.Spec.SourceType = configsync.HelmSource
 	rs.Spec.Helm = &v1beta1.HelmRootSync{HelmBase: v1beta1.HelmBase{
-		Repo:  "fake repo",
-		Chart: "fake chart",
+		Repo:  "fake-repo",
+		Chart: "fake-chart",
 		Auth:  configsync.AuthNone,
 	}}
 	for _, opt := range opts {
@@ -301,6 +301,11 @@ func TestValidateRepoSyncSpec(t *testing.T) {
 			wantErr: MissingHelmChart(configsync.RepoSyncKind),
 		},
 		{
+			name:    "illegal helm chart name with slash",
+			obj:     repoSyncWithHelm(func(rs *v1beta1.RepoSync) { rs.Spec.Helm.Chart = "foo/bar" }),
+			wantErr: IllegalHelmChartName(configsync.RepoSyncKind),
+		},
+		{
 			name:    "invalid auth type",
 			obj:     repoSyncWithHelm(helmAuth("invalid auth")),
 			wantErr: InvalidHelmAuthType(configsync.RepoSyncKind),
@@ -417,6 +422,11 @@ func TestValidateRootSyncSpec(t *testing.T) {
 				sync.Spec.Helm.DeployNamespace = "test-ns"
 			}),
 			wantErr: HelmNSAndDeployNS(configsync.RootSyncKind),
+		},
+		{
+			name:    "invalid helm chart name with slash",
+			obj:     rootSyncWithHelm(func(rs *v1beta1.RootSync) { rs.Spec.Helm.Chart = "foo/bar" }),
+			wantErr: IllegalHelmChartName(configsync.RootSyncKind),
 		},
 		{
 			name: "valid spec.override.roleRefs Role",


### PR DESCRIPTION
This change adds validation to spec.helm.chart to ensure that it contains no slashes. A KNV1061 error is returned to the user if this condition is not met.

E2E tests validate that this error is returned for both charts hosted in OCI-based registries and traditional Helm repos

b/423072233