### PR TITLE
chore: Bump otelcontribcol to 0.119.0 for CVE fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ COSIGN := $(BIN_DIR)/cosign
 GIT_SYNC_VERSION := v4.4.2-gke.2__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
-OTELCONTRIBCOL_VERSION := v0.118.0-gke.10
+OTELCONTRIBCOL_VERSION := v0.119.0-gke.2
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.


### PR DESCRIPTION
Bumps otelcontribcol to the 0.119.0 include a required CVE update for the docker/docker. Attempting to patch the previous version (v0.118.0) directly caused dependency conflicts.