### PR TITLE
chore: bump Helm to v3.20.2-gke.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-helm-image
-HELM_VERSION := v3.20.0-gke.3
+HELM_VERSION := v3.20.2-gke.1
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.20.0-gke.3"
+	HelmVersion = "v3.20.2-gke.1"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.4.2-gke.6"
 	// Helm is the binary name of the installed Helm.


### PR DESCRIPTION
Fixes CVE-2026-35206 