### PR TITLE
test: return unexpected errors when checking if Bitbucket repo exists

### DIFF
--- a/e2e/nomostest/gitproviders/bitbucket.go
+++ b/e2e/nomostest/gitproviders/bitbucket.go
@@ -118,8 +118,12 @@ func (b *BitbucketClient) CreateRepository(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if resp.StatusCode == http.StatusOK {
 		return fullName, nil
+	} else if resp.StatusCode != http.StatusNotFound {
+		// unexpected error when checking if repository exists
+		return "", fmt.Errorf("failed to check if repository exists: status %d", resp.StatusCode)
 	}
 
 	payload := map[string]any{


### PR DESCRIPTION
This helps deal with errors that may occur when checking if a Bitbucket repository exists such as `429 Too Many Requests`