### PR TITLE
ci: enable dependabot to autoupdate kind

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,6 @@ updates:
   ignore:
   - dependency-name: k8s.io/*
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # kind requires us to also update the image digests in code
-  - dependency-name: sigs.k8s.io/kind
   groups:
     k8s.io:
       applies-to: version-updates

--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -114,11 +114,6 @@ var GitHubAppConfigFile = flag.String("githubapp-config-file",
 var Debug = flag.Bool("debug", false,
 	"If true, do not destroy cluster and clean up temporary directory after test.")
 
-// KubernetesVersion is the version of Kubernetes to test against. Only has effect
-// when testing against test-created Kind clusters.
-var KubernetesVersion = flag.String("kubernetes-version", "1.33",
-	"The version of Kubernetes to create")
-
 // DefaultImagePrefix points to the local docker registry.
 const DefaultImagePrefix = "localhost:5000"
 

--- a/e2e/nomostest/client.go
+++ b/e2e/nomostest/client.go
@@ -155,11 +155,10 @@ func RestConfig(t testing.NTB, opts *ntopts.New) {
 	switch *e2e.TestCluster {
 	case e2e.Kind:
 		cluster = &clusters.KindCluster{
-			T:                 t,
-			Name:              opts.ClusterName,
-			KubeConfigPath:    opts.KubeconfigPath,
-			TmpDir:            opts.TmpDir,
-			KubernetesVersion: *e2e.KubernetesVersion,
+			T:              t,
+			Name:           opts.ClusterName,
+			KubeConfigPath: opts.KubeconfigPath,
+			TmpDir:         opts.TmpDir,
 		}
 	case e2e.GKE:
 		cluster = &clusters.GKECluster{


### PR DESCRIPTION
The kind dependency had to be updated manually in order to update the map of kind image versions. The upstream kind code defaults to the latest k8s node version when no node image is provided.

This enables the kind dependency to be autoupdated by removing the kubernetes-version argument for kind. This flag was not used by CI and is only used for local testing. Since it has not seemed to have much of a use case, the flag is simply removed.

If the test framework needs to allow setting the kind node version in the future, we could consider adding a kind-image flag which just accepts the image name/digest.