### PR TITLE
chore: bump debian-base to bookworm-v1.0.6-gke.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command:
 # gcloud container images list-tags gcr.io/gke-release/debian-base --filter="tags:bookworm*"
-DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.5-gke.11
+DEBIAN_BASE_IMAGE := gcr.io/gke-release/debian-base:bookworm-v1.0.6-gke.2
 # Base image used for gcloud install, primarily for test images.
 # We use -slim for a smaller base image where we can choose which components to install.
 # https://cloud.google.com/sdk/docs/downloads-docker#docker_image_options


### PR DESCRIPTION
This includes some CVE fixes