### PR TITLE
ci: group dependabot kustomize updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
       applies-to: version-updates
       patterns:
       - "k8s.io/*"
+    kustomize:
+      applies-to: version-updates
+      patterns:
+      - "sigs.k8s.io/kustomize/*"


### PR DESCRIPTION
kustomize contains multiple modules that are versioned together and can be grouped for updates to minimize the number of dependabot PRs