### PR TITLE
test: fix TestStressResourceGroup expectation

### DIFF
--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -677,14 +677,6 @@ func TestStressResourceGroup(t *testing.T) {
 	expectedStatus.ResourceStatuses[index] = v1alpha1.ResourceStatus{
 		Status:      v1alpha1.NotFound,
 		ObjMetadata: resources[index],
-		Conditions: []v1alpha1.Condition{
-			{
-				Message: testresourcegroup.NotOwnedMessage,
-				Reason:  v1alpha1.OwnershipEmpty,
-				Status:  v1alpha1.UnknownConditionStatus,
-				Type:    v1alpha1.Ownership,
-			},
-		},
 	}
 	nt.Must(nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(


### PR DESCRIPTION
A recent change intentionally removed the ownership condition from NotFound objects. This change updates the test expectation to be consistent with the new behavior.

Note that this was not caught in presubmits because the stress tests do not run as presubmits.

See https://github.com/GoogleContainerTools/kpt-config-sync/pull/1819