### PR TITLE
chore: remove comment about updating kind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231023142458-b9f29826ee83
 	sigs.k8s.io/controller-tools v0.18.0
-	sigs.k8s.io/kind v0.29.0 // When upgrading, update the node image versions at e2e/nomostest/clusters/kind.go
+	sigs.k8s.io/kind v0.29.0
 	sigs.k8s.io/kustomize/api v0.19.0
 	sigs.k8s.io/kustomize/kyaml v0.19.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0


### PR DESCRIPTION
The lookup table of kind node versions was removed in a previous change.

Followup to https://github.com/GoogleContainerTools/kpt-config-sync/pull/1753