### PR TITLE
feat: add SSM as a gitprovider

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -133,10 +133,14 @@ var TestCluster = flag.String("test-cluster", Kind,
 var ShareTestEnv = flag.Bool("share-test-env", false,
 	"Specify that the test is using a shared test environment instead of fresh installation per test case.")
 
+// SSMInstanceRegion is the region of the Secure Source Manager instance to be used by SSM tests
+var SSMInstanceRegion = flag.String("ssm-instance-region", util.EnvString("E2E_SSM_INSTANCE_REGION", "us-central1"),
+	"The region of the Secure Source Manager instance to be used by SSM tests. Defaults to E2E_SSM_INSTANCE_REGION env var")
+
 // GitProvider is the provider that hosts the Git repositories.
 var GitProvider = newStringEnum("git-provider", util.EnvString("E2E_GIT_PROVIDER", Local),
 	"The git provider that hosts the Git repositories. Defaults to Local.",
-	[]string{Local, Bitbucket, GitLab, CSR})
+	[]string{Local, Bitbucket, GitLab, CSR, SSM})
 
 // OCIProvider is the provider that hosts the OCI repositories.
 var OCIProvider = newStringEnum("oci-provider", util.EnvString("E2E_OCI_PROVIDER", Local),
@@ -300,6 +304,8 @@ const (
 	CSR = "csr"
 	// ArtifactRegistry indicates using Google Artifact Registry to host the repositories.
 	ArtifactRegistry = "gar"
+	// SSM indicates using Secure Source Manager to host the repositories.
+	SSM = "ssm"
 )
 
 // NumParallel returns the number of parallel test threads

--- a/e2e/nomostest/config_sync.go
+++ b/e2e/nomostest/config_sync.go
@@ -773,6 +773,9 @@ func rootSyncObjectV1Alpha1Git(name, repoURL string, sourceFormat configsync.Sou
 			rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
 			rs.Spec.Git.GCPServiceAccountEmail = gitproviders.CSRReaderEmail()
 		}
+	case e2e.SSM:
+		rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
+		rs.Spec.Git.GCPServiceAccountEmail = gitproviders.SSMServiceAccountEmail()
 	default:
 		rs.Spec.Git.Auth = configsync.AuthSSH
 		rs.Spec.Git.SecretRef = &v1alpha1.SecretReference{
@@ -821,6 +824,9 @@ func rootSyncObjectV1Beta1Git(name, repoURL string, branch, revision, syncPath s
 			rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
 			rs.Spec.Git.GCPServiceAccountEmail = gitproviders.CSRReaderEmail()
 		}
+	case e2e.SSM:
+		rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
+		rs.Spec.Git.GCPServiceAccountEmail = gitproviders.SSMServiceAccountEmail()
 	default:
 		rs.Spec.Git.Auth = configsync.AuthSSH
 		rs.Spec.Git.SecretRef = &v1beta1.SecretReference{
@@ -889,6 +895,9 @@ func repoSyncObjectV1Alpha1Git(nn types.NamespacedName, repoURL string) *v1alpha
 			rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
 			rs.Spec.Git.GCPServiceAccountEmail = gitproviders.CSRReaderEmail()
 		}
+	case e2e.SSM:
+		rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
+		rs.Spec.Git.GCPServiceAccountEmail = gitproviders.SSMServiceAccountEmail()
 	default:
 		rs.Spec.Git.Auth = configsync.AuthSSH
 		rs.Spec.Git.SecretRef = &v1alpha1.SecretReference{
@@ -939,6 +948,9 @@ func repoSyncObjectV1Beta1Git(nn types.NamespacedName, repoURL, branch, revision
 			rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
 			rs.Spec.Git.GCPServiceAccountEmail = gitproviders.CSRReaderEmail()
 		}
+	case e2e.SSM:
+		rs.Spec.Git.Auth = configsync.AuthGCPServiceAccount
+		rs.Spec.Git.GCPServiceAccountEmail = gitproviders.SSMServiceAccountEmail()
 	default:
 		rs.Spec.Git.Auth = configsync.AuthSSH
 		rs.Spec.Git.SecretRef = &v1beta1.SecretReference{

--- a/e2e/nomostest/gitproviders/cloud_source_repository.go
+++ b/e2e/nomostest/gitproviders/cloud_source_repository.go
@@ -15,19 +15,13 @@
 package gitproviders
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"kpt.dev/configsync/e2e"
+	"kpt.dev/configsync/e2e/nomostest/gitproviders/util"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testshell"
-)
-
-const (
-	repoNameMaxLen  = 63
-	repoNameHashLen = 8
 )
 
 // CSRReaderEmail returns the email of the google service account with
@@ -56,7 +50,7 @@ func newCSRClient(repoPrefix string, shell *testshell.TestShell) *CSRClient {
 }
 
 func (c *CSRClient) fullName(name string) string {
-	return sanitizeRepoName("cs-e2e-"+c.repoPrefix, name)
+	return util.SanitizeRepoName("cs-e2e-"+c.repoPrefix, name)
 }
 
 // Type returns the provider type.
@@ -127,17 +121,4 @@ func (c *CSRClient) DeleteRepositories(names ...string) error {
 // failed to be deleted after the test.
 func (c *CSRClient) DeleteObsoleteRepos() error {
 	return nil
-}
-
-// CSR repo name may contain between 3 and 63 lowercase letters, digits and hyphens.
-// sanitizeRepoName replaces all slashes with hyphens, and truncate the name.
-func sanitizeRepoName(repoPrefix, name string) string {
-	fullName := "cs-e2e-" + repoPrefix + "-" + name
-	hashBytes := sha1.Sum([]byte(fullName))
-	hashStr := hex.EncodeToString(hashBytes[:])[:repoNameHashLen]
-
-	if len(fullName) > repoNameMaxLen-1-repoNameHashLen {
-		fullName = fullName[:repoNameMaxLen-1-repoNameHashLen]
-	}
-	return fmt.Sprintf("%s-%s", strings.ReplaceAll(fullName, "/", "-"), hashStr)
 }

--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -15,6 +15,8 @@
 package gitproviders
 
 import (
+	"strings"
+
 	"kpt.dev/configsync/e2e"
 	"kpt.dev/configsync/e2e/nomostest/testing"
 	"kpt.dev/configsync/e2e/nomostest/testlogger"
@@ -62,6 +64,15 @@ func NewGitProvider(t testing.NTB, provider, clusterName string, logger *testlog
 		return client
 	case e2e.CSR:
 		return newCSRClient(clusterName, shell)
+	case e2e.SSM:
+		out, err := shell.ExecWithDebug("gcloud", "projects", "describe", *e2e.GCPProject, "--format", "value(projectNumber)")
+		if err != nil {
+			t.Fatalf("getting project number: %w", err)
+		}
+
+		projectNumber := strings.Split(string(out), "\n")[0]
+
+		return newSSMClient(clusterName, shell, projectNumber)
 	default:
 		return &LocalProvider{}
 	}

--- a/e2e/nomostest/gitproviders/repository.go
+++ b/e2e/nomostest/gitproviders/repository.go
@@ -282,6 +282,12 @@ func (g *ReadWriteRepository) Init() error {
 			// connect securely to CSR using Google Account credentials.
 			[]string{"config", fmt.Sprintf("credential.%s.helper", testing.CSRHost), "gcloud.sh"})
 	}
+	if g.GitProvider.Type() == e2e.SSM {
+		cmds = append(cmds,
+			// Use credential helper script to provide information that Git needs to
+			// connect securely to SSM using Google Account credentials.
+			[]string{"config", "credential.https://*.*.sourcemanager.dev.helper", "gcloud.sh"})
+	}
 	return g.BulkGit(cmds...)
 }
 

--- a/e2e/nomostest/gitproviders/secure_source_manager.go
+++ b/e2e/nomostest/gitproviders/secure_source_manager.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitproviders
+
+import (
+	"fmt"
+	"strings"
+
+	"kpt.dev/configsync/e2e"
+	"kpt.dev/configsync/e2e/nomostest/gitproviders/util"
+	"kpt.dev/configsync/e2e/nomostest/testing"
+	"kpt.dev/configsync/e2e/nomostest/testshell"
+)
+
+// SSMServiceAccountEmail returns the email of the google service account with
+// permission to read from Secure Source Manager.
+func SSMServiceAccountEmail() string {
+	return fmt.Sprintf("e2e-ssm-reader-sa@%s.iam.gserviceaccount.com", *e2e.GCPProject)
+}
+
+// SSMClient is the client that interacts with Google Secure Source Manager.
+type SSMClient struct {
+	// project in which to store the source repo
+	project string
+	// project number which is needed for the sync URL of the source repo
+	projectNumber string
+	// SSM instance ID where the source repo will be stored
+	instanceID string
+	// region of the SSM instance in which to store the source repo
+	region string
+	// repoPrefix is used to avoid overlap
+	repoPrefix string
+	// shell used for invoking CLI tools
+	shell *testshell.TestShell
+}
+
+var _ GitProvider = &SSMClient{}
+
+// newSSMClient instantiates a new SSM client.
+func newSSMClient(repoPrefix string, shell *testshell.TestShell, projectNumber string) *SSMClient {
+	return &SSMClient{
+		project:       *e2e.GCPProject,
+		instanceID:    testing.SSMInstanceID,
+		region:        *e2e.SSMInstanceRegion,
+		repoPrefix:    repoPrefix,
+		shell:         shell,
+		projectNumber: projectNumber,
+	}
+}
+
+func (c *SSMClient) fullName(name string) string {
+	return util.SanitizeRepoName(c.repoPrefix, name)
+}
+
+// Type returns the provider type.
+func (c *SSMClient) Type() string {
+	return e2e.SSM
+}
+
+// RemoteURL returns the Git URL for the SSM repository.
+// name refers to the repo name in the format of <NAMESPACE>/<NAME> of RootSync|RepoSync.
+func (c *SSMClient) RemoteURL(name string) (string, error) {
+	return c.SyncURL(name), nil
+}
+
+// SyncURL returns a URL for Config Sync to sync from.
+func (c *SSMClient) SyncURL(name string) string {
+	return fmt.Sprintf("https://%s-%s-git.%s.sourcemanager.dev/%s/%s", c.instanceID, c.projectNumber, c.region, c.project, name)
+}
+
+func (c *SSMClient) login() error {
+	_, err := c.shell.ExecWithDebug("gcloud", "init")
+	if err != nil {
+		return fmt.Errorf("authorizing gcloud: %w", err)
+	}
+	return nil
+}
+
+// CreateRepository calls the gcloud SDK to create a remote repository on SSM.
+// It returns the full name with a prefix.
+func (c *SSMClient) CreateRepository(name string) (string, error) {
+	fullName := c.fullName(name)
+	if err := c.login(); err != nil {
+		return fullName, err
+	}
+
+	out, err := c.shell.ExecWithDebug("gcloud", "beta", "source-manager", "repos",
+		"describe", fullName, "--region", c.region,
+		"--project", c.project)
+	if err == nil {
+		return fullName, nil // repo already exists, skip creation
+	}
+	if !strings.Contains(string(out), "NOT_FOUND") {
+		return fullName, fmt.Errorf("describing source repository: %w", err)
+	}
+
+	_, err = c.shell.ExecWithDebug("gcloud", "beta", "source-manager", "repos",
+		"create", fullName, "--region", c.region,
+		"--instance", c.instanceID,
+		"--project", c.project)
+	if err != nil {
+		return fullName, fmt.Errorf("creating source repository: %w", err)
+	}
+
+	return fullName, nil
+}
+
+// DeleteRepositories calls the gcloud SDK to delete the provided repositories from SSM.
+func (c *SSMClient) DeleteRepositories(names ...string) error {
+	for _, name := range names {
+		_, err := c.shell.ExecWithDebug("gcloud", "beta", "source-manager", "repos",
+			"delete", name,
+			"--region", c.region,
+			"--project", c.project)
+		if err != nil {
+			return fmt.Errorf("deleting source repository: %w", err)
+		}
+	}
+	return nil
+}
+
+// DeleteObsoleteRepos is a no-op because SSM repo names are determined by the
+// test cluster name and RSync namespace and name, so it can be reused if it
+// failed to be deleted after the test.
+func (c *SSMClient) DeleteObsoleteRepos() error {
+	return nil
+}

--- a/e2e/nomostest/gitproviders/util/reponame.go
+++ b/e2e/nomostest/gitproviders/util/reponame.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	repoNameMaxLen  = 63
+	repoNameHashLen = 8
+)
+
+// SanitizeRepoName replaces all slashes with hyphens, and truncate the name.
+// repo name may contain between 3 and 63 lowercase letters, digits and hyphens.
+func SanitizeRepoName(repoPrefix, name string) string {
+	fullName := "cs-e2e-" + repoPrefix + "-" + name
+	hashBytes := sha1.Sum([]byte(fullName))
+	hashStr := hex.EncodeToString(hashBytes[:])[:repoNameHashLen]
+
+	if len(fullName) > repoNameMaxLen-1-repoNameHashLen {
+		fullName = fullName[:repoNameMaxLen-1-repoNameHashLen]
+	}
+	return fmt.Sprintf("%s-%s", strings.ReplaceAll(fullName, "/", "-"), hashStr)
+}

--- a/e2e/nomostest/gitproviders/util/reponame_test.go
+++ b/e2e/nomostest/gitproviders/util/reponame_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gitproviders
+package util
 
 import (
 	"testing"
@@ -55,7 +55,7 @@ func TestSanitizeRepoName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotName := sanitizeRepoName(tc.repoPrefix, tc.repoName)
+			gotName := SanitizeRepoName(tc.repoPrefix, tc.repoName)
 			assert.Equal(t, tc.expectedName, gotName)
 		})
 	}

