### PR TITLE
test: log pods in GetDeploymentPod when there are multiple

### DIFF
--- a/e2e/nomostest/testkubeclient/client.go
+++ b/e2e/nomostest/testkubeclient/client.go
@@ -27,6 +27,7 @@ import (
 	"kpt.dev/configsync/e2e/nomostest/retry"
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
 	"kpt.dev/configsync/pkg/kinds"
+	"kpt.dev/configsync/pkg/util/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -206,8 +207,8 @@ func (tc *KubeClient) GetDeploymentPod(deploymentName, namespace string, retrytT
 			return err
 		}
 		if len(pods.Items) != 1 {
-			return fmt.Errorf("deployment has %d pods, expected 1: %s",
-				len(pods.Items), deploymentNN)
+			return fmt.Errorf("deployment has %d pods, expected 1: %s\n%s",
+				len(pods.Items), deploymentNN, log.AsYAML(pods))
 		}
 		pod = pods.Items[0].DeepCopy()
 		if pod.Status.Phase != corev1.PodRunning {


### PR DESCRIPTION
This check occasionally fails in the e2e tests and causes the test suite to hang to fail until the unhealthy Pod(s) are cleaned up. Logging the Pod state should help diagnose the issue and implement a future fix to deflake this scenario.