### PR TITLE
test: Reuse Bitbucket repos

### DIFF
--- a/e2e/nomostest/gitproviders/cloud_source_repository.go
+++ b/e2e/nomostest/gitproviders/cloud_source_repository.go
@@ -50,7 +50,7 @@ func newCSRClient(repoPrefix string, shell *testshell.TestShell) *CSRClient {
 }
 
 func (c *CSRClient) fullName(name string) string {
-	return util.SanitizeRepoName(c.repoPrefix, name)
+	return util.SanitizeGCPRepoName(c.repoPrefix, name)
 }
 
 // Type returns the provider type.

--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -51,7 +51,8 @@ type GitProvider interface {
 func NewGitProvider(t testing.NTB, provider, clusterName string, logger *testlogger.TestLogger, shell *testshell.TestShell) GitProvider {
 	switch provider {
 	case e2e.Bitbucket:
-		client, err := newBitbucketClient(clusterName, logger)
+		repoSuffix := *e2e.GCPProject + "/" + clusterName
+		client, err := newBitbucketClient(repoSuffix, logger)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/e2e/nomostest/gitproviders/secure_source_manager.go
+++ b/e2e/nomostest/gitproviders/secure_source_manager.go
@@ -61,7 +61,7 @@ func newSSMClient(repoPrefix string, shell *testshell.TestShell, projectNumber s
 }
 
 func (c *SSMClient) fullName(name string) string {
-	return util.SanitizeRepoName(c.repoPrefix, name)
+	return util.SanitizeGCPRepoName(c.repoPrefix, name)
 }
 
 // Type returns the provider type.

--- a/e2e/nomostest/gitproviders/util/reponame_test.go
+++ b/e2e/nomostest/gitproviders/util/reponame_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSanitizeRepoName(t *testing.T) {
+func TestSanitizeGCPRepoName(t *testing.T) {
 	testCases := []struct {
 		testName     string
 		repoPrefix   string
@@ -57,11 +57,22 @@ func TestSanitizeRepoName(t *testing.T) {
 			repoName:     "config-management-system/root-sync-with-a-very-long-name",
 			expectedName: "cs-e2e-test-config-management-system-root-sync-with-a-0d0af6c0",
 		},
+		{
+			testName:     "Empty repoPrefix",
+			repoPrefix:   "",
+			repoName:     "test-ns/repo-sync",
+			expectedName: "cs-e2e-test-ns-repo-sync-cf15cd55",
+		}, {
+			testName:     "Empty repoName",
+			repoPrefix:   "test",
+			repoName:     "",
+			expectedName: "",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotName := SanitizeRepoName(tc.repoPrefix, tc.repoName)
+			gotName := SanitizeGCPRepoName(tc.repoPrefix, tc.repoName)
 			assert.Equal(t, tc.expectedName, gotName)
 			assert.LessOrEqual(t, len(gotName), defaultRepoNameMaxLen)
 		})
@@ -71,45 +82,56 @@ func TestSanitizeRepoName(t *testing.T) {
 func TestSanitizeBitbucketRepoName(t *testing.T) {
 	testCases := []struct {
 		testName     string
-		repoPrefix   string
+		repoSuffix   string
 		repoName     string
 		expectedName string
 	}{
 		{
 			testName:     "RepoSync test-ns/repo-sync",
-			repoPrefix:   "test",
+			repoSuffix:   "test",
 			repoName:     "test-ns/repo-sync",
-			expectedName: "cs-e2e-test-test-ns-repo-sync-19dcbc51",
-		},
-		{
-			testName:     "The expected name shouldn't have a double dash in it",
-			repoPrefix:   "my-test-cluster",
-			repoName:     "config-management-system/root-sync",
-			expectedName: "cs-e2e-my-test-cluster-config-management-system-root-e5e2fb26",
+			expectedName: "test-ns-repo-sync-test-3b350268",
 		},
 		{
 			testName:     "RepoSync test/ns-repo-sync should not collide with RepoSync test-ns/repo-sync",
-			repoPrefix:   "test",
+			repoSuffix:   "test",
 			repoName:     "test/ns-repo-sync",
-			expectedName: "cs-e2e-test-test-ns-repo-sync-f98ca740",
+			expectedName: "test-ns-repo-sync-test-6831d08b",
 		},
 		{
-			testName:     "A very long repoPrefix should be truncated",
-			repoPrefix:   "autopilot-rapid-latest-10",
+			testName:     "The expected name shouldn't have a double dash in it",
+			repoSuffix:   "test",
+			repoName:     "config-management-system/a-new-root-sync-with-ab-123",
+			expectedName: "config-management-system-a-new-root-sync-with-ab-123-da77fbd1",
+		},
+		{
+			testName:     "A very long repoSuffix should be truncated",
+			repoSuffix:   "kpt-config-sync-ci-main/autopilot-rapid-latest-10",
 			repoName:     "config-management-system/root-sync",
-			expectedName: "cs-e2e-autopilot-rapid-latest-10-config-management-sy-0aab99c5",
+			expectedName: "config-management-system-root-sync-kpt-config-sync-ci-6485bfa0",
 		},
 		{
 			testName:     "A very long repoName should be truncated",
-			repoPrefix:   "test",
+			repoSuffix:   "test",
 			repoName:     "config-management-system/root-sync-with-a-very-long-name",
-			expectedName: "cs-e2e-test-config-management-system-root-sync-with-a-0d0af6c0",
+			expectedName: "config-management-system-root-sync-with-a-very-long-n-3b0dae1c",
+		},
+		{
+			testName:     "Empty repoSuffix",
+			repoSuffix:   "",
+			repoName:     "test-ns/repo-sync",
+			expectedName: "test-ns-repo-sync-08675d6b",
+		}, {
+			testName:     "Empty repoName",
+			repoSuffix:   "test",
+			repoName:     "",
+			expectedName: "",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotName := SanitizeBitbucketRepoName(tc.repoPrefix, tc.repoName)
+			gotName := SanitizeBitbucketRepoName(tc.repoSuffix, tc.repoName)
 			assert.Equal(t, tc.expectedName, gotName)
 			assert.LessOrEqual(t, len(gotName), bitbucketRepoNameMaxLen)
 		})


### PR DESCRIPTION
* Creates new repos based on the test cluster name and RSync namespace and name, similar to what is done by other gitproviders
* Removes the deletion of Bitbucket repos since they can now be reused
* Replaces the use of curl with the http package