### PR TITLE
fix: use write lock for DeleteIgnored

### DIFF
--- a/pkg/declared/resources.go
+++ b/pkg/declared/resources.go
@@ -109,8 +109,8 @@ func (r *Resources) IgnoredObjects() []client.Object {
 
 // DeleteIgnored deletes an ignore-mutation object from the ignored cache
 func (r *Resources) DeleteIgnored(id core.ID) bool {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	if r.mutationIgnoredObjectsMap == nil || r.mutationIgnoredObjectsMap.Len() == 0 {
 		return false
 	}


### PR DESCRIPTION
This function mutates the map in the critical section and therefore should not use a read lock.