### PR TITLE
test: reduce flakiness of TestStressLargeRequest

### DIFF
--- a/e2e/testcases/stress_test.go
+++ b/e2e/testcases/stress_test.go
@@ -222,9 +222,11 @@ func TestStressLargeRequest(t *testing.T) {
 	reconcilerOverride := v1beta1.ContainerResourcesSpec{
 		ContainerName: reconcilermanager.Reconciler,
 		MemoryLimit:   resource.MustParse("1500Mi"),
+		CPULimit:      resource.MustParse("1.5"),
 	}
 	if *e2e.GKEAutopilot {
 		reconcilerOverride.MemoryRequest = resource.MustParse("1500Mi")
+		reconcilerOverride.CPURequest = resource.MustParse("1.5")
 	}
 	repo := gitproviders.ReadOnlyRepository{
 		URL: "https://github.com/config-sync-examples/crontab-crs",
@@ -256,7 +258,7 @@ func TestStressLargeRequest(t *testing.T) {
 	nomostest.SetExpectedGitCommit(nt, rootSyncID, commit)
 
 	nt.T.Logf("Wait for the sync to complete")
-	nt.Must(nt.WatchForAllSyncs())
+	nt.Must(nt.WatchForAllSyncs(nomostest.WithTimeout(40 * time.Minute)))
 }
 
 // TestStress100CRDs applies 100 CRDs and validates that syncing still works.


### PR DESCRIPTION
This test can be flaky on autopilot, where it times out waiting for the large number of objects to be synced. This change does two things to reduce the flakiness:
- Increases the CPU request/limit. The reconciler currently has the default of ~700m, and from the cluster metrics is currently being CPU throttled.
- Increases the sync timeout from 30 minutes to 40 minutes. On successful runs it usually completes in around 25 minutes. This adds a bit more headroom.