### PR TITLE
test: fix TestStressMemoryUsageHelm timeout

### DIFF
--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -566,7 +566,7 @@ func TestStressMemoryUsageHelm(t *testing.T) {
 
 	// Validate that the resources sync without the reconciler running out of
 	// memory, getting OOMKilled, and crash looping.
-	nt.Must(nt.WatchForAllSyncs(nomostest.WithTimeout(5 * time.Minute)))
+	nt.Must(nt.WatchForAllSyncs())
 
 	nt.T.Logf("Verify the number of Anvil objects")
 	for i := 1; i <= crdCount; i++ {
@@ -598,7 +598,7 @@ func TestStressMemoryUsageHelm(t *testing.T) {
 	})
 	// Validate that the resources sync without the reconciler running out of
 	// memory, getting OOMKilled, and crash looping.
-	nt.Must(nt.WatchForAllSyncs(nomostest.WithTimeout(5 * time.Minute)))
+	nt.Must(nt.WatchForAllSyncs())
 }
 
 func TestStressResourceGroup(t *testing.T) {


### PR DESCRIPTION
This updates the WatchForAllSyncs calls in the helm stress test to use the default timeout instead of a hard coded timeout. The default timeout is set programmatically, and is longer for autopilot (10 minutes instead of the hard coded 5 minutes).

This is intended to fix timeout errors with this test on autopilot.