### PR TITLE
test: migrate to using testing.T.Context()

### DIFF
--- a/pkg/resourcegroup/controllers/handler/throttler_test.go
+++ b/pkg/resourcegroup/controllers/handler/throttler_test.go
@@ -15,7 +15,6 @@
 package handler
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -42,9 +41,7 @@ func TestThrottler(t *testing.T) {
 	throttler := NewThrottler(time.Second)
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	throttler.Generic(ctx, genericE, queue)
 
@@ -78,9 +75,7 @@ func TestThrottlerMultipleEvents(t *testing.T) {
 	throttler := NewThrottler(5 * time.Second)
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Call the event handler three times for the same event
 	throttler.Generic(ctx, genericE, queue)
@@ -131,9 +126,7 @@ func TestThrottlerMultipleObjects(t *testing.T) {
 	throttler := NewThrottler(5 * time.Second)
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Call the event handler to push two events
 	throttler.Generic(ctx, genericE, queue)

--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
@@ -79,9 +79,7 @@ func TestReconcile(t *testing.T) {
 	// Get the watch client built by the manager
 	c := mgr.GetClient().(client.WithWatch)
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Setup the controllers
 	logger := testLogger.WithName("controllers")

--- a/pkg/resourcegroup/controllers/resourcemap/resourcemap_test.go
+++ b/pkg/resourcegroup/controllers/resourcemap/resourcemap_test.go
@@ -15,7 +15,6 @@
 package resourcemap
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,9 +66,7 @@ func TestResourceMapReconcile(t *testing.T) {
 		Name:      "group2",
 	}
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var gks []schema.GroupKind
 

--- a/pkg/resourcegroup/controllers/root/root_controller_test.go
+++ b/pkg/resourcegroup/controllers/root/root_controller_test.go
@@ -15,7 +15,6 @@
 package root
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -62,9 +61,7 @@ func TestRootReconciler(t *testing.T) {
 	require.NoError(t, err)
 	c := mgr.GetClient()
 
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	logger := testLogger.WithName("controllers")
 	reconcilerKpt, err = NewReconciler(mgr, logger.WithName("root"))

--- a/pkg/resourcegroup/controllers/watch/manager_test.go
+++ b/pkg/resourcegroup/controllers/watch/manager_test.go
@@ -133,9 +133,7 @@ func TestManager_Update(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			options := &Options{
 				watcherFunc: testRunnables(ctx, tc.failedWatchers),

--- a/pkg/testing/testcontroller/testcontroller.go
+++ b/pkg/testing/testcontroller/testcontroller.go
@@ -64,8 +64,7 @@ func NewTestLogger(t *testing.T) logr.Logger {
 // This avoids async error logs from the test environment stopping before the
 // controller-manager.
 func StartTestManager(t *testing.T, mgr manager.Manager) func() {
-	// TODO: replace with `ctx := t.Context()` in Go 1.24.0+
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ctx, cancel := context.WithCancel(ctx)
 	doneCh := make(chan struct{})


### PR DESCRIPTION
* Replaces the usage of `context.WithCancel` in controller unit tests with `t.Context()`given the TODOs left in #1553