### PR TITLE
feat: Enhance nomos vet with flag validation and raw resource processing

### DIFF
--- a/cmd/nomos/flags/flags.go
+++ b/cmd/nomos/flags/flags.go
@@ -40,6 +40,9 @@ const (
 	// SkipAPIServerFlag is the flag name for SkipAPIServer below.
 	SkipAPIServerFlag = "no-api-server-check"
 
+	// NoAPIServerCheckForGroupFlag is the flag name for SkipAPIServerCheckForGroup below.
+	NoAPIServerCheckForGroupFlag = "no-api-server-check-for-group"
+
 	// OutputYAML specifies exporting the output in YAML format.
 	OutputYAML = "yaml"
 
@@ -63,6 +66,9 @@ var (
 
 	// SkipAPIServer directs whether to try to contact the API Server for checks.
 	SkipAPIServer bool
+
+	// SkipAPIServerCheckForGroup contains the list of API Groups to skip API server validation for.
+	SkipAPIServerCheckForGroup []string
 
 	// SourceFormat indicates the format of the Git repository.
 	SourceFormat string
@@ -99,6 +105,12 @@ func AddPath(cmd *cobra.Command) {
 func AddSkipAPIServerCheck(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&SkipAPIServer, SkipAPIServerFlag, false,
 		"If true, disables talking to the API Server for discovery.")
+}
+
+// AddNoAPIServerCheckForGroup adds the --no-api-server-check-for-group flag.
+func AddNoAPIServerCheckForGroup(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&SkipAPIServerCheckForGroup, NoAPIServerCheckForGroupFlag, nil,
+		"Accepts a comma-separated list of API Groups will be skipped during processing")
 }
 
 // AllClusters returns true if all clusters should be processed.

--- a/cmd/nomos/vet/vet.go
+++ b/cmd/nomos/vet/vet.go
@@ -35,6 +35,7 @@ func init() {
 	flags.AddClusters(Cmd)
 	flags.AddPath(Cmd)
 	flags.AddSkipAPIServerCheck(Cmd)
+	flags.AddNoAPIServerCheckForGroup(Cmd)
 	flags.AddSourceFormat(Cmd)
 	flags.AddOutputFormat(Cmd)
 	flags.AddAPIServerTimeout(Cmd)
@@ -75,6 +76,13 @@ returns a non-zero error code if any issues are found.
   nomos vet --path=my/directory
   nomos vet --path=/path/to/my/directory`,
 	Args: cobra.ExactArgs(0),
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		if flags.SkipAPIServer && len(flags.SkipAPIServerCheckForGroup) > 0 {
+			// If --no-api-server-check is specified, throw the error
+			return fmt.Errorf("cannot specify both --%s and --%s", flags.SkipAPIServerFlag, flags.NoAPIServerCheckForGroupFlag)
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Don't show usage on error, as argument validation passed.
 		cmd.SilenceUsage = true

--- a/e2e/testdata/gatekeeper-skip-gvk/constraint-template.yaml
+++ b/e2e/testdata/gatekeeper-skip-gvk/constraint-template.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |-
+        package k8srequiredlabels
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_]}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("you must provide labels: %v", [missing])
+        }

--- a/e2e/testdata/gatekeeper-skip-gvk/constraint.yaml
+++ b/e2e/testdata/gatekeeper-skip-gvk/constraint.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: ns-must-have-gk-label
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    labels: ["gatekeeper"]

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/config-sync/pkg/status"
 	"github.com/GoogleContainerTools/config-sync/pkg/util/discovery"
 	"github.com/GoogleContainerTools/config-sync/pkg/validate"
+	"github.com/GoogleContainerTools/config-sync/pkg/validate/fileobjects"
 	"github.com/GoogleContainerTools/config-sync/pkg/vet"
 	"github.com/Masterminds/semver"
 	clientdiscovery "k8s.io/client-go/discovery"
@@ -310,7 +311,11 @@ func ValidateOptions(rootDir cmpath.Absolute, apiServerTimeout time.Duration) (v
 	options.PolicyDir = cmpath.RelativeOS(rootDir.OSPath())
 	options.BuildScoper = discovery.ScoperBuilder(serverResourcer,
 		vet.AddCachedAPIResources(rootDir.Join(vet.APIResourcesPath)))
-	options.AllowUnknownKinds = flags.SkipAPIServer
+	if flags.SkipAPIServer {
+		options.AllowUnknownKindMatcher = &fileobjects.MatchAll{}
+	} else if len(flags.SkipAPIServerCheckForGroup) > 0 {
+		options.AllowUnknownKindMatcher = &fileobjects.GroupMatcher{Groups: flags.SkipAPIServerCheckForGroup}
+	}
 	return options, nil
 }
 


### PR DESCRIPTION
This commit expands the nomos vet command's capabilities by:
   - Introducing a flag validation, including specific handling for --skip-group.
   - Adding new unit tests within the vet package, alongside new test cases (TestVetSkipGroup, TestVetFlagExclusion), to ensure correct behavior and validation of these enhancements.

These changes specifically address issue #1633, where nomos vet failed to validate OPA Gatekeeper custom resources when a ConstraintTemplate and its corresponding Constraint were present in the same commit. The improved raw resource processing and  flag handling now allow nomos vet to correctly process such configurations, preventing the KNV1021 error.