### PR TITLE
fix: Prevent adding ownership condition for NotFound objects

### DIFF
--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller.go
@@ -283,7 +283,11 @@ func (r *reconciler) computeStatus(
 		switch {
 		case cachedStatus != nil:
 			log.V(4).Info("Resource object status found in the cache")
-			setResStatus(id, &resStatus, cachedStatus)
+			if cachedStatus.Status == v1alpha1.NotFound {
+				resStatus.Status = v1alpha1.NotFound
+			} else {
+				setResStatus(id, &resStatus, cachedStatus)
+			}
 		default:
 			log.V(4).Info("Resource object status not found in the cache")
 			resObj := new(unstructured.Unstructured)


### PR DESCRIPTION
This commit fixes a bug in the ResourceGroup controller where the ownership condition was occasionally added to the status for objects which were not found.

This happened when the object was cached as NotFound by the FilteredWatcher. The Reconcile loop would then use the cached object and call setResStatus, which incorrectly added the ownershipCondition.

The fix ensures that if the cached status is NotFound, the reconciler skips the call to setResStatus.

A unit test, TestComputeStatus, has been added to verify this behavior.