### PR TITLE
chore: bump Helm and Kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,13 @@ GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-kustomize-image
-KUSTOMIZE_VERSION := v5.4.2-gke.6
+KUSTOMIZE_VERSION := v5.4.2-gke.7
 KUSTOMIZE := $(BIN_DIR)/kustomize
 KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-helm-image
-HELM_VERSION := v3.20.2-gke.2
+HELM_VERSION := v3.20.2-gke.3
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -45,9 +45,9 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.20.2-gke.2"
+	HelmVersion = "v3.20.2-gke.3"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
-	KustomizeVersion = "v5.4.2-gke.6"
+	KustomizeVersion = "v5.4.2-gke.7"
 	// Helm is the binary name of the installed Helm.
 	Helm = "helm"
 	// Kustomize is the binary name of the installed Kustomize.


### PR DESCRIPTION
* Upgrades Helm to v3.20.2-gke.3
* Upgrades Kustomize to v5.4.2-gke.7