### PR TITLE
chore: bump Golang to 1.25.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GO_DIR := $(OUTPUT_DIR)/go
 
 # Base image used for all golang containers
 # Uses trusted google-built golang image
-GOLANG_IMAGE_VERSION := 1.25.9
+GOLANG_IMAGE_VERSION := 1.25.10
 GOLANG_IMAGE := google-go.pkg.dev/golang:$(GOLANG_IMAGE_VERSION)
 # Base image used for debian containers
 # When updating you can use this command:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/config-sync
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go/auth v0.20.0


### PR DESCRIPTION
Fixes CVEs