### PR TITLE
test: Split SyncSource feature

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -91,7 +91,7 @@ test-e2e-kind-test-group1:
 # This target runs the second group of e2e tests.
 .PHONY: test-e2e-kind-test-group2
 test-e2e-kind-test-group2:
-	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source,reconciliation-1" test-e2e-kind
+	$(MAKE) E2E_ARGS="$(E2E_ARGS) --test-features=sync-source-git,sync-source-helm,sync-source-oci,reconciliation-1" test-e2e-kind
 
 # This target runs the third group of e2e tests.
 .PHONY: test-e2e-kind-test-group3

--- a/e2e/nomostest/testing/feature.go
+++ b/e2e/nomostest/testing/feature.go
@@ -38,8 +38,12 @@ const (
 	Reconciliation1 = "reconciliation-1"
 	// Reconciliation2 verifies the second part of the reconciliation test.
 	Reconciliation2 = "reconciliation-2"
-	// SyncSource verifies the various source configs, including different source types, sync directory, branch, and etc.
-	SyncSource = "sync-source"
+	// SyncSourceGit verifies syncing from a Git repository
+	SyncSourceGit = "sync-source-git"
+	// SyncSourceOCI verifies syncing from an OCI image
+	SyncSourceOCI = "sync-source-oci"
+	// SyncSourceHelm verifies syncing from a Helm chart
+	SyncSourceHelm = "sync-source-helm"
 	// WorkloadIdentity verifies authenticating with workload identity (GKE and Fleet).
 	WorkloadIdentity = "workload-identity"
 )
