### PR TITLE
test: parametrize the bitbucket workspace

### DIFF
--- a/e2e/flags.go
+++ b/e2e/flags.go
@@ -142,6 +142,11 @@ var GitProvider = newStringEnum("git-provider", util.EnvString("E2E_GIT_PROVIDER
 	"The git provider that hosts the Git repositories. Defaults to Local.",
 	[]string{Local, Bitbucket, GitLab, CSR, SSM})
 
+// BitbucketWorkspace is the Bitbucket workspace to use when git-provider=bitbucket.
+// This is parametrized so that CI can be updated without requiring cherry-picks.
+var BitbucketWorkspace = flag.String("bitbucket-workspace", util.EnvString("E2E_BITBUCKET_WORKSPACE", "config-sync-ci-20250814"),
+	`The Bitbucket workspace to use when git-provider is set to "bitbucket".`)
+
 // OCIProvider is the provider that hosts the OCI repositories.
 var OCIProvider = newStringEnum("oci-provider", util.EnvString("E2E_OCI_PROVIDER", Local),
 	"The registry provider that hosts the OCI repositories. Defaults to Local.",


### PR DESCRIPTION
This change parametrizes the bitbucket workspace so that it can be set at runtime. The primary motivation of this change is to simplify the management of the workspace, such that it can be updated directly in the prow configuration without requiring cherry picking.