### PR TITLE
Bypass inconsistent SSM repository state using a stable version suffix

### DIFF
--- a/e2e/nomostest/gitproviders/git-provider.go
+++ b/e2e/nomostest/gitproviders/git-provider.go
@@ -74,7 +74,8 @@ func NewGitProvider(t testing.NTB, provider, clusterName string, logger *testlog
 
 		projectNumber := strings.Split(string(out), "\n")[0]
 
-		return newSSMClient(clusterName, shell, projectNumber)
+		// Add suffix for repoPrefix to fix SSM testgrid failure
+		return newSSMClient(clusterName+"-v2", shell, projectNumber)
 	default:
 		return &LocalProvider{}
 	}


### PR DESCRIPTION
This PR updates the repository name generation for Secure Source Manager (SSM) in the E2E test framework by appending a stable suffix (e.g., -v2). This change addresses an inconsistent state in the kpt-config-sync-ci-release project where specific repository names have become unusable—reporting as "already existing" during creation but "not found" during describe or delete operations.