### PR TITLE
improve error message for large resource group handling

### DIFF
--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -74,10 +74,8 @@ func SkipErrorForResource(err error, id core.ID, strategy actuation.ActuationStr
 // largeResourceGroupError indicates that the source repo has too many objects
 // to manage with a single resource group.
 func largeResourceGroupError(err error, id core.ID) status.Error {
-	e := fmt.Errorf("source repository contains too many resource objects to inventory with a single ResourceGroup: "+
-		"inventory apply failed: %v: %s. "+
-		"To mitigate, spread the source objects across multiple repositories. "+
-		"For how, see https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo",
-		id, err)
+	e := fmt.Errorf("the size of the ResourceGroup object for this repository is exceeding the row size. "+
+		"To mitigate follow instructions here https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo. "+
+		": %v", id)
 	return applierErrorBuilder.Wrap(e).Build()
 }

--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -80,6 +80,6 @@ func largeResourceGroupError(_ error, id core.ID) status.Error {
 	// Possibly in the future if the error changes we will start passing it back to the user.
 	e := fmt.Errorf("the size of the ResourceGroup object for this repository is exceeding the row size. "+
 		"To mitigate follow instructions here https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo. "+
-		": %v", id)
+		"%v", id)
 	return applierErrorBuilder.Wrap(e).Build()
 }

--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -78,8 +78,8 @@ func largeResourceGroupError(_ error, id core.ID) status.Error {
 	// says: Request entity too large: limit is 3145728 (eg)
 	// the actual size is 1.5mb, so it is a bit mislreading.
 	// Possibly in the future if the error changes we will start passing it back to the user.
-	e := fmt.Errorf("the size of the ResourceGroup object for this repository is exceeding the row size. "+
-		"To mitigate follow instructions here https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo. "+
-		"%v", id)
+	e := fmt.Errorf("the ResourceGroup object for this repository has exceeded the maximum size limit. "+
+		"To mitigate, follow instructions here https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo. "+
+		"ResourceGroup: %v", id)
 	return applierErrorBuilder.Wrap(e).Build()
 }

--- a/pkg/applier/applier_err.go
+++ b/pkg/applier/applier_err.go
@@ -73,7 +73,11 @@ func SkipErrorForResource(err error, id core.ID, strategy actuation.ActuationStr
 
 // largeResourceGroupError indicates that the source repo has too many objects
 // to manage with a single resource group.
-func largeResourceGroupError(err error, id core.ID) status.Error {
+func largeResourceGroupError(_ error, id core.ID) status.Error {
+	// the error is not used because it's confusing to the user.  The current core error
+	// says: Request entity too large: limit is 3145728 (eg)
+	// the actual size is 1.5mb, so it is a bit mislreading.
+	// Possibly in the future if the error changes we will start passing it back to the user.
 	e := fmt.Errorf("the size of the ResourceGroup object for this repository is exceeding the row size. "+
 		"To mitigate follow instructions here https://cloud.google.com/anthos-config-management/docs/how-to/breaking-up-repo. "+
 		": %v", id)


### PR DESCRIPTION
This pull request includes a minor update to the error message in the `largeResourceGroupError` function within `pkg/applier/applier_err.go`. The change simplifies the wording of the error message and adjusts the formatting for clarity because the underlying error message was too confusing.

b/418818042