### PR TITLE
test: force push remote main branch in test

### DIFF
--- a/e2e/testcases/git_sync_test.go
+++ b/e2e/testcases/git_sync_test.go
@@ -34,8 +34,8 @@ func TestMultipleRemoteBranchesOutOfSync(t *testing.T) {
 		nt.T.Fatal(err)
 	}
 
-	nt.T.Log("Create an extra remote tracking branch")
-	nt.Must(rootSyncGitRepo.Push("HEAD:upstream/main"))
+	nt.T.Log("Create an extra branch on the remote repository")
+	nt.Must(rootSyncGitRepo.Push("HEAD:upstream/main", "-f"))
 
 	nt.T.Logf("Update the remote main branch by adding a test namespace")
 	nt.Must(rootSyncGitRepo.Add("acme/namespaces/hello/ns.yaml", k8sobjects.NamespaceObject("hello")))


### PR DESCRIPTION
Force updates the remote tracking branch in TestMultipleRemoteBranchesOutOfSync since it may already exist with changes in the repo