### PR TITLE
test: fix SSM credential helper entry to use explicit hostname

### DIFF
--- a/e2e/nomostest/gitproviders/repository.go
+++ b/e2e/nomostest/gitproviders/repository.go
@@ -283,10 +283,11 @@ func (g *ReadWriteRepository) Init() error {
 			[]string{"config", fmt.Sprintf("credential.%s.helper", testing.CSRHost), "gcloud.sh"})
 	}
 	if g.GitProvider.Type() == e2e.SSM {
+		hostName := g.GitProvider.(*SSMClient).hostName()
 		cmds = append(cmds,
 			// Use credential helper script to provide information that Git needs to
 			// connect securely to SSM using Google Account credentials.
-			[]string{"config", "credential.https://*.*.sourcemanager.dev.helper", "gcloud.sh"})
+			[]string{"config", fmt.Sprintf("credential.%s.helper", hostName), "gcloud.sh"})
 	}
 	return g.BulkGit(cmds...)
 }

--- a/e2e/nomostest/gitproviders/secure_source_manager.go
+++ b/e2e/nomostest/gitproviders/secure_source_manager.go
@@ -77,7 +77,11 @@ func (c *SSMClient) RemoteURL(name string) (string, error) {
 
 // SyncURL returns a URL for Config Sync to sync from.
 func (c *SSMClient) SyncURL(name string) string {
-	return fmt.Sprintf("https://%s-%s-git.%s.sourcemanager.dev/%s/%s", c.instanceID, c.projectNumber, c.region, c.project, name)
+	return fmt.Sprintf("%s/%s/%s", c.hostName(), c.project, name)
+}
+
+func (c *SSMClient) hostName() string {
+	return fmt.Sprintf("https://%s-%s-git.%s.sourcemanager.dev", c.instanceID, c.projectNumber, c.region)
 }
 
 func (c *SSMClient) login() error {


### PR DESCRIPTION
Some versions of git do not support wildcards in the credential helper host name matching. This issue was encountered in the test environment, which was not correctly using the credential helper.

This change fixes the test runner and increases the portability/explicitness of the credential helper.