### PR TITLE
test: update SanitizeRepoName

### DIFF
--- a/e2e/nomostest/gitproviders/cloud_source_repository.go
+++ b/e2e/nomostest/gitproviders/cloud_source_repository.go
@@ -34,23 +34,23 @@ func CSRReaderEmail() string {
 type CSRClient struct {
 	// project in which to store the source repo
 	project string
-	// repoPrefix is used to avoid overlap
-	repoPrefix string
+	// repoSuffix is used to avoid overlap
+	repoSuffix string
 	// shell used for invoking CLI tools
 	shell *testshell.TestShell
 }
 
 // newCSRClient instantiates a new CSR client.
-func newCSRClient(repoPrefix string, shell *testshell.TestShell) *CSRClient {
+func newCSRClient(repoSuffix string, shell *testshell.TestShell) *CSRClient {
 	return &CSRClient{
 		project:    *e2e.GCPProject,
-		repoPrefix: repoPrefix,
+		repoSuffix: repoSuffix,
 		shell:      shell,
 	}
 }
 
 func (c *CSRClient) fullName(name string) string {
-	return util.SanitizeRepoName("cs-e2e-"+c.repoPrefix, name)
+	return util.SanitizeRepoName(c.repoSuffix, name)
 }
 
 // Type returns the provider type.

--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -62,17 +62,18 @@ func NewGitProvider(t testing.NTB, provider, clusterName string, logger *testlog
 			t.Fatal(err)
 		}
 		return client
-	case e2e.CSR:
-		return newCSRClient(clusterName, shell)
-	case e2e.SSM:
+	case e2e.CSR, e2e.SSM:
+		repoSuffix := *e2e.GCPProject + "/" + clusterName
+		if provider == e2e.CSR {
+			return newCSRClient(repoSuffix, shell)
+		}
+		// case e2e.SSM
 		out, err := shell.ExecWithDebug("gcloud", "projects", "describe", *e2e.GCPProject, "--format", "value(projectNumber)")
 		if err != nil {
 			t.Fatalf("getting project number: %w", err)
 		}
-
 		projectNumber := strings.Split(string(out), "\n")[0]
-
-		return newSSMClient(clusterName, shell, projectNumber)
+		return newSSMClient(repoSuffix, shell, projectNumber)
 	default:
 		return &LocalProvider{}
 	}

--- a/e2e/nomostest/gitproviders/secure_source_manager.go
+++ b/e2e/nomostest/gitproviders/secure_source_manager.go
@@ -40,8 +40,8 @@ type SSMClient struct {
 	instanceID string
 	// region of the SSM instance in which to store the source repo
 	region string
-	// repoPrefix is used to avoid overlap
-	repoPrefix string
+	// repoSuffix is used to avoid overlap
+	repoSuffix string
 	// shell used for invoking CLI tools
 	shell *testshell.TestShell
 }
@@ -49,19 +49,19 @@ type SSMClient struct {
 var _ GitProvider = &SSMClient{}
 
 // newSSMClient instantiates a new SSM client.
-func newSSMClient(repoPrefix string, shell *testshell.TestShell, projectNumber string) *SSMClient {
+func newSSMClient(repoSuffix string, shell *testshell.TestShell, projectNumber string) *SSMClient {
 	return &SSMClient{
 		project:       *e2e.GCPProject,
 		instanceID:    testing.SSMInstanceID,
 		region:        *e2e.SSMInstanceRegion,
-		repoPrefix:    repoPrefix,
+		repoSuffix:    repoSuffix,
 		shell:         shell,
 		projectNumber: projectNumber,
 	}
 }
 
 func (c *SSMClient) fullName(name string) string {
-	return util.SanitizeRepoName(c.repoPrefix, name)
+	return util.SanitizeRepoName(c.repoSuffix, name)
 }
 
 // Type returns the provider type.

--- a/e2e/nomostest/gitproviders/util/reponame.go
+++ b/e2e/nomostest/gitproviders/util/reponame.go
@@ -28,13 +28,16 @@ const (
 
 // SanitizeRepoName replaces all slashes with hyphens, and truncate the name.
 // repo name may contain between 3 and 63 lowercase letters, digits and hyphens.
-func SanitizeRepoName(repoPrefix, name string) string {
-	fullName := "cs-e2e-" + repoPrefix + "-" + name
+func SanitizeRepoName(repoSuffix, name string) string {
+	fullName := name + "-" + repoSuffix
 	hashBytes := sha1.Sum([]byte(fullName))
 	hashStr := hex.EncodeToString(hashBytes[:])[:repoNameHashLen]
 
 	if len(fullName) > repoNameMaxLen-1-repoNameHashLen {
 		fullName = fullName[:repoNameMaxLen-1-repoNameHashLen]
 	}
-	return fmt.Sprintf("%s-%s", strings.ReplaceAll(fullName, "/", "-"), hashStr)
+	sanitizedName := strings.ReplaceAll(fullName, "/", "-")
+	sanitizedName = strings.TrimRight(sanitizedName, "-") // Avoids double dash before the hash.
+
+	return fmt.Sprintf("%s-%s", sanitizedName, hashStr)
 }

--- a/e2e/nomostest/gitproviders/util/reponame_test.go
+++ b/e2e/nomostest/gitproviders/util/reponame_test.go
@@ -23,39 +23,45 @@ import (
 func TestSanitizeRepoName(t *testing.T) {
 	testCases := []struct {
 		testName     string
-		repoPrefix   string
+		repoSuffix   string
 		repoName     string
 		expectedName string
 	}{
 		{
 			testName:     "RepoSync test-ns/repo-sync",
-			repoPrefix:   "test",
+			repoSuffix:   "project/cluster",
 			repoName:     "test-ns/repo-sync",
-			expectedName: "cs-e2e-test-test-ns-repo-sync-19dcbc51",
+			expectedName: "test-ns-repo-sync-project-cluster-b96b1396",
 		},
 		{
 			testName:     "RepoSync test/ns-repo-sync should not collide with RepoSync test-ns/repo-sync",
-			repoPrefix:   "test",
+			repoSuffix:   "project/cluster",
 			repoName:     "test/ns-repo-sync",
-			expectedName: "cs-e2e-test-test-ns-repo-sync-f98ca740",
+			expectedName: "test-ns-repo-sync-project-cluster-d98dee7d",
 		},
 		{
-			testName:     "A very long repoPrefix should be truncated",
-			repoPrefix:   "autopilot-rapid-latest-10",
+			testName:     "A very long repoSuffix should be truncated",
+			repoSuffix:   "kpt-config-sync-ci-main/autopilot-rapid-latest-10",
 			repoName:     "config-management-system/root-sync",
-			expectedName: "cs-e2e-autopilot-rapid-latest-10-config-management-sys-0aab99c5",
+			expectedName: "config-management-system-root-sync-kpt-config-sync-ci-6485bfa0",
+		},
+		{
+			testName:     "A similar very long repoSuffix should be truncated and not collide",
+			repoSuffix:   "kpt-config-sync-ci-release/autopilot-rapid-latest-10",
+			repoName:     "config-management-system/root-sync",
+			expectedName: "config-management-system-root-sync-kpt-config-sync-ci-8b9c3b0d",
 		},
 		{
 			testName:     "A very long repoName should be truncated",
-			repoPrefix:   "test",
+			repoSuffix:   "test",
 			repoName:     "config-management-system/root-sync-with-a-very-long-name",
-			expectedName: "cs-e2e-test-config-management-system-root-sync-with-a--0d0af6c0",
+			expectedName: "config-management-system-root-sync-with-a-very-long-na-3b0dae1c",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotName := SanitizeRepoName(tc.repoPrefix, tc.repoName)
+			gotName := SanitizeRepoName(tc.repoSuffix, tc.repoName)
 			assert.Equal(t, tc.expectedName, gotName)
 		})
 	}


### PR DESCRIPTION
* Replaces repoPrefix with repoSuffix which now includes the GCP project name. This will help prevent collisions that can occur given that the ci-main and ci-release projects have the same set of cluster names
* Prevents double dashes from occuring in the santizied repo name