### PR TITLE
Add pipeline error metrics to ResourceGroup controller tests

### DIFF
--- a/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
+++ b/pkg/resourcegroup/controllers/resourcegroup/resourcegroup_controller_test.go
@@ -605,7 +605,10 @@ func TestReconcile_Metrics(t *testing.T) {
 			// Metrics test ResourceGroup (default/test-rg-metrics) - no pipeline errors
 			{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{
 				{Key: metrics.KeyComponent, Value: "readiness"},
-				{Key: metrics.KeyName, Value: "ns-reconciler-default-test-rg-metrics-15"},
+				{Key: metrics.KeyName, Value: func() string {
+					reconcilerName, _ := metrics.ComputeReconcilerNameType(types.NamespacedName{Name: "test-rg-metrics", Namespace: "default"})
+					return reconcilerName
+				}()},
 				{Key: metrics.KeyType, Value: "repo-sync"},
 			}},
 		},
@@ -753,7 +756,10 @@ func TestReconcile_Metrics_EmptyThenAddResources(t *testing.T) {
 		metrics.PipelineErrorView: {
 			{Data: &view.LastValueData{Value: 0}, Tags: []tag.Tag{
 				{Key: metrics.KeyComponent, Value: "readiness"},
-				{Key: metrics.KeyName, Value: "ns-reconciler-default-test-rg-metrics-empty-add-25"},
+				{Key: metrics.KeyName, Value: func() string {
+					reconcilerName, _ := metrics.ComputeReconcilerNameType(types.NamespacedName{Name: "test-rg-metrics-empty-add", Namespace: "default"})
+					return reconcilerName
+				}()},
 				{Key: metrics.KeyType, Value: "repo-sync"},
 			}},
 		},
@@ -767,7 +773,7 @@ func TestReconcile_Metrics_EmptyThenAddResources(t *testing.T) {
 	}
 
 	// Reset the exporter to clear accumulated metrics before testing with resources
-	exporter = exporter.Reset(
+	exporter = testmetrics.RegisterMetrics(
 		metrics.ResourceCountView,
 		metrics.ReadyResourceCountView,
 		metrics.NamespaceCountView,
@@ -892,7 +898,10 @@ func TestReconcile_Metrics_EmptyThenAddResources(t *testing.T) {
 		metrics.PipelineErrorView: {
 			{Data: &view.LastValueData{Value: 1}, Tags: []tag.Tag{
 				{Key: metrics.KeyComponent, Value: "readiness"},
-				{Key: metrics.KeyName, Value: "ns-reconciler-default-test-rg-metrics-empty-add-25"},
+				{Key: metrics.KeyName, Value: func() string {
+					reconcilerName, _ := metrics.ComputeReconcilerNameType(types.NamespacedName{Name: "test-rg-metrics-empty-add", Namespace: "default"})
+					return reconcilerName
+				}()},
 				{Key: metrics.KeyType, Value: "repo-sync"},
 			}},
 		},

--- a/pkg/testing/testmetrics/testexporter.go
+++ b/pkg/testing/testmetrics/testexporter.go
@@ -56,24 +56,6 @@ func RegisterMetrics(views ...*view.View) *TestExporter {
 	return &e
 }
 
-// Reset unregisters the given views and re-registers them with a fresh TestExporter.
-// This is useful for clearing accumulated metric data between test phases.
-func (e *TestExporter) Reset(views ...*view.View) *TestExporter {
-	// Unregister the views to clear any accumulated data
-	view.Unregister(views...)
-
-	// Clear the current exporter's data
-	e.rows = nil
-
-	// Re-register the views
-	_ = view.Register(views...)
-
-	// Return a fresh TestExporter
-	var newExporter TestExporter
-	view.RegisterExporter(&newExporter)
-	return &newExporter
-}
-
 // diff compares the exported rows' Tags and data Value with the expected
 // rows' Tags and data Value. It excludes the Start time field from the comparison.
 func diff(got, want []*view.Row) string {


### PR DESCRIPTION
- Add PipelineErrorView to metric tests
- Tests metrics validation for empty ResourceGroup transitioning to one with resources, verifying all metric types with proper tag values.