### PR TITLE
Reapply "chore: bump to Go 1.24.11 (#1972)" (#1973)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/config-sync
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/auth v0.18.0


### PR DESCRIPTION
This reverts commit a21979fe8fd12b9bbf61a069d6083367000fb228.