### PR TITLE
Revert "chore: bump to Go 1.24.11"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/config-sync
 
-go 1.24.11
+go 1.24.0
 
 require (
 	cloud.google.com/go/auth v0.18.0


### PR DESCRIPTION
Reverts GoogleContainerTools/config-sync#1972

Test failure for googleoss-kpt-config-sync-release/autopilot-stable. The root cause is an SSH authentication failure in the test harness, specifically: Host key verification failed.

This happened when the test runner tried to run a git push to the local test git server (localhost:40759). Because the push failed, the subsequent steps (reconciling the repo) never happened, leading to the root-reconciler deployment never being created (hence the NotFound errors later in the logs).