### PR TITLE
test: Add t.Skip to failing test while a fix is worked on

### DIFF
--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -221,6 +221,7 @@ func TestHydrateExternalFiles(t *testing.T) {
 }
 
 func TestHydrateHelmComponents(t *testing.T) {
+	t.Skip("Temporarily skipping failing test")
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t,
 		nomostesting.Hydration,


### PR DESCRIPTION
Example of failing test: https://oss.gprow.dev/view/gcs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-kind/1961121217469485056