### PR TITLE
test: temporarily skip failing Helm tests

### DIFF
--- a/e2e/testcases/helm_sync_test.go
+++ b/e2e/testcases/helm_sync_test.go
@@ -63,6 +63,7 @@ const (
 // TestPublicHelm can run on both Kind and GKE clusters.
 // It tests Config Sync can pull from public Helm repo without any authentication.
 func TestPublicHelm(t *testing.T) {
+	t.Skip("Temporarily skipping failing test")
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
@@ -183,6 +184,7 @@ func TestOCIHelmChartNameContainsSlash(t *testing.T) {
 // It tests that helm-sync properly watches ConfigMaps in the RSync namespace if the RSync is created before
 // the ConfigMap.
 func TestHelmWatchConfigMap(t *testing.T) {
+	t.Skip("Temporarily skipping failing test")
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 
@@ -306,6 +308,7 @@ service:
 // TestHelmConfigMapOverride can run on both Kind and GKE clusters.
 // It tests ConfigSync behavior when multiple valuesFiles are provided
 func TestHelmConfigMapOverride(t *testing.T) {
+	t.Skip("Temporarily skipping failing test")
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	cmName := "helm-config-map-override"
@@ -477,6 +480,7 @@ func TestHelmLatestVersion(t *testing.T) {
 // TestHelmVersionRange verifies the Config Sync behavior for helm charts when helm.spec.version is specified as a range.
 // Helm-sync should pull the latest helm chart version within the range.
 func TestHelmVersionRange(t *testing.T) {
+	t.Skip("Temporarily skipping failing test")
 	nt := nomostest.New(t, nomostesting.SyncSource,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 


### PR DESCRIPTION
This skips the failing Helm tests that depend on Wordpress until https://github.com/GoogleContainerTools/config-sync/pull/1888 is merged