--- a/e2e/nomostest/ntopts/new.go
+++ b/e2e/nomostest/ntopts/new.go
@@ -159,6 +159,14 @@ func RequireCloudSourceRepository(t testing.NTB) Opt {
 	return func(_ *New) {}
 }
 
+// RequireSecureSourceManagerRepository requires the --git-provider flag to be set to ssm
+func RequireSecureSourceManagerRepository(t testing.NTB) Opt {
+	if *e2e.GitProvider != e2e.SSM {
+		t.Skip("The --git-provider flag must be set to `ssm` to run this test.")
+	}
+	return func(_ *New) {}
+}
+
 // RequireHelmArtifactRegistry requires the --helm-provider flag to be set to `gar`.
 // RequireHelmArtifactRegistry implies RequireHelmProvider.
 func RequireHelmArtifactRegistry(t testing.NTB) Opt {

--- a/e2e/nomostest/ssh.go
+++ b/e2e/nomostest/ssh.go
@@ -376,7 +376,7 @@ func downloadSSHKey(nt *NT) (string, error) {
 // It skips creating the Secret if the GitProvider is CSR because CSR uses either
 // 'gcenode' or 'gcpserviceaccount' for authentication, which doesn't require a Secret.
 func CreateNamespaceSecrets(nt *NT, ns string) error {
-	if nt.GitProvider.Type() != e2e.CSR {
+	if nt.GitProvider.Type() != e2e.CSR && nt.GitProvider.Type() != e2e.SSM {
 		privateKeypath := nt.gitPrivateKeyPath
 		if len(privateKeypath) == 0 {
 			privateKeypath = privateKeyPath(nt)

--- a/e2e/nomostest/testing/env.go
+++ b/e2e/nomostest/testing/env.go
@@ -22,6 +22,9 @@ const (
 	// CSRHost is the host address of the Cloud Source Repositories
 	CSRHost = "https://source.developers.google.com"
 
+	// SSMInstanceID is the ID of the Secure Source Manager instance to be used by SSM tests
+	SSMInstanceID = "configsync-test"
+
 	// TestInfraContainerRepositoryPath is the Config Sync test-infra repository path
 	TestInfraContainerRepositoryPath = "kpt-config-sync-ci-artifacts"
 	// TestInfraArtifactRepositoryPath is the Config Sync test-infra repository path

--- a/e2e/testcases/main_test.go
+++ b/e2e/testcases/main_test.go
@@ -151,6 +151,11 @@ func validateArgs() error {
 			errs = multierr.Append(errs, fmt.Errorf("Cannot run gcenode tests on autopilot clusters"))
 		}
 	}
+	if *e2e.GitProvider == e2e.SSM { // required variables for SSM
+		if *e2e.SSMInstanceRegion == "" {
+			errs = multierr.Append(errs, fmt.Errorf("Environment variable E2E_SSM_INSTANCE_REGION is required for SSM"))
+		}
+	}
 	return errs
 }
 

--- a/pkg/auth/credential_provider.go
+++ b/pkg/auth/credential_provider.go
@@ -28,7 +28,7 @@ import (
 func GitSourceScopes() []string {
 	return []string{
 		"https://www.googleapis.com/auth/cloud-platform",
-		"https://www.googleapis.com/auth/userinfo.email",
+		"https://www.googleapis.com/auth/userinfo.email", // Required by SSM to perform git operations
 	}
 }
 


### PR DESCRIPTION
* This change adds SSM as a git provider to the E2E tests. It adds tests to validate that a repo can be created, pushed to, synced to by Config Sync, and deleted
* It also adds the `https://www.googleapis.com/auth/userinfo.email` scope to the askpass credential provider as tokens used by SSM require it
* Depends on the SSM TF setup introduced in https://github.com/GoogleContainerTools/kpt-config-sync/pull/1790