### PR TITLE
test: refactor Wait to return error

### DIFF
--- a/e2e/nomostest/testutils/fleet_membership.go
+++ b/e2e/nomostest/testutils/fleet_membership.go
@@ -112,10 +112,10 @@ func ClearMembershipInfo(nt *nomostest.NT, fleetMembership, fleetProject, gkeURI
 	// If membership exists before the reconciler-manager is deployed (test leftovers), the reconciler will be updated.
 	// If membership doesn't exist (normal scenario), the reconciler should remain the same after the reconciler-manager restarts.
 	nt.T.Logf("Restart the reconciler-manager to ensure the membership watch is not set up")
-	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, false)
-	nomostest.Wait(nt.T, "wait for FWI credentials to be absent", nt.DefaultWaitTimeout, func() error {
+	nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, false))
+	nt.Must(nomostest.Wait(nt.T, "wait for FWI credentials to be absent", nt.DefaultWaitTimeout, func() error {
 		return ReconcilerPodMissingFWICredsAnnotation(nt, nomostest.DefaultRootReconcilerName)
-	})
+	}))
 }
 
 // ReconcilerPodHasFWICredsAnnotation checks whether the reconciler Pod has the

--- a/e2e/testcases/acme_test.go
+++ b/e2e/testcases/acme_test.go
@@ -60,7 +60,7 @@ func TestAcmeCorpRepo(t *testing.T) {
 
 	checkResourceCount(nt, kinds.Namespace(), "", len(nsToFolder), nil, configSyncManagementAnnotations)
 	for namespace, folder := range nsToFolder {
-		checkNamespaceExists(nt, namespace, configSyncManagementLabels(namespace, folder), configSyncManagementAnnotations)
+		nt.Must(checkNamespaceExists(nt, namespace, configSyncManagementLabels(namespace, folder), configSyncManagementAnnotations))
 	}
 
 	// Check ClusterRoles (add one for the 'safety' ClusterRole)
@@ -128,7 +128,7 @@ func TestAcmeCorpRepo(t *testing.T) {
 	}
 
 	namespace = "frontend"
-	checkNamespaceExists(nt, namespace, map[string]string{"env": "prod"}, map[string]string{"audit": "true"})
+	nt.Must(checkNamespaceExists(nt, namespace, map[string]string{"env": "prod"}, map[string]string{"audit": "true"}))
 	checkResourceCount(nt, kinds.ConfigMap(), namespace, 1, map[string]string{"app.kubernetes.io/managed-by": "configmanagement.gke.io"}, nil)
 	if err := checkResource(nt, &corev1.ConfigMap{}, namespace, "store-inventory", nil, map[string]string{"configmanagement.gke.io/managed": "enabled"}); err != nil {
 		nt.T.Fatal(err)
@@ -241,8 +241,8 @@ func checkResource(nt *nomostest.NT, obj client.Object, namespace, name string, 
 	return nil
 }
 
-func checkNamespaceExists(nt *nomostest.NT, name string, labels, annotations map[string]string) {
-	nomostest.Wait(nt.T, "namespace exists", nt.DefaultWaitTimeout, func() error {
+func checkNamespaceExists(nt *nomostest.NT, name string, labels, annotations map[string]string) error {
+	return nomostest.Wait(nt.T, "namespace exists", nt.DefaultWaitTimeout, func() error {
 		return checkResource(nt, &corev1.Namespace{}, "", name, labels, annotations)
 	})
 }

--- a/e2e/testcases/cluster_selectors_test.go
+++ b/e2e/testcases/cluster_selectors_test.go
@@ -761,7 +761,7 @@ func renameCluster(nt *nomostest.NT, configMapName, clusterName string) {
 	}
 	nt.MustMergePatch(cm, fmt.Sprintf(`{"data":{"%s":"%s"}}`, reconcilermanager.ClusterNameKey, clusterName))
 
-	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true)
+	nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true))
 }
 
 // clusterNameConfigMapName returns the name of the ConfigMap that has the CLUSTER_NAME.

--- a/e2e/testcases/gatekeeper_test.go
+++ b/e2e/testcases/gatekeeper_test.go
@@ -85,10 +85,10 @@ func TestConstraintTemplateAndConstraintInSameCommit(t *testing.T) {
 
 	// Simulate Gatekeeper's controller behavior.
 	// Wait for the ConstraintTemplate to be applied, then apply the Constraint CRD.
-	nomostest.Wait(nt.T, "ConstraintTemplate on API server", 2*time.Minute, func() error {
+	nt.Must(nomostest.Wait(nt.T, "ConstraintTemplate on API server", 2*time.Minute, func() error {
 		ct := emptyConstraintTemplate()
 		return nt.Validate("k8sallowedrepos", "", &ct)
-	})
+	}))
 	if err := nt.ApplyGatekeeperCRD("constraint-crd.yaml", "k8sallowedrepos.constraints.gatekeeper.sh"); err != nil {
 		nt.T.Fatalf("Failed to create constraint CRD: %v", err)
 	}

--- a/e2e/testcases/namespace_repo_test.go
+++ b/e2e/testcases/namespace_repo_test.go
@@ -156,7 +156,7 @@ func validateRepoSyncRBAC(nt *nomostest.NT, ns string, nsRepo *gitproviders.Read
 	nt.T.Log("Restart the namespace reconciler Pod to force resync instead of waiting for the retry backoff")
 	// Prior updates don't need a restart because the retry backoff is within 1 minute
 	// A Pod restart on Autopilot may take longer than 1 minute
-	nomostest.DeletePodByLabel(nt, "configsync.gke.io/deployment-name", core.NsReconcilerName(ns, configsync.RepoSyncName), false)
+	nt.Must(nomostest.DeletePodByLabel(nt, "configsync.gke.io/deployment-name", core.NsReconcilerName(ns, configsync.RepoSyncName), false))
 	nt.Must(nt.Watcher.WatchForRepoSyncSyncError(ns, configsync.RepoSyncName, applier.ApplierErrorCode,
 		`failed to apply Deployment.apps, bookstore/hello-world: deployments.apps "hello-world" is forbidden: `, []v1beta1.ResourceRef{{
 			SourcePath: "acme/deployment.yaml",

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -606,7 +606,7 @@ func TestManagingReconciler(t *testing.T) {
 		}
 	})
 	nt.T.Log("Restart the reconciler-manager to pick up the manifests change")
-	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true)
+	nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true))
 	nt.T.Log("Verify the reconciler Deployment has been updated to the new manifest")
 	generation++ // generation bumped by 1 to apply the new change in the default manifests declared in the Config Map
 	nt.Must(nt.Watcher.WatchObject(kinds.Deployment(), nomostest.DefaultRootReconcilerName, configsync.ControllerNamespace,
@@ -700,7 +700,7 @@ func resetReconcilerDeploymentManifests(nt *nomostest.NT, containerName string, 
 	}
 
 	nt.T.Log("Restart the reconciler-manager to pick up the manifests change")
-	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true)
+	nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, true))
 
 	nt.T.Log("Verify the reconciler Deployment has been reverted to the original manifest")
 	err := nt.Watcher.WatchObject(kinds.Deployment(),

--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -291,7 +291,7 @@ func TestStress100CRDs(t *testing.T) {
 	}
 
 	nt.T.Log("Replacing the reconciler Pod to ensure the new CRDs are discovered")
-	nomostest.DeletePodByLabel(nt, "app", reconcilermanager.Reconciler, true)
+	nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.Reconciler, true))
 
 	nt.T.Log("Adding a test namespace to the repo to trigger a new sync")
 	nt.Must(rootSyncGitRepo.Add(fmt.Sprintf("%s/ns-%s.yaml", syncPath, ns), k8sobjects.NamespaceObject(ns)))

--- a/e2e/testcases/workload_identity_test.go
+++ b/e2e/testcases/workload_identity_test.go
@@ -272,7 +272,7 @@ func TestWorkloadIdentity(t *testing.T) {
 				// can set up the watch. Once the watch is configured, it can detect the
 				// deletion and creation of the Membership, which implies cluster unregistration and registration.
 				// The underlying reconciler should be updated with FWI creds after the reconciler-manager restarts.
-				nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, false)
+				nt.Must(nomostest.DeletePodByLabel(nt, "app", reconcilermanager.ManagerName, false))
 			}
 
 			var rootMeta, nsMeta rsyncValidateMeta


### PR DESCRIPTION
This refactors the Wait test helper functions to return an error rather than calling Fatal within the test helper. This makes it simpler for the caller to decide how to handle the error and understand the control flow from the test.

Also refactors some of the code to use newer constructs like taskgroup.