### PR TITLE
test: fix tests failing with SSM gitprovider

### DIFF
--- a/e2e/testcases/multi_sync_test.go
+++ b/e2e/testcases/multi_sync_test.go
@@ -224,8 +224,8 @@ func TestMultiSyncs_Unstructured_MixedControl(t *testing.T) {
 
 	// Reconciler-manager doesn't copy the secret of RootSync's secretRef.
 	validateReconcilerResource(nt, kinds.Secret(), map[string]string{metadata.SyncNamespaceLabel: configsync.ControllerNamespace}, 0)
-	// CSR auth type doesn't need to copy the secret
-	if nt.GitProvider.Type() != e2e.CSR {
+	// CSR and SSM auth type doesn't need to copy the secret
+	if nt.GitProvider.Type() != e2e.CSR && nt.GitProvider.Type() != e2e.SSM {
 		validateReconcilerResource(nt, kinds.Secret(), map[string]string{metadata.SyncNamespaceLabel: testNs}, 5)
 		validateReconcilerResource(nt, kinds.Secret(), map[string]string{metadata.SyncNamespaceLabel: testNs2}, 1)
 		validateReconcilerResource(nt, kinds.Secret(), map[string]string{metadata.SyncNameLabel: repoSync1ID.Name}, 2)

--- a/e2e/testcases/reconciler_manager_test.go
+++ b/e2e/testcases/reconciler_manager_test.go
@@ -444,8 +444,8 @@ func validateRepoSyncDependencies(nt *nomostest.NT, ns, rsName string) []client.
 	repoSyncDependencies = append(repoSyncDependencies, repoSyncSA)
 
 	// See nomostest.CreateNamespaceSecrets for creation of user secrets.
-	// The Secret is neither needed nor created when using CSR as the Git provider.
-	if nt.GitProvider.Type() != e2e.CSR {
+	// The Secret is neither needed nor created when using CSR or SSM as the Git provider.
+	if nt.GitProvider.Type() != e2e.CSR && nt.GitProvider.Type() != e2e.SSM {
 		repoSyncAuthSecret := &corev1.Secret{}
 		setNN(repoSyncAuthSecret, client.ObjectKey{
 			Name:      controllers.ReconcilerResourceName(repoSyncReconciler.Name, nomostest.NamespaceAuthSecretName),
@@ -941,7 +941,7 @@ func TestAutopilotReconcilerAdjustment(t *testing.T) {
 	}
 	// Filter container map down to just expected containers
 	filteredContainers := []string{reconcilermanager.Reconciler, reconcilermanager.GitSync, metrics.OtelAgentName}
-	if nt.GitProvider.Type() == e2e.CSR {
+	if nt.GitProvider.Type() == e2e.CSR || nt.GitProvider.Type() == e2e.SSM {
 		filteredContainers = append(filteredContainers, reconcilermanager.GCENodeAskpassSidecar)
 	}
 	expectedResources = filterResourceMap(expectedResources, filteredContainers...)


### PR DESCRIPTION
Since SSM uses 'gcpserviceaccount' for authentication, it doesn't require a Secret to be created. This change fixes some tests that were failing as they validated the existence of a Secret.