### PR TITLE
chore: bump kustomize to v5.8.0-gke.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ GO_JUNIT_REPORT := $(BIN_DIR)/go-junit-report
 GOLANGCI_LINT_VERSION := v1.63.4
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 
-KUSTOMIZE_VERSION := v5.4.2-gke.0
+KUSTOMIZE_VERSION := v5.8.0-gke.2
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -47,7 +47,7 @@ const (
 	// HelmVersion is the recommended version of Helm for hydration.
 	HelmVersion = "v3.18.6-gke.1"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
-	KustomizeVersion = "v5.4.2-gke.0"
+	KustomizeVersion = "v5.8.0-gke.2"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.


### PR DESCRIPTION
This fixes [CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729) and [CVE-2025-61727 ](https://security-tracker.debian.org/tracker/CVE-2025-61727)