### PR TITLE
chore: bump cloud.google.com/go/auth from 0.16.4 to 0.16.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module kpt.dev/configsync
 go 1.24.0
 
 require (
-	cloud.google.com/go/auth v0.16.4
+	cloud.google.com/go/auth v0.16.5
 	cloud.google.com/go/compute/metadata v0.8.0
 	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/monitoring v1.24.2

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.120.0 h1:wc6bgG9DHyKqF5/vQvX1CiZrtHnxJjBlKUyF9nP6meA=
 cloud.google.com/go v0.120.0/go.mod h1:/beW32s8/pGRuj4IILWQNd4uuebeT4dkOhKmkfit64Q=
-cloud.google.com/go/auth v0.16.4 h1:fXOAIQmkApVvcIn7Pc2+5J8QTMVbUGLscnSVNl11su8=
-cloud.google.com/go/auth v0.16.4/go.mod h1:j10ncYwjX/g3cdX7GpEzsdM+d+ZNsXAbb6qXA7p1Y5M=
+cloud.google.com/go/auth v0.16.5 h1:mFWNQ2FEVWAliEQWpAdH80omXFokmrnbDhUS9cBywsI=
+cloud.google.com/go/auth v0.16.5/go.mod h1:utzRfHMP+Vv0mpOkTRQoWD2q3BatTOoWbA7gCc2dUhQ=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=

--- a/pkg/auth/credential_provider_test.go
+++ b/pkg/auth/credential_provider_test.go
@@ -109,7 +109,7 @@ func TestIsCredentialsNotFoundError(t *testing.T) {
 			opts: &credentials.DetectOptions{
 				CredentialsJSON: []byte(`{}`),
 			},
-			expectedError:    errors.New("credentials: unsupported filetype '\\x00'"),
+			expectedError:    errors.New("credentials: unsupported unidentified file type"),
 			expectedNotFound: false,
 		},
 		{
@@ -119,7 +119,7 @@ func TestIsCredentialsNotFoundError(t *testing.T) {
 			opts: &credentials.DetectOptions{
 				CredentialsJSON: []byte(`{"invalid-type":{}}`),
 			},
-			expectedError:    errors.New("credentials: unsupported filetype '\\x00'"),
+			expectedError:    errors.New("credentials: unsupported unidentified file type"),
 			expectedNotFound: false,
 		},
 		{

--- a/vendor/cloud.google.com/go/auth/CHANGES.md
+++ b/vendor/cloud.google.com/go/auth/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.5](https://github.com/googleapis/google-cloud-go/compare/auth/v0.16.4...auth/v0.16.5) (2025-08-14)
+
+
+### Bug Fixes
+
+* **auth:** Improve error message for unknown credentials type ([#12673](https://github.com/googleapis/google-cloud-go/issues/12673)) ([558b164](https://github.com/googleapis/google-cloud-go/commit/558b16429f621276694405fa5f2091199f2d4c4d))
+* **auth:** Set Content-Type in userTokenProvider.exchangeToken ([#12634](https://github.com/googleapis/google-cloud-go/issues/12634)) ([1197ebc](https://github.com/googleapis/google-cloud-go/commit/1197ebcbca491f8c610da732c7361c90bc6f46d0))
+
 ## [0.16.4](https://github.com/googleapis/google-cloud-go/compare/auth/v0.16.3...auth/v0.16.4) (2025-08-06)
 
 

--- a/vendor/cloud.google.com/go/auth/credentials/filetypes.go
+++ b/vendor/cloud.google.com/go/auth/credentials/filetypes.go
@@ -36,6 +36,8 @@ func fileCredentials(b []byte, opts *DetectOptions) (*auth.Credentials, error) {
 	var projectID, universeDomain string
 	var tp auth.TokenProvider
 	switch fileType {
+	case credsfile.UnknownCredType:
+		return nil, errors.New("credentials: unsupported unidentified file type")
 	case credsfile.ServiceAccountKey:
 		f, err := credsfile.ParseServiceAccount(b)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ al.essio.dev/pkg/shellescape
 # cloud.google.com/go v0.120.0
 ## explicit; go 1.23.0
 cloud.google.com/go
-# cloud.google.com/go/auth v0.16.4
+# cloud.google.com/go/auth v0.16.5
 ## explicit; go 1.23.0
 cloud.google.com/go/auth
 cloud.google.com/go/auth/credentials


### PR DESCRIPTION
* Bumps [cloud.google.com/go/auth](https://github.com/googleapis/google-cloud-go) from 0.16.4 to 0.16.5.
* Updates TestIsCredentialsNotFoundError as error message has changed