### PR TITLE
Revert "chore: bump Helm version to 3.18.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ KUSTOMIZE_VERSION := v5.4.2-gke.0
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
-HELM_VERSION := v3.18.0-gke.1
+HELM_VERSION := v3.15.3-gke.9
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.18.0-gke.1"
+	HelmVersion = "v3.15.3-gke.9"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.4.2-gke.0"
 	// Helm is the binary name of the installed Helm.


### PR DESCRIPTION
Reverts GoogleContainerTools/config-sync#1950 until failure is fixed.