### PR TITLE
chore: bump git-sync to v4.4.2-gke.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 COSIGN_VERSION := v2.4.1
 COSIGN := $(BIN_DIR)/cosign
 
-GIT_SYNC_VERSION := v4.4.2-gke.5__linux_amd64
+GIT_SYNC_VERSION := v4.4.2-gke.9__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 OTELCONTRIBCOL_VERSION := v0.127.0-gke.1


### PR DESCRIPTION
This includes CVE fixes