@@ -49,7 +53,7 @@ func KnownFeature(f Feature) bool {
 	switch f {
 	case ACMController, NomosCLI, Selector, DriftControl, Hydration,
 		Lifecycle, MultiRepos, OverrideAPI, Reconciliation1, Reconciliation2,
-		SyncSource, WorkloadIdentity:
+		WorkloadIdentity, SyncSourceGit, SyncSourceOCI, SyncSourceHelm:
 		return true
 	}
 	return false

--- a/e2e/testcases/admission_test.go
+++ b/e2e/testcases/admission_test.go
@@ -222,7 +222,7 @@ func TestDisableWebhookConfigurationUpdateHierarchy(t *testing.T) {
 
 func TestDisableWebhookConfigurationUpdateUnstructured(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.DriftControl,
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()))
 	repoSyncGitRepo := nt.SyncSourceGitReadWriteRepository(repoSyncID)

--- a/e2e/testcases/gcenode_test.go
+++ b/e2e/testcases/gcenode_test.go
@@ -52,7 +52,7 @@ const (
 func TestGCENodeCSR(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireCloudSourceRepository(t),
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
@@ -108,7 +108,7 @@ func TestGCENodeCSR(t *testing.T) {
 func TestGCENodeOCI(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireOCIArtifactRegistry(t),
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
@@ -170,7 +170,7 @@ func TestGCENodeOCI(t *testing.T) {
 //   - `roles/artifactregistry.reader` for access image in Artifact Registry.
 func TestGCENodeHelm(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, testNs)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceHelm,
 		ntopts.RequireGKE(t), ntopts.GCENodeTest,
 		ntopts.RequireHelmArtifactRegistry(t),
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),

--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.ACMController)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	rs := k8sobjects.RootSyncObjectV1Beta1(configsync.RootSyncName)

--- a/e2e/testcases/github_test.go
+++ b/e2e/testcases/github_test.go
@@ -59,7 +59,7 @@ const (
 func TestGithubAppRootSync(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncNN := rootSyncID.ObjectKey
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.GitHubAppTest)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.GitHubAppTest)
 	githubApp, err := gitproviders.FetchGithubAppConfiguration()
 	if err != nil {
 		nt.T.Fatal(err)
@@ -154,7 +154,7 @@ func TestGithubAppRootSync(t *testing.T) {
 func TestGithubAppRepoSync(t *testing.T) {
 	repoSyncNN := nomostest.RepoSyncNN(githubAppRepoNamespace, "rs-test")
 	repoSyncID := core.RepoSyncID(repoSyncNN.Name, repoSyncNN.Namespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.GitHubAppTest,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.GitHubAppTest,
 		ntopts.WithDelegatedControl,                    // DelegatedControl to simplify updating RepoSync
 		ntopts.RepoSyncPermissions(policy.CoreAdmin()), // RepoSync manages ConfigMap
 		ntopts.SyncWithGitSource(repoSyncID))

--- a/e2e/testcases/invalid_git_branch_test.go
+++ b/e2e/testcases/invalid_git_branch_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestInvalidRootSyncBranchStatus(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Update RootSync to invalid branch name
@@ -59,7 +59,7 @@ func TestInvalidRootSyncBranchStatus(t *testing.T) {
 }
 
 func TestInvalidRootSyncRevisionStatus(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	// Update RootSync to invalid branch name
@@ -89,7 +89,7 @@ func TestInvalidRootSyncRevisionStatus(t *testing.T) {
 
 func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit,
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
@@ -143,7 +143,7 @@ func TestInvalidRepoSyncBranchStatus(t *testing.T) {
 
 func TestInvalidRepoSyncRevisionStatus(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit,
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
@@ -196,7 +196,7 @@ func TestInvalidRepoSyncRevisionStatus(t *testing.T) {
 }
 
 func TestSyncFailureAfterSuccessfulSyncs(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	nt.T.Cleanup(func() {
 		nt.T.Log("Resetting all RootSync branches to main")

--- a/e2e/testcases/kcc_test.go
+++ b/e2e/testcases/kcc_test.go
@@ -44,7 +44,7 @@ import (
 // are removed successfully.
 func TestKCCResourcesOnCSR(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.KCCTest, ntopts.RequireGKE(t))
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.KCCTest, ntopts.RequireGKE(t))
 
 	nt.T.Log("sync to the kcc resources from a CSR repo")
 	repo := gitproviders.ReadOnlyRepository{

--- a/e2e/testcases/oci_signature_verification_test.go
+++ b/e2e/testcases/oci_signature_verification_test.go
@@ -39,7 +39,7 @@ var cosignPassword = map[string]string{
 
 func TestAddPreSyncAnnotationRepoSync(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespaceRepo)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.RequireOCIProvider,
 		ntopts.SyncWithGitSource(repoSyncID),
 		ntopts.RepoSyncPermissions(policy.RBACAdmin(), policy.CoreAdmin()))
@@ -117,7 +117,7 @@ func TestAddPreSyncAnnotationRepoSync(t *testing.T) {
 func TestAddPreSyncAnnotationRootSync(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 		ntopts.RequireOCIProvider,
 	)

--- a/e2e/testcases/oci_sync_test.go
+++ b/e2e/testcases/oci_sync_test.go
@@ -71,7 +71,7 @@ func gsaGCRReaderEmail() string {
 // It tests Config Sync can pull from public OCI images without any authentication.
 func TestPublicOCI(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured))
 	var err error
 
@@ -115,7 +115,7 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 	namespace := testNs
 	rootSyncID := nomostest.DefaultRootSyncID
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.RequireOCIProvider,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
@@ -168,7 +168,7 @@ func TestSwitchFromGitToOciCentralized(t *testing.T) {
 func TestSwitchFromGitToOciDelegated(t *testing.T) {
 	namespace := testNs
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, namespace)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.WithDelegatedControl, ntopts.RequireOCIProvider,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
@@ -245,7 +245,7 @@ func isSourceType(sourceType configsync.SourceType) testpredicates.Predicate {
 func TestOciSyncWithDigest(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 		ntopts.RequireOCIProvider,
 	)

--- a/e2e/testcases/policy_dir_test.go
+++ b/e2e/testcases/policy_dir_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMissingRepoErrorWithHierarchicalFormat(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 
 	nomostest.SetRootSyncGitDir(nt, configsync.RootSyncName, "")
 
@@ -34,7 +34,7 @@ func TestMissingRepoErrorWithHierarchicalFormat(t *testing.T) {
 
 func TestPolicyDirUnset(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 	// There are 6 cluster-scoped objects under `../../examples/acme/cluster`.
 	//
@@ -58,7 +58,7 @@ func TestPolicyDirUnset(t *testing.T) {
 }
 
 func TestInvalidPolicyDir(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 
 	nt.T.Log("Break the policydir in the repo")
 	nomostest.SetRootSyncGitDir(nt, configsync.RootSyncName, "some-nonexistent-policydir")

--- a/e2e/testcases/private_cert_secret_test.go
+++ b/e2e/testcases/private_cert_secret_test.go
@@ -67,7 +67,7 @@ func secretDataDeletePatch(key string) string {
 
 func TestCACertSecretRefV1Alpha1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
@@ -181,7 +181,7 @@ func TestCACertSecretRefV1Alpha1(t *testing.T) {
 
 func TestCACertSecretRefV1Beta1(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
@@ -300,7 +300,7 @@ func TestCACertSecretRefV1Beta1(t *testing.T) {
 
 func TestCACertSecretWatch(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(repoSyncID))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 	repoSyncKey := repoSyncID.ObjectKey
@@ -384,7 +384,7 @@ func TestCACertSecretWatch(t *testing.T) {
 // It tests RootSyncs can pull from OCI images using a CA certificate.
 func TestOCICACertSecretRefRootRepo(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 		ntopts.RequireLocalOCIProvider)
 
@@ -413,7 +413,7 @@ func TestOCICACertSecretRefRootRepo(t *testing.T) {
 // It tests RepoSyncs can pull from OCI images using a CA certificate.
 func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceOCI,
 		ntopts.RequireLocalOCIProvider,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),
@@ -469,7 +469,7 @@ func TestOCICACertSecretRefNamespaceRepo(t *testing.T) {
 // It tests RootSyncs can pull from OCI images using a CA certificate.
 func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceHelm,
 		ntopts.SyncWithGitSource(rootSyncID, ntopts.Unstructured),
 		ntopts.RequireLocalHelmProvider)
 
@@ -501,7 +501,7 @@ func TestHelmCACertSecretRefRootRepo(t *testing.T) {
 // It tests RepoSyncs can pull from OCI images using a CA certificate.
 func TestHelmCACertSecretRefNamespaceRepo(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
-	nt := nomostest.New(t, nomostesting.SyncSource,
+	nt := nomostest.New(t, nomostesting.SyncSourceHelm,
 		ntopts.RequireLocalHelmProvider,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),

--- a/e2e/testcases/proxy_test.go
+++ b/e2e/testcases/proxy_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestSyncingThroughAProxy(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 
 	nt.T.Logf("Set up the tiny proxy service and Override the RootSync object with proxy setting")
 	nt.MustKubectl("apply", "-f", "../testdata/proxy")

--- a/e2e/testcases/root_sync_test.go
+++ b/e2e/testcases/root_sync_test.go
@@ -86,7 +86,7 @@ func TestDeleteRootSyncAndRootSyncV1Alpha1(t *testing.T) {
 func TestUpdateRootSyncGitDirectory(t *testing.T) {
 	rootSyncID := nomostest.DefaultRootSyncID
 	rootSyncKey := rootSyncID.ObjectKey
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(rootSyncID)
 
 	// Validate RootSync is present.
@@ -172,7 +172,7 @@ func TestUpdateRootSyncGitDirectory(t *testing.T) {
 
 func TestUpdateRootSyncGitBranch(t *testing.T) {
 	rootSyncNN := nomostest.RootSyncNN(configsync.RootSyncName)
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nsA := "ns-a"
@@ -297,7 +297,7 @@ func TestUpdateRootSyncGitBranch(t *testing.T) {
 }
 
 func TestForceRevert(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource)
+	nt := nomostest.New(t, nomostesting.SyncSourceGit)
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
 	nt.Must(rootSyncGitRepo.Remove("acme/system/repo.yaml"))

--- a/e2e/testcases/ssh_known_hosts_test.go
+++ b/e2e/testcases/ssh_known_hosts_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestRootSyncSSHKnownHost(t *testing.T) {
-	nt := nomostest.New(t, nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+	nt := nomostest.New(t, nomostesting.SyncSourceGit, ntopts.RequireLocalGitProvider,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured))
 	rootSyncGitRepo := nt.SyncSourceGitReadWriteRepository(nomostest.DefaultRootSyncID)
 
@@ -116,7 +116,7 @@ func TestRootSyncSSHKnownHost(t *testing.T) {
 func TestRepoSyncSSHKnownHost(t *testing.T) {
 	repoSyncID := core.RepoSyncID(configsync.RepoSyncName, backendNamespace)
 	nt := nomostest.New(t,
-		nomostesting.SyncSource, ntopts.RequireLocalGitProvider,
+		nomostesting.SyncSourceGit, ntopts.RequireLocalGitProvider,
 		ntopts.WithDelegatedControl,
 		ntopts.SyncWithGitSource(nomostest.DefaultRootSyncID, ntopts.Unstructured),
 		ntopts.SyncWithGitSource(repoSyncID),


### PR DESCRIPTION
This splits the SyncSource feature into SyncSourceGit, SyncSourceOCI and SyncSourceHelm respectively