### PR TITLE
[cherry-pick] chore: bump git-sync to v4.4.2 (#1757)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.3.0-gke.19__linux_amd64
+GIT_SYNC_VERSION := v4.4.2-gke.1__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.118.0-gke.9


### PR DESCRIPTION
This updates git-sync to the latest patch version. This version includes an important bug fix. For more information see:

https://github.com/kubernetes/git-sync/releases