### PR TITLE
fix: use intended 1hr backoff cap for oci-sync/helm-sync

### DIFF
--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -78,7 +78,7 @@ var (
 )
 
 func errorBackoff() wait.Backoff {
-	durationLimit := math.Max(*flWait, float64(util.MinimumSyncContainerBackoffCap))
+	durationLimit := math.Max(*flWait, util.MinimumSyncContainerBackoffCap.Seconds())
 	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
 }
 

--- a/cmd/helm-sync/main.go
+++ b/cmd/helm-sync/main.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/auth"
@@ -77,11 +75,6 @@ var (
 		"the password or personal access token to use for helm authantication")
 )
 
-func errorBackoff() wait.Backoff {
-	durationLimit := math.Max(*flWait, util.MinimumSyncContainerBackoffCap.Seconds())
-	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
-}
-
 func main() {
 	utillog.Setup()
 	log := utillog.NewLogger(textlogger.NewLogger(textlogger.NewConfig()), *flRoot, *flErrorFile)
@@ -116,7 +109,8 @@ func main() {
 
 	initialSync := true
 	failCount := 0
-	backoff := errorBackoff()
+	pollPeriod := util.WaitTime(*flWait)
+	backoff := util.SyncContainerBackoff(pollPeriod)
 
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*flSyncTimeout))
@@ -174,11 +168,11 @@ func main() {
 			initialSync = false
 		}
 
-		backoff = errorBackoff()
+		backoff = util.SyncContainerBackoff(pollPeriod)
 		failCount = 0
 		log.DeleteErrorFile()
-		log.Info("next sync", "wait_time", util.WaitTime(*flWait))
+		log.Info("next sync", "wait_time", pollPeriod)
 		cancel()
-		time.Sleep(util.WaitTime(*flWait))
+		time.Sleep(pollPeriod)
 	}
 }

--- a/cmd/oci-sync/main.go
+++ b/cmd/oci-sync/main.go
@@ -56,7 +56,7 @@ var flMaxSyncFailures = flag.Int("max-sync-failures", util.EnvInt("OCI_SYNC_MAX_
 	"the number of consecutive failures allowed before aborting (the first sync must succeed, -1 will retry forever after the initial sync)")
 
 func errorBackoff() wait.Backoff {
-	durationLimit := math.Max(*flWait, float64(util.MinimumSyncContainerBackoffCap))
+	durationLimit := math.Max(*flWait, util.MinimumSyncContainerBackoffCap.Seconds())
 	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
 }
 

--- a/cmd/oci-sync/main.go
+++ b/cmd/oci-sync/main.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2/textlogger"
 	"kpt.dev/configsync/pkg/api/configsync"
 	"kpt.dev/configsync/pkg/auth"
@@ -54,11 +52,6 @@ var flOneTime = flag.Bool("one-time", util.EnvBool("OCI_SYNC_ONE_TIME", false),
 	"exit after the first sync")
 var flMaxSyncFailures = flag.Int("max-sync-failures", util.EnvInt("OCI_SYNC_MAX_SYNC_FAILURES", 0),
 	"the number of consecutive failures allowed before aborting (the first sync must succeed, -1 will retry forever after the initial sync)")
-
-func errorBackoff() wait.Backoff {
-	durationLimit := math.Max(*flWait, util.MinimumSyncContainerBackoffCap.Seconds())
-	return util.BackoffWithDurationAndStepLimit(util.WaitTime(durationLimit), math.MaxInt32)
-}
 
 func main() {
 	utillog.Setup()
@@ -93,7 +86,8 @@ func main() {
 	initialSync := true
 	imageFromSpecHasDigest := oci.HasDigest(*flImage)
 	failCount := 0
-	backoff := errorBackoff()
+	pollPeriod := util.WaitTime(*flWait)
+	backoff := util.SyncContainerBackoff(pollPeriod)
 
 	var authenticator authn.Authenticator
 	switch configsync.AuthType(*flAuth) {
@@ -160,12 +154,12 @@ func main() {
 			initialSync = false
 		}
 
-		backoff = errorBackoff()
+		backoff = util.SyncContainerBackoff(pollPeriod)
 		failCount = 0
 		log.DeleteErrorFile()
-		log.Info("next sync", "wait_time", util.WaitTime(*flWait))
+		log.Info("next sync", "wait_time", pollPeriod)
 		cancel()
-		time.Sleep(util.WaitTime(*flWait))
+		time.Sleep(pollPeriod)
 	}
 
 }

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"errors"
+	"math"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -31,6 +32,18 @@ var (
 	// MinimumSyncContainerBackoffCap is the minimum backoff cap for oci-sync/helm-sync.
 	MinimumSyncContainerBackoffCap = time.Hour
 )
+
+// SyncContainerBackoff returns the backoff function for a *-sync container.
+// the pollPeriod argument is the configurable duration between sync attempts.
+func SyncContainerBackoff(pollPeriod time.Duration) wait.Backoff {
+	backoffCap := MinimumSyncContainerBackoffCap
+	// if the pollPeriod is configured to be greater than the default backoff cap,
+	// use the larger duration as the backoff cap.
+	if pollPeriod > backoffCap {
+		backoffCap = pollPeriod
+	}
+	return BackoffWithDurationAndStepLimit(backoffCap, math.MaxInt32)
+}
 
 // RetriableError represents a transient error that is retriable.
 type RetriableError struct {

--- a/pkg/util/retry_test.go
+++ b/pkg/util/retry_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncContainerBackoff(t *testing.T) {
+	testCases := []struct {
+		name       string
+		pollPeriod time.Duration
+		wantCap    time.Duration
+	}{
+		{
+			name:       "pollPeriod less than default backoff cap",
+			pollPeriod: 1 * time.Second,
+			wantCap:    1 * time.Hour,
+		},
+		{
+			name:       "pollPeriod greater than default backoff cap",
+			pollPeriod: 24 * time.Hour,
+			wantCap:    24 * time.Hour,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.wantCap, SyncContainerBackoff(tc.pollPeriod).Cap)
+		})
+	}
+}


### PR DESCRIPTION
fix: use intended 1hr backoff cap for oci-sync/helm-sync

Casting the default duration to float64 was resulting in the incorrect
units being used (nanoseconds instead of seconds). This bug resulted in
a much larger backoff cap than intended.

This change properly casts the value to seconds and results in the
intended default backoff cap of 1 hour.

---

refactor: consolidate error backoff for sync containers

This change consolidates the function used to construct the error
backoff for the helm-sync and oci-sync containers. A unit test is added
to verify that the Cap is set as intended.