### PR TITLE
chore: bump git-sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ COSIGN := $(BIN_DIR)/cosign
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-git-sync-image
-GIT_SYNC_VERSION := v4.4.2-gke.19__linux_amd64
+GIT_SYNC_VERSION := v4.4.2-gke.20__linux_amd64
 GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERSION)
 
 # To automatically update, run this command:


### PR DESCRIPTION
Upgrades git-sync to v4.4.2-gke.20