### PR TITLE
v1.22.1: additional cherrypick to restore test coverage

### DIFF
--- a/e2e/testcases/hydration_test.go
+++ b/e2e/testcases/hydration_test.go
@@ -221,7 +221,6 @@ func TestHydrateExternalFiles(t *testing.T) {
 }
 
 func TestHydrateHelmComponents(t *testing.T) {
-	t.Skip("Temporarily skipping failing test")
 	rootSyncID := nomostest.DefaultRootSyncID
 	nt := nomostest.New(t,
 		nomostesting.Hydration,

--- a/e2e/testdata/hydration/compiled-json/helm-components/wordpress/deployment_my-wordpress.json
+++ b/e2e/testdata/hydration/compiled-json/helm-components/wordpress/deployment_my-wordpress.json
@@ -166,7 +166,7 @@
 									}
 								],
 								"envFrom": null,
-								"image": "docker.io/bitnami/wordpress:6.1.1-debian-11-r34",
+								"image": "docker.io/bitnamilegacy/wordpress:6.1.1-debian-11-r34",
 								"imagePullPolicy": "IfNotPresent",
 								"livenessProbe": {
 									"failureThreshold": 6,

--- a/e2e/testdata/hydration/compiled/helm-components/wordpress/deployment_my-wordpress.yaml
+++ b/e2e/testdata/hydration/compiled/helm-components/wordpress/deployment_my-wordpress.yaml
@@ -115,7 +115,7 @@ spec:
         - name: APACHE_HTTPS_PORT_NUMBER
           value: "8443"
         envFrom: null
-        image: docker.io/bitnami/wordpress:6.1.1-debian-11-r34
+        image: docker.io/bitnamilegacy/wordpress:6.1.1-debian-11-r34
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6

--- a/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml
@@ -18,11 +18,13 @@ helmCharts:
   namespace: coredns
   valuesFile: https://raw.githubusercontent.com/config-sync-examples/helm-components/main/coredns-values.yaml
 - name: wordpress
-  repo: https://charts.bitnami.com/bitnami
-  version: 15.2.35
   releaseName: my-wordpress
   namespace: wordpress
   valuesInline:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/wordpress
+      tag: "6.1.1-debian-11-r34"
     service:
       type: ClusterIP
 

--- a/e2e/testdata/hydration/helm-components/kustomization.yaml
+++ b/e2e/testdata/hydration/helm-components/kustomization.yaml
@@ -17,8 +17,6 @@ helmCharts:
   releaseName: my-coredns
   namespace: coredns
 - name: wordpress
-  repo: https://charts.bitnami.com/bitnami
-  version: 15.2.35
   releaseName: my-wordpress
   namespace: wordpress
   valuesInline:
@@ -27,6 +25,10 @@ helmCharts:
       auth:
         rootPassword: abcdefg
         password: abcdefg
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/wordpress
+      tag: "6.1.1-debian-11-r34"
     service:
       type: ClusterIP
 


### PR DESCRIPTION

* Use hermetic helm chart for wordpress

* update test expectation