### PR TITLE
ci: Add TF configs for SSM

### DIFF
--- a/e2e/testinfra/terraform/common/registries.tf
+++ b/e2e/testinfra/terraform/common/registries.tf
@@ -32,3 +32,13 @@ resource "google_artifact_registry_repository" "gar" {
   description   = "A private AR repository used for Config Sync e2e tests"
   format        = "DOCKER"
 }
+
+resource "google_secure_source_manager_instance" "configsync-test-ssm-instance" {
+    location = "us-central1"
+    instance_id = "configsync-test"
+
+    # Prevent accidental deletions.
+    lifecycle {
+      prevent_destroy = true
+    }
+}

--- a/e2e/testinfra/terraform/common/service_accounts.tf
+++ b/e2e/testinfra/terraform/common/service_accounts.tf
@@ -19,7 +19,7 @@ module "e2e-csr-reader-sa" {
   gcp_sa_id = "e2e-test-csr-reader"
   gcp_sa_display_name = "Test CSR Reader"
   gcp_sa_description = "Service account used to read from Cloud Source Repositories"
-  role = "roles/source.reader"
+  roles = ["roles/source.reader"]
 }
 
 module "e2e-gar-reader-sa" {
@@ -27,7 +27,7 @@ module "e2e-gar-reader-sa" {
   gcp_sa_id = "e2e-test-ar-reader"
   gcp_sa_display_name = "Test GAR Reader"
   gcp_sa_description = "Service account used to read from Artifact Registry"
-  role = "roles/artifactregistry.reader"
+  roles = ["roles/artifactregistry.reader"]
 }
 
 module "e2e-gcr-reader-sa" {
@@ -35,7 +35,18 @@ module "e2e-gcr-reader-sa" {
   gcp_sa_id = "e2e-test-gcr-reader"
   gcp_sa_display_name = "Test GCR Reader"
   gcp_sa_description = "Service account used to read from Container Registry"
-  role = "roles/storage.objectViewer"
+  roles = ["roles/storage.objectViewer"]
+}
+
+module "e2e-ssm-reader-sa" {
+  source = "../modules/service_account"
+  gcp_sa_id = "e2e-ssm-reader-sa"
+  gcp_sa_display_name = "Test SSM Reader"
+  gcp_sa_description = "Service account used to read from Secure Source Manager Repositories"
+  roles    = [
+    "roles/securesourcemanager.repoReader",
+    "roles/securesourcemanager.instanceAccessor",
+  ]
 }
 
 data "google_project" "project" {

--- a/e2e/testinfra/terraform/common/services.tf
+++ b/e2e/testinfra/terraform/common/services.tf
@@ -24,7 +24,8 @@ resource "google_project_service" "services" {
     "container.googleapis.com",
     "compute.googleapis.com",
     "monitoring.googleapis.com",
-    "logging.googleapis.com"
+    "logging.googleapis.com",
+    "securesourcemanager.googleapis.com"
   ])
   service = each.value
   disable_on_destroy = false

--- a/e2e/testinfra/terraform/main.tf
+++ b/e2e/testinfra/terraform/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "4.36.0"
+      version = "6.43.0"
     }
   }
   backend "gcs" {

--- a/e2e/testinfra/terraform/modules/service_account/service_account.tf
+++ b/e2e/testinfra/terraform/modules/service_account/service_account.tf
@@ -84,7 +84,9 @@ resource "google_service_account_iam_member" "k8s_sa_binding" {
 }
 
 resource "google_project_iam_member" "gcp_sa_role" {
-  role    = var.role
+  for_each = toset(var.roles)
+
+  role    = each.value
   member  = "serviceAccount:${google_service_account.gcp_sa.email}"
   project = data.google_project.project.id
 }

--- a/e2e/testinfra/terraform/modules/service_account/variables.tf
+++ b/e2e/testinfra/terraform/modules/service_account/variables.tf
@@ -29,7 +29,7 @@ variable "gcp_sa_description" {
   description = "The description of the GCP service account"
 }
 
-variable "role" {
-  type = string
-  description = "The GCP project role to grant to the GCP service account"
+variable "roles" {
+  type = list(string)
+  description = "The GCP project roles to grant to the GCP service account"
 }

--- a/e2e/testinfra/terraform/prow/service_accounts.tf
+++ b/e2e/testinfra/terraform/prow/service_accounts.tf
@@ -26,6 +26,7 @@ resource "google_project_iam_member" "test-runner-iam" {
     "roles/secretmanager.admin",
     "roles/source.admin",
     "roles/logging.viewer",
+    "roles/securesourcemanager.admin",
   ])
 
   role    = each.value


### PR DESCRIPTION
This PR adds the TF configs that are needed to provision the resources needed to test SSM