### PR TITLE
test: reuse Gitlab repos

### DIFF
--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -58,7 +58,8 @@ func NewGitProvider(t testing.NTB, provider, clusterName string, logger *testlog
 		}
 		return client
 	case e2e.GitLab:
-		client, err := newGitlabClient()
+		repoSuffix := *e2e.GCPProject + "/" + clusterName
+		client, err := newGitlabClient(repoSuffix, logger)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/e2e/nomostest/gitproviders/util/reponame.go
+++ b/e2e/nomostest/gitproviders/util/reponame.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	defaultRepoNameMaxLen   = 63
-	bitbucketRepoNameMaxLen = 62
-	repoNameHashLen         = 8
+	defaultRepoNameMaxLen      = 63
+	bitbucketRepoNameMaxLen    = 62
+	gitlabProjectNameMaxLength = 256
+	repoNameHashLen            = 8
 )
 
 // SanitizeGCPRepoName replaces all slashes with hyphens, and truncates the name.
@@ -61,6 +62,23 @@ func SanitizeBitbucketRepoName(repoSuffix, name string) string {
 	hashStr := hashName(fullName)
 
 	return sanitize(fullName, hashStr, bitbucketRepoNameMaxLen)
+}
+
+// SanitizeGitlabRepoName replaces all slashes with hyphens, and truncates the name for Gitlab.
+// repo name may contain between 3 and 256 lowercase letters, digits and hyphens.
+// The repo name will be of the form <name>-<repoSuffix>-<hash>
+func SanitizeGitlabRepoName(repoSuffix, name string) string {
+	if name == "" {
+		return name // Requires at least the base repo name
+	}
+
+	fullName := name
+	if repoSuffix != "" {
+		fullName += "-" + repoSuffix
+	}
+	hashStr := hashName(fullName)
+
+	return sanitize(fullName, hashStr, gitlabProjectNameMaxLength)
 }
 
 func hashName(fullName string) string {

--- a/e2e/nomostest/gitproviders/util/reponame_test.go
+++ b/e2e/nomostest/gitproviders/util/reponame_test.go
@@ -79,6 +79,53 @@ func TestSanitizeGCPRepoName(t *testing.T) {
 	}
 }
 
+func TestSanitizeGitlabRepoName(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		repoSuffix   string
+		repoName     string
+		expectedName string
+	}{
+		{
+			testName:     "RepoSync test-ns/repo-sync",
+			repoSuffix:   "test",
+			repoName:     "test-ns/repo-sync",
+			expectedName: "test-ns-repo-sync-test-3b350268",
+		},
+		{
+			testName:     "RepoSync test/ns-repo-sync should not collide with RepoSync test-ns/repo-sync",
+			repoSuffix:   "test",
+			repoName:     "test/ns-repo-sync",
+			expectedName: "test-ns-repo-sync-test-6831d08b",
+		},
+		{
+			testName:     "A very long repoName should be truncated",
+			repoSuffix:   "test",
+			repoName:     "config-management-system/root-sync-with-a-very-long-name-that-is-definitely-going-to-be-way-too-long-for-gcp-or-bitbucket-but-not-for-gitlab-because-it-has-a-much-longer-limit-so-we-need-to-make-this-string-extra-long-to-test-truncation-logic-for-gitlab-as-well-just-in-case-someone-is-feeling-verbose",
+			expectedName: "config-management-system-root-sync-with-a-very-long-name-that-is-definitely-going-to-be-way-too-long-for-gcp-or-bitbucket-but-not-for-gitlab-because-it-has-a-much-longer-limit-so-we-need-to-make-this-string-extra-long-to-test-truncation-logic-for-b29fd62d",
+		},
+		{
+			testName:     "Empty repoSuffix",
+			repoSuffix:   "",
+			repoName:     "test-ns/repo-sync",
+			expectedName: "test-ns-repo-sync-08675d6b",
+		}, {
+			testName:     "Empty repoName",
+			repoSuffix:   "test",
+			repoName:     "",
+			expectedName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			gotName := SanitizeGitlabRepoName(tc.repoSuffix, tc.repoName)
+			assert.Equal(t, tc.expectedName, gotName)
+			assert.LessOrEqual(t, len(gotName), gitlabProjectNameMaxLength)
+		})
+	}
+}
+
 func TestSanitizeBitbucketRepoName(t *testing.T) {
 	testCases := []struct {
 		testName     string


### PR DESCRIPTION
* Creates new repos based on the test cluster name and RSync namespace and name, similar to what is done by other gitproviders
* Removes the deletion of Gitlab repos since they can now be reused
* Replaces the use of curl with the http package